### PR TITLE
Add a minimal cache layer for hot dashboard aggregates

### DIFF
--- a/agent_docs/learnings/active/2026-04-28-97-analytics-cache-hot-routes.md
+++ b/agent_docs/learnings/active/2026-04-28-97-analytics-cache-hot-routes.md
@@ -1,0 +1,13 @@
+---
+date: 2026-04-28
+issue: 97
+type: decision
+promoted_to: null
+---
+
+For the first analytics cache slice, limit scope to the two highest-leverage dashboard aggregate reads that already exist on staging:
+
+1. `/api/metrics` keyed by `range + domain + event_type` with a 60 second TTL, because the dashboard page fan-outs into five aggregate queries per refresh and the UI already presents the data as near-real-time rather than transactional.
+2. `/api/broadcasts/[id]/metrics` keyed by `broadcast_id` with a 120 second TTL, because it is a single broadcast-specific rollup that is safe to reuse briefly across repeated detail-page reads.
+
+Keep Postgres as the source of truth by only caching successful JSON payloads, serving uncached DB results on cache miss/error, and exposing an `x-namuh-cache` response header so follow-up measurement can compare hit/miss behavior without widening the implementation into warehouse or vendor work.

--- a/src/app/api/broadcasts/[id]/metrics/route.ts
+++ b/src/app/api/broadcasts/[id]/metrics/route.ts
@@ -1,20 +1,33 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import {
+  BROADCAST_METRICS_CACHE_TTL_SECONDS,
+  getBroadcastMetricsCacheKey,
+  readDashboardAggregateCache,
+  writeDashboardAggregateCache,
+} from "@/lib/cache/dashboard-aggregates";
 import { db } from "@/lib/db";
 import { broadcasts, emails } from "@/lib/db/schema";
