### PR TITLE
Make rate limiting explicitly Redis-backed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,12 @@ DASHBOARD_KEY=
 # Port the app is exposed on (docker compose only). Default: 3015.
 # PORT=3015
 
+# ── Shared Rate Limiting (recommended for staging/production) ─────
+# RATE_LIMIT_BACKEND=disabled   # local single-process dev default
+# RATE_LIMIT_BACKEND=redis      # required for shared/staging/production instances
+# REDIS_URL=rediss://default:password@your-cache-endpoint:6379
+# Use the TLS-enabled ElastiCache/Redis endpoint (`rediss://...`) when RATE_LIMIT_BACKEND=redis.
+
 # ── AWS SES (Email Sending) ─────────────────────────────────────
 # Required for sending emails. Uses ~/.aws/credentials locally,
 # or set these explicitly for Docker / production:

--- a/README.md
+++ b/README.md
@@ -188,6 +188,25 @@ For production, we recommend:
 - **Database**: Use a managed PostgreSQL (AWS RDS, Supabase, Neon, etc.) instead of the Docker Compose Postgres
 - **Reverse proxy**: Put Nginx or Caddy in front for TLS termination
 - **Secrets**: Store credentials in your cloud provider's secrets manager
+- **Rate limiting**: Use a shared Redis/ElastiCache instance instead of the disabled local default
+
+### Shared rate limiting (staging/production)
+
+Namuh Send now treats API rate limiting as an explicit runtime contract:
+
+- `RATE_LIMIT_BACKEND=disabled` skips API rate limiting entirely. This is the default for local single-process development only.
+- `RATE_LIMIT_BACKEND=redis` enables the middleware-backed shared limiter. If Redis is misconfigured or unavailable, API requests fail with `503` instead of silently falling back to per-process memory.
+- `REDIS_URL` must point at a TLS-enabled Redis endpoint such as `rediss://default:<password>@<primary-endpoint>:6379`.
+
+For AWS ElastiCache, enable **in-transit encryption** on the replication group/serverless cache and use the TLS endpoint that AWS exposes. AWS documents both the `TransitEncryptionEnabled=true` requirement and TLS client connections to the primary/configuration endpoint.
+
+Quick verification after deploy:
+
+```bash
+curl -i http://localhost:3015/api/auth/verify \
+  -H 'x-forwarded-for: 203.0.113.10'
+# Expect: X-RateLimit-Backend: redis when enabled
+```
 
 The included `Dockerfile` produces an optimized multi-stage build suitable for any container platform (AWS App Runner, Google Cloud Run, Fly.io, Railway, etc.):
 

--- a/agent_docs/learnings/active/2026-04-28-issue-14-rate-limit-runtime-contract.md
+++ b/agent_docs/learnings/active/2026-04-28-issue-14-rate-limit-runtime-contract.md
@@ -1,0 +1,14 @@
+---
+date: 2026-04-28
+issue: "#14"
+type: decision
+promoted_to: null
+---
+
+## Redis-backed rate limiting must fail explicitly, not silently downgrade
+
+**What:** Replaced the middleware's in-process `Map` fallback with an explicit `RATE_LIMIT_BACKEND` contract. `disabled` now means no API rate limiting, while `redis` requires `REDIS_URL` and returns `503` if Redis is misconfigured or unavailable.
+
+**Why:** A per-process fallback looks healthy in single-node dev but gives false confidence in staging/production because limits do not coordinate across instances.
+
+**Fix:** Keep broader cache behavior unchanged, but make rate limiting opt into shared Redis with visible headers/docs so deploys can verify the backend and catch misconfiguration quickly.

--- a/src/lib/cache/redis.ts
+++ b/src/lib/cache/redis.ts
@@ -1,19 +1,87 @@
-import { createClient } from "redis";
+import { type RedisClientType, createClient } from "redis";
 
-const REDIS_URL = process.env.REDIS_URL;
+const REDIS_URL = process.env.REDIS_URL?.trim();
+const RATE_LIMIT_BACKENDS = ["disabled", "redis"] as const;
+export type RateLimitBackend = (typeof RATE_LIMIT_BACKENDS)[number];
 
