### PR TITLE
Fix metrics API auth for dashboard sessions

### DIFF
--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,6 +1,10 @@
 // ABOUTME: Metrics API endpoint — returns aggregated email stats, daily chart data, and per-domain breakdown
 
-import { unauthorizedResponse, validateDashboardKey } from "@/lib/api-auth";
+import {
+  getServerSession,
+  unauthorizedResponse,
+  validateDashboardKey,
+} from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { emails } from "@/lib/db/schema";
 import { and, gte, inArray, like, sql } from "drizzle-orm";
@@ -51,8 +55,12 @@ function getDateRange(range: string): Date {
 
 // Dashboard-only internal endpoint
 export async function GET(request: NextRequest) {
-  const auth = validateDashboardKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  const hasDashboardKey = validateDashboardKey(
+    request.headers.get("authorization"),
+  );
+  const session = hasDashboardKey ? null : await getServerSession();
+
+  if (!hasDashboardKey && !session) return unauthorizedResponse();
 
   try {
     const searchParams = request.nextUrl.searchParams;

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -10,6 +10,7 @@ const mockDelete = vi.hoisted(() => vi.fn());
 const mockValidateApiKey = vi.hoisted(() => vi.fn());
 const mockCountFn = vi.hoisted(() => vi.fn());
 const mockValidateDashboardKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
 
 function makeChain<T>(rows: T[]) {
   return {
@@ -207,6 +208,7 @@ describe("route smoke coverage", () => {
         ...actual,
         validateApiKey: mockValidateApiKey,
         validateDashboardKey: mockValidateDashboardKey,
+        getServerSession: mockGetServerSession,
       };
     });
     mockValidateApiKey.mockResolvedValue({
@@ -214,17 +216,22 @@ describe("route smoke coverage", () => {
       permission: "full_access",
     });
     mockValidateDashboardKey.mockReturnValue(true);
+    mockGetServerSession.mockResolvedValue({
+      session: { id: "session-1" },
+      user: { id: "user-1" },
+    });
   });
 
-  it("covers metrics auth failure and happy path", async () => {
+  it("covers metrics auth failure, session auth, and dashboard key auth", async () => {
     mockValidateDashboardKey.mockReturnValueOnce(false);
+    mockGetServerSession.mockResolvedValueOnce(null);
     const metricsRoute = await import("@/app/api/metrics/route");
     const unauthorized = await metricsRoute.GET(
       makeNextRequest("http://localhost/api/metrics") as never,
     );
     expect(unauthorized.status).toBe(401);
 
-    mockValidateDashboardKey.mockReturnValue(true);
+    mockValidateDashboardKey.mockReturnValueOnce(false);
     mockSelect
       .mockReturnValueOnce(
         makeChain([
@@ -253,15 +260,15 @@ describe("route smoke coverage", () => {
         ]),
       );
 
-    const response = await metricsRoute.GET(
+    const sessionResponse = await metricsRoute.GET(
       makeNextRequest(
         "http://localhost/api/metrics?range=last_7_days&domain=example.com&event_type=delivered",
-        { headers: { authorization: "Bearer token" } },
       ) as never,
     );
 
-    expect(response.status).toBe(200);
-    const json = await response.json();
+    expect(sessionResponse.status).toBe(200);
+    expect(mockGetServerSession).toHaveBeenCalledTimes(2);
+    const json = await sessionResponse.json();
     expect(json.totalEmails).toBe(10);
     expect(json.deliverabilityRate).toBe(70);
     expect(json.bounceRate).toBe(20);
@@ -270,6 +277,34 @@ describe("route smoke coverage", () => {
     expect(json.domainBreakdown).toEqual([
       { domain: "example.com", count: 10, rate: 70 },
     ]);
+
+    mockSelect
+      .mockReturnValueOnce(
+        makeChain([
+          {
+            total: 0,
+            delivered: 0,
+            bounced: 0,
+            hard_bounced: 0,
+            soft_bounced: 0,
+            undetermined_bounced: 0,
+            complained: 0,
+          },
+        ]),
+      )
+      .mockReturnValueOnce(makeChain([]))
+      .mockReturnValueOnce(makeChain([]))
+      .mockReturnValueOnce(makeChain([]))
+      .mockReturnValueOnce(makeChain([]));
+    mockValidateDashboardKey.mockReturnValueOnce(true);
+    const dashboardKeyResponse = await metricsRoute.GET(
+      makeNextRequest("http://localhost/api/metrics", {
+        headers: { authorization: "Bearer token" },
+      }) as never,
+    );
+
+    expect(dashboardKeyResponse.status).toBe(200);
+    expect(mockGetServerSession).toHaveBeenCalledTimes(2);
   });
 
   it("covers usage auth failure and happy path", async () => {


### PR DESCRIPTION
## Summary
- allow `/api/metrics` to authorize either a valid dashboard key or an authenticated dashboard session
- keep dashboard-key behavior intact while skipping session lookup when the key is present
- extend the route smoke test to cover unauthorized access, session-backed access, and dashboard-key access

## Testing
- npm exec -- vitest run tests/api-auth-date-range-routes.test.ts -t "covers metrics auth failure, session auth, and dashboard key auth"
- npm exec -- vitest run tests/metrics-page.test.ts
- npm exec -- biome check src/app/api/metrics/route.ts

## Notes
- removed the internal-only learning note from the branch before commit
- `make check` still fails on pre-existing type errors in `src/app/api/emails/route.ts`
- `npm exec -- vitest run tests/api-auth-date-range-routes.test.ts` still has two unrelated pre-existing failures in non-metrics smoke tests (`segments/[id]/contacts` and `contacts/[id]/segments/[segment_id]` mock coverage)

Closes #87