### PR TITLE
Harden SES SNS ingest verification and dedupe

### DIFF
--- a/agent_docs/learnings/active/2026-04-28-issue-68-sns-source-id-idempotency.md
+++ b/agent_docs/learnings/active/2026-04-28-issue-68-sns-source-id-idempotency.md
@@ -1,0 +1,10 @@
+---
+date: 2026-04-28
+issue: 68
+type: decision
+promoted_to: null
+---
+
+For SES SNS ingestion, idempotency is anchored on the SNS envelope `MessageId`, not the SES `mail.messageId`.
+
+Why: Amazon SNS retries reuse the original SNS `MessageId`, while the SES mail message ID identifies the email itself and can legitimately appear across multiple different notifications (delivery, open, click). A dedicated nullable `email_events.source_id` unique index lets the ingester drop exact SNS redeliveries without collapsing distinct lifecycle events for the same email.

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "better-auth": "^1.6.8",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
+        "hono": "^4.12.15",
         "lucide-react": "^1.11.0",
         "next": "^16.2.1",
         "papaparse": "^5.5.3",
@@ -850,6 +851,8 @@
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.15", "", {}, "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
 

--- a/drizzle/0003_sturdy_ses_ingest.sql
+++ b/drizzle/0003_sturdy_ses_ingest.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "email_events" ADD COLUMN "source_id" varchar(255);--> statement-breakpoint
+CREATE UNIQUE INDEX "email_events_source_id_idx" ON "email_events" USING btree ("source_id");

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "better-auth": "^1.6.8",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
+    "hono": "^4.12.15",
     "lucide-react": "^1.11.0",
     "next": "^16.2.1",
     "papaparse": "^5.5.3",

--- a/packages/core/src/auth/api-auth.ts
+++ b/packages/core/src/auth/api-auth.ts
@@ -1,9 +1,9 @@
 import { createHash } from "node:crypto";
+import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { apiKeys } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { headers } from "next/headers";
-import { auth } from "./auth";
 
 export interface AuthResult {
   apiKeyId: string;

--- a/packages/core/src/db/repositories/emailEventRepo.ts
+++ b/packages/core/src/db/repositories/emailEventRepo.ts
@@ -31,6 +31,55 @@ export const emailEventRepo = {
     });
   },
 