-const client = REDIS_URL ? createClient({ url: REDIS_URL }) : null;
+type RedisClient = RedisClientType;
 
-if (client) {
-  client.on("error", (err) => console.error("Redis Client Error", err));
-  client.connect().catch((err) => console.error("Redis Connection Error", err));
+let client: RedisClient | null = null;
+let connectPromise: Promise<RedisClient | null> | null = null;
+const loggedMessages = new Set<string>();
+
+function logRedisMessageOnce(level: "warn" | "error", message: string) {
+  if (loggedMessages.has(message)) return;
+  loggedMessages.add(message);
+  console[level](message);
+}
+
+function normalizeRateLimitBackend(
+  value: string | undefined,
+): RateLimitBackend {
+  if (!value) return "disabled";
+
+  if ((RATE_LIMIT_BACKENDS as readonly string[]).includes(value)) {
+    return value as RateLimitBackend;
+  }
+
+  logRedisMessageOnce(
+    "warn",
+    `[rate-limit] Unsupported RATE_LIMIT_BACKEND="${value}". Falling back to "disabled".`,
+  );
+  return "disabled";
+}
+
+export function getRateLimitBackend(): RateLimitBackend {
+  return normalizeRateLimitBackend(
+    process.env.RATE_LIMIT_BACKEND?.trim().toLowerCase(),
+  );
+}
+
+export function isRedisConfigured(): boolean {
+  return Boolean(REDIS_URL);
+}
+
+function getClient(): RedisClient | null {
+  if (!REDIS_URL) return null;
+
+  if (!client) {
+    client = createClient({ url: REDIS_URL });
+    client.on("error", (err) => {
+      console.error("Redis Client Error", err);
+    });
+  }
+
+  return client;
+}
+
+async function getConnectedClient(): Promise<RedisClient | null> {
+  const redisClient = getClient();
+  if (!redisClient) return null;
+
+  if (redisClient.isOpen) return redisClient;
+
+  if (!connectPromise) {
+    connectPromise = redisClient
+      .connect()
+      .then(() => redisClient)
+      .catch((err) => {
+        connectPromise = null;
+        console.error("Redis Connection Error", err);
+        return null;
+      });
+  }
+
+  return connectPromise;
 }
 
 export async function getCached<T>(key: string): Promise<T | null> {
-  if (!client) return null;
+  const redisClient = await getConnectedClient();
+  if (!redisClient) return null;
+
   try {
-    const value = await client.get(key);
-    return value ? JSON.parse(value) : null;
+    const value = await redisClient.get(key);
+    return value ? (JSON.parse(value) as T) : null;
   } catch {
     return null;
   }
@@ -21,12 +89,14 @@ export async function getCached<T>(key: string): Promise<T | null> {
 
 export async function setCache(
   key: string,
-  value: any,
+  value: unknown,
   ttlSeconds = 300,
 ): Promise<void> {
-  if (!client) return;
+  const redisClient = await getConnectedClient();
+  if (!redisClient) return;
+
   try {
-    await client.set(key, JSON.stringify(value), { EX: ttlSeconds });
+    await redisClient.set(key, JSON.stringify(value), { EX: ttlSeconds });
   } catch {
     // Fail silently - cache is optional
   }
@@ -36,32 +106,43 @@ export async function incrCache(
   key: string,
   ttlSeconds: number,
 ): Promise<number | null> {
-  if (!client) return null;
+  const redisClient = await getConnectedClient();
+  if (!redisClient) return null;
+
   try {
-    const multi = client.multi();
-    multi.incr(key);
-    multi.expire(key, ttlSeconds, "NX");
-    const replies = await multi.exec();
+    const replies = await redisClient
+      .multi()
+      .incr(key)
+      .expire(key, ttlSeconds, "NX")
+      .exec();
     const count = replies?.[0];
     return typeof count === "number" ? count : null;
   } catch {
+    logRedisMessageOnce(
+      "error",
+      "[rate-limit] Redis rate limit command failed; requests will receive 503 until Redis recovers.",
+    );
     return null;
   }
 }
 
 export async function getTtl(key: string): Promise<number | null> {
-  if (!client) return null;
+  const redisClient = await getConnectedClient();
+  if (!redisClient) return null;
+
   try {
-    return await client.ttl(key);
+    return await redisClient.ttl(key);
   } catch {
     return null;
   }
 }
 
 export async function invalidateCache(key: string): Promise<void> {
-  if (!client) return;
+  const redisClient = await getConnectedClient();
+  if (!redisClient) return;
+
   try {
-    await client.del(key);
+    await redisClient.del(key);
   } catch {
     // Fail silently
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,53 +1,63 @@
-import { getTtl, incrCache } from "@/lib/cache/redis";
+import {
+  getRateLimitBackend,
+  getTtl,
+  incrCache,
+  isRedisConfigured,
+} from "@/lib/cache/redis";
 import { getSessionCookie } from "better-auth/cookies";
 import { type NextRequest, NextResponse } from "next/server";
 
-// Fallback in-memory rate limiter if Redis is unavailable
-const hits = new Map<string, { count: number; resetAt: number }>();
+type RateCheckResult =
+  | { allowed: true }
+  | { allowed: false; retryAfter: number; status: 429 }
+  | { allowed: false; error: string; status: 503 };
+
+const RATE_LIMIT_BACKEND_UNAVAILABLE_ERROR =
+  "Rate limiting is temporarily unavailable.";
+let hasLoggedRateLimitConfigError = false;
 
 async function checkRate(
   key: string,
   maxRequests: number,
   windowMs: number,
-): Promise<{ allowed: true } | { allowed: false; retryAfter: number }> {
-  const redisKey = `ratelimit:${key}`;
-  const count = await incrCache(redisKey, Math.ceil(windowMs / 1000));
-
-  if (count !== null) {
-    if (count <= maxRequests) {
-      return { allowed: true };
+): Promise<RateCheckResult> {
+  if (!isRedisConfigured()) {
+    if (!hasLoggedRateLimitConfigError) {
+      hasLoggedRateLimitConfigError = true;
+      console.error(
+        "[rate-limit] RATE_LIMIT_BACKEND=redis requires REDIS_URL to be set.",
+      );
     }
-    const ttl = await getTtl(redisKey);
-    return { allowed: false, retryAfter: ttl || Math.ceil(windowMs / 1000) };
+    return {
+      allowed: false,
+      error: RATE_LIMIT_BACKEND_UNAVAILABLE_ERROR,
+      status: 503,
+    };
   }
 
-  // Fallback to in-memory
-  const now = Date.now();
-  const entry = hits.get(key);
+  const redisKey = `ratelimit:${key}`;
+  const windowSeconds = Math.ceil(windowMs / 1000);
+  const count = await incrCache(redisKey, windowSeconds);
 
-  if (!entry || now >= entry.resetAt) {
-    hits.set(key, { count: 1, resetAt: now + windowMs });
+  if (count === null) {
+    return {
+      allowed: false,
+      error: RATE_LIMIT_BACKEND_UNAVAILABLE_ERROR,
+      status: 503,
+    };
+  }
+
+  if (count <= maxRequests) {
     return { allowed: true };
   }
 
-  if (entry.count < maxRequests) {
-    entry.count++;
-    return { allowed: true };
-  }
-
+  const ttl = await getTtl(redisKey);
   return {
     allowed: false,
-    retryAfter: Math.ceil((entry.resetAt - now) / 1000),
+    retryAfter: ttl && ttl > 0 ? ttl : windowSeconds,
+    status: 429,
   };
 }
-
-// Clean up stale entries every 5 minutes
-setInterval(() => {
-  const now = Date.now();
-  for (const [key, entry] of hits) {
-    if (now >= entry.resetAt) hits.delete(key);
-  }
-}, 300_000);
 
 // Rate limit tiers by route pattern
 function getLimits(
@@ -101,6 +111,13 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
+  const backend = getRateLimitBackend();
+  const responseHeaders = new Headers({ "X-RateLimit-Backend": backend });
+
+  if (backend === "disabled") {
+    return NextResponse.next({ headers: responseHeaders });
+  }
+
   const rawIp =
     request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "";
   const ip = /^[\d.a-fA-F:]+$/.test(rawIp) ? rawIp : "unknown";
@@ -112,15 +129,26 @@ export async function middleware(request: NextRequest) {
 
   if (!result.allowed) {
     return NextResponse.json(
-      { error: "Rate limit exceeded. Try again later." },
       {
-        status: 429,
-        headers: { "Retry-After": String(result.retryAfter) },
+        error:
+          result.status === 429
+            ? "Rate limit exceeded. Try again later."
+            : result.error,
+      },
+      {
+        status: result.status,
+        headers:
+          result.status === 429
+            ? {
+                "Retry-After": String(result.retryAfter),
+                "X-RateLimit-Backend": backend,
+              }
+            : { "X-RateLimit-Backend": backend },
       },
     );
   }
 
-  return NextResponse.next();
+  return NextResponse.next({ headers: responseHeaders });
 }
 
 export const config = {

--- a/tests/middleware-rate-limit.test.ts
+++ b/tests/middleware-rate-limit.test.ts
@@ -1,0 +1,102 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetRateLimitBackend = vi.hoisted(() => vi.fn());
+const mockIsRedisConfigured = vi.hoisted(() => vi.fn());
+const mockIncrCache = vi.hoisted(() => vi.fn());
+const mockGetTtl = vi.hoisted(() => vi.fn());
+const mockGetSessionCookie = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/cache/redis", () => ({
+  getRateLimitBackend: mockGetRateLimitBackend,
+  isRedisConfigured: mockIsRedisConfigured,
+  incrCache: mockIncrCache,
+  getTtl: mockGetTtl,
+}));
+
+vi.mock("better-auth/cookies", () => ({
+  getSessionCookie: mockGetSessionCookie,
+}));
+
+function makeRequest(url: string, init?: RequestInit): NextRequest {
+  const request = new Request(url, init) as Request & { nextUrl: URL };
+  request.nextUrl = new URL(url);
+  return request as unknown as NextRequest;
+}
+
+describe("middleware rate limiting", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockGetSessionCookie.mockReturnValue("session");
+    mockIsRedisConfigured.mockReturnValue(true);
+    mockGetRateLimitBackend.mockReturnValue("disabled");
+  });
+
+  it("skips API rate limiting when RATE_LIMIT_BACKEND is disabled", async () => {
+    const { middleware } = await import("@/middleware");
+
+    const response = await middleware(
+      makeRequest("https://example.com/api/emails", { method: "POST" }),
+    );
+
+    expect(mockIncrCache).not.toHaveBeenCalled();
+    expect(response.headers.get("x-ratelimit-backend")).toBe("disabled");
+  });
+
+  it("enforces Redis-backed limits for API routes", async () => {
+    mockGetRateLimitBackend.mockReturnValue("redis");
+    mockIncrCache.mockResolvedValue(1);
+
+    const { middleware } = await import("@/middleware");
+    const response = await middleware(
+      makeRequest("https://example.com/api/emails", {
+        method: "POST",
+        headers: {
+          "x-forwarded-for": "203.0.113.10",
+          authorization: "Bearer test-api-key",
+        },
+      }),
+    );
+
+    expect(mockIncrCache).toHaveBeenCalledWith(
+      "ratelimit:203.0.113.10:Bearer test-api-key:/api/emails",
+      60,
+    );
+    expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
+  });
+
+  it("returns 429 with Retry-After once the Redis limit is exceeded", async () => {
+    mockGetRateLimitBackend.mockReturnValue("redis");
+    mockIncrCache.mockResolvedValue(21);
+    mockGetTtl.mockResolvedValue(17);
+
+    const { middleware } = await import("@/middleware");
+    const response = await middleware(
+      makeRequest("https://example.com/api/emails", { method: "POST" }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("17");
+    expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
+    await expect(response.json()).resolves.toEqual({
+      error: "Rate limit exceeded. Try again later.",
+    });
+  });
+
+  it("returns 503 when Redis-backed rate limiting is unavailable", async () => {
+    mockGetRateLimitBackend.mockReturnValue("redis");
+    mockIncrCache.mockResolvedValue(null);
+
+    const { middleware } = await import("@/middleware");
+    const response = await middleware(
+      makeRequest("https://example.com/api/emails", { method: "POST" }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
+    await expect(response.json()).resolves.toEqual({
+      error: "Rate limiting is temporarily unavailable.",
+    });
+  });
+});

--- a/tests/redis-cache.test.ts
+++ b/tests/redis-cache.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCreateClient = vi.hoisted(() => vi.fn());
+const mockConnect = vi.hoisted(() => vi.fn());
+const mockOn = vi.hoisted(() => vi.fn());
+const mockGet = vi.hoisted(() => vi.fn());
+const mockSet = vi.hoisted(() => vi.fn());
+const mockDel = vi.hoisted(() => vi.fn());
+const mockTtl = vi.hoisted(() => vi.fn());
+const mockExec = vi.hoisted(() => vi.fn());
+const mockIncr = vi.hoisted(() => vi.fn());
+const mockExpire = vi.hoisted(() => vi.fn());
+
+vi.mock("redis", () => ({
+  createClient: mockCreateClient,
+}));
+
+function configureRedisMock() {
+  const multi = {
+    incr: mockIncr.mockReturnThis(),
+    expire: mockExpire.mockReturnThis(),
+    exec: mockExec,
+  };
+
+  const client = {
+    isOpen: false,
+    on: mockOn,
+    connect: mockConnect.mockImplementation(async () => {
+      client.isOpen = true;
+      return client;
+    }),
+    get: mockGet,
+    set: mockSet,
+    del: mockDel,
+    ttl: mockTtl,
+    multi: vi.fn(() => multi),
+  };
+
+  mockCreateClient.mockReturnValue(client);
+  return { client, multi };
+}
+
+describe("lib/cache/redis", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.REDIS_URL = "";
+    process.env.RATE_LIMIT_BACKEND = "";
+  });
+
+  it("defaults RATE_LIMIT_BACKEND to disabled and no-ops without REDIS_URL", async () => {
+    const { getRateLimitBackend, incrCache } = await import(
+      "@/lib/cache/redis"
+    );
+
+    expect(getRateLimitBackend()).toBe("disabled");
+    await expect(incrCache("ratelimit:test", 60)).resolves.toBeNull();
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it("uses the configured Redis URL for cache and rate-limit commands", async () => {
+    process.env.RATE_LIMIT_BACKEND = "redis";
+    process.env.REDIS_URL = "rediss://cache.example:6379";
+    configureRedisMock();
+    mockExec.mockResolvedValue([3, 1]);
+    mockTtl.mockResolvedValue(42);
+    mockGet.mockResolvedValue('{"ok":true}');
+
+    const { getCached, getRateLimitBackend, getTtl, incrCache, setCache } =
+      await import("@/lib/cache/redis");
+
+    expect(getRateLimitBackend()).toBe("redis");
+    await setCache("cache:key", { ok: true }, 120);
+    await expect(getCached<{ ok: boolean }>("cache:key")).resolves.toEqual({
+      ok: true,
+    });
+    await expect(incrCache("ratelimit:test", 60)).resolves.toBe(3);
+    await expect(getTtl("ratelimit:test")).resolves.toBe(42);
+
+    expect(mockCreateClient).toHaveBeenCalledWith({
+      url: "rediss://cache.example:6379",
+    });
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+    expect(mockSet).toHaveBeenCalledWith("cache:key", '{"ok":true}', {
+      EX: 120,
+    });
+    expect(mockIncr).toHaveBeenCalledWith("ratelimit:test");
+    expect(mockExpire).toHaveBeenCalledWith("ratelimit:test", 60, "NX");
+  });
+});


### PR DESCRIPTION
## Summary
- remove the per-process middleware Map fallback and make the rate-limit backend explicit via `RATE_LIMIT_BACKEND`
- keep general cache behavior untouched while making `redis` rate limiting fail with `503` if `REDIS_URL` is missing or Redis is unavailable
- document the staging/production `rediss://` + ElastiCache TLS contract and add unit coverage for middleware/cache paths

## Verification
- `bunx biome check src/middleware.ts src/lib/cache/redis.ts tests/middleware-rate-limit.test.ts tests/redis-cache.test.ts README.md .env.example`
- `bun run typecheck`
- `bun run test -- tests/middleware-rate-limit.test.ts tests/redis-cache.test.ts`