-import { and, eq, sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await validateApiKey(_request.headers.get("authorization"));
+  const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
 
   try {
     const { id } = await params;
+    const cacheKey = getBroadcastMetricsCacheKey(id);
 
-    // Verify broadcast exists
+    const cached = await readDashboardAggregateCache<unknown>(cacheKey);
+    if (cached) {
+      return NextResponse.json(cached, {
+        headers: { "x-namuh-cache": "hit" },
+      });
+    }
+
     const [broadcast] = await db
       .select({ id: broadcasts.id })
       .from(broadcasts)
@@ -27,12 +40,6 @@ export async function GET(
         { status: 404 },
       );
     }
-
-    // Query aggregated stats from emails table linked by tags or headers?
-    // Current schema doesn't have a direct link from email to broadcast,
-    // but the broadcast implementation likely tags them or includes a header.
-    // For now, assume we're looking for emails where a tag "broadcast_id" matches.
-    // (If this isn't how it's linked, we'll need to update the send logic too)
 
     const condition = sql`${emails.tags} @> ${[{ name: "broadcast_id", value: id }]}`;
 
@@ -59,7 +66,7 @@ export async function GET(
 
     const total = stats.total;
 
-    return NextResponse.json({
+    const payload = {
       object: "broadcast_metrics",
       broadcast_id: id,
       total,
@@ -72,6 +79,16 @@ export async function GET(
       open_rate: total > 0 ? (stats.opened / total) * 100 : 0,
       click_rate: total > 0 ? (stats.clicked / total) * 100 : 0,
       bounce_rate: total > 0 ? (stats.bounced / total) * 100 : 0,
+    };
+
+    await writeDashboardAggregateCache(
+      cacheKey,
+      payload,
+      BROADCAST_METRICS_CACHE_TTL_SECONDS,
+    );
+
+    return NextResponse.json(payload, {
+      headers: { "x-namuh-cache": "miss" },
     });
   } catch (error) {
     console.error("Failed to fetch broadcast metrics:", error);

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -5,6 +5,12 @@ import {
   unauthorizedResponse,
   validateDashboardKey,
 } from "@/lib/api-auth";
+import {
+  DASHBOARD_METRICS_CACHE_TTL_SECONDS,
+  getMetricsAggregateCacheKey,
+  readDashboardAggregateCache,
+  writeDashboardAggregateCache,
+} from "@/lib/cache/dashboard-aggregates";
 import { getDateRangeBounds } from "@/lib/date-range";
 import { db } from "@/lib/db";
 import { emails } from "@/lib/db/schema";
@@ -54,10 +60,17 @@ export async function GET(request: NextRequest) {
     const range = searchParams.get("range") || "last_15_days";
     const domain = searchParams.get("domain");
     const eventType = searchParams.get("event_type");
+    const cacheKey = getMetricsAggregateCacheKey({ range, domain, eventType });
+
+    const cached = await readDashboardAggregateCache<unknown>(cacheKey);
+    if (cached) {
+      return NextResponse.json(cached, {
+        headers: { "x-namuh-cache": "hit" },
+      });
+    }
 
     const { start, end } = getMetricsDateRange(range);
 
-    // Build conditions
     const conditions = [
       gte(emails.createdAt, start),
       lte(emails.createdAt, end),
@@ -66,7 +79,6 @@ export async function GET(request: NextRequest) {
       conditions.push(eq(senderDomainSql, domain));
     }
 
-    // Query aggregated stats
     const result = await db
       .select({
         total: sql<number>`count(*)::int`,
@@ -104,7 +116,6 @@ export async function GET(request: NextRequest) {
         ? Math.round((stats.complained / totalEmails) * 10000) / 100
         : 0;
 
-    // Build daily chart query — optionally filtered by event type
     const dailyConditions = [...conditions];
     if (eventType && eventType !== "all" && EVENT_TYPE_TO_STATUS[eventType]) {
       const statuses = EVENT_TYPE_TO_STATUS[eventType];
@@ -126,7 +137,6 @@ export async function GET(request: NextRequest) {
       count: r.count,
     }));
 
-    // Daily bounce rate data (percentage per day)
     const dailyBounceRows = await db
       .select({
         date: sql<string>`to_char(${emails.createdAt}::date, 'YYYY-MM-DD')`,
@@ -143,7 +153,6 @@ export async function GET(request: NextRequest) {
       rate: r.total > 0 ? Math.round((r.bounced / r.total) * 10000) / 100 : 0,
     }));
 
-    // Daily complain rate data (percentage per day)
     const dailyComplainRows = await db
       .select({
         date: sql<string>`to_char(${emails.createdAt}::date, 'YYYY-MM-DD')`,
@@ -161,7 +170,6 @@ export async function GET(request: NextRequest) {
         r.total > 0 ? Math.round((r.complained / r.total) * 10000) / 100 : 0,
     }));
 
-    // Per-domain breakdown
     const domainBreakdownRows = await db
       .select({
         domain: senderDomainSql,
@@ -182,15 +190,12 @@ export async function GET(request: NextRequest) {
           r.total > 0 ? Math.round((r.delivered / r.total) * 10000) / 100 : 0,
       }));
 
-    // Get unique domain names for the filter
-    const domains = domainBreakdown.map((d) => d.domain);
-
-    return NextResponse.json({
+    const payload = {
       totalEmails,
       deliverabilityRate,
       bounceRate,
       complainRate,
-      domains,
+      domains: domainBreakdown.map((d) => d.domain),
       dailyData,
       domainBreakdown,
       bounceBreakdown: {
@@ -202,6 +207,16 @@ export async function GET(request: NextRequest) {
       complained: stats.complained,
       dailyComplainData,
       lastUpdated: new Date().toISOString(),
+    };
+
+    await writeDashboardAggregateCache(
+      cacheKey,
+      payload,
+      DASHBOARD_METRICS_CACHE_TTL_SECONDS,
+    );
+
+    return NextResponse.json(payload, {
+      headers: { "x-namuh-cache": "miss" },
     });
   } catch (error) {
     console.error("Failed to fetch metrics:", error);

--- a/src/lib/cache/dashboard-aggregates.ts
+++ b/src/lib/cache/dashboard-aggregates.ts
@@ -1,0 +1,47 @@
+import { getCached, setCache } from "@/lib/cache/redis";
+
+const DASHBOARD_AGGREGATE_CACHE_PREFIX = "dashboard-aggregate:v1";
+
+export const DASHBOARD_METRICS_CACHE_TTL_SECONDS = 60;
+export const BROADCAST_METRICS_CACHE_TTL_SECONDS = 120;
+
+function normalizeCacheSegment(value: string | null | undefined): string {
+  if (!value || value.trim() === "") return "all";
+  return encodeURIComponent(value.trim());
+}
+
+export function getMetricsAggregateCacheKey(params: {
+  range: string;
+  domain: string | null;
+  eventType: string | null;
+}): string {
+  return [
+    DASHBOARD_AGGREGATE_CACHE_PREFIX,
+    "metrics",
+    normalizeCacheSegment(params.range),
+    normalizeCacheSegment(params.domain),
+    normalizeCacheSegment(params.eventType),
+  ].join(":");
+}
+
+export function getBroadcastMetricsCacheKey(broadcastId: string): string {
+  return [
+    DASHBOARD_AGGREGATE_CACHE_PREFIX,
+    "broadcast-metrics",
+    normalizeCacheSegment(broadcastId),
+  ].join(":");
+}
+
+export async function readDashboardAggregateCache<T>(
+  key: string,
+): Promise<T | null> {
+  return getCached<T>(key);
+}
+
+export async function writeDashboardAggregateCache(
+  key: string,
+  value: unknown,
+  ttlSeconds: number,
+): Promise<void> {
+  await setCache(key, value, ttlSeconds);
+}

--- a/tests/broadcast-metrics-route.test.ts
+++ b/tests/broadcast-metrics-route.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockReadDashboardAggregateCache = vi.hoisted(() => vi.fn());
+const mockWriteDashboardAggregateCache = vi.hoisted(() => vi.fn());
+const mockSelect = vi.hoisted(() => vi.fn());
+
+function makeChain<T>(rows: T[]) {
+  const chain = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    // biome-ignore lint/suspicious/noThenProperty: mocks Drizzle's thenable query builder
+    then: (resolve: (value: T[]) => unknown) => Promise.resolve(resolve(rows)),
+  };
+
+  return chain;
+}
+
+vi.mock("@/lib/api-auth", () => ({
+  unauthorizedResponse: () =>
+    new Response(JSON.stringify({ error: "Missing or invalid API key" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    }),
+  validateApiKey: mockValidateApiKey,
+}));
+
+vi.mock("@/lib/cache/dashboard-aggregates", () => ({
+  BROADCAST_METRICS_CACHE_TTL_SECONDS: 120,
+  getBroadcastMetricsCacheKey: (id: string) =>
+    `dashboard-aggregate:v1:broadcast-metrics:${id}`,
+  readDashboardAggregateCache: mockReadDashboardAggregateCache,
+  writeDashboardAggregateCache: mockWriteDashboardAggregateCache,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: mockSelect,
+  },
+}));
+
+function makeNextRequest(url: string, init?: RequestInit) {
+  const request = new Request(url, init) as Request & { nextUrl: URL };
+  request.nextUrl = new URL(url);
+  return request;
+}
+
+describe("broadcast metrics route cache", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue({ apiKeyId: "k1" });
+    mockReadDashboardAggregateCache.mockResolvedValue(null);
+    mockWriteDashboardAggregateCache.mockResolvedValue(undefined);
+  });
+
+  it("returns cached broadcast aggregates without querying the database", async () => {
+    mockReadDashboardAggregateCache.mockResolvedValue({
+      object: "broadcast_metrics",
+      broadcast_id: "b1",
+      total: 5,
+      delivered: 4,
+      bounced: 1,
+      complained: 0,
+      opened: 3,
+      clicked: 1,
+      delivery_rate: 80,
+      open_rate: 60,
+      click_rate: 20,
+      bounce_rate: 20,
+    });
+
+    const route = await import("@/app/api/broadcasts/[id]/metrics/route");
+    const response = await route.GET(
+      makeNextRequest("http://localhost/api/broadcasts/b1/metrics", {
+        headers: { authorization: "Bearer token" },
+      }) as never,
+      { params: Promise.resolve({ id: "b1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-namuh-cache")).toBe("hit");
+    expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockWriteDashboardAggregateCache).not.toHaveBeenCalled();
+  });
+
+  it("caches fresh broadcast aggregates with a short ttl", async () => {
+    mockSelect
+      .mockReturnValueOnce(makeChain([{ id: "b1" }]))
+      .mockReturnValueOnce(
+        makeChain([
+          {
+            total: 100,
+            delivered: 95,
+            bounced: 2,
+            complained: 0,
+            opened: 40,
+            clicked: 10,
+          },
+        ]),
+      );
+
+    const route = await import("@/app/api/broadcasts/[id]/metrics/route");
+    const response = await route.GET(
+      makeNextRequest("http://localhost/api/broadcasts/b1/metrics", {
+        headers: { authorization: "Bearer token" },
+      }) as never,
+      { params: Promise.resolve({ id: "b1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-namuh-cache")).toBe("miss");
+    expect(mockWriteDashboardAggregateCache).toHaveBeenCalledOnce();
+    expect(mockWriteDashboardAggregateCache).toHaveBeenCalledWith(
+      "dashboard-aggregate:v1:broadcast-metrics:b1",
+      expect.objectContaining({
+        object: "broadcast_metrics",
+        broadcast_id: "b1",
+        total: 100,
+      }),
+      120,
+    );
+  });
+});

--- a/tests/metrics-route.test.ts
+++ b/tests/metrics-route.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mockSelect = vi.hoisted(() => vi.fn());
 const mockValidateDashboardKey = vi.hoisted(() => vi.fn());
 const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockReadDashboardAggregateCache = vi.hoisted(() => vi.fn());
+const mockWriteDashboardAggregateCache = vi.hoisted(() => vi.fn());
 const mockGte = vi.hoisted(() =>
   vi.fn((left, right) => ({ kind: "gte", left, right })),
 );
@@ -50,6 +52,22 @@ vi.mock("@/lib/api-auth", () => ({
       headers: { "content-type": "application/json" },
     }),
   validateDashboardKey: mockValidateDashboardKey,
+}));
+
+vi.mock("@/lib/cache/dashboard-aggregates", () => ({
+  DASHBOARD_METRICS_CACHE_TTL_SECONDS: 60,
+  getMetricsAggregateCacheKey: ({
+    range,
+    domain,
+    eventType,
+  }: {
+    range: string;
+    domain: string | null;
+    eventType: string | null;
+  }) =>
+    `dashboard-aggregate:v1:metrics:${range}:${domain ?? "all"}:${eventType ?? "all"}`,
+  readDashboardAggregateCache: mockReadDashboardAggregateCache,
+  writeDashboardAggregateCache: mockWriteDashboardAggregateCache,
 }));
 
 vi.mock("drizzle-orm", async () => {
@@ -151,6 +169,8 @@ describe("metrics route filters", () => {
       session: { id: "session-1" },
       user: { id: "user-1" },
     });
+    mockReadDashboardAggregateCache.mockResolvedValue(null);
+    mockWriteDashboardAggregateCache.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -167,6 +187,7 @@ describe("metrics route filters", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("x-namuh-cache")).toBe("miss");
 
     const firstWhere = whereArgs[0] as {
       kind: string;
@@ -258,5 +279,63 @@ describe("metrics route filters", () => {
       conds: Array<{ kind: string }>;
     };
     expect(firstWhere.conds.some((cond) => cond.kind === "eq")).toBe(true);
+  });
+
+  it("returns cached metrics payloads without hitting the database", async () => {
+    mockReadDashboardAggregateCache.mockResolvedValue({
+      totalEmails: 99,
+      deliverabilityRate: 98,
+      bounceRate: 1,
+      complainRate: 0,
+      complained: 0,
+      domains: ["example.com"],
+      dailyData: [],
+      domainBreakdown: [],
+      bounceBreakdown: {
+        permanent: 0,
+        transient: 0,
+        undetermined: 0,
+      },
+      dailyBounceData: [],
+      dailyComplainData: [],
+      lastUpdated: "2026-04-23T06:45:30.000Z",
+    });
+
+    const metricsRoute = await import("@/app/api/metrics/route");
+    const response = await metricsRoute.GET(
+      makeNextRequest(
+        "http://localhost/api/metrics?range=last_7_days&domain=example.com&event_type=delivered",
+      ) as never,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-namuh-cache")).toBe("hit");
+    expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockWriteDashboardAggregateCache).not.toHaveBeenCalled();
+
+    const json = await response.json();
+    expect(json.totalEmails).toBe(99);
+    expect(mockReadDashboardAggregateCache).toHaveBeenCalledWith(
+      "dashboard-aggregate:v1:metrics:last_7_days:example.com:delivered",
+    );
+  });
+
+  it("writes a fresh aggregate response to cache with a short ttl", async () => {
+    const whereArgs: unknown[] = [];
+    queueMetricsQueries(whereArgs);
+
+    const metricsRoute = await import("@/app/api/metrics/route");
+    const response = await metricsRoute.GET(
+      makeNextRequest(
+        "http://localhost/api/metrics?range=last_7_days&event_type=opened",
+      ) as never,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockWriteDashboardAggregateCache).toHaveBeenCalledOnce();
+    expect(mockWriteDashboardAggregateCache.mock.calls[0]?.[0]).toBe(
+      "dashboard-aggregate:v1:metrics:last_7_days:all:opened",
+    );
+    expect(mockWriteDashboardAggregateCache.mock.calls[0]?.[2]).toBe(60);
   });
 });


### PR DESCRIPTION
## Summary
- add a shared Redis-backed helper for short-lived dashboard aggregate response caching
- cache the hot `/api/metrics` and `/api/broadcasts/[id]/metrics` reads with safe keys, short TTLs, and cache hit/miss headers
- cover cache hits and misses with focused Vitest route tests, plus a short measurement note in `agent_docs/learnings`

## Cache slice
- `/api/metrics`
  - key: `dashboard-aggregate:v1:metrics:<range>:<domain|all>:<event_type|all>`
  - TTL: 60 seconds
- `/api/broadcasts/[id]/metrics`
  - key: `dashboard-aggregate:v1:broadcast-metrics:<broadcast_id>`
  - TTL: 120 seconds

## Safety
- Postgres remains the source of truth on every cache miss
- cache read/write failures fall back to the existing DB path
- `x-namuh-cache: hit|miss` makes follow-up sampling measurable without widening scope into vendor work

## Verification
- `bunx biome check src/lib/cache/dashboard-aggregates.ts src/app/api/metrics/route.ts src/app/api/broadcasts/[id]/metrics/route.ts tests/metrics-route.test.ts tests/broadcast-metrics-route.test.ts`
- `bun run test -- tests/metrics-route.test.ts tests/broadcast-metrics-route.test.ts`
- `bun run typecheck`
