### PR TITLE
Restore dashboard audience management auth

### DIFF
--- a/agent_docs/learnings/active/2026-04-28-audit-dashboard-audience-session-auth.md
+++ b/agent_docs/learnings/active/2026-04-28-audit-dashboard-audience-session-auth.md
@@ -1,0 +1,10 @@
+---
+date: 2026-04-28
+issue: audit
+type: decision
+promoted_to: null
+---
+
+Dashboard audience management list/create routes were calling same-origin `/api/contacts`, `/api/segments`, `/api/topics`, and `/api/properties` without Authorization headers, while those routes only accepted API-key auth.
+
+For internal dashboard-managed resources, the minimal safe fix was to share the metrics/usage auth model: allow either API key, dashboard master key, or authenticated dashboard session. This restores dashboard behavior without widening public API access beyond existing dashboard session permissions.

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -1,4 +1,7 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import {
+  authorizeDashboardOrApiKey,
+  unauthorizedResponse,
+} from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { contacts, segments, topics } from "@/lib/db/schema";
 import { createContactSchema } from "@/lib/validation/contacts";
@@ -6,7 +9,9 @@ import { type SQL, and, desc, eq, ilike, lt, or, sql } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
   if (!auth) return unauthorizedResponse();
 
   try {
@@ -109,7 +114,9 @@ export async function POST(request: NextRequest) {
 }
 
 export async function GET(request: Request) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
   if (!auth) return unauthorizedResponse();
 
   const url = new URL(request.url);

--- a/src/app/api/properties/route.ts
+++ b/src/app/api/properties/route.ts
@@ -1,11 +1,16 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import {
+  authorizeDashboardOrApiKey,
+  unauthorizedResponse,
+} from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { contactProperties } from "@/lib/db/schema";
 import { asc, count } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
 export async function GET(request: NextRequest) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
   if (!auth) return unauthorizedResponse();
 
   try {
@@ -58,7 +63,9 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
   if (!auth) return unauthorizedResponse();
 
   try {

--- a/src/app/api/segments/route.ts
+++ b/src/app/api/segments/route.ts
@@ -1,11 +1,16 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import {
+  authorizeDashboardOrApiKey,
+  unauthorizedResponse,
+} from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { segments } from "@/lib/db/schema";
 import { and, asc, count, desc, ilike, lt } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
 export async function GET(request: NextRequest) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
   if (!auth) return unauthorizedResponse();
 
   try {
@@ -64,7 +69,9 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
   if (!auth) return unauthorizedResponse();
 
   try {

--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -1,11 +1,16 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import {
+  authorizeDashboardOrApiKey,
+  unauthorizedResponse,
+} from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { topics } from "@/lib/db/schema";
 import { and, asc, count, desc, eq, ilike, lt } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
 export async function GET(request: NextRequest) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
   if (!auth) return unauthorizedResponse();
 
   try {
@@ -70,7 +75,9 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
   if (!auth) return unauthorizedResponse();
 
   try {

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -107,3 +107,29 @@ export function unauthorizedResponse(): Response {
 export async function getServerSession() {
   return auth.api.getSession({ headers: await headers() });
 }
+
+/**
+ * Validate access for dashboard-managed routes that should accept either:
+ * - a regular API key,
+ * - the dashboard master key, or
+ * - an authenticated dashboard session.
+ */
+export async function authorizeDashboardOrApiKey(
+  authHeader: string | null | undefined,
+): Promise<AuthResult | { dashboard: true } | null> {
+  const apiKeyAuth = await validateApiKey(authHeader);
+  if (apiKeyAuth) {
+    return apiKeyAuth;
+  }
+
+  if (validateDashboardKey(authHeader)) {
+    return { dashboard: true };
+  }
+
+  const session = await getServerSession();
+  if (session) {
+    return { dashboard: true };
+  }
+
+  return null;
+}

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -11,6 +11,7 @@ const mockValidateApiKey = vi.hoisted(() => vi.fn());
 const mockCountFn = vi.hoisted(() => vi.fn());
 const mockValidateDashboardKey = vi.hoisted(() => vi.fn());
 const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
 
 function makeChain<T>(rows: T[]) {
   return {
@@ -214,9 +215,14 @@ describe("route smoke coverage", () => {
         validateApiKey: mockValidateApiKey,
         validateDashboardKey: mockValidateDashboardKey,
         getServerSession: mockGetServerSession,
+        authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
       };
     });
     mockValidateApiKey.mockResolvedValue({
+      apiKeyId: "key-1",
+      permission: "full_access",
+    });
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue({
       apiKeyId: "key-1",
       permission: "full_access",
     });
@@ -363,6 +369,101 @@ describe("route smoke coverage", () => {
     json = await dashboardKeyResponse.json();
     expect(json.transactional.monthlyUsed).toBe(7);
     expect(mockGetServerSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows dashboard-session auth for audience list routes", async () => {
+    mockAuthorizeDashboardOrApiKey.mockResolvedValueOnce({ dashboard: true });
+    mockSelect.mockReturnValueOnce(
+      makeChain([
+        {
+          id: "c1",
+          email: "alice@example.com",
+          firstName: "Alice",
+          lastName: "Example",
+          unsubscribed: false,
+          segments: ["VIP"],
+          createdAt: new Date("2026-04-27T00:00:00.000Z"),
+        },
+      ]),
+    );
+
+    const contactsRoute = await import("@/app/api/contacts/route");
+    const response = await contactsRoute.GET(
+      makeNextRequest("http://localhost/api/contacts"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      object: "list",
+      data: [
+        expect.objectContaining({
+          email: "alice@example.com",
+          status: "subscribed",
+        }),
+      ],
+    });
+  });
+
+  it("allows dashboard-session auth for audience create routes", async () => {
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue({ dashboard: true });
+    mockInsert
+      .mockReturnValueOnce(makeChain([{ id: "segment-1", name: "VIP" }]))
+      .mockReturnValueOnce(
+        makeChain([
+          {
+            id: "topic-1",
+            name: "Product updates",
+            description: null,
+            defaultSubscription: "opt_out",
+            visibility: "public",
+            createdAt: new Date("2026-04-27T00:00:00.000Z"),
+          },
+        ]),
+      )
+      .mockReturnValueOnce(
+        makeChain([
+          {
+            id: "property-1",
+            key: "company",
+            name: "Company",
+            type: "string",
+            fallbackValue: null,
+            createdAt: new Date("2026-04-27T00:00:00.000Z"),
+            updatedAt: new Date("2026-04-27T00:00:00.000Z"),
+          },
+        ]),
+      );
+
+    const segmentsRoute = await import("@/app/api/segments/route");
+    const topicsRoute = await import("@/app/api/topics/route");
+    const propertiesRoute = await import("@/app/api/properties/route");
+
+    await expect(
+      segmentsRoute.POST(
+        makeNextRequest("http://localhost/api/segments", {
+          method: "POST",
+          body: JSON.stringify({ name: "VIP" }),
+        }) as never,
+      ),
+    ).resolves.toHaveProperty("status", 201);
+
+    await expect(
+      topicsRoute.POST(
+        makeNextRequest("http://localhost/api/topics", {
+          method: "POST",
+          body: JSON.stringify({ name: "Product updates" }),
+        }) as never,
+      ),
+    ).resolves.toHaveProperty("status", 201);
+
+    await expect(
+      propertiesRoute.POST(
+        makeNextRequest("http://localhost/api/properties", {
+          method: "POST",
+          body: JSON.stringify({ name: "Company" }),
+        }) as never,
+      ),
+    ).resolves.toHaveProperty("status", 201);
   });
 
   it("covers segments get/post happy path and validation", async () => {

--- a/tests/contacts-list.test.ts
+++ b/tests/contacts-list.test.ts
@@ -16,15 +16,17 @@ function createChainMock(resolvedData: unknown[], count: number) {
     orderBy: () => chain,
     limit: () => chain,
     offset: () => chain,
-    then: (resolve: (v: any) => any) => Promise.resolve(resolve(resolvedData)),
-    catch: (reject: (e: any) => any) => chain,
+    // biome-ignore lint/suspicious/noThenProperty: mocks Drizzle's thenable query builder
+    then: (resolve: (value: unknown[]) => unknown) =>
+      Promise.resolve(resolve(resolvedData)),
+    catch: (_reject: (error: unknown) => unknown) => chain,
     $count: () => Promise.resolve(count),
   };
   return { db: chain };
 }
 
 vi.mock("@/lib/api-auth", () => ({
-  validateApiKey: () =>
+  authorizeDashboardOrApiKey: () =>
     Promise.resolve({
       apiKeyId: "test",
       permission: "full_access",

--- a/tests/topics.test.ts
+++ b/tests/topics.test.ts
@@ -299,7 +299,7 @@ describe("Topics API route", () => {
     vi.clearAllMocks();
     vi.resetModules();
     vi.doMock("@/lib/api-auth", () => ({
-      validateApiKey: () =>
+      authorizeDashboardOrApiKey: () =>
         Promise.resolve({
           apiKeyId: "test",
           permission: "full_access",


### PR DESCRIPTION
## Summary
- allow dashboard-managed audience routes to accept dashboard session auth in addition to API keys
- apply the shared authorizer to contacts, segments, topics, and properties list/create routes
- add regression tests covering dashboard-session access for audience list/create flows

## Verification
- bun x vitest run tests/api-auth-date-range-routes.test.ts tests/contacts-list.test.ts
- bunx biome check src/lib/api-auth.ts src/app/api/contacts/route.ts src/app/api/segments/route.ts src/app/api/topics/route.ts src/app/api/properties/route.ts tests/api-auth-date-range-routes.test.ts tests/contacts-list.test.ts

## Notes
- → TypeCheck...
  ✓ TypeCheck passed
→ Lint & Format...
The number of diagnostics exceeds the number allowed by Biome.
Diagnostics not shown: 3.
Checked 267 files in 86ms. No fixes applied.
Found 23 errors. is still failing on current  because of unrelated pre-existing Biome diagnostics outside this diff.