### PR TITLE
Fix metrics date and domain filter correctness

### DIFF
--- a/agent_docs/learnings/active/2026-04-28-88-89-metrics-range-domain-alignment.md
+++ b/agent_docs/learnings/active/2026-04-28-88-89-metrics-range-domain-alignment.md
@@ -1,0 +1,10 @@
+---
+date: 2026-04-28
+issue: 88-89
+type: decision
+promoted_to: null
+---
+
+For the dashboard metrics API, keep preset date filtering derived from `src/lib/date-range.ts` rather than re-implementing day math in the route. The route needs both a lower and upper bound so `Yesterday` stays isolated and rolling presets stay inclusive of today with the same semantics as the UI picker.
+
+For domain filtering, reuse the same parsed sender-domain SQL expression that powers the metrics domain breakdown instead of substring matching on `emails.from`. This keeps filter semantics aligned across grouped output and filtered queries, and avoids false positives like `notexample.com` when filtering `example.com`.

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -5,18 +5,19 @@ import {
   unauthorizedResponse,
   validateDashboardKey,
 } from "@/lib/api-auth";
+import { getDateRangeBounds } from "@/lib/date-range";
 import { db } from "@/lib/db";
 import { emails } from "@/lib/db/schema";
-import { and, gte, inArray, like, sql } from "drizzle-orm";
+import { and, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
-const RANGE_MAP: Record<string, number> = {
-  today: 0,
-  yesterday: 1,
-  last_3_days: 3,
-  last_7_days: 7,
-  last_15_days: 15,
-  last_30_days: 30,
+const RANGE_TO_PRESET: Record<string, string> = {
+  today: "Today",
+  yesterday: "Yesterday",
+  last_3_days: "Last 3 days",
+  last_7_days: "Last 7 days",
+  last_15_days: "Last 15 days",
+  last_30_days: "Last 30 days",
 };
 
 // Map event type filter values to email status values
@@ -33,25 +34,11 @@ const EVENT_TYPE_TO_STATUS: Record<string, string[]> = {
   suppressed: ["suppressed"],
 };
 
-function getDateRange(range: string): Date {
-  const now = new Date();
-  const days = RANGE_MAP[range] ?? 15;
-  if (range === "yesterday") {
-    const d = new Date(now);
-    d.setDate(d.getDate() - 1);
-    d.setHours(0, 0, 0, 0);
-    return d;
-  }
-  if (range === "today") {
-    const d = new Date(now);
-    d.setHours(0, 0, 0, 0);
-    return d;
-  }
-  const d = new Date(now);
-  d.setDate(d.getDate() - days);
-  d.setHours(0, 0, 0, 0);
-  return d;
+function getMetricsDateRange(range: string): { start: Date; end: Date } {
+  return getDateRangeBounds(RANGE_TO_PRESET[range] || "Last 15 days");
 }
+
+const senderDomainSql = sql<string>`substring(${emails.from} from '@([^>]+)')`;
 
 // Dashboard-only internal endpoint
 export async function GET(request: NextRequest) {
@@ -68,12 +55,15 @@ export async function GET(request: NextRequest) {
     const domain = searchParams.get("domain");
     const eventType = searchParams.get("event_type");
 
-    const startDate = getDateRange(range);
+    const { start, end } = getMetricsDateRange(range);
 
     // Build conditions
-    const conditions = [gte(emails.createdAt, startDate)];
+    const conditions = [
+      gte(emails.createdAt, start),
+      lte(emails.createdAt, end),
+    ];
     if (domain) {
-      conditions.push(like(emails.from, `%@${domain}%`));
+      conditions.push(eq(senderDomainSql, domain));
     }
 
     // Query aggregated stats
@@ -174,13 +164,13 @@ export async function GET(request: NextRequest) {
     // Per-domain breakdown
     const domainBreakdownRows = await db
       .select({
-        domain: sql<string>`substring(${emails.from} from '@([^>]+)')`,
+        domain: senderDomainSql,
         total: sql<number>`count(*)::int`,
         delivered: sql<number>`count(*) filter (where ${emails.status} = 'delivered')::int`,
       })
       .from(emails)
       .where(and(...conditions))
-      .groupBy(sql`substring(${emails.from} from '@([^>]+)')`)
+      .groupBy(senderDomainSql)
       .orderBy(sql`count(*) desc`);
 
     const domainBreakdown = domainBreakdownRows

--- a/tests/metrics-route.test.ts
+++ b/tests/metrics-route.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSelect = vi.hoisted(() => vi.fn());
+const mockValidateDashboardKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockGte = vi.hoisted(() =>
+  vi.fn((left, right) => ({ kind: "gte", left, right })),
+);
+const mockLte = vi.hoisted(() =>
+  vi.fn((left, right) => ({ kind: "lte", left, right })),
+);
+const mockEq = vi.hoisted(() =>
+  vi.fn((left, right) => ({ kind: "eq", left, right })),
+);
+const mockLike = vi.hoisted(() =>
+  vi.fn((left, right) => ({ kind: "like", left, right })),
+);
+const mockAnd = vi.hoisted(() => vi.fn((...conds) => ({ kind: "and", conds })));
+const mockInArray = vi.hoisted(() =>
+  vi.fn((left, right) => ({ kind: "inArray", left, right })),
+);
+
+function makeQueryChain<T>(rows: T[], whereArgs: unknown[]) {
+  const chain = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn((arg: unknown) => {
+      whereArgs.push(arg);
+      return chain;
+    }),
+    groupBy: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    // biome-ignore lint/suspicious/noThenProperty: mocks Drizzle's thenable query builder
+    then: (resolve: (value: T[]) => unknown) => Promise.resolve(resolve(rows)),
+  };
+
+  return chain;
+}
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: mockSelect,
+  },
+}));
+
+vi.mock("@/lib/api-auth", () => ({
+  getServerSession: mockGetServerSession,
+  unauthorizedResponse: () =>
+    new Response(JSON.stringify({ error: "Missing or invalid API key" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    }),
+  validateDashboardKey: mockValidateDashboardKey,
+}));
+
+vi.mock("drizzle-orm", async () => {
+  const actual =
+    await vi.importActual<typeof import("drizzle-orm")>("drizzle-orm");
+
+  return {
+    ...actual,
+    and: mockAnd,
+    eq: mockEq,
+    gte: mockGte,
+    inArray: mockInArray,
+    like: mockLike,
+    lte: mockLte,
+  };
+});
+
+function makeNextRequest(url: string, init?: RequestInit) {
+  const request = new Request(url, init) as Request & { nextUrl: URL };
+  request.nextUrl = new URL(url);
+  return request;
+}
+
+function queueMetricsQueries(whereArgs: unknown[]) {
+  mockSelect
+    .mockReturnValueOnce(
+      makeQueryChain(
+        [
+          {
+            total: 10,
+            delivered: 7,
+            bounced: 2,
+            hard_bounced: 1,
+            soft_bounced: 1,
+            undetermined_bounced: 0,
+            complained: 1,
+          },
+        ],
+        whereArgs,
+      ),
+    )
+    .mockReturnValueOnce(
+      makeQueryChain([{ date: "2026-04-23", count: 7 }], whereArgs),
+    )
+    .mockReturnValueOnce(
+      makeQueryChain(
+        [{ date: "2026-04-23", total: 10, bounced: 2 }],
+        whereArgs,
+      ),
+    )
+    .mockReturnValueOnce(
+      makeQueryChain(
+        [{ date: "2026-04-23", total: 10, complained: 1 }],
+        whereArgs,
+      ),
+    )
+    .mockReturnValueOnce(
+      makeQueryChain(
+        [{ domain: "example.com", total: 10, delivered: 7 }],
+        whereArgs,
+      ),
+    );
+}
+
+function expectLocalDateParts(
+  date: Date,
+  expected: {
+    year: number;
+    month: number;
+    day: number;
+    hour: number;
+    minute: number;
+    second: number;
+    millisecond: number;
+  },
+) {
+  expect(date.getFullYear()).toBe(expected.year);
+  expect(date.getMonth()).toBe(expected.month);
+  expect(date.getDate()).toBe(expected.day);
+  expect(date.getHours()).toBe(expected.hour);
+  expect(date.getMinutes()).toBe(expected.minute);
+  expect(date.getSeconds()).toBe(expected.second);
+  expect(date.getMilliseconds()).toBe(expected.millisecond);
+}
+
+function requireCondition<T>(value: T | undefined): T {
+  expect(value).toBeDefined();
+  return value as T;
+}
+
+describe("metrics route filters", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 3, 23, 15, 45, 30));
+    mockValidateDashboardKey.mockReturnValue(true);
+    mockGetServerSession.mockResolvedValue({
+      session: { id: "session-1" },
+      user: { id: "user-1" },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("matches Yesterday exactly instead of leaking into today", async () => {
+    const whereArgs: unknown[] = [];
+    queueMetricsQueries(whereArgs);
+
+    const metricsRoute = await import("@/app/api/metrics/route");
+    const response = await metricsRoute.GET(
+      makeNextRequest("http://localhost/api/metrics?range=yesterday") as never,
+    );
+
+    expect(response.status).toBe(200);
+
+    const firstWhere = whereArgs[0] as {
+      kind: string;
+      conds: Array<{ kind: string; right: Date }>;
+    };
+
+    const lowerBound = firstWhere.conds.find((cond) => cond.kind === "gte");
+    const upperBound = firstWhere.conds.find((cond) => cond.kind === "lte");
+
+    expectLocalDateParts(requireCondition(lowerBound).right, {
+      year: 2026,
+      month: 3,
+      day: 22,
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+    });
+    expectLocalDateParts(requireCondition(upperBound).right, {
+      year: 2026,
+      month: 3,
+      day: 22,
+      hour: 23,
+      minute: 59,
+      second: 59,
+      millisecond: 999,
+    });
+  });
+
+  it("uses inclusive rolling preset bounds that match date-range.ts", async () => {
+    const whereArgs: unknown[] = [];
+    queueMetricsQueries(whereArgs);
+
+    const metricsRoute = await import("@/app/api/metrics/route");
+    const response = await metricsRoute.GET(
+      makeNextRequest(
+        "http://localhost/api/metrics?range=last_7_days",
+      ) as never,
+    );
+
+    expect(response.status).toBe(200);
+
+    const firstWhere = whereArgs[0] as {
+      kind: string;
+      conds: Array<{ kind: string; right: Date }>;
+    };
+
+    const lowerBound = firstWhere.conds.find((cond) => cond.kind === "gte");
+    const upperBound = firstWhere.conds.find((cond) => cond.kind === "lte");
+
+    expectLocalDateParts(requireCondition(lowerBound).right, {
+      year: 2026,
+      month: 3,
+      day: 17,
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+    });
+    expectLocalDateParts(requireCondition(upperBound).right, {
+      year: 2026,
+      month: 3,
+      day: 23,
+      hour: 23,
+      minute: 59,
+      second: 59,
+      millisecond: 999,
+    });
+  });
+
+  it("filters by exact sender domain instead of raw from substring matches", async () => {
+    const whereArgs: unknown[] = [];
+    queueMetricsQueries(whereArgs);
+
+    const metricsRoute = await import("@/app/api/metrics/route");
+    const response = await metricsRoute.GET(
+      makeNextRequest(
+        "http://localhost/api/metrics?range=last_7_days&domain=example.com",
+      ) as never,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockEq).toHaveBeenCalledOnce();
+    expect(mockEq.mock.calls[0]?.[1]).toBe("example.com");
+    expect(mockLike).not.toHaveBeenCalled();
+
+    const firstWhere = whereArgs[0] as {
+      kind: string;
+      conds: Array<{ kind: string }>;
+    };
+    expect(firstWhere.conds.some((cond) => cond.kind === "eq")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- align metrics preset date filtering with the shared `src/lib/date-range.ts` semantics
- stop `Yesterday` from leaking today by applying both start and end bounds
- switch metrics domain filtering from raw `from` substring matching to exact parsed sender-domain matching
- add focused metrics route regression tests for date bounds and domain filtering

## Verification
- `bunx biome check src/app/api/metrics/route.ts tests/metrics-route.test.ts`
- `bun run typecheck`
- `bun run test -- tests/metrics-route.test.ts tests/api-auth-date-range-routes.test.ts`
- `bun run lint` *(fails on existing unrelated baseline issues outside this diff, e.g. `src/components/logs-list-page.tsx`, `src/lib/auth.ts`, `src/lib/cache/redis.ts`, `src/lib/templates/parser.ts`, `src/lib/workers/scheduled-emails.ts`, `tests/contacts-list.test.ts`)*
