### PR TITLE
Fix settings usage tab dashboard auth flow

### DIFF
--- a/agent_docs/learnings/active/2026-04-27-issue-90-usage-tab-dashboard-session-auth.md
+++ b/agent_docs/learnings/active/2026-04-27-issue-90-usage-tab-dashboard-session-auth.md
@@ -1,0 +1,15 @@
+---
+date: 2026-04-27
+issue: 90
+type: decision
+promoted_to: null
+---
+
+## Context
+The Settings Usage tab fetched `/api/usage` with the user's API key from `localStorage`, but the route only accepted dashboard auth. The client also stored any JSON response without checking `res.ok`.
+
+## Decision
+Treat `/api/usage` like the dashboard metrics endpoint: accept either the dashboard bearer key or an authenticated dashboard session, and have the client fetch without injecting an API key header. On the client, ignore non-OK or malformed payloads so the usage state stays on the last known-good/default shape.
+
+## Why
+The settings page already runs behind dashboard session protection, so same-origin session auth is the correct default. This keeps the fix small, avoids widening API-key access for an internal route, and prevents `{ error: ... }` payloads from being rendered as quota data.

--- a/src/app/api/usage/route.ts
+++ b/src/app/api/usage/route.ts
@@ -1,13 +1,21 @@
-import { unauthorizedResponse, validateDashboardKey } from "@/lib/api-auth";
+import {
+  getServerSession,
+  unauthorizedResponse,
+  validateDashboardKey,
+} from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { contacts, domains, emails, segments } from "@/lib/db/schema";
-import { count, gte } from "drizzle-orm";
+import { gte } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
 // Dashboard-only internal endpoint
 export async function GET(request: Request) {
-  const auth = validateDashboardKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  const hasDashboardKey = validateDashboardKey(
+    request.headers.get("authorization"),
+  );
+  const session = hasDashboardKey ? null : await getServerSession();
+
+  if (!hasDashboardKey && !session) return unauthorizedResponse();
 
   try {
     const now = new Date();

--- a/src/components/settings-page.tsx
+++ b/src/components/settings-page.tsx
@@ -6,6 +6,33 @@ import { TeamTab } from "@/components/settings-team";
 import { type UsageData, UsageTab } from "@/components/settings-usage";
 import { useEffect, useState } from "react";
 
+function isUsageData(value: unknown): value is UsageData {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<UsageData> & Record<string, unknown>;
+
+  return (
+    typeof candidate.transactional === "object" &&
+    candidate.transactional !== null &&
+    typeof candidate.transactional.monthlyUsed === "number" &&
+    typeof candidate.transactional.monthlyLimit === "number" &&
+    typeof candidate.transactional.dailyUsed === "number" &&
+    typeof candidate.transactional.dailyLimit === "number" &&
+    typeof candidate.marketing === "object" &&
+    candidate.marketing !== null &&
+    typeof candidate.marketing.contactsUsed === "number" &&
+    typeof candidate.marketing.contactsLimit === "number" &&
+    typeof candidate.marketing.segmentsUsed === "number" &&
+    typeof candidate.marketing.segmentsLimit === "number" &&
+    candidate.marketing.broadcastsLimit === "Unlimited" &&
+    typeof candidate.team === "object" &&
+    candidate.team !== null &&
+    typeof candidate.team.domainsUsed === "number" &&
+    typeof candidate.team.domainsLimit === "number" &&
+    typeof candidate.team.rateLimit === "number"
+  );
+}
+
 const SMTP_CREDENTIALS = [
   { label: "Host", value: "smtp.namuh-send.com" },
   { label: "Port", value: "465" },
@@ -37,16 +64,19 @@ export function SettingsPage() {
   const [usage, setUsage] = useState<UsageData>(DEFAULT_USAGE);
 
   useEffect(() => {
-    if (activeTab === "usage") {
-      const apiKey =
-        typeof window !== "undefined" ? localStorage.getItem("api_key") : null;
-      const authHeaders: Record<string, string> = {};
-      if (apiKey) authHeaders.Authorization = `Bearer ${apiKey}`;
-      fetch("/api/usage", { headers: authHeaders })
-        .then((r) => r.json())
-        .then((data) => setUsage(data))
-        .catch(() => {});
-    }
+    if (activeTab !== "usage") return;
+
+    fetch("/api/usage")
+      .then(async (response) => {
+        if (!response.ok) return null;
+
+        const data: unknown = await response.json();
+        return isUsageData(data) ? data : null;
+      })
+      .then((data) => {
+        if (data) setUsage(data);
+      })
+      .catch(() => {});
   }, [activeTab]);
 
   return (

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -312,15 +312,20 @@ describe("route smoke coverage", () => {
     expect(mockGetServerSession).toHaveBeenCalledTimes(2);
   });
 
-  it("covers usage auth failure and happy path", async () => {
+  it("covers usage auth failure, session auth, and dashboard key auth", async () => {
     mockValidateDashboardKey.mockReturnValueOnce(false);
+    mockGetServerSession.mockResolvedValueOnce(null);
     const usageRoute = await import("@/app/api/usage/route");
     const unauthorized = await usageRoute.GET(
       makeNextRequest("http://localhost/api/usage"),
     );
     expect(unauthorized.status).toBe(401);
 
-    mockValidateDashboardKey.mockReturnValue(true);
+    mockValidateDashboardKey.mockReturnValueOnce(false);
+    mockGetServerSession.mockResolvedValueOnce({
+      session: { id: "session-1" },
+      user: { id: "user-1" },
+    });
     mockCountFn.mockResolvedValue(0);
     mockCountFn.mockResolvedValueOnce(42);
     mockCountFn.mockResolvedValueOnce(3);
@@ -328,19 +333,36 @@ describe("route smoke coverage", () => {
     mockCountFn.mockResolvedValueOnce(4);
     mockCountFn.mockResolvedValueOnce(2);
 
-    const response = await usageRoute.GET(
-      makeNextRequest("http://localhost/api/usage", {
-        headers: { authorization: "Bearer token" },
-      }),
+    const sessionResponse = await usageRoute.GET(
+      makeNextRequest("http://localhost/api/usage"),
     );
 
-    expect(response.status).toBe(200);
-    const json = await response.json();
+    expect(sessionResponse.status).toBe(200);
+    let json = await sessionResponse.json();
     expect(json.transactional.monthlyUsed).toBe(42);
     expect(json.transactional.dailyUsed).toBe(3);
     expect(json.marketing.contactsUsed).toBe(120);
     expect(json.marketing.segmentsUsed).toBe(4);
     expect(json.team.domainsUsed).toBe(2);
+
+    mockValidateDashboardKey.mockReturnValueOnce(true);
+    mockCountFn.mockResolvedValue(0);
+    mockCountFn.mockResolvedValueOnce(7);
+    mockCountFn.mockResolvedValueOnce(1);
+    mockCountFn.mockResolvedValueOnce(8);
+    mockCountFn.mockResolvedValueOnce(2);
+    mockCountFn.mockResolvedValueOnce(1);
+
+    const dashboardKeyResponse = await usageRoute.GET(
+      makeNextRequest("http://localhost/api/usage", {
+        headers: { authorization: "Bearer token" },
+      }),
+    );
+
+    expect(dashboardKeyResponse.status).toBe(200);
+    json = await dashboardKeyResponse.json();
+    expect(json.transactional.monthlyUsed).toBe(7);
+    expect(mockGetServerSession).toHaveBeenCalledTimes(2);
   });
 
   it("covers segments get/post happy path and validation", async () => {

--- a/tests/settings-page.test.tsx
+++ b/tests/settings-page.test.tsx
@@ -1,0 +1,59 @@
+import { SettingsPage } from "@/components/settings-page";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+afterEach(cleanup);
+
+describe("SettingsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads usage through the dashboard session flow without an API key header", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          transactional: {
+            monthlyUsed: 12,
+            monthlyLimit: 3000,
+            dailyUsed: 2,
+            dailyLimit: 100,
+          },
+          marketing: {
+            contactsUsed: 5,
+            contactsLimit: 1000,
+            segmentsUsed: 1,
+            segmentsLimit: 3,
+            broadcastsLimit: "Unlimited",
+          },
+          team: {
+            domainsUsed: 2,
+            domainsLimit: 3,
+            rateLimit: 2,
+          },
+        }),
+    });
+
+    render(<SettingsPage />);
+
+    await waitFor(() => expect(screen.getByText("12 / 3,000")).toBeTruthy());
+    expect(mockFetch).toHaveBeenCalledWith("/api/usage");
+  });
+
+  it("ignores non-ok usage responses instead of treating errors as quota data", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ error: "Missing or invalid API key" }),
+    });
+
+    render(<SettingsPage />);
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+    expect(screen.getByText("0 / 3,000")).toBeTruthy();
+    expect(screen.queryByText("Missing or invalid API key")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- switch the settings usage endpoint to the same dashboard auth contract as metrics by allowing a dashboard session or dashboard key
- stop the settings page from sending the browser API key to 
- ignore non-OK or malformed usage payloads and add regression coverage for both the route and client fetch flow

## Testing
- bun run typecheck
- bunx biome check src/components/settings-page.tsx src/app/api/usage/route.ts tests/settings-page.test.tsx tests/api-auth-date-range-routes.test.ts
- make test
- make check *(typecheck passed; full-project Biome currently reports unrelated pre-existing diagnostics outside this slice)*
