### PR TITLE
Close #73: add domain lookup cache invalidation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,7 @@ DASHBOARD_KEY=
 # RATE_LIMIT_BACKEND=redis      # required for shared/staging/production instances
 # REDIS_URL=rediss://default:password@your-cache-endpoint:6379
 # Use the TLS-enabled ElastiCache/Redis endpoint (`rediss://...`) when RATE_LIMIT_BACKEND=redis.
+# REDIS_URL also backs API-key auth caching and domain metadata caching.
 
 # ── AWS SES (Email Sending) ─────────────────────────────────────
 # Required for sending emails. Uses ~/.aws/credentials locally,

--- a/README.md
+++ b/README.md
@@ -200,6 +200,17 @@ Namuh Send now treats API rate limiting as an explicit runtime contract:
 
 For AWS ElastiCache, enable **in-transit encryption** on the replication group/serverless cache and use the TLS endpoint that AWS exposes. AWS documents both the `TransitEncryptionEnabled=true` requirement and TLS client connections to the primary/configuration endpoint.
 
+### Redis-backed auth/domain metadata cache
+
+The same `REDIS_URL` is also used for hot-path metadata caching:
+
+- API key auth lookups are cached by token hash for 5 minutes.
+- Domain DB detail lookups are cached by domain id for 5 minutes.
+- SES domain identity lookups are cached by domain name for 2 minutes.
+- API key create/delete and domain create/update/delete/verify/auto-configure flows invalidate affected cache entries immediately.
+
+Local dev stays safe if Redis is absent: requests fall back to Postgres/SES as the source of truth. In staging/production, point `REDIS_URL` at a shared TLS-enabled Redis/ElastiCache endpoint so multiple app instances see the same cache state.
+
 Quick verification after deploy:
 
 ```bash

--- a/agent_docs/learnings/active/2026-04-28-issue-73-cache-invalidation-scope.md
+++ b/agent_docs/learnings/active/2026-04-28-issue-73-cache-invalidation-scope.md
@@ -1,0 +1,19 @@
+---
+date: 2026-04-28
+issue: "#73"
+type: decision
+promoted_to: null
+---
+
+## Cache only reusable metadata, and invalidate on every mutation path
+
+For issue #73, keep Redis caching scoped to metadata that already has a clear authoritative source (`api_keys`, `domains`, SES identity status), rather than introducing speculative request/result caches.
+
+That means:
+
+- API key auth stays cached by token hash.
+- Domain DB lookups are cached by domain id.
+- SES identity lookups are cached by domain name.
+- Every practical API key/domain mutation route explicitly invalidates the affected cache entries right after the write.
+
+This keeps stale-read windows short without expanding into rate limiting or analytics cache ownership.

--- a/src/app/api/api-keys/[id]/route.ts
+++ b/src/app/api/api-keys/[id]/route.ts
@@ -1,4 +1,8 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import {
+  invalidateApiKeyAuthCache,
+  unauthorizedResponse,
+  validateApiKey,
+} from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { apiKeys } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -49,14 +53,22 @@ export async function DELETE(
 
   const { id } = await params;
   try {
+    const [existing] = await db
+      .select({ tokenHash: apiKeys.tokenHash })
+      .from(apiKeys)
+      .where(eq(apiKeys.id, id))
+      .limit(1);
+
+    if (!existing) {
+      return Response.json({ error: "API key not found" }, { status: 404 });
+    }
+
     const [deleted] = await db
       .delete(apiKeys)
       .where(eq(apiKeys.id, id))
       .returning({ id: apiKeys.id });
 
-    if (!deleted) {
-      return Response.json({ error: "API key not found" }, { status: 404 });
-    }
+    await invalidateApiKeyAuthCache(existing.tokenHash);
 
     return new Response(null, { status: 200 });
   } catch (err) {

--- a/src/app/api/api-keys/route.ts
+++ b/src/app/api/api-keys/route.ts
@@ -1,5 +1,9 @@
 import { createHash, randomUUID } from "node:crypto";
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import {
+  invalidateApiKeyAuthCache,
+  unauthorizedResponse,
+  validateApiKey,
+} from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { apiKeys } from "@/lib/db/schema";
 import { and, desc, lt } from "drizzle-orm";
@@ -100,6 +104,8 @@ export async function POST(request: Request): Promise<Response> {
         domain: body.domain_id ?? null,
       })
       .returning();
+
+    await invalidateApiKeyAuthCache(created.tokenHash);
 
     return Response.json(
       {

--- a/src/app/api/domains/[id]/auto-configure/route.ts
+++ b/src/app/api/domains/[id]/auto-configure/route.ts
@@ -2,7 +2,12 @@ import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { autoConfigureDomain } from "@/lib/cloudflare";
 import { db } from "@/lib/db";
 import { domains } from "@/lib/db/schema";
-import { createDomainIdentity, getDomainIdentity } from "@/lib/ses";
+import {
+  getCachedDomainById,
+  getCachedDomainIdentity,
+  invalidateDomainCaches,
+} from "@/lib/domain-cache";
+import { createDomainIdentity } from "@/lib/ses";
 import { autoConfigureDomainParamsSchema } from "@/lib/validation/domains";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
@@ -25,24 +30,18 @@ export async function POST(
   const { id } = parsedParams.data;
 
   try {
-    const rows = await db
-      .select()
-      .from(domains)
-      .where(eq(domains.id, id))
-      .limit(1);
+    const domain = await getCachedDomainById(id);
 
-    if (rows.length === 0) {
+    if (!domain) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
-
-    const domain = rows[0];
 
     let dkimTokens: string[];
     try {
       const identity = await createDomainIdentity(domain.name);
       dkimTokens = identity.dkimTokens;
     } catch {
-      const existing = await getDomainIdentity(domain.name);
+      const existing = await getCachedDomainIdentity(domain.name);
       dkimTokens = existing.dkimTokens;
     }
 
@@ -67,6 +66,8 @@ export async function POST(
         status: "pending",
       })
       .where(eq(domains.id, id));
+
+    await invalidateDomainCaches({ id, name: domain.name });
 
     return NextResponse.json({
       ok: true,

--- a/src/app/api/domains/[id]/route.ts
+++ b/src/app/api/domains/[id]/route.ts
@@ -2,6 +2,10 @@ import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { deleteDNSRecord, listDNSRecords } from "@/lib/cloudflare";
 import { db } from "@/lib/db";
 import { domains } from "@/lib/db/schema";
+import {
+  getCachedDomainById,
+  invalidateDomainCaches,
+} from "@/lib/domain-cache";
 import { deleteDomainIdentity } from "@/lib/ses";
 import {
   domainRouteParamsSchema,
@@ -32,11 +36,7 @@ export async function GET(
 
   try {
     const { id } = parsedParams.data;
-    const [domain] = await db
-      .select()
-      .from(domains)
-      .where(eq(domains.id, id))
-      .limit(1);
+    const domain = await getCachedDomainById(id);
 
     if (!domain) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -99,6 +99,11 @@ export async function PATCH(
     const { id } = parsedParams.data;
     const validated = result.data;
     const updates: Record<string, unknown> = {};
+    const existingDomain = await getCachedDomainById(id);
+
+    if (!existingDomain) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
 
     if (validated.click_tracking !== undefined) {
       updates.trackClicks = validated.click_tracking;
@@ -116,31 +121,20 @@ export async function PATCH(
       validated.sending_enabled !== undefined ||
       validated.receiving_enabled !== undefined
     ) {
-      const [existing] = await db
-        .select({ capabilities: domains.capabilities })
-        .from(domains)
-        .where(eq(domains.id, id))
-        .limit(1);
-
-      if (existing) {
-        const currentCaps = existing.capabilities || defaultCapabilities;
-        const newCaps = currentCaps.map((cap) => {
-          if (
-            cap.name === "sending" &&
-            validated.sending_enabled !== undefined
-          ) {
-            return { ...cap, enabled: validated.sending_enabled };
-          }
-          if (
-            cap.name === "receiving" &&
-            validated.receiving_enabled !== undefined
-          ) {
-            return { ...cap, enabled: validated.receiving_enabled };
-          }
-          return cap;
-        });
-        updates.capabilities = newCaps;
-      }
+      const currentCaps = existingDomain.capabilities || defaultCapabilities;
+      const newCaps = currentCaps.map((cap) => {
+        if (cap.name === "sending" && validated.sending_enabled !== undefined) {
+          return { ...cap, enabled: validated.sending_enabled };
+        }
+        if (
+          cap.name === "receiving" &&
+          validated.receiving_enabled !== undefined
+        ) {
+          return { ...cap, enabled: validated.receiving_enabled };
+        }
+        return cap;
+      });
+      updates.capabilities = newCaps;
     }
 
     if (validated.tls !== undefined) {
@@ -154,8 +148,11 @@ export async function PATCH(
       .returning();
 
     if (!updated) {
+      await invalidateDomainCaches({ id, name: existingDomain.name });
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
+
+    await invalidateDomainCaches({ id: updated.id, name: updated.name });
 
     return NextResponse.json({
       object: "domain",
@@ -187,12 +184,7 @@ export async function DELETE(
 
   try {
     const { id } = parsedParams.data;
-
-    const [domain] = await db
-      .select({ name: domains.name })
-      .from(domains)
-      .where(eq(domains.id, id))
-      .limit(1);
+    const domain = await getCachedDomainById(id);
 
     if (!domain) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -207,13 +199,13 @@ export async function DELETE(
     try {
       const records = await listDNSRecords({ name: domain.name });
       const sesRecords = records.filter(
-        (r) =>
-          r.content.includes("amazonses.com") ||
-          r.name.includes("_domainkey") ||
-          r.content.startsWith("v=spf1"),
+        (record) =>
+          record.content.includes("amazonses.com") ||
+          record.name.includes("_domainkey") ||
+          record.content.startsWith("v=spf1"),
       );
 
-      await Promise.all(sesRecords.map((r) => deleteDNSRecord(r.id)));
+      await Promise.all(sesRecords.map((record) => deleteDNSRecord(record.id)));
     } catch (cfErr) {
       console.warn(
         `Failed to cleanup Cloudflare records for ${domain.name}:`,
@@ -225,6 +217,12 @@ export async function DELETE(
       .delete(domains)
       .where(eq(domains.id, id))
       .returning({ id: domains.id });
+
+    await invalidateDomainCaches({ id, name: domain.name });
+
+    if (!deleted) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
 
     return NextResponse.json({
       object: "domain",

--- a/src/app/api/domains/[id]/verify/route.ts
+++ b/src/app/api/domains/[id]/verify/route.ts
@@ -1,8 +1,12 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { domains } from "@/lib/db/schema";
+import {
+  getCachedDomainById,
+  getCachedDomainIdentity,
+  invalidateDomainCaches,
+} from "@/lib/domain-cache";
 import { queueEvent } from "@/lib/events";
-import { getDomainIdentity } from "@/lib/ses";
 import { verifyDomainParamsSchema } from "@/lib/validation/domains";
 import { eq } from "drizzle-orm";
 
@@ -24,15 +28,13 @@ export async function POST(
   const { id } = parsedParams.data;
 
   try {
-    const domain = await db.query.domains.findFirst({
-      where: eq(domains.id, id),
-    });
+    const domain = await getCachedDomainById(id);
 
     if (!domain) {
       return Response.json({ error: "Domain not found" }, { status: 404 });
     }
 
-    const identity = await getDomainIdentity(domain.name);
+    const identity = await getCachedDomainIdentity(domain.name);
 
     let verificationStatus:
       | "pending"
@@ -73,6 +75,13 @@ export async function POST(
       })
       .where(eq(domains.id, id))
       .returning();
+
+    if (!updated) {
+      await invalidateDomainCaches({ id, name: domain.name });
+      return Response.json({ error: "Domain not found" }, { status: 404 });
+    }
+
+    await invalidateDomainCaches({ id: updated.id, name: updated.name });
 
     if (updated.status !== previousStatus) {
       await queueEvent({

--- a/src/app/api/domains/route.ts
+++ b/src/app/api/domains/route.ts
@@ -1,6 +1,7 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { domains } from "@/lib/db/schema";
+import { invalidateDomainCaches } from "@/lib/domain-cache";
 import { createDomainIdentity } from "@/lib/ses";
 import { createDomainSchema } from "@/lib/validation/domains";
 import { and, desc, lt } from "drizzle-orm";
@@ -79,6 +80,8 @@ export async function POST(request: Request) {
         capabilities: validated.capabilities || defaultCapabilities,
       })
       .returning();
+
+    await invalidateDomainCaches({ id: row.id, name: row.name });
 
     return NextResponse.json(
       {

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { getCached, setCache } from "@/lib/cache/redis";
+import { deleteCache, readCache, writeCache } from "@/lib/cache/redis";
 import { db } from "@/lib/db";
 import { apiKeys } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -11,6 +11,38 @@ export interface AuthResult {
   permission: string;
   domain: string | null;
   userId: string | null;
+}
+
+const API_KEY_AUTH_CACHE_TTL_SECONDS = 300;
+
+function getApiKeyAuthCacheKeyFromHash(tokenHash: string): string {
+  return `auth:apikey:${tokenHash}`;
+}
+
+function logApiKeyCache(
+  event: "hit" | "miss" | "unavailable" | "error" | "write" | "invalidate",
+  tokenHash: string,
+) {
+  console.info("[cache][api-key-auth]", {
+    event,
+    tokenHashPrefix: tokenHash.slice(0, 12),
+  });
+}
+
+export async function invalidateApiKeyAuthCache(
+  tokenHash: string | null | undefined,
+): Promise<void> {
+  if (!tokenHash) return;
+
+  const status = await deleteCache(getApiKeyAuthCacheKeyFromHash(tokenHash));
+  logApiKeyCache(
+    status === "deleted"
+      ? "invalidate"
+      : status === "unavailable"
+        ? "unavailable"
+        : "error",
+    tokenHash,
+  );
 }
 
 /**
@@ -29,11 +61,12 @@ export async function validateApiKey(
   if (!rawKey) return null;
 
   const hashedKey = createHash("sha256").update(rawKey).digest("hex");
-  const cacheKey = `auth:apikey:${hashedKey}`;
+  const cacheKey = getApiKeyAuthCacheKeyFromHash(hashedKey);
 
   // 1. Try Cache
-  const cached = await getCached<AuthResult>(cacheKey);
-  if (cached) return cached;
+  const cached = await readCache<AuthResult>(cacheKey);
+  logApiKeyCache(cached.status, hashedKey);
+  if (cached.status === "hit") return cached.value;
 
   // 2. Try DB
   const found = await db.query.apiKeys.findFirst({
@@ -50,7 +83,19 @@ export async function validateApiKey(
   };
 
   // 3. Set Cache (5 min TTL)
-  await setCache(cacheKey, result, 300);
+  const writeStatus = await writeCache(
+    cacheKey,
+    result,
+    API_KEY_AUTH_CACHE_TTL_SECONDS,
+  );
+  logApiKeyCache(
+    writeStatus === "written"
+      ? "write"
+      : writeStatus === "unavailable"
+        ? "unavailable"
+        : "error",
+    hashedKey,
+  );
 
   // Background update lastUsedAt to avoid blocking the request
   // Only update once per minute to avoid write amplification

--- a/src/lib/cache/redis.ts
+++ b/src/lib/cache/redis.ts
@@ -6,6 +6,10 @@ export type RateLimitBackend = (typeof RATE_LIMIT_BACKENDS)[number];
 
 type RedisClient = RedisClientType;
 
+export type CacheReadStatus = "hit" | "miss" | "unavailable" | "error";
+export type CacheWriteStatus = "written" | "unavailable" | "error";
+export type CacheDeleteStatus = "deleted" | "unavailable" | "error";
+
 let client: RedisClient | null = null;
 let connectPromise: Promise<RedisClient | null> | null = null;
 const loggedMessages = new Set<string>();
@@ -75,15 +79,43 @@ async function getConnectedClient(): Promise<RedisClient | null> {
   return connectPromise;
 }
 
-export async function getCached<T>(key: string): Promise<T | null> {
+export async function readCache<T>(
+  key: string,
+): Promise<{ status: CacheReadStatus; value: T | null }> {
   const redisClient = await getConnectedClient();
-  if (!redisClient) return null;
+  if (!redisClient) {
+    return { status: "unavailable", value: null };
+  }
 
   try {
     const value = await redisClient.get(key);
-    return value ? (JSON.parse(value) as T) : null;
+    if (!value) {
+      return { status: "miss", value: null };
+    }
+    return { status: "hit", value: JSON.parse(value) as T };
   } catch {
-    return null;
+    return { status: "error", value: null };
+  }
+}
+
+export async function getCached<T>(key: string): Promise<T | null> {
+  const { value } = await readCache<T>(key);
+  return value;
+}
+
+export async function writeCache(
+  key: string,
+  value: unknown,
+  ttlSeconds = 300,
+): Promise<CacheWriteStatus> {
+  const redisClient = await getConnectedClient();
+  if (!redisClient) return "unavailable";
+
+  try {
+    await redisClient.set(key, JSON.stringify(value), { EX: ttlSeconds });
+    return "written";
+  } catch {
+    return "error";
   }
 }
 
@@ -92,14 +124,7 @@ export async function setCache(
   value: unknown,
   ttlSeconds = 300,
 ): Promise<void> {
-  const redisClient = await getConnectedClient();
-  if (!redisClient) return;
-
-  try {
-    await redisClient.set(key, JSON.stringify(value), { EX: ttlSeconds });
-  } catch {
-    // Fail silently - cache is optional
-  }
+  await writeCache(key, value, ttlSeconds);
 }
 
 export async function incrCache(
@@ -138,12 +163,17 @@ export async function getTtl(key: string): Promise<number | null> {
 }
 
 export async function invalidateCache(key: string): Promise<void> {
+  await deleteCache(key);
+}
+
+export async function deleteCache(key: string): Promise<CacheDeleteStatus> {
   const redisClient = await getConnectedClient();
-  if (!redisClient) return;
+  if (!redisClient) return "unavailable";
 
   try {
     await redisClient.del(key);
+    return "deleted";
   } catch {
-    // Fail silently
+    return "error";
   }
 }

--- a/src/lib/domain-cache.ts
+++ b/src/lib/domain-cache.ts
@@ -1,0 +1,139 @@
+import { deleteCache, readCache, writeCache } from "@/lib/cache/redis";
+import { db } from "@/lib/db";
+import { domains } from "@/lib/db/schema";
+import { type GetDomainResult, getDomainIdentity } from "@/lib/ses";
+import { eq } from "drizzle-orm";
+
+const DOMAIN_DB_CACHE_TTL_SECONDS = 300;
+const DOMAIN_IDENTITY_CACHE_TTL_SECONDS = 120;
+
+type DomainRow = typeof domains.$inferSelect;
+
+function getDomainByIdCacheKey(id: string): string {
+  return `domain:by-id:${id}`;
+}
+
+function getDomainIdentityCacheKey(domainName: string): string {
+  return `domain:identity:${domainName.trim().toLowerCase()}`;
+}
+
+function logDomainCache(
+  scope: "db" | "identity",
+  event: "hit" | "miss" | "unavailable" | "error" | "write" | "invalidate",
+  detail: string,
+) {
+  console.info(`[cache][domain:${scope}]`, {
+    event,
+    detail,
+  });
+}
+
+export async function getCachedDomainById(
+  id: string,
+): Promise<DomainRow | null> {
+  const cacheKey = getDomainByIdCacheKey(id);
+  const cached = await readCache<DomainRow>(cacheKey);
+  logDomainCache("db", cached.status, id);
+
+  if (cached.status === "hit") {
+    return cached.value;
+  }
+
+  const domain = await db.query.domains.findFirst({
+    where: eq(domains.id, id),
+  });
+
+  if (!domain) {
+    return null;
+  }
+
+  const writeStatus = await writeCache(
+    cacheKey,
+    domain,
+    DOMAIN_DB_CACHE_TTL_SECONDS,
+  );
+  logDomainCache(
+    "db",
+    writeStatus === "written"
+      ? "write"
+      : writeStatus === "unavailable"
+        ? "unavailable"
+        : "error",
+    id,
+  );
+
+  return domain;
+}
+
+export async function getCachedDomainIdentity(
+  domainName: string,
+): Promise<GetDomainResult> {
+  const normalizedName = domainName.trim().toLowerCase();
+  const cacheKey = getDomainIdentityCacheKey(normalizedName);
+  const cached = await readCache<GetDomainResult>(cacheKey);
+  logDomainCache("identity", cached.status, normalizedName);
+
+  if (cached.status === "hit" && cached.value) {
+    return cached.value;
+  }
+
+  const identity = await getDomainIdentity(normalizedName);
+  const writeStatus = await writeCache(
+    cacheKey,
+    identity,
+    DOMAIN_IDENTITY_CACHE_TTL_SECONDS,
+  );
+  logDomainCache(
+    "identity",
+    writeStatus === "written"
+      ? "write"
+      : writeStatus === "unavailable"
+        ? "unavailable"
+        : "error",
+    normalizedName,
+  );
+  return identity;
+}
+
+export async function invalidateDomainByIdCache(id: string): Promise<void> {
+  const status = await deleteCache(getDomainByIdCacheKey(id));
+  logDomainCache(
+    "db",
+    status === "deleted"
+      ? "invalidate"
+      : status === "unavailable"
+        ? "unavailable"
+        : "error",
+    id,
+  );
+}
+
+export async function invalidateDomainIdentityCache(
+  domainName: string | null | undefined,
+): Promise<void> {
+  if (!domainName) return;
+
+  const normalizedName = domainName.trim().toLowerCase();
+  const status = await deleteCache(getDomainIdentityCacheKey(normalizedName));
+  logDomainCache(
+    "identity",
+    status === "deleted"
+      ? "invalidate"
+      : status === "unavailable"
+        ? "unavailable"
+        : "error",
+    normalizedName,
+  );
+}
+
+export async function invalidateDomainCaches(params: {
+  id?: string | null;
+  name?: string | null;
+}): Promise<void> {
+  await Promise.all([
+    params.id ? invalidateDomainByIdCache(params.id) : Promise.resolve(),
+    params.name
+      ? invalidateDomainIdentityCache(params.name)
+      : Promise.resolve(),
+  ]);
+}

--- a/tests/api-auth-cache.test.ts
+++ b/tests/api-auth-cache.test.ts
@@ -1,0 +1,113 @@
+import { createHash } from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFindFirst = vi.hoisted(() => vi.fn());
+const mockDeleteCache = vi.hoisted(() => vi.fn());
+const mockReadCache = vi.hoisted(() => vi.fn());
+const mockWriteCache = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    update: vi.fn(),
+    query: {
+      apiKeys: {
+        findFirst: mockFindFirst,
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/cache/redis", () => ({
+  deleteCache: mockDeleteCache,
+  readCache: mockReadCache,
+  writeCache: mockWriteCache,
+}));
+
+describe("api key auth cache", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.spyOn(console, "info").mockImplementation(() => {});
+  });
+
+  it("returns cached auth results without hitting the database", async () => {
+    const rawKey = "re_cached";
+    const tokenHash = createHash("sha256").update(rawKey).digest("hex");
+    mockReadCache.mockResolvedValue({
+      status: "hit",
+      value: {
+        apiKeyId: "key-1",
+        permission: "full_access",
+        domain: "example.com",
+        userId: "user-1",
+      },
+    });
+
+    const { validateApiKey } = await import("@/lib/api-auth");
+    const result = await validateApiKey(`Bearer ${rawKey}`);
+
+    expect(mockReadCache).toHaveBeenCalledWith(`auth:apikey:${tokenHash}`);
+    expect(mockFindFirst).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      apiKeyId: "key-1",
+      permission: "full_access",
+      domain: "example.com",
+      userId: "user-1",
+    });
+  });
+
+  it("falls back to the database on cache miss and writes the result back", async () => {
+    const rawKey = "re_miss";
+    const tokenHash = createHash("sha256").update(rawKey).digest("hex");
+    mockReadCache.mockResolvedValue({ status: "miss", value: null });
+    mockFindFirst.mockResolvedValue({
+      id: "key-2",
+      permission: "sending_access",
+      domain: "example.com",
+      userId: "user-2",
+      lastUsedAt: null,
+    });
+    mockWriteCache.mockResolvedValue("written");
+
+    const { validateApiKey } = await import("@/lib/api-auth");
+    const result = await validateApiKey(`Bearer ${rawKey}`);
+
+    expect(mockFindFirst).toHaveBeenCalledOnce();
+    expect(mockWriteCache).toHaveBeenCalledWith(
+      `auth:apikey:${tokenHash}`,
+      {
+        apiKeyId: "key-2",
+        permission: "sending_access",
+        domain: "example.com",
+        userId: "user-2",
+      },
+      300,
+    );
+    expect(result).toEqual({
+      apiKeyId: "key-2",
+      permission: "sending_access",
+      domain: "example.com",
+      userId: "user-2",
+    });
+  });
+
+  it("logs and falls back cleanly when redis is unavailable", async () => {
+    mockReadCache.mockResolvedValue({ status: "unavailable", value: null });
+    mockFindFirst.mockResolvedValue(null);
+
+    const { validateApiKey } = await import("@/lib/api-auth");
+
+    await expect(validateApiKey("Bearer re_unknown")).resolves.toBeNull();
+    expect(mockFindFirst).toHaveBeenCalledOnce();
+  });
+
+  it("invalidates auth cache entries by token hash", async () => {
+    mockDeleteCache.mockResolvedValue("deleted");
+
+    const { invalidateApiKeyAuthCache } = await import("@/lib/api-auth");
+
+    await invalidateApiKeyAuthCache("abc123");
+
+    expect(mockDeleteCache).toHaveBeenCalledWith("auth:apikey:abc123");
+  });
+});

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -82,6 +82,7 @@ describe("lib/api-auth", () => {
       apiKeyId: "key-1",
       permission: "full_access",
       domain: "example.com",
+      userId: undefined,
     });
     expect(tokenHash).toHaveLength(64);
   });

--- a/tests/api-domains.test.ts
+++ b/tests/api-domains.test.ts
@@ -205,21 +205,13 @@ describe("Domain API validation", () => {
     expect(res.status).toBe(422);
     expect(json.error).toBe("Validation failed");
     expect(json.details.fieldErrors.id).toBeDefined();
-    expect(mockDb.select).not.toHaveBeenCalled();
+    expect(mockDb.query.domains.findFirst).not.toHaveBeenCalled();
   });
 
   it("auto-configures domain when params are valid", async () => {
-    mockDb.select.mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([
-            {
-              id: VALID_DOMAIN_ID,
-              name: "example.com",
-            },
-          ]),
-        }),
-      }),
+    mockDb.query.domains.findFirst.mockResolvedValue({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
     });
     mockCreateDomainIdentity.mockResolvedValue({
       dkimTokens: ["dkim-1", "dkim-2", "dkim-3"],

--- a/tests/cache-invalidation-routes.test.ts
+++ b/tests/cache-invalidation-routes.test.ts
@@ -1,0 +1,302 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockInvalidateApiKeyAuthCache = vi.hoisted(() => vi.fn());
+const mockGetCachedDomainById = vi.hoisted(() => vi.fn());
+const mockGetCachedDomainIdentity = vi.hoisted(() => vi.fn());
+const mockInvalidateDomainCaches = vi.hoisted(() => vi.fn());
+const mockCreateDomainIdentity = vi.hoisted(() => vi.fn());
+const mockDeleteDomainIdentity = vi.hoisted(() => vi.fn());
+const mockAutoConfigureDomain = vi.hoisted(() => vi.fn());
+const mockListDNSRecords = vi.hoisted(() => vi.fn());
+const mockDeleteDNSRecord = vi.hoisted(() => vi.fn());
+const mockQueueEvent = vi.hoisted(() => vi.fn());
+
+const VALID_DOMAIN_ID = "11111111-1111-4111-8111-111111111111";
+
+const mockDb = vi.hoisted(() => ({
+  select: vi.fn(),
+  insert: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock("@/lib/api-auth", () => ({
+  invalidateApiKeyAuthCache: mockInvalidateApiKeyAuthCache,
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+  validateApiKey: mockValidateApiKey,
+}));
+
+vi.mock("@/lib/domain-cache", () => ({
+  getCachedDomainById: mockGetCachedDomainById,
+  getCachedDomainIdentity: mockGetCachedDomainIdentity,
+  invalidateDomainCaches: mockInvalidateDomainCaches,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockDb,
+}));
+
+vi.mock("@/lib/ses", () => ({
+  createDomainIdentity: mockCreateDomainIdentity,
+  deleteDomainIdentity: mockDeleteDomainIdentity,
+}));
+
+vi.mock("@/lib/cloudflare", () => ({
+  autoConfigureDomain: mockAutoConfigureDomain,
+  deleteDNSRecord: mockDeleteDNSRecord,
+  listDNSRecords: mockListDNSRecords,
+}));
+
+vi.mock("@/lib/events", () => ({
+  queueEvent: mockQueueEvent,
+}));
+
+vi.mock("drizzle-orm", async () => {
+  const actual = await vi.importActual("drizzle-orm");
+  return {
+    ...actual,
+    eq: vi.fn((...args: unknown[]) => ({ op: "eq", args })),
+  };
+});
+
+describe("cache invalidation routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue({
+      apiKeyId: "key-1",
+      permission: "full_access",
+      domain: null,
+      userId: "user-1",
+    });
+  });
+
+  it("invalidates new api-key auth entries after create", async () => {
+    mockDb.insert.mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi
+          .fn()
+          .mockResolvedValue([{ id: "created-key", tokenHash: "hash-123" }]),
+      }),
+    });
+
+    const route = await import("@/app/api/api-keys/route");
+    const response = await route.POST(
+      new Request("http://localhost/api/api-keys", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer admin",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ name: "Primary" }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockInvalidateApiKeyAuthCache).toHaveBeenCalledWith("hash-123");
+  });
+
+  it("invalidates domain caches after create", async () => {
+    mockCreateDomainIdentity.mockResolvedValue({
+      dkimTokens: ["a", "b", "c"],
+      status: "PENDING",
+    });
+    mockDb.insert.mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([
+          {
+            id: VALID_DOMAIN_ID,
+            name: "example.com",
+            status: "not_started",
+            region: "us-east-1",
+            records: [],
+            trackOpens: false,
+            trackClicks: false,
+            trackingSubdomain: null,
+            tls: "opportunistic",
+            capabilities: [{ name: "sending", enabled: true }],
+            createdAt: new Date("2026-04-28T00:00:00.000Z"),
+          },
+        ]),
+      }),
+    });
+
+    const route = await import("@/app/api/domains/route");
+    const response = await route.POST(
+      new Request("http://localhost/api/domains", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer key",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ name: "example.com" }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockInvalidateDomainCaches).toHaveBeenCalledWith({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+    });
+  });
+
+  it("invalidates cached api-key auth entries on delete", async () => {
+    mockDb.select.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ tokenHash: "hash-456" }]),
+        }),
+      }),
+    });
+    mockDb.delete.mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: "key-1" }]),
+      }),
+    });
+
+    const route = await import("@/app/api/api-keys/[id]/route");
+    const response = await route.DELETE(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "key-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockInvalidateApiKeyAuthCache).toHaveBeenCalledWith("hash-456");
+  });
+
+  it("invalidates domain caches after patch", async () => {
+    mockGetCachedDomainById.mockResolvedValue({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+      capabilities: [{ name: "sending", enabled: true }],
+    });
+    mockDb.update.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([
+            {
+              id: VALID_DOMAIN_ID,
+              name: "example.com",
+            },
+          ]),
+        }),
+      }),
+    });
+
+    const route = await import("@/app/api/domains/[id]/route");
+    const response = await route.PATCH(
+      new Request("http://localhost", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ click_tracking: true }),
+      }),
+      {
+        params: Promise.resolve({ id: VALID_DOMAIN_ID }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockInvalidateDomainCaches).toHaveBeenCalledWith({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+    });
+  });
+
+  it("invalidates domain caches after auto-configure", async () => {
+    mockGetCachedDomainById.mockResolvedValue({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+    });
+    mockCreateDomainIdentity.mockResolvedValue({
+      dkimTokens: ["a", "b", "c"],
+    });
+    mockAutoConfigureDomain.mockResolvedValue({
+      records: [
+        { type: "TXT", name: "example.com", content: "v=spf1", priority: 10 },
+      ],
+      warnings: [],
+    });
+    mockDb.update.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    });
+
+    const route = await import("@/app/api/domains/[id]/auto-configure/route");
+    const response = await route.POST(new Request("http://localhost"), {
+      params: Promise.resolve({ id: VALID_DOMAIN_ID }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockInvalidateDomainCaches).toHaveBeenCalledWith({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+    });
+  });
+
+  it("invalidates domain caches after verify", async () => {
+    mockGetCachedDomainById.mockResolvedValue({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+      status: "pending",
+      records: [],
+    });
+    mockGetCachedDomainIdentity.mockResolvedValue({
+      verified: true,
+      dkimStatus: "SUCCESS",
+      dkimTokens: ["a"],
+    });
+    mockDb.update.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([
+            {
+              id: VALID_DOMAIN_ID,
+              name: "example.com",
+              status: "verified",
+              records: [],
+              createdAt: new Date("2026-04-28T00:00:00.000Z"),
+            },
+          ]),
+        }),
+      }),
+    });
+
+    const route = await import("@/app/api/domains/[id]/verify/route");
+    const response = await route.POST(new Request("http://localhost"), {
+      params: Promise.resolve({ id: VALID_DOMAIN_ID }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockInvalidateDomainCaches).toHaveBeenCalledWith({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+    });
+    expect(mockQueueEvent).toHaveBeenCalledOnce();
+  });
+
+  it("invalidates domain caches after delete", async () => {
+    mockGetCachedDomainById.mockResolvedValue({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+    });
+    mockListDNSRecords.mockResolvedValue([]);
+    mockDb.delete.mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: VALID_DOMAIN_ID }]),
+      }),
+    });
+
+    const route = await import("@/app/api/domains/[id]/route");
+    const response = await route.DELETE(new Request("http://localhost"), {
+      params: Promise.resolve({ id: VALID_DOMAIN_ID }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockInvalidateDomainCaches).toHaveBeenCalledWith({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+    });
+  });
+});

--- a/tests/redis-cache.test.ts
+++ b/tests/redis-cache.test.ts
@@ -49,12 +49,24 @@ describe("lib/cache/redis", () => {
   });
 
   it("defaults RATE_LIMIT_BACKEND to disabled and no-ops without REDIS_URL", async () => {
-    const { getRateLimitBackend, incrCache } = await import(
-      "@/lib/cache/redis"
-    );
+    const {
+      getRateLimitBackend,
+      incrCache,
+      readCache,
+      writeCache,
+      deleteCache,
+    } = await import("@/lib/cache/redis");
 
     expect(getRateLimitBackend()).toBe("disabled");
     await expect(incrCache("ratelimit:test", 60)).resolves.toBeNull();
+    await expect(readCache("cache:key")).resolves.toEqual({
+      status: "unavailable",
+      value: null,
+    });
+    await expect(writeCache("cache:key", { ok: true }, 60)).resolves.toBe(
+      "unavailable",
+    );
+    await expect(deleteCache("cache:key")).resolves.toBe("unavailable");
     expect(mockCreateClient).not.toHaveBeenCalled();
   });
 
@@ -66,16 +78,32 @@ describe("lib/cache/redis", () => {
     mockTtl.mockResolvedValue(42);
     mockGet.mockResolvedValue('{"ok":true}');
 
-    const { getCached, getRateLimitBackend, getTtl, incrCache, setCache } =
-      await import("@/lib/cache/redis");
+    const {
+      deleteCache,
+      getCached,
+      getRateLimitBackend,
+      getTtl,
+      incrCache,
+      readCache,
+      setCache,
+      writeCache,
+    } = await import("@/lib/cache/redis");
 
     expect(getRateLimitBackend()).toBe("redis");
     await setCache("cache:key", { ok: true }, 120);
+    await expect(writeCache("cache:key", { ok: true }, 120)).resolves.toBe(
+      "written",
+    );
     await expect(getCached<{ ok: boolean }>("cache:key")).resolves.toEqual({
       ok: true,
     });
+    await expect(readCache<{ ok: boolean }>("cache:key")).resolves.toEqual({
+      status: "hit",
+      value: { ok: true },
+    });
     await expect(incrCache("ratelimit:test", 60)).resolves.toBe(3);
     await expect(getTtl("ratelimit:test")).resolves.toBe(42);
+    await expect(deleteCache("cache:key")).resolves.toBe("deleted");
 
     expect(mockCreateClient).toHaveBeenCalledWith({
       url: "rediss://cache.example:6379",
@@ -84,6 +112,7 @@ describe("lib/cache/redis", () => {
     expect(mockSet).toHaveBeenCalledWith("cache:key", '{"ok":true}', {
       EX: 120,
     });
+    expect(mockDel).toHaveBeenCalledWith("cache:key");
     expect(mockIncr).toHaveBeenCalledWith("ratelimit:test");
     expect(mockExpire).toHaveBeenCalledWith("ratelimit:test", 60, "NX");
   });


### PR DESCRIPTION
## Summary\n- add explicit Redis cache read/write/delete status helpers and structured cache logging\n- cache API-key auth, domain-by-id, and SES domain identity lookups with mutation-path invalidation\n- add focused cache hit/miss/invalidation tests and document REDIS_URL cache behavior\n\n## Testing\n- bun run test tests/api-auth-cache.test.ts tests/cache-invalidation-routes.test.ts tests/redis-cache.test.ts tests/api-auth-date-range-routes.test.ts\n- bun x biome check src/lib/cache/redis.ts src/lib/api-auth.ts src/lib/domain-cache.ts src/app/api/api-keys/route.ts src/app/api/api-keys/[id]/route.ts src/app/api/domains/route.ts src/app/api/domains/[id]/route.ts src/app/api/domains/[id]/auto-configure/route.ts src/app/api/domains/[id]/verify/route.ts tests/api-auth-cache.test.ts tests/cache-invalidation-routes.test.ts tests/redis-cache.test.ts tests/api-auth-date-range-routes.test.ts README.md .env.example agent_docs/learnings/active/2026-04-28-issue-73-cache-invalidation-scope.md\n- bun run typecheck\n\nCloses #73