### PR TITLE
Fix SES ingestion normalization and email status propagation

### DIFF
--- a/agent_docs/learnings/active/2026-04-28-audit-ingester-event-normalization-regression.md
+++ b/agent_docs/learnings/active/2026-04-28-audit-ingester-event-normalization-regression.md
@@ -1,0 +1,10 @@
+---
+date: 2026-04-28
+issue: audit
+type: mistake
+promoted_to: null
+---
+
+Ashley's core/ingester extraction split SES ingestion and email-event persistence, but the exported `packages/core/src/db/repositories/emailEventRepo.ts` dropped the prior transactional email-status update and the ingester route stored raw SES event names (`delivery`, `bounce`, `complaint`) instead of the app's delivered/bounced/complained taxonomy.
+
+Pattern: when extracting package code, compare the new exported implementation against any older in-repo copy before deleting or bypassing behavior; otherwise event/status side effects can silently disappear while tests still pass outside the package tree.

--- a/packages/core/src/db/repositories/emailEventRepo.ts
+++ b/packages/core/src/db/repositories/emailEventRepo.ts
@@ -1,6 +1,12 @@
-import { and, desc, eq, lt } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { db } from "../client";
-import { emailEvents } from "../schema";
+import { emailEvents, emails } from "../schema";
+
+const STATUS_BY_EVENT_TYPE: Record<string, string> = {
+  delivered: "delivered",
+  bounced: "bounced",
+  complained: "complained",
+};
 
 export const emailEventRepo = {
   async findById(id: string) {
@@ -10,8 +16,19 @@ export const emailEventRepo = {
   },
 
   async create(data: typeof emailEvents.$inferInsert) {
-    const results = await db.insert(emailEvents).values(data).returning();
-    return results[0];
+    return await db.transaction(async (tx) => {
+      const [event] = await tx.insert(emailEvents).values(data).returning();
+      const nextStatus = STATUS_BY_EVENT_TYPE[data.type];
+
+      if (nextStatus) {
+        await tx
+          .update(emails)
+          .set({ status: nextStatus })
+          .where(eq(emails.id, data.emailId));
+      }
+
+      return event;
+    });
   },
 
   async listByEmailId(emailId: string) {

--- a/packages/ingester/src/dispatcher.ts
+++ b/packages/ingester/src/dispatcher.ts
@@ -13,9 +13,13 @@ export class WebhookDispatcher {
     const timestamp = Math.floor(Date.now() / 1000).toString();
     const msgId = `wh_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
 
+    const webhookEventType = event.type.includes(".")
+      ? event.type
+      : `email.${event.type}`;
+
     const body = JSON.stringify({
       id: msgId,
-      type: event.type,
+      type: webhookEventType,
       created_at: new Date().toISOString(),
       data: event.payload,
     });

--- a/packages/ingester/src/index.ts
+++ b/packages/ingester/src/index.ts
@@ -1,5 +1,7 @@
-import { emailEventRepo, webhookDispatcher, webhookRepo } from "@namuh/core";
+import { emailEventRepo, webhookRepo } from "@namuh/core";
 import { Hono } from "hono";
+import { webhookDispatcher } from "./dispatcher";
+import { normalizeSesEvent } from "./ses-event-normalization";
 
 const app = new Hono();
 
@@ -19,8 +21,16 @@ app.post("/events/ses", async (c) => {
     const sesMessage = JSON.parse(body.Message);
     const sesId = sesMessage.mail.messageId;
     const eventType = sesMessage.eventType;
+    const normalizedEvent = normalizeSesEvent(eventType);
 
     console.log(`Received SES event ${eventType} for message ${sesId}`);
+
+    if (!normalizedEvent) {
+      console.warn(
+        `Unsupported SES event type ${eventType} for message ${sesId}`,
+      );
+      return c.text("OK");
+    }
 
     // SES tags are sometimes nested in mail.tags
     const emailId = sesMessage.mail.headers?.find(
@@ -30,17 +40,20 @@ app.post("/events/ses", async (c) => {
     if (emailId) {
       const event = await emailEventRepo.create({
         emailId,
-        type: eventType.toLowerCase(),
-        payload: sesMessage[eventType.toLowerCase()] || sesMessage,
+        type: normalizedEvent.type,
+        payload: sesMessage[normalizedEvent.payloadKey] || sesMessage,
       });
 
       // Simple fan-out: dispatch to all active webhooks subscribed to this type
       const { data: hooks } = await webhookRepo.list({ limit: 100 });
       for (const hook of hooks) {
         const types = hook.eventTypes as string[];
+        const webhookEventType = `email.${event.type}`;
         if (
           hook.status === "active" &&
-          (types.includes("*") || types.includes(event.type))
+          (types.includes("*") ||
+            types.includes(event.type) ||
+            types.includes(webhookEventType))
         ) {
           // Fire and forget for now in this context, or await if we want serial
           webhookDispatcher.dispatch(hook.id, event).catch((err) => {

--- a/packages/ingester/src/ses-event-normalization.ts
+++ b/packages/ingester/src/ses-event-normalization.ts
@@ -1,0 +1,22 @@
+const SES_EVENT_TYPE_MAP: Record<string, { type: string; payloadKey: string }> =
+  {
+    Send: { type: "sent", payloadKey: "send" },
+    Delivery: { type: "delivered", payloadKey: "delivery" },
+    Bounce: { type: "bounced", payloadKey: "bounce" },
+    Complaint: { type: "complained", payloadKey: "complaint" },
+    DeliveryDelay: {
+      type: "delivery_delayed",
+      payloadKey: "deliveryDelay",
+    },
+    Open: { type: "opened", payloadKey: "open" },
+    Click: { type: "clicked", payloadKey: "click" },
+    Reject: { type: "failed", payloadKey: "reject" },
+    RenderingFailure: {
+      type: "failed",
+      payloadKey: "failure",
+    },
+  };
+
+export function normalizeSesEvent(eventType: string) {
+  return SES_EVENT_TYPE_MAP[eventType] ?? null;
+}

--- a/tests/core-email-event-repo.test.ts
+++ b/tests/core-email-event-repo.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFindFirst = vi.fn();
+const mockInsertReturning = vi.fn();
+const mockUpdateWhere = vi.fn();
+const mockUpdateSet = vi.fn();
+const mockUpdate = vi.fn();
+const mockTransaction = vi.fn();
+
+vi.mock("../packages/core/src/db/client", () => ({
+  db: {
+    query: {
+      emailEvents: {
+        findFirst: mockFindFirst,
+      },
+    },
+    transaction: mockTransaction,
+  },
+}));
+
+describe("packages/core emailEventRepo.create", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mockUpdateWhere.mockResolvedValue(undefined);
+    mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
+    mockUpdate.mockReturnValue({ set: mockUpdateSet });
+
+    mockTransaction.mockImplementation(async (callback) =>
+      callback({
+        insert: () => ({
+          values: () => ({
+            returning: mockInsertReturning,
+          }),
+        }),
+        update: mockUpdate,
+      }),
+    );
+  });
+
+  it("updates the parent email status when a delivered event is recorded", async () => {
+    const event = {
+      id: "evt_1",
+      emailId: "email_1",
+      type: "delivered",
+      payload: { smtpResponse: "250 ok" },
+    };
+    mockInsertReturning.mockResolvedValue([event]);
+
+    const { emailEventRepo } = await import(
+      "../packages/core/src/db/repositories/emailEventRepo"
+    );
+
+    const result = await emailEventRepo.create(event);
+
+    expect(result).toEqual(event);
+    expect(mockUpdate).toHaveBeenCalledOnce();
+    expect(mockUpdateSet).toHaveBeenCalledWith({ status: "delivered" });
+    expect(mockUpdateWhere).toHaveBeenCalledOnce();
+  });
+
+  it("does not update the parent email status for non-terminal events", async () => {
+    const event = {
+      id: "evt_2",
+      emailId: "email_1",
+      type: "opened",
+      payload: { ipAddress: "127.0.0.1" },
+    };
+    mockInsertReturning.mockResolvedValue([event]);
+
+    const { emailEventRepo } = await import(
+      "../packages/core/src/db/repositories/emailEventRepo"
+    );
+
+    const result = await emailEventRepo.create(event);
+
+    expect(result).toEqual(event);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ingester-ses-normalization.test.ts
+++ b/tests/ingester-ses-normalization.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSesEvent } from "../packages/ingester/src/ses-event-normalization";
+
+describe("SES event normalization", () => {
+  it("maps Delivery to the delivered app event taxonomy", () => {
+    expect(normalizeSesEvent("Delivery")).toEqual({
+      type: "delivered",
+      payloadKey: "delivery",
+    });
+  });
+
+  it("maps Complaint to the complained app event taxonomy", () => {
+    expect(normalizeSesEvent("Complaint")).toEqual({
+      type: "complained",
+      payloadKey: "complaint",
+    });
+  });
+
+  it("maps multiword SES events to their payload keys", () => {
+    expect(normalizeSesEvent("DeliveryDelay")).toEqual({
+      type: "delivery_delayed",
+      payloadKey: "deliveryDelay",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- normalize ingested SES events to the app's delivered/bounced/complained taxonomy before persistence
- restore transactional email status propagation in `emailEventRepo.create`
- emit/match `email.*` webhook event types while preserving raw-type compatibility

## Audit evidence
- Ashley commit cluster inspected: `0f267eb`, `8b47fa7`, `0fb8e20`, `aa289bc`, `86468bf`, `ed3c8ac`
- Core regression source: `aa289bc` added `packages/core/src/db/repositories/emailEventRepo.ts` without the earlier status update behavior still present in `packages/core/packages/core/src/db/repositories/emailEventRepo.ts`
- Ingest path mismatch source: `packages/ingester/src/index.ts` stored raw SES names like `delivery` / `complaint`, which missed the app taxonomy and configured `email.*` webhook subscriptions

## Verification
- `bun x biome check packages/core/src/db/repositories/emailEventRepo.ts packages/ingester/src/index.ts packages/ingester/src/dispatcher.ts packages/ingester/src/ses-event-normalization.ts tests/core-email-event-repo.test.ts tests/ingester-ses-normalization.test.ts`
- `bun x vitest run tests/core-email-event-repo.test.ts tests/ingester-ses-normalization.test.ts`
