### PR TITLE
Issue #69: persist and retry webhook dispatch attempts

### DIFF
--- a/agent_docs/learnings/active/2026-04-28-issue-69-webhook-dispatcher-safe-slice.md
+++ b/agent_docs/learnings/active/2026-04-28-issue-69-webhook-dispatcher-safe-slice.md
@@ -1,0 +1,10 @@
+---
+date: 2026-04-28
+issue: 69
+type: decision
+promoted_to: null
+---
+
+For the first mergeable webhook-dispatcher slice, persist a `pending` delivery row before any outbound POST, then immediately hand that row to the dispatcher for the first attempt.
+
+Why: this keeps current customer-visible webhook behavior alive while introducing the durable delivery record and retry metadata needed for a later cron/worker-driven retry loop. If ingestion switches to queue-only before a dispatcher trigger exists in production, webhooks silently stop delivering. The safe incremental path is queue-first persistence plus best-effort immediate dispatch, with retries left pending for a later scheduler pass.

--- a/packages/core/src/db/repositories/webhookDeliveryRepo.ts
+++ b/packages/core/src/db/repositories/webhookDeliveryRepo.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, lt } from "drizzle-orm";
+import { and, asc, desc, eq, isNull, lt, lte, or } from "drizzle-orm";
 import { db } from "../client";
 import { webhookDeliveries } from "../schema";
 
@@ -48,16 +48,25 @@ export const webhookDeliveryRepo = {
     return { data, hasMore };
   },
 
-  async findPendingRetries() {
+  async findDispatchable(options: { limit?: number; now?: Date } = {}) {
+    const { limit = 25, now = new Date() } = options;
+
     return await db
       .select()
       .from(webhookDeliveries)
       .where(
         and(
           eq(webhookDeliveries.status, "pending"),
-          lt(webhookDeliveries.nextRetryAt, new Date()),
+          or(
+            isNull(webhookDeliveries.nextRetryAt),
+            lte(webhookDeliveries.nextRetryAt, now),
+          ),
         ),
       )
-      .orderBy(desc(webhookDeliveries.createdAt));
+      .orderBy(
+        asc(webhookDeliveries.nextRetryAt),
+        asc(webhookDeliveries.createdAt),
+      )
+      .limit(limit);
   },
 };

--- a/packages/ingester/src/dispatcher.ts
+++ b/packages/ingester/src/dispatcher.ts
@@ -1,26 +1,82 @@
 import {
-  type emailEvents,
+  emailEventRepo,
   signWebhookPayload,
   webhookDeliveryRepo,
   webhookRepo,
 } from "@namuh/core";
 
