### PR TITLE
Harden issue #72 email/domain validation boundaries

### DIFF
--- a/agent_docs/learnings/active/2026-04-28-issue-72-domain-validation-boundaries.md
+++ b/agent_docs/learnings/active/2026-04-28-issue-72-domain-validation-boundaries.md
@@ -1,0 +1,14 @@
+---
+date: 2026-04-28
+issue: "#72"
+type: decision
+promoted_to: null
+---
+
+## Validate domain route params at the API boundary
+
+**What:** Added reusable Zod schemas for domain route params and used them in detail/update/delete/verify/auto-configure routes, with a `src/lib/validation/index.ts` barrel for stable contract exports.
+
+**Why:** The issue scope is contract hardening at TypeScript boundaries, and the verify/auto-configure routes only accept path params. Treating those params as validated inputs closes the remaining boundary gap without broad route refactors.
+
+**Fix:** Reuse `domainRouteParamsSchema` aliases for verify/auto-configure and keep SDK/domain payload types mirrored to the stabilized validation module.

--- a/packages/core/src/dto/index.ts
+++ b/packages/core/src/dto/index.ts
@@ -39,6 +39,10 @@ export interface EmailResponse {
 
 export type SendEmailResponse = EmailResponse;
 
+export interface BatchEmailResponse {
+  data: EmailResponse[];
+}
+
 export interface EmailListItem {
   id: string;
   from: string;
@@ -90,6 +94,16 @@ export interface DomainOptions {
   capabilities?: DomainCapability[];
 }
 
+export interface UpdateDomainPayload {
+  click_tracking?: boolean;
+  open_tracking?: boolean;
+  tracking_subdomain?: string;
+  capabilities?: DomainCapability[];
+  sending_enabled?: boolean;
+  receiving_enabled?: boolean;
+  tls?: "opportunistic" | "enforced";
+}
+
 export interface DomainResponse {
   object: "domain";
   id: string;
@@ -118,6 +132,13 @@ export interface DomainListResponse {
   object: "list";
   data: DomainListItem[];
   has_more: boolean;
+}
+
+export interface AutoConfigureDomainResponse {
+  ok: boolean;
+  records: DomainRecord[];
+  cloudflare_records: number;
+  warnings?: string[];
 }
 
 export interface CreateApiKeyPayload {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,6 +1,8 @@
 import type {
   ApiKeyListResponse,
   ApiKeyResponse,
+  AutoConfigureDomainResponse,
+  BatchEmailResponse,
   ContactListItem,
   ContactListResponse,
   ContactResponse,
@@ -16,6 +18,7 @@ import type {
   EmailListResponse,
   EmailOptions,
   EmailResponse,
+  UpdateDomainPayload,
 } from "../../core/src/dto";
 
 interface SDKOptions {
@@ -135,6 +138,16 @@ class Emails {
     return this.http.request<EmailResponse>("POST", "/api/emails", rest);
   }
 
+  async sendBatch(
+    payload: SendEmailPayload[],
+  ): Promise<ApiResponse<BatchEmailResponse>> {
+    return this.http.request<BatchEmailResponse>(
+      "POST",
+      "/api/emails/batch",
+      payload,
+    );
+  }
+
   async list(): Promise<ApiResponse<EmailListResponse>> {
     return this.http.request<EmailListResponse>("GET", "/api/emails");
   }
@@ -159,10 +172,30 @@ class Domains {
     return this.http.request<DomainResponse>("GET", `/api/domains/${id}`);
   }
 
+  async update(
+    id: string,
+    payload: UpdateDomainPayload,
+  ): Promise<ApiResponse<Pick<DomainResponse, "object" | "id">>> {
+    return this.http.request<Pick<DomainResponse, "object" | "id">>(
+      "PATCH",
+      `/api/domains/${id}`,
+      payload,
+    );
+  }
+
   async verify(id: string): Promise<ApiResponse<DomainResponse>> {
     return this.http.request<DomainResponse>(
       "POST",
       `/api/domains/${id}/verify`,
+    );
+  }
+
+  async autoConfigure(
+    id: string,
+  ): Promise<ApiResponse<AutoConfigureDomainResponse>> {
+    return this.http.request<AutoConfigureDomainResponse>(
+      "POST",
+      `/api/domains/${id}/auto-configure`,
     );
   }
 }
@@ -233,13 +266,16 @@ export type {
   ApiResponse,
   EmailOptions,
   EmailResponse,
+  BatchEmailResponse,
   EmailListItem,
   EmailListResponse,
   EmailDetailResponse,
   DomainOptions,
+  UpdateDomainPayload,
   DomainResponse,
   DomainListItem,
   DomainListResponse,
+  AutoConfigureDomainResponse,
   CreateApiKeyPayload,
   ApiKeyResponse,
   ApiKeyListResponse,

--- a/src/app/api/domains/[id]/auto-configure/route.ts
+++ b/src/app/api/domains/[id]/auto-configure/route.ts
@@ -3,6 +3,7 @@ import { autoConfigureDomain } from "@/lib/cloudflare";
 import { db } from "@/lib/db";
 import { domains } from "@/lib/db/schema";
 import { createDomainIdentity, getDomainIdentity } from "@/lib/ses";
+import { autoConfigureDomainParamsSchema } from "@/lib/validation/domains";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
@@ -13,7 +14,15 @@ export async function POST(
   const auth = await validateApiKey(_req.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
 
-  const { id } = await params;
+  const parsedParams = autoConfigureDomainParamsSchema.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsedParams.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  const { id } = parsedParams.data;
 
   try {
     const rows = await db
@@ -28,34 +37,29 @@ export async function POST(
 
     const domain = rows[0];
 
-    // Step 1: Create domain identity in SES (gets DKIM tokens)
     let dkimTokens: string[];
     try {
       const identity = await createDomainIdentity(domain.name);
       dkimTokens = identity.dkimTokens;
     } catch {
-      // Identity may already exist — try to get existing DKIM tokens
       const existing = await getDomainIdentity(domain.name);
       dkimTokens = existing.dkimTokens;
     }
 
-    // Step 2: Auto-configure DNS records via Cloudflare
     const { records: cfRecords, warnings } = await autoConfigureDomain(
       domain.name,
       dkimTokens,
     );
 
-    // Step 3: Build records array for DB storage from what was actually created
-    const allRecords = cfRecords.map((r) => ({
-      type: r.type,
-      name: r.name,
-      value: r.content,
+    const allRecords = cfRecords.map((record) => ({
+      type: record.type,
+      name: record.name,
+      value: record.content,
       status: "pending" as const,
       ttl: "Auto",
-      ...(r.priority !== undefined ? { priority: r.priority } : {}),
+      ...(record.priority !== undefined ? { priority: record.priority } : {}),
     }));
 
-    // Step 4: Update domain in DB with records and pending status
     await db
       .update(domains)
       .set({

--- a/src/app/api/domains/[id]/route.ts
+++ b/src/app/api/domains/[id]/route.ts
@@ -3,8 +3,17 @@ import { deleteDNSRecord, listDNSRecords } from "@/lib/cloudflare";
 import { db } from "@/lib/db";
 import { domains } from "@/lib/db/schema";
 import { deleteDomainIdentity } from "@/lib/ses";
+import {
+  domainRouteParamsSchema,
+  updateDomainSchema,
+} from "@/lib/validation/domains";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
+
+const defaultCapabilities = [
+  { name: "sending", enabled: true },
+  { name: "receiving", enabled: false },
+];
 
 export async function GET(
   _req: Request,
@@ -13,8 +22,16 @@ export async function GET(
   const auth = await validateApiKey(_req.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
 
+  const parsedParams = domainRouteParamsSchema.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsedParams.error.flatten() },
+      { status: 422 },
+    );
+  }
+
   try {
-    const { id } = await params;
+    const { id } = parsedParams.data;
     const [domain] = await db
       .select()
       .from(domains)
@@ -55,26 +72,50 @@ export async function PATCH(
   const auth = await validateApiKey(req.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
 
+  let body: unknown;
   try {
-    const { id } = await params;
-    const body = await req.json();
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = updateDomainSchema.safeParse(body);
+  if (!result.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: result.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  const parsedParams = domainRouteParamsSchema.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsedParams.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  try {
+    const { id } = parsedParams.data;
+    const validated = result.data;
     const updates: Record<string, unknown> = {};
 
-    if (body.click_tracking !== undefined)
-      updates.trackClicks = body.click_tracking;
-    if (body.open_tracking !== undefined)
-      updates.trackOpens = body.open_tracking;
-    if (body.tracking_subdomain !== undefined)
-      updates.trackingSubdomain = body.tracking_subdomain;
+    if (validated.click_tracking !== undefined) {
+      updates.trackClicks = validated.click_tracking;
+    }
+    if (validated.open_tracking !== undefined) {
+      updates.trackOpens = validated.open_tracking;
+    }
+    if (validated.tracking_subdomain !== undefined) {
+      updates.trackingSubdomain = validated.tracking_subdomain;
+    }
 
-    // Support both 'capabilities' array and individual boolean toggles
-    if (body.capabilities !== undefined) {
-      updates.capabilities = body.capabilities;
+    if (validated.capabilities !== undefined) {
+      updates.capabilities = validated.capabilities;
     } else if (
-      body.sending_enabled !== undefined ||
-      body.receiving_enabled !== undefined
+      validated.sending_enabled !== undefined ||
+      validated.receiving_enabled !== undefined
     ) {
-      // Fetch current capabilities to merge
       const [existing] = await db
         .select({ capabilities: domains.capabilities })
         .from(domains)
@@ -82,19 +123,19 @@ export async function PATCH(
         .limit(1);
 
       if (existing) {
-        const currentCaps = existing.capabilities || [
-          { name: "sending", enabled: true },
-          { name: "receiving", enabled: false },
-        ];
+        const currentCaps = existing.capabilities || defaultCapabilities;
         const newCaps = currentCaps.map((cap) => {
-          if (cap.name === "sending" && body.sending_enabled !== undefined) {
-            return { ...cap, enabled: body.sending_enabled };
+          if (
+            cap.name === "sending" &&
+            validated.sending_enabled !== undefined
+          ) {
+            return { ...cap, enabled: validated.sending_enabled };
           }
           if (
             cap.name === "receiving" &&
-            body.receiving_enabled !== undefined
+            validated.receiving_enabled !== undefined
           ) {
-            return { ...cap, enabled: body.receiving_enabled };
+            return { ...cap, enabled: validated.receiving_enabled };
           }
           return cap;
         });
@@ -102,15 +143,8 @@ export async function PATCH(
       }
     }
 
-    if (body.tls !== undefined) {
-      const val = body.tls;
-      if (val === "opportunistic" || val === "enforced") {
-        updates.tls = val;
-      }
-    }
-
-    if (Object.keys(updates).length === 0) {
-      return NextResponse.json({ error: "No valid fields" }, { status: 400 });
+    if (validated.tls !== undefined) {
+      updates.tls = validated.tls;
     }
 
     const [updated] = await db
@@ -143,8 +177,16 @@ export async function DELETE(
   const auth = await validateApiKey(_req.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
 
+  const parsedParams = domainRouteParamsSchema.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsedParams.error.flatten() },
+      { status: 422 },
+    );
+  }
+
   try {
-    const { id } = await params;
+    const { id } = parsedParams.data;
 
     const [domain] = await db
       .select({ name: domains.name })
@@ -156,15 +198,12 @@ export async function DELETE(
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 
-    // Cleanup SES identity
     try {
       await deleteDomainIdentity(domain.name);
     } catch (sesErr) {
       console.warn(`Failed to delete SES identity for ${domain.name}:`, sesErr);
-      // Continue even if SES cleanup fails
     }
 
-    // Cleanup Cloudflare DNS records (if configured)
     try {
       const records = await listDNSRecords({ name: domain.name });
       const sesRecords = records.filter(

--- a/src/app/api/domains/[id]/verify/route.ts
+++ b/src/app/api/domains/[id]/verify/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/lib/db";
 import { domains } from "@/lib/db/schema";
 import { queueEvent } from "@/lib/events";
 import { getDomainIdentity } from "@/lib/ses";
+import { verifyDomainParamsSchema } from "@/lib/validation/domains";
 import { eq } from "drizzle-orm";
 
 export async function POST(
@@ -12,7 +13,15 @@ export async function POST(
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
 
-  const { id } = await params;
+  const parsedParams = verifyDomainParamsSchema.safeParse(await params);
+  if (!parsedParams.success) {
+    return Response.json(
+      { error: "Validation failed", details: parsedParams.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  const { id } = parsedParams.data;
 
   try {
     const domain = await db.query.domains.findFirst({
@@ -23,12 +32,7 @@ export async function POST(
       return Response.json({ error: "Domain not found" }, { status: 404 });
     }
 
-    // Check verification status with SES
     const identity = await getDomainIdentity(domain.name);
-
-    // Identity from ses.ts (mocked or real) provides verified boolean,
-    // plus often richer data if we expand the SES wrapper.
-    // For parity, we simulate multi-state inspection of the record state.
 
     let verificationStatus:
       | "pending"
@@ -40,7 +44,6 @@ export async function POST(
     if (identity.verified) {
       verificationStatus = "verified";
     } else {
-      // Simulate checking if some records passed but not all
       const records =
         (domain.records as Array<{
           type: string;
@@ -51,20 +54,18 @@ export async function POST(
           priority?: number;
         }>) ?? [];
       const verifiedCount = records.filter(
-        (r) => r.status === "verified",
+        (record) => record.status === "verified",
       ).length;
 
       if (verifiedCount > 0 && verifiedCount < records.length) {
         verificationStatus = "partially_verified";
       } else if (verifiedCount === 0 && records.length > 0) {
-        // Only mark as failed if explicitly checked and nothing found
         verificationStatus = "pending";
       }
     }
 
     const previousStatus = domain.status;
 
-    // Update domain status in DB
     const [updated] = await db
       .update(domains)
       .set({
@@ -73,7 +74,6 @@ export async function POST(
       .where(eq(domains.id, id))
       .returning();
 
-    // Fire webhook if status changed
     if (updated.status !== previousStatus) {
       await queueEvent({
         type: "domain.updated",

--- a/src/app/api/domains/route.ts
+++ b/src/app/api/domains/route.ts
@@ -2,46 +2,45 @@ import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { domains } from "@/lib/db/schema";
 import { createDomainIdentity } from "@/lib/ses";
+import { createDomainSchema } from "@/lib/validation/domains";
 import { and, desc, lt } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
-const VALID_REGIONS = ["us-east-1", "eu-west-1", "sa-east-1", "ap-northeast-1"];
+const defaultCapabilities = [
+  { name: "sending", enabled: true },
+  { name: "receiving", enabled: false },
+];
 
 export async function POST(request: Request) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
 
+  let body: unknown;
   try {
-    const body = await request.json();
-    const { name, region = "us-east-1" } = body;
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
 
-    if (!name || typeof name !== "string" || !name.trim()) {
-      return NextResponse.json(
-        { error: "Domain name is required" },
-        { status: 400 },
-      );
-    }
+  const result = createDomainSchema.safeParse(body);
+  if (!result.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: result.error.flatten() },
+      { status: 422 },
+    );
+  }
 
-    const domainName = name.trim().toLowerCase();
+  try {
+    const validated = result.data;
+    const domainName = validated.name.toLowerCase();
 
-    if (!VALID_REGIONS.includes(region)) {
-      return NextResponse.json(
-        {
-          error: `Invalid region. Must be one of: ${VALID_REGIONS.join(", ")}`,
-        },
-        { status: 400 },
-      );
-    }
-
-    // 1. Initialize Domain Identity in SES to get DKIM tokens
     const identity = await createDomainIdentity(domainName);
 
-    // 2. Build DNS records for the response
     const dkimRecords = identity.dkimTokens.map((token) => ({
       type: "CNAME",
       name: `${token}._domainkey.${domainName}`,
       value: `${token}.dkim.amazonses.com`,
-      status: "pending",
+      status: "pending" as const,
       ttl: "Auto",
     }));
 
@@ -49,39 +48,35 @@ export async function POST(request: Request) {
       type: "TXT",
       name: domainName,
       value: "v=spf1 include:amazonses.com ~all",
-      status: "pending",
+      status: "pending" as const,
       ttl: "Auto",
     };
 
     const mxRecord = {
       type: "MX",
       name: domainName,
-      value: `feedback-smtp.${region}.amazonses.com`,
-      status: "pending",
+      value: `feedback-smtp.${validated.region}.amazonses.com`,
+      status: "pending" as const,
       ttl: "Auto",
       priority: 10,
     };
 
     const allRecords = [...dkimRecords, spfRecord, mxRecord];
 
-    // 3. Store in DB
     const [row] = await db
       .insert(domains)
       .values({
         name: domainName,
-        region,
+        region: validated.region,
         status: "not_started",
         dkimTokens: identity.dkimTokens,
         records: allRecords,
-        customReturnPath: body.custom_return_path || null,
-        trackOpens: body.open_tracking ?? false,
-        trackClicks: body.click_tracking ?? false,
-        trackingSubdomain: body.tracking_subdomain || null,
-        tls: body.tls || "opportunistic",
-        capabilities: body.capabilities || [
-          { name: "sending", enabled: true },
-          { name: "receiving", enabled: false },
-        ],
+        customReturnPath: validated.custom_return_path || null,
+        trackOpens: validated.open_tracking ?? false,
+        trackClicks: validated.click_tracking ?? false,
+        trackingSubdomain: validated.tracking_subdomain || null,
+        tls: validated.tls,
+        capabilities: validated.capabilities || defaultCapabilities,
       })
       .returning();
 

--- a/src/app/api/emails/batch/route.ts
+++ b/src/app/api/emails/batch/route.ts
@@ -30,13 +30,6 @@ export async function POST(request: Request): Promise<Response> {
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  if (Array.isArray(body) && body.length > 100) {
-    return Response.json(
-      { error: "Batch size cannot exceed 100 emails" },
-      { status: 400 },
-    );
-  }
-
   const result = batchSendEmailSchema.safeParse(body);
   if (!result.success) {
     return Response.json(

--- a/src/lib/validation/domains.ts
+++ b/src/lib/validation/domains.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+
+export const validDomainRegions = [
+  "us-east-1",
+  "eu-west-1",
+  "sa-east-1",
+  "ap-northeast-1",
+] as const;
+
+export const domainIdSchema = z.string().uuid();
+
+export const domainRouteParamsSchema = z.object({
+  id: domainIdSchema,
+});
+
+export const domainRegionSchema = z.enum(validDomainRegions);
+
+export const domainTlsSchema = z.enum(["opportunistic", "enforced"]);
+
+export const domainCapabilitySchema = z.object({
+  name: z.string().min(1).max(255),
+  enabled: z.boolean(),
+});
+
+export const createDomainSchema = z.object({
+  name: z.string().trim().min(1, "Domain name is required").max(255),
+  region: domainRegionSchema.optional().default("us-east-1"),
+  custom_return_path: z.string().trim().min(1).max(255).optional(),
+  open_tracking: z.boolean().optional(),
+  click_tracking: z.boolean().optional(),
+  tracking_subdomain: z.string().trim().min(1).max(255).optional(),
+  tls: domainTlsSchema.optional().default("opportunistic"),
+  capabilities: z.array(domainCapabilitySchema).optional(),
+});
+
+export const updateDomainSchema = z
+  .object({
+    click_tracking: z.boolean().optional(),
+    open_tracking: z.boolean().optional(),
+    tracking_subdomain: z.string().trim().min(1).max(255).optional(),
+    capabilities: z.array(domainCapabilitySchema).optional(),
+    sending_enabled: z.boolean().optional(),
+    receiving_enabled: z.boolean().optional(),
+    tls: domainTlsSchema.optional(),
+  })
+  .refine(
+    (data) =>
+      data.click_tracking !== undefined ||
+      data.open_tracking !== undefined ||
+      data.tracking_subdomain !== undefined ||
+      data.capabilities !== undefined ||
+      data.sending_enabled !== undefined ||
+      data.receiving_enabled !== undefined ||
+      data.tls !== undefined,
+    {
+      message: "At least one updatable field is required",
+    },
+  );
+
+export const verifyDomainParamsSchema = domainRouteParamsSchema;
+export const autoConfigureDomainParamsSchema = domainRouteParamsSchema;
+
+export type DomainRouteParams = z.infer<typeof domainRouteParamsSchema>;
+export type CreateDomainRequest = z.infer<typeof createDomainSchema>;
+export type UpdateDomainRequest = z.infer<typeof updateDomainSchema>;

--- a/src/lib/validation/index.ts
+++ b/src/lib/validation/index.ts
@@ -1,0 +1,4 @@
+export * from "./contacts";
+export * from "./domains";
+export * from "./emails";
+export * from "./webhooks";

--- a/tests/api-domains.test.ts
+++ b/tests/api-domains.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockDeleteDNSRecord = vi.hoisted(() => vi.fn());
+const mockListDNSRecords = vi.hoisted(() => vi.fn());
+const mockAutoConfigureDomain = vi.hoisted(() => vi.fn());
+const mockQueueEvent = vi.hoisted(() => vi.fn());
+const mockDeleteDomainIdentity = vi.hoisted(() => vi.fn());
+const mockGetDomainIdentity = vi.hoisted(() => vi.fn());
+const mockCreateDomainIdentity = vi.hoisted(() => vi.fn());
+const mockDb = vi.hoisted(() => ({
+  insert: vi.fn(),
+  update: vi.fn(),
+  select: vi.fn(),
+  query: {
+    domains: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockDb,
+}));
+
+vi.mock("@/lib/api-auth", () => ({
+  validateApiKey: mockValidateApiKey,
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/cloudflare", () => ({
+  autoConfigureDomain: mockAutoConfigureDomain,
+  deleteDNSRecord: mockDeleteDNSRecord,
+  listDNSRecords: mockListDNSRecords,
+}));
+
+vi.mock("@/lib/events", () => ({
+  queueEvent: mockQueueEvent,
+}));
+
+vi.mock("@/lib/ses", () => ({
+  createDomainIdentity: mockCreateDomainIdentity,
+  deleteDomainIdentity: mockDeleteDomainIdentity,
+  getDomainIdentity: mockGetDomainIdentity,
+}));
+
+const AUTH_RESULT = {
+  apiKeyId: "key-uuid",
+  permission: "full_access",
+  domainId: null,
+};
+
+const VALID_DOMAIN_ID = "11111111-1111-4111-8111-111111111111";
+
+function makeRequest(
+  url: string,
+  method: string,
+  body?: Record<string, unknown>,
+): Request {
+  const init: RequestInit = {
+    method,
+    headers: {
+      Authorization: "Bearer re_test123",
+      "Content-Type": "application/json",
+    },
+  };
+
+  if (body) {
+    init.body = JSON.stringify(body);
+  }
+
+  return new Request(url, init);
+}
+
+describe("Domain API validation", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockValidateApiKey.mockResolvedValue(AUTH_RESULT);
+    mockDeleteDNSRecord.mockReset();
+    mockListDNSRecords.mockReset();
+    mockAutoConfigureDomain.mockReset();
+    mockQueueEvent.mockReset();
+    mockDeleteDomainIdentity.mockReset();
+    mockGetDomainIdentity.mockReset();
+    mockCreateDomainIdentity.mockReset();
+    mockDb.insert.mockReset();
+    mockDb.update.mockReset();
+    mockDb.select.mockReset();
+    mockDb.query.domains.findFirst.mockReset();
+  });
+
+  it("returns 422 for invalid domain create payload", async () => {
+    const { POST } = await import("@/app/api/domains/route");
+    const req = makeRequest("http://localhost:3015/api/domains", "POST", {
+      name: "",
+      region: "moon-1",
+    });
+
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(json.error).toBe("Validation failed");
+    expect(json.details.fieldErrors.name).toBeDefined();
+    expect(json.details.fieldErrors.region).toBeDefined();
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 for invalid domain update payload", async () => {
+    const { PATCH } = await import("@/app/api/domains/[id]/route");
+    const req = makeRequest(
+      `http://localhost:3015/api/domains/${VALID_DOMAIN_ID}`,
+      "PATCH",
+      {
+        click_tracking: "yes" as unknown as boolean,
+        tls: "strict",
+      },
+    );
+
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: VALID_DOMAIN_ID }),
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(json.error).toBe("Validation failed");
+    expect(json.details.fieldErrors.click_tracking).toBeDefined();
+    expect(json.details.fieldErrors.tls).toBeDefined();
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 for invalid domain verify params", async () => {
+    const { POST } = await import("@/app/api/domains/[id]/verify/route");
+    const req = makeRequest(
+      "http://localhost:3015/api/domains/not-a-uuid/verify",
+      "POST",
+    );
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: "not-a-uuid" }),
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(json.error).toBe("Validation failed");
+    expect(json.details.fieldErrors.id).toBeDefined();
+    expect(mockDb.query.domains.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("verifies domain when params are valid", async () => {
+    const domain = {
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+      status: "pending",
+      records: [{ status: "pending" }],
+    };
+    const updated = {
+      ...domain,
+      status: "verified",
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    };
+
+    mockDb.query.domains.findFirst.mockResolvedValue(domain);
+    mockGetDomainIdentity.mockResolvedValue({ verified: true });
+    mockDb.update.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([updated]),
+        }),
+      }),
+    });
+
+    const { POST } = await import("@/app/api/domains/[id]/verify/route");
+    const req = makeRequest(
+      `http://localhost:3015/api/domains/${VALID_DOMAIN_ID}/verify`,
+      "POST",
+    );
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: VALID_DOMAIN_ID }),
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.status).toBe("verified");
+    expect(mockDb.query.domains.findFirst).toHaveBeenCalledTimes(1);
+    expect(mockQueueEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 422 for invalid auto-configure params", async () => {
+    const { POST } = await import(
+      "@/app/api/domains/[id]/auto-configure/route"
+    );
+    const req = makeRequest(
+      "http://localhost:3015/api/domains/not-a-uuid/auto-configure",
+      "POST",
+    );
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: "not-a-uuid" }),
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(json.error).toBe("Validation failed");
+    expect(json.details.fieldErrors.id).toBeDefined();
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it("auto-configures domain when params are valid", async () => {
+    mockDb.select.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([
+            {
+              id: VALID_DOMAIN_ID,
+              name: "example.com",
+            },
+          ]),
+        }),
+      }),
+    });
+    mockCreateDomainIdentity.mockResolvedValue({
+      dkimTokens: ["dkim-1", "dkim-2", "dkim-3"],
+    });
+    mockAutoConfigureDomain.mockResolvedValue({
+      records: [
+        {
+          type: "TXT",
+          name: "example.com",
+          content: "v=spf1 include:amazonses.com ~all",
+        },
+      ],
+      warnings: [],
+    });
+    mockDb.update.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    });
+
+    const { POST } = await import(
+      "@/app/api/domains/[id]/auto-configure/route"
+    );
+    const req = makeRequest(
+      `http://localhost:3015/api/domains/${VALID_DOMAIN_ID}/auto-configure`,
+      "POST",
+    );
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: VALID_DOMAIN_ID }),
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.cloudflare_records).toBe(1);
+    expect(mockAutoConfigureDomain).toHaveBeenCalledWith("example.com", [
+      "dkim-1",
+      "dkim-2",
+      "dkim-3",
+    ]);
+  });
+});

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -263,9 +263,10 @@ describe("POST /api/emails/batch", () => {
       Authorization: "Bearer re_test123",
     });
     const res = await POST(req);
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     const json = await res.json();
-    expect(json.error).toBe("Batch size cannot exceed 100 emails");
+    expect(json.error).toBe("Validation failed");
+    expect(json.details.formErrors[0]).toContain("100");
   });
 
   it("sends batch and returns array of ids", async () => {


### PR DESCRIPTION
## Summary
- add reusable Zod schemas for domain create/update/id params and apply them to domain detail/update/delete/verify/auto-configure routes
- keep batch email route on the shared Zod error shape and add focused route tests for batch/domain validation paths
- extend shared DTO/SDK contracts for batch send and domain update/auto-configure to stay aligned with the covered surfaces

## Verification
- `npx biome check packages/core/src/dto/index.ts packages/sdk/src/index.ts src/lib/validation/domains.ts src/lib/validation/index.ts src/app/api/domains/route.ts 'src/app/api/domains/[id]/route.ts' 'src/app/api/domains/[id]/verify/route.ts' 'src/app/api/domains/[id]/auto-configure/route.ts' src/app/api/emails/batch/route.ts tests/api-domains.test.ts tests/api-emails.test.ts`
- `npx vitest run tests/api-domains.test.ts tests/api-emails.test.ts`
- `cd packages/sdk && npx tsc --pretty false`

## Residual risk
- repo-wide `npx tsc --noEmit --pretty false` and the default push guardrail still fail on existing missing-dependency/typecheck drift outside this slice (`hono`, `papaparse`, `lucide-react`, `clsx`, `redis`), so this PR is verified only with the targeted commands above
