### PR TITLE
Make SDK DTOs shared and publish-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ bun add namuh-send
 import { NamuhSend } from "namuh-send";
 
 const client = new NamuhSend("YOUR_API_KEY", {
-  baseUrl: "http://localhost:3015",
+  baseUrl: "https://your-deployment.example.com",
 });
 
 await client.emails.send({

--- a/agent_docs/learnings/active/2026-04-28-67-sdk-core-dto-packaging.md
+++ b/agent_docs/learnings/active/2026-04-28-67-sdk-core-dto-packaging.md
@@ -1,0 +1,14 @@
+---
+date: 2026-04-28
+issue: "#67"
+type: decision
+promoted_to: null
+---
+
+## Bundle core DTO declarations into the SDK build output
+
+**What:** The SDK now sources its exported HTTP DTO types from `packages/core/src/dto/index.ts`, and the SDK TypeScript build includes that DTO source so the published `dist/` stays self-contained.
+
+**Why:** A thin publishable SDK should not duplicate request/response shapes in `packages/sdk/src/index.ts`, but it also cannot ship declaration files that reference a private workspace package consumers do not install.
+
+**Fix:** Keep SDK DTOs in `@namuh/core`, import them by source path inside the monorepo, and compile the DTO source into `packages/sdk/dist/core/...` alongside the SDK declaration output.

--- a/packages/core/src/dto/index.ts
+++ b/packages/core/src/dto/index.ts
@@ -1,3 +1,21 @@
+export interface EmailAttachment {
+  filename: string;
+  content?: string;
+  path?: string;
+  content_type?: string;
+  content_id?: string;
+}
+
+export interface EmailTag {
+  name: string;
+  value: string;
+}
+
+export interface EmailTemplateReference {
+  id: string;
+  variables?: Record<string, unknown>;
+}
+
 export interface EmailOptions {
   from: string;
   to: string | string[];
@@ -6,38 +24,171 @@ export interface EmailOptions {
   text?: string;
   cc?: string | string[];
   bcc?: string | string[];
-  replyTo?: string | string[];
+  reply_to?: string | string[];
   headers?: Record<string, string>;
   attachments?: EmailAttachment[];
   tags?: EmailTag[];
-  scheduledAt?: string;
-  topicId?: string;
+  scheduled_at?: string;
+  topic_id?: string;
+  template?: EmailTemplateReference;
 }
 
-export interface EmailAttachment {
-  filename: string;
-  content: string | Buffer;
+export interface EmailResponse {
+  id: string;
 }
 
-export interface EmailTag {
+export type SendEmailResponse = EmailResponse;
+
+export interface EmailListItem {
+  id: string;
+  from: string;
+  to: string[];
+  subject: string;
+  cc: string[] | null;
+  bcc: string[] | null;
+  reply_to: string[] | null;
+  last_event: string;
+  scheduled_at: string | null;
+  created_at: string;
+}
+
+export interface EmailListResponse {
+  object: "list";
+  has_more: boolean;
+  data: EmailListItem[];
+}
+
+export interface EmailDetailResponse extends EmailListItem {
+  object: "email";
+  html: string | null;
+  text: string | null;
+  tags: EmailTag[] | null;
+}
+
+export interface DomainCapability {
+  name: string;
+  enabled: boolean;
+}
+
+export interface DomainRecord {
+  type: string;
   name: string;
   value: string;
-}
-
-export interface SendEmailResponse {
-  id: string;
+  status: string;
+  ttl: string;
+  priority?: number;
 }
 
 export interface DomainOptions {
   name: string;
-  region?: "us-east-1" | "us-west-2" | "eu-west-1";
+  region?: "us-east-1" | "eu-west-1" | "sa-east-1" | "ap-northeast-1";
+  custom_return_path?: string;
+  open_tracking?: boolean;
+  click_tracking?: boolean;
+  tracking_subdomain?: string;
+  tls?: "opportunistic" | "enforced";
+  capabilities?: DomainCapability[];
 }
 
 export interface DomainResponse {
+  object: "domain";
   id: string;
   name: string;
-  status: "pending" | "verified" | "failed";
-  createdAt: string;
+  status: string;
   region: string;
-  dkimTokens?: string[];
+  records: DomainRecord[];
+  open_tracking?: boolean;
+  click_tracking?: boolean;
+  tracking_subdomain?: string | null;
+  tls?: "opportunistic" | "enforced";
+  capabilities?: DomainCapability[];
+  created_at: string;
+}
+
+export interface DomainListItem {
+  id: string;
+  name: string;
+  status: string;
+  region: string;
+  capabilities: DomainCapability[] | null;
+  created_at: string;
+}
+
+export interface DomainListResponse {
+  object: "list";
+  data: DomainListItem[];
+  has_more: boolean;
+}
+
+export interface CreateApiKeyPayload {
+  name: string;
+  permission?: "full_access" | "sending_access";
+  domain_id?: string;
+}
+
+export interface ApiKeyResponse {
+  id: string;
+  token: string;
+}
+
+export interface ApiKeyListItem {
+  id: string;
+  name: string;
+  created_at: string;
+  last_used_at: string | null;
+}
+
+export interface ApiKeyListResponse {
+  object: "list";
+  data: ApiKeyListItem[];
+  has_more: boolean;
+}
+
+export interface CreateContactPayload {
+  email: string;
+  first_name?: string;
+  last_name?: string;
+  unsubscribed?: boolean;
+  properties?: Record<string, string>;
+  segments?: string[];
+  topics?: Array<string | { id: string; subscription: "opt_in" | "opt_out" }>;
+}
+
+export interface CreateContactResponse {
+  object: "contact";
+  id: string;
+}
+
+export interface ContactTopicPreference {
+  id: string;
+  subscription: "opt_in" | "opt_out";
+}
+
+export interface ContactResponse {
+  object: "contact";
+  id: string;
+  email: string;
+  first_name: string | null;
+  last_name: string | null;
+  unsubscribed: boolean;
+  properties: Record<string, string> | null;
+  segments: string[];
+  topics: ContactTopicPreference[];
+  created_at: string;
+}
+
+export interface ContactListItem {
+  id: string;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+  status: "subscribed" | "unsubscribed";
+  segments: string[];
+  created_at: string;
+}
+
+export interface ContactListResponse {
+  object: "list";
+  data: ContactListItem[];
+  has_more: boolean;
 }

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -92,8 +92,8 @@ await client.apiKeys.delete("key-id");
 ## Contacts
 
 ```typescript
-// Create contacts
-await client.contacts.create({ emails: ["user@example.com"] });
+// Create a contact
+await client.contacts.create({ email: "user@example.com" });
 
 // List contacts
 const { data } = await client.contacts.list();
@@ -116,4 +116,15 @@ if (error) {
 
 // data is guaranteed non-null here
 console.log(data.id);
+```
+
+## Configuration
+
+The SDK is publish-ready and does not assume a local dev server. Pass your
+deployment origin explicitly:
+
+```typescript
+const client = new NamuhSend("re_your_api_key", {
+  baseUrl: "https://api.your-deployment.example.com",
+});
 ```

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,8 +2,14 @@
   "name": "namuh-send",
   "version": "1.0.0",
   "description": "TypeScript SDK for the Namuh Send email API",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/sdk/src/index.js",
+  "types": "dist/sdk/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/sdk/src/index.d.ts",
+      "default": "./dist/sdk/src/index.js"
+    }
+  },
   "files": ["dist"],
   "scripts": {
     "build": "tsc",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,14 +1,25 @@
 import type {
-  DomainResponse as CoreDomainResponse,
+  ApiKeyListResponse,
+  ApiKeyResponse,
+  ContactListItem,
+  ContactListResponse,
+  ContactResponse,
+  CreateApiKeyPayload,
+  CreateContactPayload,
+  CreateContactResponse,
+  DomainListItem,
+  DomainListResponse,
   DomainOptions,
+  DomainResponse,
+  EmailDetailResponse,
+  EmailListItem,
+  EmailListResponse,
   EmailOptions,
   EmailResponse,
-} from "@namuh/core";
-
-// ── Types ────────────────────────────────────────────────────────
+} from "../../core/src/dto";
 
 interface SDKOptions {
-  baseUrl?: string;
+  baseUrl: string;
 }
 
 interface ApiResponse<T> {
@@ -16,124 +27,46 @@ interface ApiResponse<T> {
   error: { message: string; statusCode: number } | null;
 }
 
-// ── Email Types ──────────────────────────────────────────────────
-
 export type SendEmailPayload = EmailOptions & {
   react?: unknown;
 };
-
-export type { EmailResponse };
-
-interface EmailListItem {
-  id: string;
-  from: string;
-  to: string[];
-  subject: string;
-  cc: string[] | null;
-  bcc: string[] | null;
-  reply_to: string | null;
-  last_event: string;
-  scheduled_at: string | null;
-  created_at: string;
-}
-
-interface EmailListResponse {
-  object: string;
-  has_more: boolean;
-  data: EmailListItem[];
-}
-
-interface EmailDetailResponse {
-  id: string;
-  from: string;
-  to: string[];
-  subject: string;
-  html: string | null;
-  text: string | null;
-  cc: string[] | null;
-  bcc: string[] | null;
-  reply_to: string | null;
-  last_event: string;
-  created_at: string;
-}
-
-// ── Domain Types ─────────────────────────────────────────────────
-
 export type CreateDomainPayload = DomainOptions;
-export type DomainResponse = CoreDomainResponse;
 
-interface DomainListResponse {
-  data: DomainResponse[];
-}
+function normalizeBaseUrl(baseUrl?: string): string {
+  if (!baseUrl?.trim()) {
+    throw new Error("A non-empty baseUrl is required");
+  }
 
-// ── API Key Types ────────────────────────────────────────────────
-
-interface CreateApiKeyPayload {
-  name: string;
-  permission?: "full_access" | "sending_access";
-  domain_id?: string;
-}
-
-interface ApiKeyResponse {
-  id: string;
-  name: string;
-  token?: string;
-  key_prefix: string;
-  permission: string;
-  domain_id: string | null;
-  created_at: string;
-}
-
-interface ApiKeyListResponse {
-  data: ApiKeyResponse[];
-}
-
-// ── Contact Types ────────────────────────────────────────────────
-
-interface CreateContactPayload {
-  emails: string[];
-  segment_ids?: string[];
-}
-
-interface ContactResponse {
-  id: string;
-  email: string;
-  first_name: string | null;
-  last_name: string | null;
-  unsubscribed: boolean;
-}
-
-interface ContactListResponse {
-  data: ContactResponse[];
-  total: number;
-  page: number;
-  limit: number;
-}
-
-// ── React rendering helper ───────────────────────────────────────
-
-function renderReactToHtml(element: unknown): string | null {
+  let normalized: URL;
   try {
-    // Dynamic import to avoid hard dependency on react-dom
-    const ReactDOMServer = require("react-dom/server") as {
-      renderToStaticMarkup: (element: unknown) => string;
-    };
-    return ReactDOMServer.renderToStaticMarkup(element);
+    normalized = new URL(baseUrl);
+  } catch {
+    throw new Error("baseUrl must be a valid absolute URL");
+  }
+
+  if (!["http:", "https:"].includes(normalized.protocol)) {
+    throw new Error("baseUrl must use http or https");
+  }
+
+  return normalized.toString().replace(/\/$/, "");
+}
+
+async function renderReactToHtml(element: unknown): Promise<string | null> {
+  try {
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    return renderToStaticMarkup(
+      element as Parameters<typeof renderToStaticMarkup>[0],
+    );
   } catch {
     return null;
   }
 }
 
-// ── HTTP Client ──────────────────────────────────────────────────
-
 class HttpClient {
-  private baseUrl: string;
-  private apiKey: string;
-
-  constructor(apiKey: string, baseUrl: string) {
-    this.apiKey = apiKey;
-    this.baseUrl = baseUrl.replace(/\/$/, "");
-  }
+  constructor(
+    private readonly apiKey: string,
+    private readonly baseUrl: string,
+  ) {}
 
   async request<T>(
     method: string,
@@ -152,28 +85,33 @@ class HttpClient {
       }
 
       const response = await fetch(`${this.baseUrl}${path}`, options);
+      const rawBody = await response.text();
+      const parsedBody = rawBody ? (JSON.parse(rawBody) as unknown) : null;
 
       if (!response.ok) {
-        const errorBody = await response.json().catch(() => ({
-          error: response.statusText,
-        }));
+        const errorBody =
+          parsedBody && typeof parsedBody === "object" ? parsedBody : null;
+
         return {
           data: null,
           error: {
             message:
-              (errorBody as Record<string, string>).error ?? "Request failed",
+              errorBody &&
+              "error" in errorBody &&
+              typeof errorBody.error === "string"
+                ? errorBody.error
+                : response.statusText || "Request failed",
             statusCode: response.status,
           },
         };
       }
 
-      const data = (await response.json()) as T;
-      return { data, error: null };
-    } catch (err) {
+      return { data: parsedBody as T | null, error: null };
+    } catch (error) {
       return {
         data: null,
         error: {
-          message: err instanceof Error ? err.message : "Unknown error",
+          message: error instanceof Error ? error.message : "Unknown error",
           statusCode: 500,
         },
       };
@@ -181,21 +119,14 @@ class HttpClient {
   }
 }
 
-// ── Resource Classes ─────────────────────────────────────────────
-
 class Emails {
-  private http: HttpClient;
-
-  constructor(http: HttpClient) {
-    this.http = http;
-  }
+  constructor(private readonly http: HttpClient) {}
 
   async send(payload: SendEmailPayload): Promise<ApiResponse<EmailResponse>> {
     const { react, ...rest } = payload;
 
-    // If react prop is provided, render it to HTML
     if (react != null) {
-      const rendered = renderReactToHtml(react);
+      const rendered = await renderReactToHtml(react);
       if (rendered) {
         rest.html = rendered;
       }
@@ -214,15 +145,9 @@ class Emails {
 }
 
 class Domains {
-  private http: HttpClient;
+  constructor(private readonly http: HttpClient) {}
 
-  constructor(http: HttpClient) {
-    this.http = http;
-  }
-
-  async create(
-    payload: CreateDomainPayload,
-  ): Promise<ApiResponse<DomainResponse>> {
+  async create(payload: DomainOptions): Promise<ApiResponse<DomainResponse>> {
     return this.http.request<DomainResponse>("POST", "/api/domains", payload);
   }
 
@@ -243,11 +168,7 @@ class Domains {
 }
 
 class ApiKeys {
-  private http: HttpClient;
-
-  constructor(http: HttpClient) {
-    this.http = http;
-  }
+  constructor(private readonly http: HttpClient) {}
 
   async create(
     payload: CreateApiKeyPayload,
@@ -259,25 +180,18 @@ class ApiKeys {
     return this.http.request<ApiKeyListResponse>("GET", "/api/api-keys");
   }
 
-  async delete(id: string): Promise<ApiResponse<{ deleted: boolean }>> {
-    return this.http.request<{ deleted: boolean }>(
-      "DELETE",
-      `/api/api-keys/${id}`,
-    );
+  async delete(id: string): Promise<ApiResponse<null>> {
+    return this.http.request<null>("DELETE", `/api/api-keys/${id}`);
   }
 }
 
 class Contacts {
-  private http: HttpClient;
-
-  constructor(http: HttpClient) {
-    this.http = http;
-  }
+  constructor(private readonly http: HttpClient) {}
 
   async create(
     payload: CreateContactPayload,
-  ): Promise<ApiResponse<{ created: number; ids: string[] }>> {
-    return this.http.request<{ created: number; ids: string[] }>(
+  ): Promise<ApiResponse<CreateContactResponse>> {
+    return this.http.request<CreateContactResponse>(
       "POST",
       "/api/contacts",
       payload,
@@ -293,21 +207,18 @@ class Contacts {
   }
 }
 
-// ── Main SDK Class ───────────────────────────────────────────────
-
 class NamuhSend {
   public readonly emails: Emails;
   public readonly domains: Domains;
   public readonly apiKeys: ApiKeys;
   public readonly contacts: Contacts;
 
-  constructor(apiKey: string, options?: SDKOptions) {
+  constructor(apiKey: string, options: SDKOptions) {
     if (!apiKey) {
       throw new Error("API key is required");
     }
 
-    const baseUrl = options?.baseUrl ?? "http://localhost:3015";
-    const http = new HttpClient(apiKey, baseUrl);
+    const http = new HttpClient(apiKey, normalizeBaseUrl(options.baseUrl));
 
     this.emails = new Emails(http);
     this.domains = new Domains(http);
@@ -320,18 +231,21 @@ export { NamuhSend };
 export type {
   SDKOptions,
   ApiResponse,
-  SendEmailPayload,
+  EmailOptions,
   EmailResponse,
   EmailListItem,
   EmailListResponse,
   EmailDetailResponse,
-  CreateDomainPayload,
+  DomainOptions,
   DomainResponse,
+  DomainListItem,
   DomainListResponse,
   CreateApiKeyPayload,
   ApiKeyResponse,
   ApiKeyListResponse,
   CreateContactPayload,
+  CreateContactResponse,
   ContactResponse,
+  ContactListItem,
   ContactListResponse,
 };

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,19 +1,20 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
-    "lib": ["ES2020"],
+    "module": "Node16",
+    "lib": ["ES2020", "DOM"],
     "declaration": true,
     "strict": true,
     "noEmit": false,
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": "..",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "moduleResolution": "node16"
   },
-  "include": ["src"],
+  "include": ["src", "../core/src/dto/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/tests/sdk-client.test.tsx
+++ b/tests/sdk-client.test.tsx
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NamuhSend } from "../packages/sdk/src";
+
+describe("NamuhSend SDK", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("requires an explicit baseUrl", () => {
+    expect(() => new NamuhSend("re_test", {} as never)).toThrow(
+      "A non-empty baseUrl is required",
+    );
+  });
+
+  it("normalizes the baseUrl and sends requests to the HTTP API", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ id: "email_123" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new NamuhSend("re_test", {
+      baseUrl: "https://api.example.com/",
+    });
+
+    const response = await client.emails.send({
+      from: "hello@example.com",
+      to: "user@example.com",
+      subject: "Hello",
+      html: "<p>Hello</p>",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/api/emails",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer re_test",
+        }),
+      }),
+    );
+    expect(response).toEqual({
+      data: { id: "email_123" },
+      error: null,
+    });
+  });
+
+  it("renders react payloads to html before sending", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ id: "email_456" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new NamuhSend("re_test", {
+      baseUrl: "https://api.example.com",
+    });
+
+    await client.emails.send({
+      from: "hello@example.com",
+      to: "user@example.com",
+      subject: "Hello",
+      react: <strong>Hello</strong>,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, options] = fetchMock.mock.calls[0] ?? [];
+    expect(options?.body).toContain("<strong>Hello</strong>");
+  });
+
+  it("treats empty successful responses as null data", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new NamuhSend("re_test", {
+      baseUrl: "https://api.example.com",
+    });
+
+    const response = await client.apiKeys.delete("key_123");
+
+    expect(response).toEqual({
+      data: null,
+      error: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary\n- move SDK-exposed HTTP DTOs into  and reuse them from \n- make  require an explicit absolute  and handle empty successful responses\n- update SDK packaging/docs and add targeted SDK tests\n\n## Verification\n- \n- \n- Checked 5 files in 2ms. No fixes applied.\n- 
 RUN  v2.1.9 /Users/jaeyunha/wt/namuh-send/issue-67-sdk-dto

 ✓ tests/sdk-client.test.tsx (4 tests) 19ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  02:05:16
   Duration  537ms (transform 26ms, setup 0ms, collect 27ms, tests 19ms, environment 231ms, prepare 36ms)