+const DEFAULT_RETRY_DELAYS_SECONDS = [10, 60, 300, 1800, 7200, 21600, 86400];
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_ATTEMPTS = DEFAULT_RETRY_DELAYS_SECONDS.length + 1;
+const RESPONSE_BODY_SNIPPET_LIMIT = 1_000;
+
+type WebhookDispatcherOptions = {
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+  retryDelaysSeconds?: number[];
+  maxAttempts?: number;
+  timeoutMs?: number;
+};
+
 export class WebhookDispatcher {
-  async dispatch(webhookId: string, event: typeof emailEvents.$inferSelect) {
-    const webhook = await webhookRepo.findById(webhookId);
-    if (!webhook || webhook.status !== "active") return;
+  private readonly fetchImpl: typeof fetch;
+  private readonly now: () => Date;
+  private readonly retryDelaysSeconds: number[];
+  private readonly maxAttempts: number;
+  private readonly timeoutMs: number;
 
-    const timestamp = Math.floor(Date.now() / 1000).toString();
-    const msgId = `wh_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+  constructor(options: WebhookDispatcherOptions = {}) {
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.now = options.now ?? (() => new Date());
+    this.retryDelaysSeconds =
+      options.retryDelaysSeconds ?? DEFAULT_RETRY_DELAYS_SECONDS;
+    this.maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
 
-    const webhookEventType = event.type.includes(".")
-      ? event.type
-      : `email.${event.type}`;
+  async enqueue(webhookId: string, eventId: string) {
+    return await webhookDeliveryRepo.create({
+      webhookId,
+      eventId,
+      status: "pending",
+      attempt: 0,
+      nextRetryAt: null,
+    });
+  }
 
+  async dispatchDelivery(deliveryId: string) {
+    const delivery = await webhookDeliveryRepo.findById(deliveryId);
+    if (!delivery) return null;
+
+    const [webhook, event] = await Promise.all([
+      webhookRepo.findById(delivery.webhookId),
+      emailEventRepo.findById(delivery.eventId),
+    ]);
+
+    if (!webhook) {
+      return await this.markTerminal(delivery, "Webhook not found");
+    }
+
+    if (webhook.status !== "active") {
+      return await this.markTerminal(delivery, "Webhook is disabled");
+    }
+
+    if (!event) {
+      return await this.markTerminal(delivery, "Webhook event not found");
+    }
+
+    const attemptedAt = this.now();
+    const attemptNumber = delivery.attempt + 1;
+    const timestamp = Math.floor(attemptedAt.getTime() / 1000).toString();
+    const msgId = `whd_${delivery.id}_${attemptNumber}`;
+    const eventType =
+      typeof event.type === "string" && event.type.includes(".")
+        ? event.type
+        : `email.${event.type}`;
     const body = JSON.stringify({
       id: msgId,
-      type: webhookEventType,
-      created_at: new Date().toISOString(),
+      type: eventType,
+      created_at: attemptedAt.toISOString(),
       data: event.payload,
     });
 
@@ -31,15 +87,8 @@ export class WebhookDispatcher {
       body,
     );
 
-    const delivery = await webhookDeliveryRepo.create({
-      webhookId: webhook.id,
-      eventId: event.id,
-      status: "pending",
-      attempt: 1,
-    });
-
     try {
-      const res = await fetch(webhook.url, {
+      const response = await this.fetchImpl(webhook.url, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -48,43 +97,96 @@ export class WebhookDispatcher {
           "svix-signature": signature,
         },
         body,
+        signal: AbortSignal.timeout(this.timeoutMs),
       });
 
-      const responseBody = await res.text();
+      const responseBody = this.toSnippet(await response.text());
+      const nextRetryAt = response.ok
+        ? null
+        : this.calculateNextRetry(attemptNumber);
+      const nextStatus = response.ok
+        ? "success"
+        : attemptNumber >= this.maxAttempts
+          ? "dead_letter"
+          : "pending";
 
-      await webhookDeliveryRepo.update(delivery.id, {
-        statusCode: res.status,
+      return await webhookDeliveryRepo.update(delivery.id, {
+        attempt: attemptNumber,
+        attemptedAt,
+        statusCode: response.status,
         responseBody,
-        status: res.ok ? "success" : "failed",
-        attemptedAt: new Date(),
-        nextRetryAt: res.ok ? null : this.calculateNextRetry(1),
+        status: nextStatus,
+        nextRetryAt: nextStatus === "pending" ? nextRetryAt : null,
       });
-
-      return {
-        statusCode: res.status,
-        success: res.ok,
-      };
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      await webhookDeliveryRepo.update(delivery.id, {
-        status: "failed",
-        responseBody: message,
-        attemptedAt: new Date(),
-        nextRetryAt: this.calculateNextRetry(1),
-      });
+      const message = this.toSnippet(
+        error instanceof Error ? error.message : String(error),
+      );
+      const nextStatus =
+        attemptNumber >= this.maxAttempts ? "dead_letter" : "pending";
 
-      return {
-        success: false,
-        error: message,
-      };
+      return await webhookDeliveryRepo.update(delivery.id, {
+        attempt: attemptNumber,
+        attemptedAt,
+        responseBody: message,
+        statusCode: null,
+        status: nextStatus,
+        nextRetryAt:
+          nextStatus === "pending"
+            ? this.calculateNextRetry(attemptNumber)
+            : null,
+      });
     }
   }
 
-  private calculateNextRetry(attempt: number): Date {
-    // 10s, 1m, 5m, 30m, 2h, 6h, 24h
-    const intervals = [10, 60, 300, 1800, 7200, 21600, 86400];
-    const seconds = intervals[attempt - 1] || 86400;
-    return new Date(Date.now() + seconds * 1000);
+  async dispatchPendingDeliveries(
+    options: { limit?: number; now?: Date } = {},
+  ) {
+    const deliveries = await webhookDeliveryRepo.findDispatchable(options);
+
+    const results = [];
+    for (const delivery of deliveries) {
+      const result = await this.dispatchDelivery(delivery.id);
+      if (result) {
+        results.push(result);
+      }
+    }
+
+    return {
+      processed: results.length,
+      results,
+    };
+  }
+
+  private calculateNextRetry(attemptNumber: number): Date {
+    const seconds =
+      this.retryDelaysSeconds[attemptNumber - 1] ??
+      this.retryDelaysSeconds[this.retryDelaysSeconds.length - 1] ??
+      86_400;
+
+    return new Date(this.now().getTime() + seconds * 1_000);
+  }
+
+  private async markTerminal(
+    delivery: {
+      id: string;
+      attempt: number;
+    },
+    message: string,
+  ) {
+    return await webhookDeliveryRepo.update(delivery.id, {
+      attempt: delivery.attempt,
+      status: "failed",
+      responseBody: this.toSnippet(message),
+      statusCode: null,
+      nextRetryAt: null,
+    });
+  }
+
+  private toSnippet(value: string) {
+    return value.length > RESPONSE_BODY_SNIPPET_LIMIT
+      ? `${value.slice(0, RESPONSE_BODY_SNIPPET_LIMIT)}…`
+      : value;
   }
 }
 

--- a/packages/ingester/src/index.ts
+++ b/packages/ingester/src/index.ts
@@ -80,8 +80,12 @@ app.post("/events/ses", async (c) => {
           types.includes(event.type) ||
           types.includes(webhookEventType))
       ) {
-        webhookDispatcher.dispatch(hook.id, event).catch((err) => {
-          console.error(`Error dispatching webhook ${hook.id}:`, err);
+        const delivery = await webhookDispatcher.enqueue(hook.id, event.id);
+        webhookDispatcher.dispatchDelivery(delivery.id).catch((err) => {
+          console.error(
+            `Error dispatching webhook delivery ${delivery.id}:`,
+            err,
+          );
         });
       }
     }

--- a/tests/ingester-ses-route.test.ts
+++ b/tests/ingester-ses-route.test.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockCreateOrIgnoreDuplicate = vi.fn();
 const mockWebhookList = vi.fn();
-const mockDispatch = vi.fn();
+const mockEnqueue = vi.fn();
+const mockDispatchDelivery = vi.fn();
 
 vi.mock("@namuh/core", () => ({
   emailEventRepo: {
@@ -60,7 +61,8 @@ vi.mock("hono", () => {
 
 vi.mock("../packages/ingester/src/dispatcher", () => ({
   webhookDispatcher: {
-    dispatch: mockDispatch,
+    enqueue: mockEnqueue,
+    dispatchDelivery: mockDispatchDelivery,
   },
 }));
 
@@ -152,7 +154,8 @@ describe("SES SNS ingestion route", () => {
     vi.resetModules();
     vi.clearAllMocks();
 
-    mockDispatch.mockResolvedValue(undefined);
+    mockEnqueue.mockResolvedValue({ id: "delivery-1" });
+    mockDispatchDelivery.mockResolvedValue(undefined);
     mockWebhookList.mockResolvedValue({
       data: [
         {
@@ -205,7 +208,8 @@ describe("SES SNS ingestion route", () => {
       type: "delivered",
       payload: { smtpResponse: "250 ok" },
     });
-    expect(mockDispatch).toHaveBeenCalledWith("hook-1", persistedEvent);
+    expect(mockEnqueue).toHaveBeenCalledWith("hook-1", persistedEvent.id);
+    expect(mockDispatchDelivery).toHaveBeenCalledWith("delivery-1");
   });
 
   it("rejects invalid SNS signatures before touching persistence", async () => {
@@ -229,7 +233,8 @@ describe("SES SNS ingestion route", () => {
       "SNS signature verification failed",
     );
     expect(mockCreateOrIgnoreDuplicate).not.toHaveBeenCalled();
-    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(mockEnqueue).not.toHaveBeenCalled();
+    expect(mockDispatchDelivery).not.toHaveBeenCalled();
   });
 
   it("acks duplicate SNS notifications without re-dispatching downstream webhooks", async () => {
@@ -257,7 +262,8 @@ describe("SES SNS ingestion route", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(mockEnqueue).not.toHaveBeenCalled();
+    expect(mockDispatchDelivery).not.toHaveBeenCalled();
     expect(mockWebhookList).not.toHaveBeenCalled();
   });
 

--- a/tests/webhook-dispatcher.test.ts
+++ b/tests/webhook-dispatcher.test.ts
@@ -1,0 +1,338 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCreate = vi.fn();
+const mockFindById = vi.fn();
+const mockUpdate = vi.fn();
+const mockFindDispatchable = vi.fn();
+const mockFindWebhookById = vi.fn();
+const mockFindEventById = vi.fn();
+const mockSignWebhookPayload = vi.fn();
+
+vi.mock("@namuh/core", () => ({
+  emailEventRepo: {
+    findById: mockFindEventById,
+  },
+  signWebhookPayload: mockSignWebhookPayload,
+  webhookDeliveryRepo: {
+    create: mockCreate,
+    findById: mockFindById,
+    update: mockUpdate,
+    findDispatchable: mockFindDispatchable,
+  },
+  webhookRepo: {
+    findById: mockFindWebhookById,
+  },
+}));
+
+describe("WebhookDispatcher", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+
+    mockCreate.mockImplementation(async (data) => ({
+      id: "delivery-new",
+      ...data,
+    }));
+    mockFindDispatchable.mockResolvedValue([]);
+    mockSignWebhookPayload.mockReturnValue("v1,test-signature");
+  });
+
+  it("enqueues a pending delivery with zero attempts", async () => {
+    const { WebhookDispatcher } = await import(
+      "../packages/ingester/src/dispatcher"
+    );
+    const dispatcher = new WebhookDispatcher();
+
+    const delivery = await dispatcher.enqueue("hook-1", "event-1");
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      webhookId: "hook-1",
+      eventId: "event-1",
+      status: "pending",
+      attempt: 0,
+      nextRetryAt: null,
+    });
+    expect(delivery).toMatchObject({
+      id: "delivery-new",
+      webhookId: "hook-1",
+      eventId: "event-1",
+    });
+  });
+
+  it("dispatches a signed webhook and records a successful attempt", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-28T00:00:00.000Z"));
+
+    mockFindById.mockResolvedValue({
+      id: "delivery-1",
+      webhookId: "hook-1",
+      eventId: "event-1",
+      attempt: 0,
+      status: "pending",
+    });
+    mockFindWebhookById.mockResolvedValue({
+      id: "hook-1",
+      url: "https://example.com/webhook",
+      status: "active",
+      signingSecret: "whsec_test_secret",
+    });
+    mockFindEventById.mockResolvedValue({
+      id: "event-1",
+      type: "delivered",
+      payload: { smtpResponse: "250 ok" },
+    });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => "accepted",
+    });
+    mockUpdate.mockImplementation(async (_id, data) => ({
+      id: "delivery-1",
+      ...data,
+    }));
+
+    const { WebhookDispatcher } = await import(
+      "../packages/ingester/src/dispatcher"
+    );
+    const dispatcher = new WebhookDispatcher({ fetchImpl: fetchMock });
+
+    const result = await dispatcher.dispatchDelivery("delivery-1");
+
+    expect(mockSignWebhookPayload).toHaveBeenCalledWith(
+      "whsec_test_secret",
+      "whd_delivery-1_1",
+      "1777334400",
+      JSON.stringify({
+        id: "whd_delivery-1_1",
+        type: "email.delivered",
+        created_at: "2026-04-28T00:00:00.000Z",
+        data: { smtpResponse: "250 ok" },
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith("https://example.com/webhook", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "svix-id": "whd_delivery-1_1",
+        "svix-timestamp": "1777334400",
+        "svix-signature": "v1,test-signature",
+      },
+      body: JSON.stringify({
+        id: "whd_delivery-1_1",
+        type: "email.delivered",
+        created_at: "2026-04-28T00:00:00.000Z",
+        data: { smtpResponse: "250 ok" },
+      }),
+      signal: expect.any(AbortSignal),
+    });
+    expect(mockUpdate).toHaveBeenCalledWith(
+      "delivery-1",
+      expect.objectContaining({
+        attempt: 1,
+        status: "success",
+        statusCode: 200,
+        responseBody: "accepted",
+        nextRetryAt: null,
+        attemptedAt: new Date("2026-04-28T00:00:00.000Z"),
+      }),
+    );
+    expect(result).toMatchObject({ status: "success", attempt: 1 });
+  });
+
+  it("schedules the first retry after a failed response", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-28T00:00:00.000Z"));
+
+    mockFindById.mockResolvedValue({
+      id: "delivery-2",
+      webhookId: "hook-2",
+      eventId: "event-2",
+      attempt: 0,
+      status: "pending",
+    });
+    mockFindWebhookById.mockResolvedValue({
+      id: "hook-2",
+      url: "https://example.com/fail",
+      status: "active",
+      signingSecret: "whsec_test_secret",
+    });
+    mockFindEventById.mockResolvedValue({
+      id: "event-2",
+      type: "bounced",
+      payload: { reason: "smtp 500" },
+    });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => "server error",
+    });
+    mockUpdate.mockImplementation(async (_id, data) => ({
+      id: "delivery-2",
+      ...data,
+    }));
+
+    const { WebhookDispatcher } = await import(
+      "../packages/ingester/src/dispatcher"
+    );
+    const dispatcher = new WebhookDispatcher({ fetchImpl: fetchMock });
+
+    const result = await dispatcher.dispatchDelivery("delivery-2");
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      "delivery-2",
+      expect.objectContaining({
+        attempt: 1,
+        status: "pending",
+        statusCode: 500,
+        responseBody: "server error",
+        nextRetryAt: new Date("2026-04-28T00:00:10.000Z"),
+      }),
+    );
+    expect(result).toMatchObject({ status: "pending", attempt: 1 });
+  });
+
+  it("marks a delivery dead-letter when the final attempt throws", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-28T00:00:00.000Z"));
+
+    mockFindById.mockResolvedValue({
+      id: "delivery-3",
+      webhookId: "hook-3",
+      eventId: "event-3",
+      attempt: 1,
+      status: "pending",
+    });
+    mockFindWebhookById.mockResolvedValue({
+      id: "hook-3",
+      url: "https://example.com/timeout",
+      status: "active",
+      signingSecret: "whsec_test_secret",
+    });
+    mockFindEventById.mockResolvedValue({
+      id: "event-3",
+      type: "complained",
+      payload: { reason: "abuse" },
+    });
+    const fetchMock = vi.fn().mockRejectedValue(new Error("timeout"));
+    mockUpdate.mockImplementation(async (_id, data) => ({
+      id: "delivery-3",
+      ...data,
+    }));
+
+    const { WebhookDispatcher } = await import(
+      "../packages/ingester/src/dispatcher"
+    );
+    const dispatcher = new WebhookDispatcher({
+      fetchImpl: fetchMock,
+      maxAttempts: 2,
+      retryDelaysSeconds: [10],
+    });
+
+    const result = await dispatcher.dispatchDelivery("delivery-3");
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      "delivery-3",
+      expect.objectContaining({
+        attempt: 2,
+        status: "dead_letter",
+        statusCode: null,
+        responseBody: "timeout",
+        nextRetryAt: null,
+      }),
+    );
+    expect(result).toMatchObject({ status: "dead_letter", attempt: 2 });
+  });
+
+  it("marks disabled webhooks terminal without sending", async () => {
+    mockFindById.mockResolvedValue({
+      id: "delivery-4",
+      webhookId: "hook-4",
+      eventId: "event-4",
+      attempt: 0,
+      status: "pending",
+    });
+    mockFindWebhookById.mockResolvedValue({
+      id: "hook-4",
+      url: "https://example.com/disabled",
+      status: "disabled",
+      signingSecret: "whsec_test_secret",
+    });
+    const fetchMock = vi.fn();
+    mockUpdate.mockImplementation(async (_id, data) => ({
+      id: "delivery-4",
+      ...data,
+    }));
+
+    const { WebhookDispatcher } = await import(
+      "../packages/ingester/src/dispatcher"
+    );
+    const dispatcher = new WebhookDispatcher({ fetchImpl: fetchMock });
+
+    const result = await dispatcher.dispatchDelivery("delivery-4");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mockUpdate).toHaveBeenCalledWith(
+      "delivery-4",
+      expect.objectContaining({
+        status: "failed",
+        responseBody: "Webhook is disabled",
+        nextRetryAt: null,
+      }),
+    );
+    expect(result).toMatchObject({ status: "failed" });
+  });
+
+  it("loads and processes dispatchable pending deliveries", async () => {
+    mockFindDispatchable.mockResolvedValue([
+      { id: "delivery-a" },
+      { id: "delivery-b" },
+    ]);
+    mockFindById
+      .mockResolvedValueOnce({
+        id: "delivery-a",
+        webhookId: "hook-a",
+        eventId: "event-a",
+        attempt: 0,
+        status: "pending",
+      })
+      .mockResolvedValueOnce({
+        id: "delivery-b",
+        webhookId: "hook-b",
+        eventId: "event-b",
+        attempt: 0,
+        status: "pending",
+      });
+    mockFindWebhookById
+      .mockResolvedValueOnce({
+        id: "hook-a",
+        url: "https://example.com/a",
+        status: "active",
+        signingSecret: "whsec_test_secret",
+      })
+      .mockResolvedValueOnce({
+        id: "hook-b",
+        url: "https://example.com/b",
+        status: "active",
+        signingSecret: "whsec_test_secret",
+      });
+    mockFindEventById
+      .mockResolvedValueOnce({ id: "event-a", type: "delivered", payload: {} })
+      .mockResolvedValueOnce({ id: "event-b", type: "bounced", payload: {} });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, status: 200, text: async () => "ok" });
+    mockUpdate.mockImplementation(async (id, data) => ({ id, ...data }));
+
+    const { WebhookDispatcher } = await import(
+      "../packages/ingester/src/dispatcher"
+    );
+    const dispatcher = new WebhookDispatcher({ fetchImpl: fetchMock });
+
+    const result = await dispatcher.dispatchPendingDeliveries({ limit: 2 });
+
+    expect(mockFindDispatchable).toHaveBeenCalledWith({ limit: 2 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.processed).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- enqueue a durable `webhook_deliveries` row before dispatch and preserve immediate first-attempt delivery
- reload pending deliveries through the dispatcher so each attempt persists status/body snippet, retry timing, and dead-letter state
- add focused tests for enqueue-on-ingest, signed POST dispatch, disabled hooks, first retry scheduling, pending-loader processing, and terminal failure

## Verification
- `./node_modules/.bin/biome check packages/core/src/db/repositories/webhookDeliveryRepo.ts packages/ingester/src/dispatcher.ts packages/ingester/src/index.ts tests/ingester-ses-route.test.ts tests/webhook-dispatcher.test.ts`
- `./node_modules/.bin/vitest run tests/ingester-ses-route.test.ts tests/webhook-dispatcher.test.ts`
- `./node_modules/.bin/tsc --noEmit`

## Residuals
- `dispatchPendingDeliveries()` is implemented but not yet wired to a cron/deployment trigger; issue #70 should own runtime wiring
- no manual replay/admin recovery surface in this slice
- no stronger claim/lock semantics for multiple concurrent retry workers yet

Closes #69
