### PR TITLE
Fix email sending filter URL resync drift

### DIFF
--- a/agent_docs/learnings/active/2026-04-27-92-email-filter-url-sync.md
+++ b/agent_docs/learnings/active/2026-04-27-92-email-filter-url-sync.md
@@ -1,0 +1,8 @@
+---
+date: 2026-04-27
+issue: 92
+type: decision
+promoted_to: null
+---
+
+When a filter bar debounces outward updates but also needs to resync from URL-derived props, clear any pending debounce timer before applying the new prop state. Otherwise a stale delayed callback can re-emit the pre-navigation filters and push the URL back out of sync.

--- a/src/components/emails-sending-filter-bar.tsx
+++ b/src/components/emails-sending-filter-bar.tsx
@@ -21,6 +21,15 @@ interface EmailsSendingFilterBarProps {
   onFiltersChange: (filters: EmailFilters) => void;
 }
 
+function getFilters(initialFilters?: Partial<EmailFilters>): EmailFilters {
+  return {
+    search: initialFilters?.search ?? "",
+    dateRange: initialFilters?.dateRange ?? "Last 15 days",
+    status: initialFilters?.status ?? "",
+    apiKeyId: initialFilters?.apiKeyId ?? "",
+  };
+}
+
 const STATUS_OPTIONS: DropdownFilterOption[] = [
   { value: "", label: "All Statuses" },
   { value: "bounced", label: "Bounced", color: "#EF4444" },
@@ -42,12 +51,9 @@ export function EmailsSendingFilterBar({
   initialFilters,
   onFiltersChange,
 }: EmailsSendingFilterBarProps) {
-  const [filters, setFilters] = useState<EmailFilters>({
-    search: initialFilters?.search ?? "",
-    dateRange: initialFilters?.dateRange ?? "Last 15 days",
-    status: initialFilters?.status ?? "",
-    apiKeyId: initialFilters?.apiKeyId ?? "",
-  });
+  const [filters, setFilters] = useState<EmailFilters>(
+    getFilters(initialFilters),
+  );
   const searchTimeout = useRef<ReturnType<typeof setTimeout>>(null);
 
   useEffect(() => {
@@ -57,6 +63,15 @@ export function EmailsSendingFilterBar({
       }
     };
   }, []);
+
+  useEffect(() => {
+    if (searchTimeout.current) {
+      clearTimeout(searchTimeout.current);
+      searchTimeout.current = null;
+    }
+
+    setFilters(getFilters(initialFilters));
+  }, [initialFilters]);
 
   const updateFilters = (
     overrides: Partial<EmailFilters>,

--- a/src/components/emails-sending-page.tsx
+++ b/src/components/emails-sending-page.tsx
@@ -75,6 +75,10 @@ export function EmailsSendingPage({ apiKeys, emails }: EmailsSendingPageProps) {
   const [filters, setFilters] = useState<EmailFilters>(initialFilters);
 
   useEffect(() => {
+    setFilters(initialFilters);
+  }, [initialFilters]);
+
+  useEffect(() => {
     const nextQuery = buildQueryString(filters);
     const nextUrl = nextQuery ? `${pathname}?${nextQuery}` : pathname;
     router.replace(nextUrl);

--- a/tests/e2e/emails-filter-bar.spec.ts
+++ b/tests/e2e/emails-filter-bar.spec.ts
@@ -38,4 +38,21 @@ test.describe("Emails Sending Filter Bar", () => {
     // Button should now show "Today"
     await expect(page.getByText("Today")).toBeVisible();
   });
+
+  test("resyncs search controls when the URL search params change after mount", async ({
+    page,
+  }) => {
+    await page.goto("/emails?search=alice");
+
+    const searchInput = page.getByPlaceholder("Search...");
+    await expect(searchInput).toHaveValue("alice");
+
+    await page.evaluate(() => {
+      window.history.pushState({}, "", "/emails?search=bob");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    await expect(page).toHaveURL(/\/emails\?search=bob/);
+    await expect(searchInput).toHaveValue("bob");
+  });
 });

--- a/tests/emails-filter-bar.test.tsx
+++ b/tests/emails-filter-bar.test.tsx
@@ -182,4 +182,46 @@ describe("EmailsSendingFilterBar", () => {
       expect.objectContaining({ dateRange: "Today" }),
     );
   });
+
+  it("resyncs its controls when initial filters change after mount", () => {
+    const { rerender } = render(
+      <EmailsSendingFilterBar
+        apiKeys={defaultApiKeys}
+        initialFilters={{
+          search: "alice@example.com",
+          dateRange: "Today",
+          status: "delivered",
+          apiKeyId: "key-1",
+        }}
+        onFiltersChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByPlaceholderText("Search...").getAttribute("value")).toBe(
+      "alice@example.com",
+    );
+    expect(screen.getByText("Today")).toBeDefined();
+    expect(screen.getByText("Delivered")).toBeDefined();
+    expect(screen.getByText("My API Key")).toBeDefined();
+
+    rerender(
+      <EmailsSendingFilterBar
+        apiKeys={defaultApiKeys}
+        initialFilters={{
+          search: "bob@example.com",
+          dateRange: "Yesterday",
+          status: "bounced",
+          apiKeyId: "key-2",
+        }}
+        onFiltersChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByPlaceholderText("Search...").getAttribute("value")).toBe(
+      "bob@example.com",
+    );
+    expect(screen.getByText("Yesterday")).toBeDefined();
+    expect(screen.getByText("Bounced")).toBeDefined();
+    expect(screen.getByText("Production Key")).toBeDefined();
+  });
 });

--- a/tests/emails-sending-page.test.tsx
+++ b/tests/emails-sending-page.test.tsx
@@ -38,6 +38,10 @@ afterEach(() => {
   mockSearchParams = new URLSearchParams();
 });
 
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
 describe("EmailsSendingPage", () => {
   const apiKeys = [
     { id: "key-1", name: "Production Key" },
@@ -50,7 +54,14 @@ describe("EmailsSendingPage", () => {
       to: ["alice@example.com"],
       lastEvent: "delivered",
       subject: "Welcome email",
-      createdAt: "2026-03-29T10:00:00Z",
+      createdAt: daysAgo(1),
+    },
+    {
+      id: "email-2",
+      to: ["bob@example.com"],
+      lastEvent: "bounced",
+      subject: "Follow-up email",
+      createdAt: daysAgo(2),
     },
   ];
 
@@ -87,5 +98,33 @@ describe("EmailsSendingPage", () => {
         "/emails?search=alice&status=delivered&apiKeyId=key-1&dateRange=Today",
       );
     });
+  });
+
+  it("resyncs the filter bar and table when search params change after mount", async () => {
+    mockSearchParams = new URLSearchParams("search=alice&status=delivered");
+
+    const { rerender } = render(
+      <EmailsSendingPage apiKeys={apiKeys} emails={emails} />,
+    );
+
+    expect(screen.getByPlaceholderText("Search...").getAttribute("value")).toBe(
+      "alice",
+    );
+    expect(screen.getByRole("button", { name: /Delivered/i })).toBeDefined();
+    expect(screen.getByText("alice@example.com")).toBeDefined();
+    expect(screen.queryByText("bob@example.com")).toBeNull();
+
+    mockSearchParams = new URLSearchParams("search=bob&status=bounced");
+    rerender(<EmailsSendingPage apiKeys={apiKeys} emails={emails} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText("Search...").getAttribute("value"),
+      ).toBe("bob");
+      expect(screen.getByRole("button", { name: /Bounced/i })).toBeDefined();
+      expect(screen.getByText("bob@example.com")).toBeDefined();
+    });
+
+    expect(screen.queryByText("alice@example.com")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- resync the sending page filters when URL search params change after mount
- resync the filter bar controls from updated URL-derived props and cancel stale debounced search callbacks
- add focused unit coverage for control/table resync plus a Playwright spec for browser-level URL-sync behavior

## Testing
- bunx tsc --noEmit
- bunx biome check src/components/emails-sending-page.tsx src/components/emails-sending-filter-bar.tsx tests/emails-filter-bar.test.tsx tests/emails-sending-page.test.tsx tests/e2e/emails-filter-bar.spec.ts
- bunx vitest run tests/emails-filter-bar.test.tsx tests/emails-sending-page.test.tsx
- bunx playwright test tests/e2e/emails-filter-bar.spec.ts --grep "resyncs search controls when the URL search params change after mount" *(currently blocked by a pre-existing Next middleware build error on `node:crypto` before `/emails` renders in this worktree)*

Closes #92