+  async findBySourceId(sourceId: string) {
+    return await db.query.emailEvents.findFirst({
+      where: eq(emailEvents.sourceId, sourceId),
+    });
+  },
+
+  async createOrIgnoreDuplicate(data: typeof emailEvents.$inferInsert) {
+    if (!data.sourceId) {
+      return { event: await this.create(data), created: true };
+    }
+
+    const insertedEvent = await db.transaction(async (tx) => {
+      const [event] = await tx
+        .insert(emailEvents)
+        .values(data)
+        .onConflictDoNothing({ target: emailEvents.sourceId })
+        .returning();
+
+      if (!event) {
+        return null;
+      }
+
+      const nextStatus = STATUS_BY_EVENT_TYPE[data.type];
+
+      if (nextStatus) {
+        await tx
+          .update(emails)
+          .set({ status: nextStatus })
+          .where(eq(emails.id, data.emailId));
+      }
+
+      return event;
+    });
+
+    if (insertedEvent) {
+      return { event: insertedEvent, created: true };
+    }
+
+    const existingEvent = await this.findBySourceId(data.sourceId);
+
+    if (!existingEvent) {
+      throw new Error(
+        `Duplicate SES event ${data.sourceId} was ignored but could not be reloaded`,
+      );
+    }
+
+    return { event: existingEvent, created: false };
+  },
+
   async listByEmailId(emailId: string) {
     return await db
       .select()

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -334,13 +334,17 @@ export const emailEvents = pgTable(
     emailId: uuid("email_id")
       .notNull()
       .references(() => emails.id),
+    sourceId: varchar("source_id", { length: 255 }),
     type: varchar("type", { length: 50 }).notNull(),
     payload: jsonb("payload").notNull(),
     receivedAt: timestamp("received_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
   },
-  (t) => [index("email_events_email_id_idx").on(t.emailId)],
+  (t) => [
+    index("email_events_email_id_idx").on(t.emailId),
+    uniqueIndex("email_events_source_id_idx").on(t.sourceId),
+  ],
 );
 
 export const webhookDeliveries = pgTable(

--- a/packages/core/src/services/email.ts
+++ b/packages/core/src/services/email.ts
@@ -30,7 +30,7 @@ export class EmailService {
     let providerId: string | null = null;
     if (!params.scheduledAt) {
       const res = await emailProvider.sendEmail(params);
-      providerId = res.id;
+      providerId = res.id ?? null;
     }
 
     const [record] = await emailRepo.create({

--- a/packages/ingester/src/index.ts
+++ b/packages/ingester/src/index.ts
@@ -2,23 +2,40 @@ import { emailEventRepo, webhookRepo } from "@namuh/core";
 import { Hono } from "hono";
 import { webhookDispatcher } from "./dispatcher";
 import { normalizeSesEvent } from "./ses-event-normalization";
+import {
+  SnsValidationError,
+  extractEmailId,
+  parseSesNotification,
+  parseSnsEnvelope,
+  verifySnsSignature,
+} from "./sns-message";
 
 const app = new Hono();
 
 app.get("/health", (c) => c.text("OK"));
 
 app.post("/events/ses", async (c) => {
-  const body = await c.req.json();
-  const snsType = c.req.header("x-amz-sns-message-type");
+  try {
+    const body = await c.req.json();
+    const snsType = c.req.header("x-amz-sns-message-type");
+    const snsMessage = parseSnsEnvelope(body, snsType);
 
-  if (snsType === "SubscriptionConfirmation") {
-    console.log("SNS Subscription Confirmation URL:", body.SubscribeURL);
-    // In a real environment, you'd fetch this URL to confirm
-    return c.text("OK");
-  }
+    await verifySnsSignature(snsMessage);
 
-  if (snsType === "Notification") {
-    const sesMessage = JSON.parse(body.Message);
+    if (snsMessage.Type === "SubscriptionConfirmation") {
+      console.log(
+        "SNS Subscription Confirmation URL:",
+        snsMessage.SubscribeURL,
+      );
+      return c.text("OK");
+    }
+
+    if (snsMessage.Type === "UnsubscribeConfirmation") {
+      console.warn("Received SNS UnsubscribeConfirmation for SES endpoint");
+      return c.text("OK");
+    }
+
+    const sesMessage = parseSesNotification(snsMessage.Message);
     const sesId = sesMessage.mail.messageId;
     const eventType = sesMessage.eventType;
     const normalizedEvent = normalizeSesEvent(eventType);
@@ -32,39 +49,53 @@ app.post("/events/ses", async (c) => {
       return c.text("OK");
     }
 
-    // SES tags are sometimes nested in mail.tags
-    const emailId = sesMessage.mail.headers?.find(
-      (h: { name: string; value: string }) => h.name === "X-Entity-ID",
-    )?.value;
+    const emailId = extractEmailId(sesMessage);
 
-    if (emailId) {
-      const event = await emailEventRepo.create({
-        emailId,
-        type: normalizedEvent.type,
-        payload: sesMessage[normalizedEvent.payloadKey] || sesMessage,
-      });
+    if (!emailId) {
+      console.warn(
+        `Skipping SES event ${eventType} for ${sesId}: missing X-Entity-ID`,
+      );
+      return c.text("OK");
+    }
 
-      // Simple fan-out: dispatch to all active webhooks subscribed to this type
-      const { data: hooks } = await webhookRepo.list({ limit: 100 });
-      for (const hook of hooks) {
-        const types = hook.eventTypes as string[];
-        const webhookEventType = `email.${event.type}`;
-        if (
-          hook.status === "active" &&
-          (types.includes("*") ||
-            types.includes(event.type) ||
-            types.includes(webhookEventType))
-        ) {
-          // Fire and forget for now in this context, or await if we want serial
-          webhookDispatcher.dispatch(hook.id, event).catch((err) => {
-            console.error(`Error dispatching webhook ${hook.id}:`, err);
-          });
-        }
+    const { event, created } = await emailEventRepo.createOrIgnoreDuplicate({
+      emailId,
+      sourceId: snsMessage.MessageId,
+      type: normalizedEvent.type,
+      payload: sesMessage[normalizedEvent.payloadKey] || sesMessage,
+    });
+
+    if (!created) {
+      console.log(`Ignoring duplicate SNS message ${snsMessage.MessageId}`);
+      return c.text("OK");
+    }
+
+    const { data: hooks } = await webhookRepo.list({ limit: 100 });
+    for (const hook of hooks) {
+      const types = hook.eventTypes as string[];
+      const webhookEventType = `email.${event.type}`;
+      if (
+        hook.status === "active" &&
+        (types.includes("*") ||
+          types.includes(event.type) ||
+          types.includes(webhookEventType))
+      ) {
+        webhookDispatcher.dispatch(hook.id, event).catch((err) => {
+          console.error(`Error dispatching webhook ${hook.id}:`, err);
+        });
       }
     }
-  }
 
-  return c.text("OK");
+    return c.text("OK");
+  } catch (error) {
+    if (error instanceof SnsValidationError) {
+      console.warn(error.message);
+      return new Response(error.message, { status: error.status });
+    }
+
+    console.error("Unhandled SES ingestion error", error);
+    return new Response("Internal Server Error", { status: 500 });
+  }
 });
 
 export default app;

--- a/packages/ingester/src/sns-message.ts
+++ b/packages/ingester/src/sns-message.ts
@@ -1,0 +1,312 @@
+import { createPublicKey, createVerify } from "node:crypto";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type SnsMessageType =
+  | "Notification"
+  | "SubscriptionConfirmation"
+  | "UnsubscribeConfirmation";
+
+type SesHeader = {
+  name: string;
+  value: string;
+};
+
+type SesMail = {
+  messageId: string;
+  headers?: SesHeader[];
+  tags?: Record<string, string[]>;
+};
+
+export type SesNotification = {
+  eventType: string;
+  mail: SesMail;
+  [key: string]: unknown;
+};
+
+export type SnsEnvelope = {
+  Type: SnsMessageType;
+  MessageId: string;
+  TopicArn: string;
+  Message: string;
+  Timestamp: string;
+  SignatureVersion: string;
+  Signature: string;
+  SigningCertURL: string;
+  Subject?: string;
+  SubscribeURL?: string;
+  Token?: string;
+};
+
+export class SnsValidationError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "SnsValidationError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+
+  throw new SnsValidationError(`SNS payload is missing ${key}`, 400);
+}
+
+function readOptionalString(record: Record<string, unknown>, key: string) {
+  const value = record[key];
+
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+
+  throw new SnsValidationError(`SNS payload has invalid ${key}`, 400);
+}
+
+function normalizeSnsType(type: string): SnsMessageType {
+  if (
+    type === "Notification" ||
+    type === "SubscriptionConfirmation" ||
+    type === "UnsubscribeConfirmation"
+  ) {
+    return type;
+  }
+
+  throw new SnsValidationError(`Unsupported SNS message type ${type}`, 400);
+}
+
+function buildStringToSign(message: SnsEnvelope) {
+  const fields =
+    message.Type === "Notification"
+      ? ["Message", "MessageId", "Subject", "Timestamp", "TopicArn", "Type"]
+      : [
+          "Message",
+          "MessageId",
+          "SubscribeURL",
+          "Timestamp",
+          "Token",
+          "TopicArn",
+          "Type",
+        ];
+
+  const lines: string[] = [];
+
+  for (const field of fields) {
+    const value = message[field as keyof SnsEnvelope];
+
+    if (typeof value !== "string" || value.length === 0) {
+      if (field === "Subject" && message.Type === "Notification") {
+        continue;
+      }
+
+      throw new SnsValidationError(
+        `SNS payload is missing ${field} required for signature verification`,
+        400,
+      );
+    }
+
+    lines.push(field, value);
+  }
+
+  return lines.join("\n");
+}
+
+function assertTrustedSigningCertUrl(signingCertUrl: string) {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(signingCertUrl);
+  } catch {
+    throw new SnsValidationError("SNS SigningCertURL is invalid", 400);
+  }
+
+  if (parsedUrl.protocol !== "https:") {
+    throw new SnsValidationError("SNS SigningCertURL must use HTTPS", 400);
+  }
+
+  if (!/^sns\.[a-z0-9-]+\.amazonaws\.com(\.cn)?$/i.test(parsedUrl.hostname)) {
+    throw new SnsValidationError(
+      "SNS SigningCertURL must point to an AWS SNS host",
+      400,
+    );
+  }
+
+  if (!parsedUrl.pathname.endsWith(".pem")) {
+    throw new SnsValidationError(
+      "SNS SigningCertURL must reference a PEM certificate",
+      400,
+    );
+  }
+}
+
+export function parseSnsEnvelope(
+  body: unknown,
+  headerType?: string,
+): SnsEnvelope {
+  if (!isRecord(body)) {
+    throw new SnsValidationError("SNS payload must be a JSON object", 400);
+  }
+
+  const Type = normalizeSnsType(readString(body, "Type"));
+
+  if (headerType && headerType !== Type) {
+    throw new SnsValidationError(
+      `SNS header type ${headerType} does not match body type ${Type}`,
+      400,
+    );
+  }
+
+  return {
+    Type,
+    MessageId: readString(body, "MessageId"),
+    TopicArn: readString(body, "TopicArn"),
+    Message: readString(body, "Message"),
+    Timestamp: readString(body, "Timestamp"),
+    SignatureVersion: readString(body, "SignatureVersion"),
+    Signature: readString(body, "Signature"),
+    SigningCertURL: readString(body, "SigningCertURL"),
+    Subject: readOptionalString(body, "Subject"),
+    SubscribeURL: readOptionalString(body, "SubscribeURL"),
+    Token: readOptionalString(body, "Token"),
+  };
+}
+
+export async function verifySnsSignature(message: SnsEnvelope) {
+  assertTrustedSigningCertUrl(message.SigningCertURL);
+
+  const algorithm =
+    message.SignatureVersion === "1"
+      ? "RSA-SHA1"
+      : message.SignatureVersion === "2"
+        ? "RSA-SHA256"
+        : null;
+
+  if (!algorithm) {
+    throw new SnsValidationError(
+      `Unsupported SNS signature version ${message.SignatureVersion}`,
+      400,
+    );
+  }
+
+  const certificateResponse = await fetch(message.SigningCertURL);
+
+  if (!certificateResponse.ok) {
+    throw new SnsValidationError(
+      `Unable to fetch SNS signing certificate (${certificateResponse.status})`,
+      401,
+    );
+  }
+
+  const certificatePem = await certificateResponse.text();
+  const verifier = createVerify(algorithm);
+  verifier.update(buildStringToSign(message), "utf8");
+  verifier.end();
+
+  const isValid = verifier.verify(
+    createPublicKey(certificatePem),
+    Buffer.from(message.Signature, "base64"),
+  );
+
+  if (!isValid) {
+    throw new SnsValidationError("SNS signature verification failed", 401);
+  }
+}
+
+export function parseSesNotification(rawMessage: string): SesNotification {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(rawMessage);
+  } catch {
+    throw new SnsValidationError("SNS Message must be valid JSON", 400);
+  }
+
+  if (!isRecord(parsed)) {
+    throw new SnsValidationError(
+      "SES notification payload must be an object",
+      400,
+    );
+  }
+
+  const eventType = readString(parsed, "eventType");
+  const mail = parsed.mail;
+
+  if (!isRecord(mail)) {
+    throw new SnsValidationError("SES notification is missing mail", 400);
+  }
+
+  const messageId = readString(mail, "messageId");
+  const headers = mail.headers;
+
+  if (
+    headers !== undefined &&
+    (!Array.isArray(headers) ||
+      headers.some(
+        (header) =>
+          !isRecord(header) ||
+          typeof header.name !== "string" ||
+          typeof header.value !== "string",
+      ))
+  ) {
+    throw new SnsValidationError(
+      "SES mail.headers must be an array of headers",
+      400,
+    );
+  }
+
+  const tags = mail.tags;
+
+  if (
+    tags !== undefined &&
+    (!isRecord(tags) ||
+      Object.values(tags).some(
+        (value) =>
+          !Array.isArray(value) ||
+          value.some((entry) => typeof entry !== "string"),
+      ))
+  ) {
+    throw new SnsValidationError(
+      "SES mail.tags must be a string array map",
+      400,
+    );
+  }
+
+  return {
+    ...parsed,
+    eventType,
+    mail: {
+      messageId,
+      headers: headers as SesHeader[] | undefined,
+      tags: tags as Record<string, string[]> | undefined,
+    },
+  };
+}
+
+export function extractEmailId(notification: SesNotification) {
+  const headerValue = notification.mail.headers?.find(
+    (header) => header.name.toLowerCase() === "x-entity-id",
+  )?.value;
+
+  const tagValue = notification.mail.tags?.["X-Entity-ID"]?.[0];
+  const candidate = headerValue ?? tagValue;
+
+  if (!candidate || !UUID_REGEX.test(candidate)) {
+    return null;
+  }
+
+  return candidate;
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -342,13 +342,17 @@ export const emailEvents = pgTable(
     emailId: uuid("email_id")
       .notNull()
       .references(() => emails.id),
+    sourceId: varchar("source_id", { length: 255 }),
     type: varchar("type", { length: 50 }).notNull(),
     payload: jsonb("payload").notNull(),
     receivedAt: timestamp("received_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
   },
-  (t) => [index("email_events_email_id_idx").on(t.emailId)],
+  (t) => [
+    index("email_events_email_id_idx").on(t.emailId),
+    uniqueIndex("email_events_source_id_idx").on(t.sourceId),
+  ],
 );
 
 export const webhookDeliveries = pgTable(

--- a/tests/core-email-event-repo.test.ts
+++ b/tests/core-email-event-repo.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFindFirst = vi.fn();
 const mockInsertReturning = vi.fn();
+const mockOnConflictDoNothing = vi.fn();
 const mockUpdateWhere = vi.fn();
 const mockUpdateSet = vi.fn();
 const mockUpdate = vi.fn();
@@ -26,12 +27,14 @@ describe("packages/core emailEventRepo.create", () => {
     mockUpdateWhere.mockResolvedValue(undefined);
     mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
     mockUpdate.mockReturnValue({ set: mockUpdateSet });
+    mockOnConflictDoNothing.mockReturnValue({ returning: mockInsertReturning });
 
     mockTransaction.mockImplementation(async (callback) =>
       callback({
         insert: () => ({
           values: () => ({
             returning: mockInsertReturning,
+            onConflictDoNothing: mockOnConflictDoNothing,
           }),
         }),
         update: mockUpdate,
@@ -76,6 +79,28 @@ describe("packages/core emailEventRepo.create", () => {
     const result = await emailEventRepo.create(event);
 
     expect(result).toEqual(event);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("returns the existing event when a source id hits the duplicate guard", async () => {
+    const existingEvent = {
+      id: "evt_3",
+      emailId: "email_1",
+      sourceId: "sns-msg-1",
+      type: "delivered",
+      payload: { smtpResponse: "250 ok" },
+    };
+    mockInsertReturning.mockResolvedValue([]);
+    mockFindFirst.mockResolvedValue(existingEvent);
+
+    const { emailEventRepo } = await import(
+      "../packages/core/src/db/repositories/emailEventRepo"
+    );
+
+    const result = await emailEventRepo.createOrIgnoreDuplicate(existingEvent);
+
+    expect(result).toEqual({ event: existingEvent, created: false });
+    expect(mockOnConflictDoNothing).toHaveBeenCalledOnce();
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 });

--- a/tests/ingester-ses-route.test.ts
+++ b/tests/ingester-ses-route.test.ts
@@ -1,0 +1,287 @@
+import { generateKeyPairSync, sign } from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCreateOrIgnoreDuplicate = vi.fn();
+const mockWebhookList = vi.fn();
+const mockDispatch = vi.fn();
+
+vi.mock("@namuh/core", () => ({
+  emailEventRepo: {
+    createOrIgnoreDuplicate: mockCreateOrIgnoreDuplicate,
+  },
+  webhookRepo: {
+    list: mockWebhookList,
+  },
+}));
+
+vi.mock("hono", () => {
+  type Handler = (context: {
+    req: {
+      header: (name: string) => string | undefined;
+      json: () => Promise<unknown>;
+    };
+    text: (body: string, status?: number) => Response;
+  }) => Response | Promise<Response>;
+
+  class MockHono {
+    private routes = new Map<string, Handler>();
+
+    get(path: string, handler: Handler) {
+      this.routes.set(`GET ${path}`, handler);
+    }
+
+    post(path: string, handler: Handler) {
+      this.routes.set(`POST ${path}`, handler);
+    }
+
+    async request(input: string, init?: RequestInit) {
+      const request = new Request(input, init);
+      const url = new URL(request.url);
+      const handler = this.routes.get(`${request.method} ${url.pathname}`);
+
+      if (!handler) {
+        return new Response("Not Found", { status: 404 });
+      }
+
+      return await handler({
+        req: {
+          header: (name: string) => request.headers.get(name) ?? undefined,
+          json: async () => await request.json(),
+        },
+        text: (body: string, status = 200) => new Response(body, { status }),
+      });
+    }
+  }
+
+  return {
+    Hono: MockHono,
+  };
+});
+
+vi.mock("../packages/ingester/src/dispatcher", () => ({
+  webhookDispatcher: {
+    dispatch: mockDispatch,
+  },
+}));
+
+const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+});
+const publicKeyPem = publicKey
+  .export({ format: "pem", type: "spki" })
+  .toString();
+
+function createSignedEnvelope(options?: {
+  messageType?: "Notification" | "SubscriptionConfirmation";
+  signatureVersion?: "1" | "2";
+  sesMessage?: Record<string, unknown>;
+  overrides?: Record<string, string>;
+}) {
+  const messageType = options?.messageType ?? "Notification";
+  const signatureVersion = options?.signatureVersion ?? "2";
+  const sesMessage = options?.sesMessage ?? {
+    eventType: "Delivery",
+    mail: {
+      messageId: "ses-msg-1",
+      headers: [
+        {
+          name: "X-Entity-ID",
+          value: "550e8400-e29b-41d4-a716-446655440000",
+        },
+      ],
+    },
+    delivery: { smtpResponse: "250 ok" },
+  };
+
+  const base = {
+    Type: messageType,
+    MessageId: "sns-msg-1",
+    TopicArn: "arn:aws:sns:us-east-1:123456789012:ses-events",
+    Message:
+      messageType === "Notification"
+        ? JSON.stringify(sesMessage)
+        : "Please confirm your subscription",
+    Timestamp: "2026-04-28T00:00:00.000Z",
+    SignatureVersion: signatureVersion,
+    SigningCertURL:
+      "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-test.pem",
+    ...(messageType === "Notification"
+      ? { Subject: "SES event" }
+      : {
+          SubscribeURL:
+            "https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription",
+          Token: "token-123",
+        }),
+    ...options?.overrides,
+  };
+
+  const fields =
+    messageType === "Notification"
+      ? ["Message", "MessageId", "Subject", "Timestamp", "TopicArn", "Type"]
+      : [
+          "Message",
+          "MessageId",
+          "SubscribeURL",
+          "Timestamp",
+          "Token",
+          "TopicArn",
+          "Type",
+        ];
+  const stringToSign = fields
+    .filter((field) => {
+      const value = base[field as keyof typeof base];
+      return typeof value === "string" && value.length > 0;
+    })
+    .flatMap((field) => [field, base[field as keyof typeof base] as string])
+    .join("\n");
+  const algorithm = signatureVersion === "1" ? "RSA-SHA1" : "RSA-SHA256";
+  const signature = sign(
+    algorithm,
+    Buffer.from(stringToSign, "utf8"),
+    privateKey,
+  ).toString("base64");
+
+  return {
+    ...base,
+    Signature: signature,
+  };
+}
+
+describe("SES SNS ingestion route", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mockDispatch.mockResolvedValue(undefined);
+    mockWebhookList.mockResolvedValue({
+      data: [
+        {
+          id: "hook-1",
+          status: "active",
+          eventTypes: ["email.delivered"],
+        },
+      ],
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => publicKeyPem,
+      }),
+    );
+  });
+
+  it("verifies the SNS signature, persists a normalized event, and dispatches webhooks", async () => {
+    const persistedEvent = {
+      id: "evt-1",
+      emailId: "550e8400-e29b-41d4-a716-446655440000",
+      sourceId: "sns-msg-1",
+      type: "delivered",
+      payload: { smtpResponse: "250 ok" },
+    };
+    mockCreateOrIgnoreDuplicate.mockResolvedValue({
+      event: persistedEvent,
+      created: true,
+    });
+
+    const app = (await import("../packages/ingester/src/index")).default;
+    const envelope = createSignedEnvelope();
+
+    const response = await app.request("http://localhost/events/ses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-amz-sns-message-type": "Notification",
+      },
+      body: JSON.stringify(envelope),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockCreateOrIgnoreDuplicate).toHaveBeenCalledWith({
+      emailId: "550e8400-e29b-41d4-a716-446655440000",
+      sourceId: "sns-msg-1",
+      type: "delivered",
+      payload: { smtpResponse: "250 ok" },
+    });
+    expect(mockDispatch).toHaveBeenCalledWith("hook-1", persistedEvent);
+  });
+
+  it("rejects invalid SNS signatures before touching persistence", async () => {
+    const app = (await import("../packages/ingester/src/index")).default;
+    const envelope = {
+      ...createSignedEnvelope(),
+      Signature: "invalid-signature",
+    };
+
+    const response = await app.request("http://localhost/events/ses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-amz-sns-message-type": "Notification",
+      },
+      body: JSON.stringify(envelope),
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.text()).toContain(
+      "SNS signature verification failed",
+    );
+    expect(mockCreateOrIgnoreDuplicate).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it("acks duplicate SNS notifications without re-dispatching downstream webhooks", async () => {
+    mockCreateOrIgnoreDuplicate.mockResolvedValue({
+      event: {
+        id: "evt-1",
+        emailId: "550e8400-e29b-41d4-a716-446655440000",
+        sourceId: "sns-msg-1",
+        type: "delivered",
+        payload: { smtpResponse: "250 ok" },
+      },
+      created: false,
+    });
+
+    const app = (await import("../packages/ingester/src/index")).default;
+    const envelope = createSignedEnvelope();
+
+    const response = await app.request("http://localhost/events/ses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-amz-sns-message-type": "Notification",
+      },
+      body: JSON.stringify(envelope),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(mockWebhookList).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed SES notifications with a 400", async () => {
+    const app = (await import("../packages/ingester/src/index")).default;
+    const envelope = createSignedEnvelope({
+      sesMessage: {
+        mail: {
+          headers: [],
+        },
+      },
+    });
+
+    const response = await app.request("http://localhost/events/ses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-amz-sns-message-type": "Notification",
+      },
+      body: JSON.stringify(envelope),
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("eventType");
+    expect(mockCreateOrIgnoreDuplicate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- verify SNS signatures against trusted AWS-hosted PEMs before processing SES notifications
- validate SNS/SES payload shape and drop malformed notifications with explicit 4xx responses
- dedupe redelivered SNS envelopes by source id and add route/repo regression coverage

## Verification
- bunx vitest run tests/ingester-ses-route.test.ts tests/ingester-ses-normalization.test.ts tests/core-email-event-repo.test.ts
- bunx biome check packages/ingester/src/index.ts packages/ingester/src/sns-message.ts packages/core/src/db/repositories/emailEventRepo.ts packages/core/src/db/schema.ts src/lib/db/schema.ts packages/core/src/auth/api-auth.ts packages/core/src/services/email.ts tests/ingester-ses-route.test.ts tests/ingester-ses-normalization.test.ts tests/core-email-event-repo.test.ts drizzle/0003_sturdy_ses_ingest.sql
- bun run typecheck