### PR TITLE
Add staging verification note for PRs #93 and #94

### DIFF
--- a/agent_docs/release-notes/2026-04-27-staging-verification.md
+++ b/agent_docs/release-notes/2026-04-27-staging-verification.md
@@ -1,0 +1,37 @@
+# Staging verification note — 2026-04-27
+
+Reviewed against `staging` head `b1a574c` after PR #93 and PR #94 merged.
+
+## Merged PRs
+- [#93 — Fix onboarding and CI drift from PR #3](https://github.com/namuh-eng/namuh-send/pull/93) (`5368a16`)
+- [#94 — Fix metrics API auth for dashboard sessions](https://github.com/namuh-eng/namuh-send/pull/94) (`b1a574c`)
+
+## What changed
+- **#93** restores the local onboarding path: `make setup` now bootstraps `.env`, generates `DASHBOARD_KEY`, waits for Postgres, pushes schema, seeds data, and installs versioned Git hooks. Docs/config now clarify localhost vs container DB usage and allow `POSTGRES_PORT` overrides.
+- **#94** lets `/api/metrics` authorize either a dashboard key or an authenticated dashboard session, which matches how the dashboard metrics page already calls that API.
+
+## Manual verification checklist
+- **Bootstrap / onboarding (#93)**
+  - [ ] From `staging`, run `cp .env.example .env` if needed.
+  - [ ] If port `5432` is busy, set both `POSTGRES_PORT` and the port inside `DATABASE_URL` in `.env`.
+  - [ ] Run `make setup` and confirm it completes through Postgres startup, schema push, and seed.
+  - [ ] Run `npm run hooks:install && git config --get core.hooksPath` and confirm the output is `.githooks`.
+  - [ ] Run `docker compose config` and confirm Compose renders cleanly.
+- **Metrics auth (#94)**
+  - [ ] Log into the dashboard on staging and open the metrics page.
+  - [ ] Confirm the page loads metrics successfully without a 401 loop.
+  - [ ] In browser devtools, confirm the authenticated session-backed `/api/metrics` request returns `200` without needing an `Authorization` header.
+  - [ ] In a logged-out/incognito session, request `/api/metrics` without credentials and confirm it returns `401`.
+  - [ ] Request `/api/metrics` with a valid dashboard key and confirm it still returns `200`.
+
+## Re-verified on the merged staging branch
+- `npm exec -- vitest run tests/api-auth-date-range-routes.test.ts -t "covers metrics auth failure, session auth, and dashboard key auth"` ✅
+- `npm exec -- vitest run tests/metrics-page.test.ts` ✅
+- `npm exec -- biome check src/app/api/metrics/route.ts` ✅
+- `npm run hooks:install` + `git config --get core.hooksPath` → `.githooks` ✅
+- `docker compose config` ✅
+
+## Residual risks / baseline failures
+- `make check` still fails on pre-existing TypeScript errors in `src/app/api/emails/route.ts` (currently at lines 133 and 145 on `staging`).
+- `npm exec -- vitest run tests/api-auth-date-range-routes.test.ts` still has two unrelated baseline failures in the segments/contact-segment smoke coverage paths.
+- The new session-backed metrics authorization path still lacks Playwright coverage for a real authenticated browser flow.


### PR DESCRIPTION
## Summary
- add a dated staging verification note for the PR #93 / #94 merge set
- link the merged PRs, summarize the merged behavior, and list the exact human verification checklist
- capture the current baseline failures on staging so reviewers know what is pre-existing

## Verification
- npm exec -- vitest run tests/api-auth-date-range-routes.test.ts -t "covers metrics auth failure, session auth, and dashboard key auth"
- npm exec -- vitest run tests/metrics-page.test.ts
- npm exec -- biome check src/app/api/metrics/route.ts
- npm run hooks:install && git config --get core.hooksPath
- docker compose config
- make check *(documents pre-existing staging failure in src/app/api/emails/route.ts)*
- npm exec -- vitest run tests/api-auth-date-range-routes.test.ts *(documents unrelated baseline smoke-test failures)*