### PR TITLE
Fix App Runner redeploys to honor requested image tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ scripts/*
 !scripts/seed.ts
 !scripts/install-git-hooks.mjs
 !scripts/check-changed-files.mjs
+!scripts/deploy.sh
 
 # Playwright test artifacts
 test-results/

--- a/agent_docs/learnings/active/2026-04-27-issue-91-apprunner-tag-updates.md
+++ b/agent_docs/learnings/active/2026-04-27-issue-91-apprunner-tag-updates.md
@@ -1,0 +1,12 @@
+---
+date: 2026-04-27
+issue: 91
+type: decision
+promoted_to: null
+---
+
+`scripts/deploy.sh` had been previously introduced but was no longer tracked because `.gitignore` ignored most of `scripts/`.
+
+For App Runner services that already exist, the minimal safe fix was to read the current `Service.SourceConfiguration`, replace only `ImageRepository.ImageIdentifier`, and send that JSON back through `aws apprunner update-service`.
+
+This avoids re-hardcoding the entire existing service source configuration during updates while still making tag-based deployments effective.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# ABOUTME: Deploy script for AWS App Runner via ECR
+# ABOUTME: Builds Docker image, pushes to ECR, creates/updates App Runner service
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Configuration
+AWS_REGION="us-east-1"
+AWS_ACCOUNT_ID="699486076867"
+ECR_REPO="resend-clone"
+ECR_URI="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPO}"
+APP_RUNNER_SERVICE="resend-clone"
+IMAGE_TAG="${1:-latest}"
+IMAGE_IDENTIFIER="${ECR_URI}:${IMAGE_TAG}"
+
+echo "=== Deploying to App Runner ==="
+echo "Region: ${AWS_REGION}"
+echo "ECR: ${IMAGE_IDENTIFIER}"
+echo ""
+
+CREATE_SOURCE_CONFIGURATION=$(cat <<JSON
+{
+  "AuthenticationConfiguration": {
+    "AccessRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/AppRunnerECRAccessRole"
+  },
+  "ImageRepository": {
+    "ImageIdentifier": "${IMAGE_IDENTIFIER}",
+    "ImageRepositoryType": "ECR",
+    "ImageConfiguration": {
+      "Port": "3000",
+      "RuntimeEnvironmentVariables": {
+        "NODE_ENV": "production"
+      }
+    }
+  }
+}
+JSON
+)
+
+INSTANCE_CONFIGURATION=$(cat <<'JSON'
+{
+  "Cpu": "1024",
+  "Memory": "2048"
+}
+JSON
+)
+
+# Step 1: Authenticate Docker with ECR
+echo "→ Authenticating with ECR..."
+aws ecr get-login-password --region "${AWS_REGION}" | \
+  docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+
+# Step 2: Build Docker image
+echo "→ Building Docker image..."
+docker build -t "${ECR_REPO}:${IMAGE_TAG}" .
+
+# Step 3: Tag and push to ECR
+echo "→ Pushing to ECR..."
+docker tag "${ECR_REPO}:${IMAGE_TAG}" "${IMAGE_IDENTIFIER}"
+docker push "${IMAGE_IDENTIFIER}"
+
+# Step 4: Check if App Runner service exists
+echo "→ Checking App Runner service..."
+SERVICE_ARN=$(aws apprunner list-services --region "${AWS_REGION}" \
+  --query "ServiceSummaryList[?ServiceName=='${APP_RUNNER_SERVICE}'].ServiceArn | [0]" \
+  --output text 2>/dev/null || echo "None")
+
+if [ "${SERVICE_ARN}" = "None" ] || [ -z "${SERVICE_ARN}" ]; then
+  # Step 5a: Create new App Runner service
+  echo "→ Creating App Runner service..."
+  aws apprunner create-service \
+    --region "${AWS_REGION}" \
+    --service-name "${APP_RUNNER_SERVICE}" \
+    --source-configuration "${CREATE_SOURCE_CONFIGURATION}" \
+    --instance-configuration "${INSTANCE_CONFIGURATION}"
+
+  echo "✓ App Runner service created. It may take a few minutes to deploy."
+else
+  # Step 5b: Update existing App Runner service
+  echo "→ Updating App Runner service (${SERVICE_ARN})..."
+  CURRENT_SOURCE_CONFIGURATION=$(aws apprunner describe-service \
+    --region "${AWS_REGION}" \
+    --service-arn "${SERVICE_ARN}" \
+    --query 'Service.SourceConfiguration' \
+    --output json)
+
+  UPDATED_SOURCE_CONFIGURATION=$(CURRENT_SOURCE_CONFIGURATION="${CURRENT_SOURCE_CONFIGURATION}" IMAGE_IDENTIFIER="${IMAGE_IDENTIFIER}" python3 - <<'PY'
+import json
+import os
+
+source_configuration = json.loads(os.environ["CURRENT_SOURCE_CONFIGURATION"])
+image_repository = source_configuration.get("ImageRepository")
+if not image_repository:
+    raise SystemExit("Existing App Runner service is not configured with an image repository")
+image_repository["ImageIdentifier"] = os.environ["IMAGE_IDENTIFIER"]
+print(json.dumps(source_configuration, separators=(",", ":")))
+PY
+)
+
+  aws apprunner update-service \
+    --region "${AWS_REGION}" \
+    --service-arn "${SERVICE_ARN}" \
+    --source-configuration "${UPDATED_SOURCE_CONFIGURATION}"
+
+  echo "✓ Service update started."
+fi
+
+# Step 6: Get service URL
+echo ""
+echo "→ Fetching service URL..."
+SERVICE_URL=$(aws apprunner describe-service \
+  --region "${AWS_REGION}" \
+  --service-arn "$(aws apprunner list-services --region "${AWS_REGION}" \
+    --query "ServiceSummaryList[?ServiceName=='${APP_RUNNER_SERVICE}'].ServiceArn | [0]" \
+    --output text)" \
+  --query "Service.ServiceUrl" \
+  --output text 2>/dev/null || echo "pending")
+
+echo ""
+echo "=== Deployment Complete ==="
+echo "Service: ${APP_RUNNER_SERVICE}"
+echo "URL: https://${SERVICE_URL}"
+echo ""

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -29,12 +29,15 @@ describe("deploy-001: ECS Fargate deployment configuration", () => {
     expect(dockerfile).toContain("ENV PORT=8080");
   });
 
-  it("deploy script targets ECR + ECS when present", () => {
+  it("deploy script updates existing App Runner services to the requested image tag", () => {
     const scriptPath = join(root, "scripts", "deploy.sh");
-    if (!existsSync(scriptPath)) return; // script is gitignored, skip if absent
+    expect(existsSync(scriptPath)).toBe(true);
     const script = readFileSync(scriptPath, "utf-8");
-    expect(script).toContain("ecr");
-    expect(script).toMatch(/ecs|fargate/i);
+    expect(script).toContain("aws apprunner update-service");
+    expect(script).toContain("Service.SourceConfiguration");
+    expect(script).toContain(
+      'image_repository["ImageIdentifier"] = os.environ["IMAGE_IDENTIFIER"]',
+    );
   });
 
   it("package.json has build script", () => {


### PR DESCRIPTION
## Summary
- restore `scripts/deploy.sh` as a tracked script
- update existing App Runner services via `aws apprunner update-service` instead of `start-deployment` alone
- preserve the current service `SourceConfiguration` and replace only `ImageRepository.ImageIdentifier`
- add a focused deploy test covering the existing-service tag update path

## Verification
- `bash -n scripts/deploy.sh`
- `bun test tests/deploy.test.ts`
- `make test`
- `make check` *(blocked by pre-existing repo Biome errors unrelated to this change)*

## Notes
- Full end-to-end AWS App Runner verification was not possible locally, so the fix is validated via script syntax checks and unit coverage.
- Never merges to `main`; PR targets `staging`.
