### PR TITLE
Add AWS-first observability baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,10 @@ DASHBOARD_KEY=
 # Protects /jobs/* endpoints when set on the ingester.
 # INGESTER_JOB_TOKEN=
 
+# ── Observability (CloudWatch EMF / structured logs) ─────────────
+# Optional namespace override for emitted CloudWatch Embedded Metric Format logs.
+# CLOUDWATCH_METRICS_NAMESPACE=NamuhSend
+
 # ── AWS S3 (File Storage) ───────────────────────────────────────
 # Bucket for email attachments and assets. Required for attachment support.
 # S3_BUCKET_NAME=

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ CLOUDFLARE_ZONE_ID=your-zone-id
 S3_BUCKET_NAME=your-bucket             # For email attachments
 BACKGROUND_JOBS_QUEUE_URL=...          # Optional locally; required for async production sending
 BACKGROUND_WORKER_POLL=true            # Set on the ingester worker when SQS is configured
+CLOUDWATCH_METRICS_NAMESPACE=NamuhSend  # Optional CloudWatch EMF namespace override
 ```
 
 `.env.example` keeps `DATABASE_URL` on `localhost` for host-run commands like `bun run dev` and `bun run db:push`. Docker Compose injects its own internal `postgres` hostname for the containerized app and migration services.
@@ -194,6 +195,7 @@ For production, we recommend:
 - **Secrets**: Store credentials in your cloud provider's secrets manager
 - **Rate limiting**: Use a shared Redis/ElastiCache instance instead of the disabled local default
 - **Background jobs**: Use SQS with a redrive policy/DLQ, plus EventBridge to trigger scheduled-email and webhook retry scans
+- **Observability**: Emit structured JSON logs, trace/correlation headers, and CloudWatch EMF metrics for send and worker flows
 
 ### Shared rate limiting (staging/production)
 
@@ -226,6 +228,12 @@ Operational shape:
 5. Retries/DLQ: configure the SQS queue redrive policy with a DLQ. Worker failures leave messages undeleted so SQS retry/redrive owns retry exhaustion.
 
 Local dev remains Docker-friendly if no queue is configured: publishes are logged/skipped and API calls still persist rows. To exercise the real worker locally, set `BACKGROUND_JOBS_QUEUE_URL` and `BACKGROUND_WORKER_POLL=true` on the ingester.
+
+### Observability
+
+Email accept and worker flows emit structured JSON logs with `x-correlation-id`, W3C/OpenTelemetry-compatible `traceparent`, sanitized span events, and CloudWatch EMF metrics for accept latency, send outcomes, queue depth, retries, and worker failures. Set `CLOUDWATCH_METRICS_NAMESPACE` to override the default `NamuhSend` namespace.
+
+See [`docs/observability.md`](docs/observability.md) for PII-safe logging rules, metric names, alarms, and the runbook for tracing an email from API acceptance to SES/provider result.
 
 ### Redis-backed auth/domain metadata cache
 

--- a/agent_docs/learnings/active/2026-04-28-issue-18-observability-baseline.md
+++ b/agent_docs/learnings/active/2026-04-28-issue-18-observability-baseline.md
@@ -1,0 +1,14 @@
+---
+date: 2026-04-28
+issue: "#18"
+type: decision
+promoted_to: null
+---
+
+## Keep the first observability slice AWS-native and trace-context compatible
+
+**What:** The observability baseline emits structured JSON logs plus CloudWatch EMF metrics from the API, queue publisher, worker, and SES ingester paths, and carries W3C/OpenTelemetry-compatible `traceparent`/`x-correlation-id` through background job payloads and SQS attributes.
+
+**Why:** The immediate production need is AWS-visible request-to-worker debugging without adding a collector or non-AWS vendor dependency. CloudWatch can derive metrics from EMF stdout logs today, while the W3C trace carrier leaves room for a later OpenTelemetry SDK/exporter when the deployment has a collector destination.
+
+**Fix:** Keep telemetry helpers centralized in `packages/core/src/observability/telemetry.ts`, use low-cardinality dimensions only, and route every log/metric through the sanitizer so email addresses/content are redacted or hashed by default.

--- a/docs/ingester-deploy.md
+++ b/docs/ingester-deploy.md
@@ -51,6 +51,7 @@ Required production environment for both app and ingester:
 BACKGROUND_JOBS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/<account>/namuh-send-background
 BACKGROUND_JOBS_REQUIRE_QUEUE=true
 BACKGROUND_JOBS_EVENT_BUS_NAME=namuh-send-background-jobs # optional lifecycle/event hook bus
+CLOUDWATCH_METRICS_NAMESPACE=NamuhSend # optional EMF namespace override
 ```
 
 Set this only on the ingester worker service when SQS is ready:
@@ -94,6 +95,10 @@ https://<ingester-service-url>/events/ses
 ```
 
 Do not leave SES pointed at the Next.js app URL once the split is active.
+
+## Observability
+
+The app and ingester emit structured JSON logs, W3C/OpenTelemetry-compatible trace context, and CloudWatch EMF metrics for queue depth, worker failures, retry count, send latency, send outcomes, and SES ingest results. Use `docs/observability.md` for metric names, PII-safe logging rules, and the full API-to-provider tracing runbook.
 
 ## Tail ingester logs
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,112 @@
+# Observability runbook
+
+Namuh Send emits an AWS-first observability baseline for the email accept and delivery flow. The implementation uses structured JSON logs, W3C/OpenTelemetry-compatible `traceparent` propagation, and CloudWatch Embedded Metric Format (EMF) records so the same application logs can drive CloudWatch Logs and Metrics.
+
+## Telemetry model
+
+Every instrumented request/job has:
+
+- `correlation_id` — stable identifier for support/debugging. API callers can provide `x-correlation-id`; otherwise Namuh Send derives one from the trace id.
+- `trace_id`, `span_id`, `parent_span_id`, `traceparent`, `tracestate` — W3C trace context fields that keep API, SQS, worker, SES, and webhook jobs connected.
+- `event` — machine-readable log event such as `email.accepted`, `queue.publish`, `worker.email.send`, or `ses.event.received`.
+- low-cardinality metric dimensions only: `Service`, `Operation`, `Outcome`, `JobType`, and `EventType`.
+
+The API response for `POST /api/emails` and `POST /api/emails/batch` includes `x-correlation-id` and `traceparent`. Background jobs persist the same carrier under the job `trace` field and also publish `correlationId` / `traceparent` SQS message attributes.
+
+## PII-safe logging rules
+
+Do not log raw email content or recipient data. The shared telemetry sanitizer enforces this for structured logs and EMF fields:
+
+- Redacted keys: `authorization`, `cookie`, `token`, `api_key`, `rawKey`, `from`, `to`, `cc`, `bcc`, `replyTo`, `subject`, `html`, `text`, `body`, `headers`, `attachments`, and content payload fields.
+- Email-address-shaped strings in freeform fields are replaced with deterministic SHA-256 hashes.
+- Safe identifiers such as `email_id`, `job_id`, `delivery_id`, SNS/SES message ids, status, and retry counters may be logged.
+- CloudWatch metric dimensions must stay low-cardinality; never use email addresses, domains, subjects, message bodies, or arbitrary customer input as dimensions.
+
+## CloudWatch metrics
+
+Metrics are emitted as EMF JSON log records in the `NamuhSend` namespace by default. Override with `CLOUDWATCH_METRICS_NAMESPACE` when an environment needs a distinct namespace.
+
+| Area | Metrics | Dimensions |
+| --- | --- | --- |
+| API email accept | `EmailAccept`, `EmailAcceptLatency` | `Service=api`, `Operation=email.accept`, `Outcome=queued|scheduled|failed|unauthorized|invalid` |
+| API batch accept | `EmailBatchAccepted`, `EmailBatchAcceptLatency`, `EmailBatchAcceptFailed` | `Service=api`, `Operation=email.batch_accept`, `Outcome=accepted|failed|unauthorized|invalid` |
+| Queue publish | `QueuePublish`, `QueuePublishLatency` | `Service=api|ingester|worker`, `Operation=queue.publish`, `JobType`, `Outcome=published|skipped|failed` |
+| Queue depth | `QueueDepthVisible`, `QueueDepthInFlight` | `Service=worker`, `Operation=queue.depth` |
+| Worker jobs | `WorkerJobLatency`, `WorkerJobProcessed`, `WorkerFailures`, `RetryCount` | `Service=worker`, `Operation=job.process`, `JobType`, `Outcome` |
+| SES send | `SendLatency`, `SendOutcome` | `Service=worker`, `Operation=ses.send`, `Outcome=sent|failed` |
+| SES ingest | `SesEventIngested`, `SesEventIngestFailed` | `Service=ingester`, `Operation=ses.ingest`, `EventType`, `Outcome` |
+
+Recommended alarms for staging/production:
+
+- `WorkerFailures > 0` for 5 minutes.
+- `SendOutcome` with `Outcome=failed` above the expected baseline.
+- `QueueDepthVisible` increasing for 10 minutes while `WorkerJobProcessed` stays flat.
+- `QueueDepthInFlight` near the SQS visibility/in-flight limit.
+- `EmailAcceptLatency` p95 above the request-path target.
+
+## Trace a send from API accept to provider result
+
+1. Send an email with an explicit correlation id:
+
+   ```bash
+   curl -i -X POST "$APP_URL/api/emails" \
+     -H "Authorization: Bearer $API_KEY" \
+     -H "Content-Type: application/json" \
+     -H "x-correlation-id: debug-$(date +%s)" \
+     -d '{
+       "from":"hello@example.com",
+       "to":["recipient@example.com"],
+       "subject":"Observability probe",
+       "html":"<p>probe</p>"
+     }'
+   ```
+
+2. Copy the response `x-correlation-id`, `traceparent`, and returned email `id`.
+3. In CloudWatch Logs Insights, query the app and ingester application log groups:
+
+   ```sql
+   fields @timestamp, level, event, service, operation, correlation_id, trace_id, email_id, job_id, job_type, status, reason, duration_ms
+   | filter correlation_id = "debug-..." or traceparent = "00-..." or email_id = "..."
+   | sort @timestamp asc
+   ```
+
+4. Expected event sequence for an immediate send:
+
+   ```text
+   api.request.start
+   email.accepted
+   span.start / queue.publish
+   metric.emf QueuePublish
+   span.start / worker.email.send
+   span.start / ses.send
+   span.end / ses.send
+   metric.emf SendOutcome + SendLatency
+   span.end / worker.email.send
+   metric.emf WorkerJobProcessed + WorkerJobLatency
+   ses.event.received
+   metric.emf SesEventIngested
+   span.start / queue.publish (webhook.dispatch, when matching webhooks exist)
+   ```
+
+5. If the API accepted the email but no worker send appears:
+
+   - Check `QueuePublish` for `Outcome=published` on the same `correlation_id`.
+   - Check `QueueDepthVisible` and `QueueDepthInFlight`.
+   - Confirm the ingester has `BACKGROUND_WORKER_POLL=true` and `BACKGROUND_JOBS_QUEUE_URL` set.
+   - Tail the ingester log group described in `docs/ingester-deploy.md`.
+
+6. If the worker failed:
+
+   - Query for `event = "email.send.failed"` or `WorkerFailures` with the same `trace_id`.
+   - Check `RetryCount`; SQS retries remain visible through receive count and redrive to the configured DLQ.
+   - Inspect SES permissions, sender verification, sandbox status, and AWS service errors in the sanitized `error_name` / `error_message` fields.
+
+## Local verification
+
+Local logs go to stdout/stderr as JSON. With no SQS queue configured, queue publishes emit `queue.publish.skipped` and `QueuePublish` with `Outcome=skipped`, which is expected for Docker-friendly development.
+
+Use the unit coverage for regression checks:
+
+```bash
+bun run test -- tests/observability.test.ts tests/background-jobs.test.ts tests/api-emails.test.ts tests/queue-worker.test.ts tests/ingester-ses-route.test.ts
+```

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,3 +22,4 @@ export * from "./services/email";
 export * from "./services/emailProvider";
 export * from "./services/storage";
 export * from "./jobs/background-jobs";
+export * from "./observability/telemetry";

--- a/packages/core/src/jobs/background-jobs.ts
+++ b/packages/core/src/jobs/background-jobs.ts
@@ -3,6 +3,16 @@ import {
   PutEventsCommand,
 } from "@aws-sdk/client-eventbridge";
 import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  type TelemetryCarrier,
+  createTelemetryContext,
+  emitCloudWatchMetric,
+  finishTelemetrySpan,
+  getTelemetryCarrier,
+  logTelemetry,
+  recordTelemetryError,
+  startTelemetrySpan,
+} from "../observability/telemetry";
 
 const MAX_SQS_DELAY_SECONDS = 900;
 const BACKGROUND_JOB_EVENT_SOURCE = "namuh-send.background-jobs";
@@ -27,6 +37,7 @@ interface BaseBackgroundJob {
   requestedAt: string;
   source: BackgroundJobSource;
   attempt?: number;
+  trace?: TelemetryCarrier;
 }
 
 export interface EmailSendJob extends BaseBackgroundJob {
@@ -103,6 +114,12 @@ function requiresQueue(options: PublishBackgroundJobOptions): boolean {
   );
 }
 
+function serviceForJobSource(source: BackgroundJobSource): string {
+  if (source === "api") return "api";
+  if (source === "ses-ingest") return "ingester";
+  return "worker";
+}
+
 function getSqsClient(): SQSClient {
   if (!sqsClient) {
     sqsClient = new SQSClient({ region: getRegion() });
@@ -142,51 +159,142 @@ export async function publishBackgroundJob(
   job: BackgroundJob,
   options: PublishBackgroundJobOptions = {},
 ): Promise<PublishBackgroundJobResult> {
+  const telemetry = createTelemetryContext({
+    service: serviceForJobSource(job.source),
+    operation: "background_job.publish",
+    carrier: job.trace,
+  });
+  const publishSpan = startTelemetrySpan(telemetry, {
+    operation: "queue.publish",
+    attributes: {
+      job_id: job.id,
+      job_type: job.type,
+      job_source: job.source,
+    },
+  });
   const queueUrl = getQueueUrl();
 
   if (!queueUrl) {
     if (requiresQueue(options)) {
-      throw new Error("BACKGROUND_JOBS_QUEUE_URL is required to publish jobs");
+      const error = new Error(
+        "BACKGROUND_JOBS_QUEUE_URL is required to publish jobs",
+      );
+      recordTelemetryError(
+        publishSpan.context,
+        "queue.publish.missing_queue",
+        error,
+        {
+          job_id: job.id,
+          job_type: job.type,
+        },
+      );
+      emitQueuePublishMetric(publishSpan.context, 0, job, "failed");
+      finishTelemetrySpan(publishSpan, { status: "error" });
+      throw error;
     }
-    console.info("[jobs] queue URL missing; skipping background job publish", {
-      jobId: job.id,
-      jobType: job.type,
+
+    logTelemetry("warn", "queue.publish.skipped", publishSpan.context, {
+      job_id: job.id,
+      job_type: job.type,
+      reason: "queue_url_missing",
     });
+    emitQueuePublishMetric(publishSpan.context, 0, job, "skipped");
+    finishTelemetrySpan(publishSpan, { status: "skipped" });
     return { status: "skipped", reason: "queue_url_missing" };
   }
 
-  const fifo = isFifoQueue(queueUrl);
-  const message = await getSqsClient().send(
-    new SendMessageCommand({
-      QueueUrl: queueUrl,
-      MessageBody: JSON.stringify(job),
-      DelaySeconds: sanitizeDelaySeconds(options.delaySeconds),
-      MessageAttributes: {
-        jobId: { DataType: "String", StringValue: job.id },
-        jobType: { DataType: "String", StringValue: job.type },
-        source: { DataType: "String", StringValue: job.source },
+  try {
+    const fifo = isFifoQueue(queueUrl);
+    const tracedJob = {
+      ...job,
+      trace: getTelemetryCarrier(publishSpan.context),
+    };
+    const message = await getSqsClient().send(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: JSON.stringify(tracedJob),
+        DelaySeconds: sanitizeDelaySeconds(options.delaySeconds),
+        MessageAttributes: {
+          jobId: { DataType: "String", StringValue: job.id },
+          jobType: { DataType: "String", StringValue: job.type },
+          source: { DataType: "String", StringValue: job.source },
+          correlationId: {
+            DataType: "String",
+            StringValue: publishSpan.context.correlationId,
+          },
+          traceparent: {
+            DataType: "String",
+            StringValue: publishSpan.context.traceparent,
+          },
+        },
+        ...(fifo
+          ? {
+              MessageDeduplicationId: options.deduplicationId ?? job.id,
+              MessageGroupId: options.groupId ?? job.type,
+            }
+          : {}),
+      }),
+    );
+
+    const eventId = await publishBackgroundJobEvent(
+      tracedJob,
+      message.MessageId,
+      publishSpan.context,
+    );
+    const durationMs = finishTelemetrySpan(publishSpan, {
+      status: "ok",
+      attributes: {
+        job_id: job.id,
+        job_type: job.type,
+        message_id: message.MessageId ?? null,
       },
-      ...(fifo
-        ? {
-            MessageDeduplicationId: options.deduplicationId ?? job.id,
-            MessageGroupId: options.groupId ?? job.type,
-          }
-        : {}),
-    }),
-  );
+    });
+    emitQueuePublishMetric(publishSpan.context, durationMs, job, "published");
 
-  const eventId = await publishBackgroundJobEvent(job, message.MessageId);
+    return {
+      status: "published",
+      messageId: message.MessageId ?? null,
+      eventId,
+    };
+  } catch (error) {
+    recordTelemetryError(publishSpan.context, "queue.publish.failed", error, {
+      job_id: job.id,
+      job_type: job.type,
+    });
+    finishTelemetrySpan(publishSpan, { status: "error" });
+    emitQueuePublishMetric(publishSpan.context, 0, job, "failed");
+    throw error;
+  }
+}
 
-  return {
-    status: "published",
-    messageId: message.MessageId ?? null,
-    eventId,
-  };
+function emitQueuePublishMetric(
+  context: TelemetryCarrier,
+  durationMs: number,
+  job: BackgroundJob,
+  outcome: "published" | "skipped" | "failed",
+): void {
+  emitCloudWatchMetric(context, {
+    metrics: [
+      { name: "QueuePublish", value: 1, unit: "Count" },
+      {
+        name: "QueuePublishLatency",
+        value: Math.round(durationMs),
+        unit: "Milliseconds",
+      },
+    ],
+    dimensions: {
+      Service: serviceForJobSource(job.source),
+      Operation: "queue.publish",
+      JobType: job.type,
+      Outcome: outcome,
+    },
+  });
 }
 
 async function publishBackgroundJobEvent(
   job: BackgroundJob,
   messageId: string | undefined,
+  context: TelemetryCarrier,
 ): Promise<string | null> {
   const eventBusName = getEventBusName();
   if (!eventBusName) return null;
@@ -206,10 +314,10 @@ async function publishBackgroundJobEvent(
     );
     return result.Entries?.[0]?.EventId ?? null;
   } catch (error) {
-    console.warn("[jobs] failed to publish EventBridge job event", {
-      jobId: job.id,
-      jobType: job.type,
-      error: error instanceof Error ? error.message : String(error),
+    recordTelemetryError(context, "queue.eventbridge_publish_failed", error, {
+      job_id: job.id,
+      job_type: job.type,
+      message_id: messageId ?? null,
     });
     return null;
   }
@@ -235,6 +343,7 @@ export function parseBackgroundJob(raw: string): BackgroundJob {
         requestedAt,
         source,
         ...(attempt !== undefined ? { attempt } : {}),
+        ...optionalTrace(parsed),
         emailId: getRequiredString(parsed, "emailId"),
       };
     case "scheduled-email.scan":
@@ -244,6 +353,7 @@ export function parseBackgroundJob(raw: string): BackgroundJob {
         requestedAt,
         source,
         ...(attempt !== undefined ? { attempt } : {}),
+        ...optionalTrace(parsed),
         ...optionalLimit(parsed),
       };
     case "webhook.dispatch":
@@ -253,6 +363,7 @@ export function parseBackgroundJob(raw: string): BackgroundJob {
         requestedAt,
         source,
         ...(attempt !== undefined ? { attempt } : {}),
+        ...optionalTrace(parsed),
         deliveryId: getRequiredString(parsed, "deliveryId"),
       };
     case "webhook-delivery.scan":
@@ -262,6 +373,7 @@ export function parseBackgroundJob(raw: string): BackgroundJob {
         requestedAt,
         source,
         ...(attempt !== undefined ? { attempt } : {}),
+        ...optionalTrace(parsed),
         ...optionalLimit(parsed),
       };
     default:
@@ -272,6 +384,29 @@ export function parseBackgroundJob(raw: string): BackgroundJob {
 function optionalLimit(value: Record<string, unknown>): { limit?: number } {
   const limit = getOptionalNumber(value, "limit");
   return limit === undefined ? {} : { limit };
+}
+
+function optionalTrace(value: Record<string, unknown>): {
+  trace?: TelemetryCarrier;
+} {
+  const trace = value.trace;
+  if (!isRecord(trace)) return {};
+
+  const traceparent =
+    typeof trace.traceparent === "string" ? trace.traceparent : null;
+  const correlationId =
+    typeof trace.correlationId === "string" ? trace.correlationId : null;
+  if (!traceparent || !correlationId) return {};
+
+  return {
+    trace: {
+      traceparent,
+      correlationId,
+      ...(typeof trace.tracestate === "string"
+        ? { tracestate: trace.tracestate }
+        : {}),
+    },
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/core/src/observability/telemetry.ts
+++ b/packages/core/src/observability/telemetry.ts
@@ -1,0 +1,412 @@
+import { createHash, randomBytes } from "node:crypto";
+
+const TRACE_ID_BYTES = 16;
+const SPAN_ID_BYTES = 8;
+const TRACE_FLAGS_SAMPLED = "01";
+const TRACEPARENT_VERSION = "00";
+const DEFAULT_NAMESPACE = "NamuhSend";
+const MAX_SANITIZE_DEPTH = 4;
+
+const TRACEPARENT_PATTERN =
+  /^([\da-f]{2})-([\da-f]{32})-([\da-f]{16})-([\da-f]{2})$/i;
+const ZERO_TRACE_ID = "0".repeat(32);
+const ZERO_SPAN_ID = "0".repeat(16);
+const EMAIL_PATTERN = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+
+const SENSITIVE_KEYS = new Set([
+  "authorization",
+  "cookie",
+  "set-cookie",
+  "token",
+  "apikey",
+  "api_key",
+  "rawkey",
+  "secret",
+  "password",
+  "from",
+  "to",
+  "cc",
+  "bcc",
+  "replyto",
+  "reply_to",
+  "subject",
+  "html",
+  "text",
+  "body",
+  "requestbody",
+  "responsebody",
+  "headers",
+  "attachments",
+  "content",
+]);
+
+export type TelemetryLevel = "info" | "warn" | "error";
+
+export type MetricUnit =
+  | "Count"
+  | "Milliseconds"
+  | "Seconds"
+  | "Microseconds"
+  | "Bytes"
+  | "None";
+
+export interface TelemetryCarrier {
+  traceparent: string;
+  tracestate?: string;
+  correlationId: string;
+}
+
+export interface TelemetryContext extends TelemetryCarrier {
+  service: string;
+  operation: string;
+  traceId: string;
+  spanId: string;
+  parentSpanId: string | null;
+  sampled: boolean;
+}
+
+export interface TelemetryMetric {
+  name: string;
+  value: number;
+  unit: MetricUnit;
+}
+
+export interface TelemetrySpanResult {
+  context: TelemetryContext;
+  startedAt: number;
+}
+
+export type TelemetryFields = Record<string, unknown>;
+export type TelemetryDimensions = Record<string, string>;
+
+type HeaderLike = Headers | Record<string, string | null | undefined>;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function randomHex(bytes: number): string {
+  return randomBytes(bytes).toString("hex");
+}
+
+function hashValue(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+function getHeader(
+  headers: HeaderLike | undefined,
+  key: string,
+): string | null {
+  if (!headers) return null;
+
+  if ("get" in headers && typeof headers.get === "function") {
+    return headers.get(key);
+  }
+
+  const lowerKey = key.toLowerCase();
+  for (const [headerKey, value] of Object.entries(headers)) {
+    if (headerKey.toLowerCase() === lowerKey) return value ?? null;
+  }
+  return null;
+}
+
+function parseTraceparent(
+  traceparent: string | null | undefined,
+): Pick<TelemetryContext, "traceId" | "parentSpanId" | "sampled"> | null {
+  if (!traceparent) return null;
+
+  const match = TRACEPARENT_PATTERN.exec(traceparent.trim());
+  if (!match) return null;
+
+  const [, version, traceId, spanId, flags] = match;
+  if (!version || !traceId || !spanId || !flags) return null;
+  if (version.toLowerCase() !== TRACEPARENT_VERSION) return null;
+  if (traceId === ZERO_TRACE_ID || spanId === ZERO_SPAN_ID) return null;
+
+  return {
+    traceId: traceId.toLowerCase(),
+    parentSpanId: spanId.toLowerCase(),
+    sampled: (Number.parseInt(flags, 16) & 1) === 1,
+  };
+}
+
+function buildTraceparent(
+  traceId: string,
+  spanId: string,
+  sampled: boolean,
+): string {
+  return `${TRACEPARENT_VERSION}-${traceId}-${spanId}-${sampled ? TRACE_FLAGS_SAMPLED : "00"}`;
+}
+
+function normalizeCorrelationId(value: string | null | undefined): string {
+  const trimmed = value?.trim();
+  if (!trimmed) return randomHex(8);
+  return trimmed.slice(0, 128);
+}
+
+export function createTelemetryContext(input: {
+  service: string;
+  operation: string;
+  headers?: HeaderLike;
+  carrier?: Partial<TelemetryCarrier>;
+  correlationId?: string | null;
+}): TelemetryContext {
+  const incomingTraceparent =
+    input.carrier?.traceparent ?? getHeader(input.headers, "traceparent");
+  const parsed = parseTraceparent(incomingTraceparent);
+  const traceId = parsed?.traceId ?? randomHex(TRACE_ID_BYTES);
+  const spanId = randomHex(SPAN_ID_BYTES);
+  const sampled = parsed?.sampled ?? true;
+  const tracestate =
+    input.carrier?.tracestate ??
+    getHeader(input.headers, "tracestate") ??
+    undefined;
+  const correlationId = normalizeCorrelationId(
+    input.correlationId ??
+      input.carrier?.correlationId ??
+      getHeader(input.headers, "x-correlation-id") ??
+      traceId,
+  );
+
+  return {
+    service: input.service,
+    operation: input.operation,
+    traceId,
+    spanId,
+    parentSpanId: parsed?.parentSpanId ?? null,
+    sampled,
+    traceparent: buildTraceparent(traceId, spanId, sampled),
+    ...(tracestate ? { tracestate } : {}),
+    correlationId,
+  };
+}
+
+export function createChildTelemetryContext(
+  parent: TelemetryContext | TelemetryCarrier,
+  input: { service?: string; operation: string },
+): TelemetryContext {
+  const parsed = parseTraceparent(parent.traceparent);
+  const traceId = parsed?.traceId ?? randomHex(TRACE_ID_BYTES);
+  const parentSpanId = parsed?.parentSpanId ?? null;
+  const spanId = randomHex(SPAN_ID_BYTES);
+  const sampled = parsed?.sampled ?? true;
+
+  return {
+    service:
+      "service" in parent ? parent.service : (input.service ?? "unknown"),
+    operation: input.operation,
+    traceId,
+    spanId,
+    parentSpanId,
+    sampled,
+    traceparent: buildTraceparent(traceId, spanId, sampled),
+    ...(parent.tracestate ? { tracestate: parent.tracestate } : {}),
+    correlationId: parent.correlationId,
+  };
+}
+
+export function getTelemetryCarrier(
+  context: TelemetryContext,
+): TelemetryCarrier {
+  return {
+    traceparent: context.traceparent,
+    ...(context.tracestate ? { tracestate: context.tracestate } : {}),
+    correlationId: context.correlationId,
+  };
+}
+
+export function startTelemetrySpan(
+  parent: TelemetryContext | TelemetryCarrier,
+  input: { service?: string; operation: string; attributes?: TelemetryFields },
+): TelemetrySpanResult {
+  const context = createChildTelemetryContext(parent, input);
+  const startedAt = performance.now();
+  logTelemetry("info", "span.start", context, input.attributes ?? {});
+  return { context, startedAt };
+}
+
+export function finishTelemetrySpan(
+  span: TelemetrySpanResult,
+  input: {
+    status?: "ok" | "error" | "skipped";
+    attributes?: TelemetryFields;
+  } = {},
+): number {
+  const durationMs = performance.now() - span.startedAt;
+  logTelemetry("info", "span.end", span.context, {
+    status: input.status ?? "ok",
+    duration_ms: Math.round(durationMs),
+    ...(input.attributes ?? {}),
+  });
+  return durationMs;
+}
+
+export function recordTelemetryError(
+  context: TelemetryContext | TelemetryCarrier,
+  event: string,
+  error: unknown,
+  fields: TelemetryFields = {},
+): void {
+  logTelemetry("error", event, context, {
+    ...fields,
+    error_name: error instanceof Error ? error.name : "Error",
+    error_message: error instanceof Error ? error.message : String(error),
+  });
+}
+
+export function logTelemetry(
+  level: TelemetryLevel,
+  event: string,
+  context: TelemetryContext | TelemetryCarrier,
+  fields: TelemetryFields = {},
+): void {
+  const entry = sanitizeTelemetryFields({
+    timestamp: nowIso(),
+    level,
+    event,
+    service: "service" in context ? context.service : undefined,
+    operation: "operation" in context ? context.operation : undefined,
+    trace_id:
+      "traceId" in context
+        ? context.traceId
+        : parseTraceparent(context.traceparent)?.traceId,
+    span_id:
+      "spanId" in context
+        ? context.spanId
+        : parseTraceparent(context.traceparent)?.parentSpanId,
+    parent_span_id:
+      "parentSpanId" in context ? context.parentSpanId : undefined,
+    traceparent: context.traceparent,
+    tracestate: context.tracestate,
+    correlation_id: context.correlationId,
+    ...fields,
+  });
+
+  const line = JSON.stringify(entry);
+  if (level === "error") {
+    console.error(line);
+  } else if (level === "warn") {
+    console.warn(line);
+  } else {
+    console.info(line);
+  }
+}
+
+export function emitCloudWatchMetric(
+  context: TelemetryContext | TelemetryCarrier,
+  input: {
+    namespace?: string;
+    metrics: TelemetryMetric[];
+    dimensions: TelemetryDimensions;
+    fields?: TelemetryFields;
+  },
+): void {
+  if (input.metrics.length === 0) return;
+
+  const dimensions = sanitizeDimensions(input.dimensions);
+  const metricValues = Object.fromEntries(
+    input.metrics.map((metric) => [metric.name, metric.value]),
+  );
+  const metricDefinitions = input.metrics.map((metric) => ({
+    Name: metric.name,
+    Unit: metric.unit,
+    StorageResolution: 60,
+  }));
+
+  logTelemetry("info", "metric.emf", context, {
+    _aws: {
+      Timestamp: Date.now(),
+      CloudWatchMetrics: [
+        {
+          Namespace:
+            input.namespace ??
+            process.env.CLOUDWATCH_METRICS_NAMESPACE?.trim() ??
+            DEFAULT_NAMESPACE,
+          Dimensions: [Object.keys(dimensions)],
+          Metrics: metricDefinitions,
+        },
+      ],
+    },
+    ...dimensions,
+    ...metricValues,
+    ...(input.fields ?? {}),
+  });
+}
+
+function sanitizeDimensions(
+  dimensions: TelemetryDimensions,
+): TelemetryDimensions {
+  const sanitized: TelemetryDimensions = {};
+  for (const [key, value] of Object.entries(dimensions)) {
+    if (!key || !value) continue;
+    sanitized[key] = value.slice(0, 128);
+  }
+  return sanitized;
+}
+
+export function sanitizeTelemetryFields(value: unknown): unknown {
+  return sanitizeValue(value, 0, null);
+}
+
+function sanitizeValue(
+  value: unknown,
+  depth: number,
+  key: string | null,
+): unknown {
+  if (depth > MAX_SANITIZE_DEPTH) return "[redacted:depth]";
+  if (value == null) return value;
+
+  if (typeof value === "string") {
+    if (key && isSensitiveKey(key)) return redactString(value);
+    return redactEmails(value);
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    if (key && isSensitiveKey(key)) return `[redacted:array:${value.length}]`;
+    return value.map((item) => sanitizeValue(item, depth + 1, key));
+  }
+
+  if (typeof value === "object") {
+    const output: Record<string, unknown> = {};
+    for (const [childKey, childValue] of Object.entries(value)) {
+      if (childKey === "_aws") {
+        output[childKey] = childValue;
+      } else if (isSensitiveKey(childKey)) {
+        output[childKey] = summarizeRedacted(childValue);
+      } else {
+        output[childKey] = sanitizeValue(childValue, depth + 1, childKey);
+      }
+    }
+    return output;
+  }
+
+  return String(value);
+}
+
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEYS.has(key.toLowerCase());
+}
+
+function summarizeRedacted(value: unknown): string {
+  if (typeof value === "string") return redactString(value);
+  if (Array.isArray(value)) return `[redacted:array:${value.length}]`;
+  if (value && typeof value === "object") return "[redacted:object]";
+  if (value == null) return "[redacted:null]";
+  return "[redacted]";
+}
+
+function redactString(value: string): string {
+  return `[redacted:sha256:${hashValue(value)}]`;
+}
+
+function redactEmails(value: string): string {
+  return value.replace(EMAIL_PATTERN, (match) => redactString(match));
+}

--- a/packages/ingester/src/index.ts
+++ b/packages/ingester/src/index.ts
@@ -1,7 +1,12 @@
 import {
   createBackgroundJob,
+  createTelemetryContext,
   emailEventRepo,
+  emitCloudWatchMetric,
+  getTelemetryCarrier,
+  logTelemetry,
   publishBackgroundJob,
+  recordTelemetryError,
   webhookRepo,
 } from "@namuh/core";
 import { Hono } from "hono";
@@ -56,6 +61,16 @@ app.post("/jobs/webhooks", async (c) =>
 );
 
 app.post("/events/ses", async (c) => {
+  const telemetry = createTelemetryContext({
+    service: "ingester",
+    operation: "POST /events/ses",
+    headers: {
+      traceparent: c.req.header("traceparent"),
+      tracestate: c.req.header("tracestate"),
+      "x-correlation-id": c.req.header("x-correlation-id"),
+    },
+  });
+
   try {
     const body = await c.req.json();
     const snsType = c.req.header("x-amz-sns-message-type");
@@ -64,15 +79,16 @@ app.post("/events/ses", async (c) => {
     await verifySnsSignature(snsMessage);
 
     if (snsMessage.Type === "SubscriptionConfirmation") {
-      console.log(
-        "SNS Subscription Confirmation URL:",
-        snsMessage.SubscribeURL,
-      );
+      logTelemetry("info", "ses.sns.subscription_confirmation", telemetry, {
+        sns_message_id: snsMessage.MessageId,
+      });
       return c.text("OK");
     }
 
     if (snsMessage.Type === "UnsubscribeConfirmation") {
-      console.warn("Received SNS UnsubscribeConfirmation for SES endpoint");
+      logTelemetry("warn", "ses.sns.unsubscribe_confirmation", telemetry, {
+        sns_message_id: snsMessage.MessageId,
+      });
       return c.text("OK");
     }
 
@@ -81,21 +97,26 @@ app.post("/events/ses", async (c) => {
     const eventType = sesMessage.eventType;
     const normalizedEvent = normalizeSesEvent(eventType);
 
-    console.log(`Received SES event ${eventType} for message ${sesId}`);
+    logTelemetry("info", "ses.event.received", telemetry, {
+      ses_message_id: sesId,
+      ses_event_type: eventType,
+    });
 
     if (!normalizedEvent) {
-      console.warn(
-        `Unsupported SES event type ${eventType} for message ${sesId}`,
-      );
+      logTelemetry("warn", "ses.event.unsupported", telemetry, {
+        ses_message_id: sesId,
+        ses_event_type: eventType,
+      });
       return c.text("OK");
     }
 
     const emailId = extractEmailId(sesMessage);
 
     if (!emailId) {
-      console.warn(
-        `Skipping SES event ${eventType} for ${sesId}: missing X-Entity-ID`,
-      );
+      logTelemetry("warn", "ses.event.missing_email_id", telemetry, {
+        ses_message_id: sesId,
+        ses_event_type: eventType,
+      });
       return c.text("OK");
     }
 
@@ -107,9 +128,22 @@ app.post("/events/ses", async (c) => {
     });
 
     if (!created) {
-      console.log(`Ignoring duplicate SNS message ${snsMessage.MessageId}`);
+      logTelemetry("info", "ses.event.duplicate", telemetry, {
+        sns_message_id: snsMessage.MessageId,
+        email_id: emailId,
+      });
       return c.text("OK");
     }
+
+    emitCloudWatchMetric(telemetry, {
+      metrics: [{ name: "SesEventIngested", value: 1, unit: "Count" }],
+      dimensions: {
+        Service: "ingester",
+        Operation: "ses.ingest",
+        EventType: event.type,
+        Outcome: "created",
+      },
+    });
 
     const { data: hooks } = await webhookRepo.list({ limit: 100 });
     for (const hook of hooks) {
@@ -128,6 +162,7 @@ app.post("/events/ses", async (c) => {
             type: "webhook.dispatch",
             source: "ses-ingest",
             deliveryId: delivery.id,
+            trace: getTelemetryCarrier(telemetry),
           }),
           {
             deduplicationId: `webhook.dispatch:${delivery.id}`,
@@ -140,11 +175,19 @@ app.post("/events/ses", async (c) => {
     return c.text("OK");
   } catch (error) {
     if (error instanceof SnsValidationError) {
-      console.warn(error.message);
+      recordTelemetryError(telemetry, "ses.sns.validation_failed", error);
       return new Response(error.message, { status: error.status });
     }
 
-    console.error("Unhandled SES ingestion error", error);
+    recordTelemetryError(telemetry, "ses.ingest.failed", error);
+    emitCloudWatchMetric(telemetry, {
+      metrics: [{ name: "SesEventIngestFailed", value: 1, unit: "Count" }],
+      dimensions: {
+        Service: "ingester",
+        Operation: "ses.ingest",
+        Outcome: "failed",
+      },
+    });
     return new Response("Internal Server Error", { status: 500 });
   }
 });

--- a/packages/ingester/src/queue-worker.ts
+++ b/packages/ingester/src/queue-worker.ts
@@ -1,16 +1,25 @@
 import {
   ChangeMessageVisibilityCommand,
   DeleteMessageCommand,
+  GetQueueAttributesCommand,
   ReceiveMessageCommand,
   SQSClient,
 } from "@aws-sdk/client-sqs";
 import {
   type BackgroundJob,
+  type TelemetryContext,
   createBackgroundJob,
+  createTelemetryContext,
   emailProvider,
   emailRepo,
+  emitCloudWatchMetric,
+  finishTelemetrySpan,
+  getTelemetryCarrier,
+  logTelemetry,
   parseBackgroundJob,
   publishBackgroundJob,
+  recordTelemetryError,
+  startTelemetrySpan,
 } from "@namuh/core";
 import { webhookDispatcher } from "./dispatcher";
 
@@ -79,7 +88,11 @@ export class QueueWorker {
     this.started = true;
     this.pollForever().catch((error) => {
       this.started = false;
-      console.error("[jobs] background worker stopped", error);
+      const telemetry = createTelemetryContext({
+        service: "worker",
+        operation: "queue.poll_forever",
+      });
+      recordTelemetryError(telemetry, "queue.worker.stopped", error);
     });
   }
 
@@ -93,10 +106,19 @@ export class QueueWorker {
   }
 
   async pollOnce(): Promise<PollResult> {
+    const pollTelemetry = createTelemetryContext({
+      service: "worker",
+      operation: "queue.poll",
+    });
+
     if (!this.queueUrl) {
-      console.info("[jobs] BACKGROUND_JOBS_QUEUE_URL missing; poll skipped");
+      logTelemetry("warn", "queue.poll.skipped", pollTelemetry, {
+        reason: "queue_url_missing",
+      });
       return { received: 0, processed: 0, deleted: 0, errors: 0 };
     }
+
+    await this.emitQueueDepthMetric(pollTelemetry);
 
     const response = await this.sqsClient.send(
       new ReceiveMessageCommand({
@@ -118,6 +140,10 @@ export class QueueWorker {
     };
 
     for (const message of messages) {
+      let failureTelemetry: TelemetryContext = pollTelemetry;
+      let failureJobType: string | null = null;
+      let jobSpan: ReturnType<typeof startTelemetrySpan> | null = null;
+
       if (!message.Body || !message.ReceiptHandle) {
         result.errors++;
         continue;
@@ -125,7 +151,22 @@ export class QueueWorker {
 
       try {
         const job = parseBackgroundJob(message.Body);
-        await this.processJob(job);
+        failureJobType = job.type;
+        const jobTelemetry = createTelemetryContext({
+          service: "worker",
+          operation: `job.${job.type}`,
+          carrier: job.trace,
+        });
+        jobSpan = startTelemetrySpan(jobTelemetry, {
+          operation: `worker.${job.type}`,
+          attributes: {
+            job_id: job.id,
+            job_type: job.type,
+            receive_count: getReceiveCount(message.Attributes),
+          },
+        });
+        failureTelemetry = jobSpan.context;
+        await this.processJob(job, jobSpan.context);
         result.processed++;
         await this.sqsClient.send(
           new DeleteMessageCommand({
@@ -134,9 +175,17 @@ export class QueueWorker {
           }),
         );
         result.deleted++;
+        const durationMs = finishTelemetrySpan(jobSpan, { status: "ok" });
+        emitWorkerJobMetric(jobSpan.context, {
+          durationMs,
+          jobType: job.type,
+          outcome: "success",
+          receiveCount: getReceiveCount(message.Attributes),
+        });
       } catch (error) {
         result.errors++;
         const delaySeconds = getRetryDelaySeconds(message.Attributes);
+        const retryCount = getReceiveCount(message.Attributes) - 1;
         if (delaySeconds !== null) {
           await this.sqsClient.send(
             new ChangeMessageVisibilityCommand({
@@ -146,19 +195,91 @@ export class QueueWorker {
             }),
           );
         }
-        console.error("[jobs] failed to process background job", error);
+        if (jobSpan) finishTelemetrySpan(jobSpan, { status: "error" });
+        recordTelemetryError(failureTelemetry, "worker.job.failed", error, {
+          retry_count: retryCount,
+          retry_delay_seconds: delaySeconds,
+        });
+        emitCloudWatchMetric(failureTelemetry, {
+          metrics: [
+            { name: "WorkerFailures", value: 1, unit: "Count" },
+            {
+              name: "RetryCount",
+              value: Math.max(0, retryCount),
+              unit: "Count",
+            },
+          ],
+          dimensions: {
+            Service: "worker",
+            Operation: "job.process",
+            ...(failureJobType ? { JobType: failureJobType } : {}),
+            Outcome: "failed",
+          },
+        });
       }
     }
 
     return result;
   }
 
-  async processJob(job: BackgroundJob): Promise<unknown> {
+  private async emitQueueDepthMetric(
+    telemetry: TelemetryContext,
+  ): Promise<void> {
+    if (!this.queueUrl) return;
+
+    try {
+      const response = await this.sqsClient.send(
+        new GetQueueAttributesCommand({
+          QueueUrl: this.queueUrl,
+          AttributeNames: [
+            "ApproximateNumberOfMessages",
+            "ApproximateNumberOfMessagesNotVisible",
+          ],
+        }),
+      );
+      const visible = Number(
+        response.Attributes?.ApproximateNumberOfMessages ?? "0",
+      );
+      const notVisible = Number(
+        response.Attributes?.ApproximateNumberOfMessagesNotVisible ?? "0",
+      );
+
+      emitCloudWatchMetric(telemetry, {
+        metrics: [
+          {
+            name: "QueueDepthVisible",
+            value: Number.isFinite(visible) ? visible : 0,
+            unit: "Count",
+          },
+          {
+            name: "QueueDepthInFlight",
+            value: Number.isFinite(notVisible) ? notVisible : 0,
+            unit: "Count",
+          },
+        ],
+        dimensions: {
+          Service: "worker",
+          Operation: "queue.depth",
+        },
+      });
+    } catch (error) {
+      recordTelemetryError(telemetry, "queue.depth.failed", error);
+    }
+  }
+
+  async processJob(
+    job: BackgroundJob,
+    telemetry = createTelemetryContext({
+      service: "worker",
+      operation: `job.${job.type}`,
+      carrier: job.trace,
+    }),
+  ): Promise<unknown> {
     switch (job.type) {
       case "email.send":
-        return await this.processEmailSend(job.emailId);
+        return await this.processEmailSend(job.emailId, telemetry);
       case "scheduled-email.scan":
-        return await this.processDueScheduledEmails(job.limit);
+        return await this.processDueScheduledEmails(job.limit, telemetry);
       case "webhook.dispatch":
         return await webhookDispatcher.dispatchDelivery(job.deliveryId);
       case "webhook-delivery.scan":
@@ -168,7 +289,13 @@ export class QueueWorker {
     }
   }
 
-  async processDueScheduledEmails(limit = 50): Promise<{
+  async processDueScheduledEmails(
+    limit = 50,
+    telemetry = createTelemetryContext({
+      service: "worker",
+      operation: "scheduled-email.scan",
+    }),
+  ): Promise<{
     scanned: number;
     enqueued: number;
   }> {
@@ -182,6 +309,7 @@ export class QueueWorker {
           type: "email.send",
           source: "scheduled-scan",
           emailId: email.id,
+          trace: getTelemetryCarrier(telemetry),
         }),
         {
           deduplicationId: `email.send:${email.id}`,
@@ -198,24 +326,49 @@ export class QueueWorker {
     return { scanned: due.length, enqueued };
   }
 
-  private async processEmailSend(emailId: string): Promise<{
+  private async processEmailSend(
+    emailId: string,
+    telemetry: TelemetryContext,
+  ): Promise<{
     status: "sent" | "skipped";
     reason?: string;
   }> {
     const email = await emailRepo.findById(emailId);
-    if (!email) return { status: "skipped", reason: "not_found" };
+    if (!email) {
+      logTelemetry("warn", "email.send.skipped", telemetry, {
+        reason: "not_found",
+        email_id: emailId,
+      });
+      return { status: "skipped", reason: "not_found" };
+    }
     if (email.status === "sent") {
+      logTelemetry("info", "email.send.skipped", telemetry, {
+        reason: "already_sent",
+        email_id: email.id,
+      });
       return { status: "skipped", reason: "already_sent" };
     }
     if (email.status === "cancelled" || email.status === "canceled") {
+      logTelemetry("info", "email.send.skipped", telemetry, {
+        reason: "cancelled",
+        email_id: email.id,
+      });
       return { status: "skipped", reason: "cancelled" };
     }
     if (email.scheduledAt && email.scheduledAt > new Date()) {
+      logTelemetry("info", "email.send.skipped", telemetry, {
+        reason: "scheduled_for_future",
+        email_id: email.id,
+      });
       return { status: "skipped", reason: "scheduled_for_future" };
     }
 
     await emailRepo.update(email.id, { status: "processing" });
 
+    const sesSpan = startTelemetrySpan(telemetry, {
+      operation: "ses.send",
+      attributes: { email_id: email.id },
+    });
     try {
       await emailProvider.sendEmail({
         from: email.from,
@@ -229,17 +382,91 @@ export class QueueWorker {
         headers: email.headers ?? undefined,
         attachments: normalizeAttachmentsForSend(email.attachments),
       });
+      const sendDurationMs = finishTelemetrySpan(sesSpan, { status: "ok" });
 
       await emailRepo.update(email.id, {
         status: "sent",
         sentAt: new Date(),
       });
+      emitSendMetric(telemetry, {
+        durationMs: sendDurationMs,
+        outcome: "sent",
+      });
       return { status: "sent" };
     } catch (error) {
+      finishTelemetrySpan(sesSpan, { status: "error" });
       await emailRepo.update(email.id, { status: "queued" });
+      recordTelemetryError(telemetry, "email.send.failed", error, {
+        email_id: email.id,
+      });
+      emitSendMetric(telemetry, {
+        durationMs: 0,
+        outcome: "failed",
+      });
       throw error;
     }
   }
+}
+
+function emitWorkerJobMetric(
+  telemetry: TelemetryContext,
+  input: {
+    durationMs: number;
+    jobType: string;
+    outcome: "success" | "failed";
+    receiveCount: number;
+  },
+): void {
+  emitCloudWatchMetric(telemetry, {
+    metrics: [
+      {
+        name: "WorkerJobLatency",
+        value: Math.round(input.durationMs),
+        unit: "Milliseconds",
+      },
+      { name: "WorkerJobProcessed", value: 1, unit: "Count" },
+      {
+        name: "RetryCount",
+        value: Math.max(0, input.receiveCount - 1),
+        unit: "Count",
+      },
+    ],
+    dimensions: {
+      Service: "worker",
+      Operation: "job.process",
+      JobType: input.jobType,
+      Outcome: input.outcome,
+    },
+  });
+}
+
+function emitSendMetric(
+  telemetry: TelemetryContext,
+  input: { durationMs: number; outcome: "sent" | "failed" },
+): void {
+  emitCloudWatchMetric(telemetry, {
+    metrics: [
+      {
+        name: "SendLatency",
+        value: Math.round(input.durationMs),
+        unit: "Milliseconds",
+      },
+      { name: "SendOutcome", value: 1, unit: "Count" },
+    ],
+    dimensions: {
+      Service: "worker",
+      Operation: "ses.send",
+      Outcome: input.outcome,
+    },
+  });
+}
+
+function getReceiveCount(
+  attributes: Record<string, string> | undefined,
+): number {
+  const receiveCount = Number(attributes?.ApproximateReceiveCount ?? "1");
+  if (!Number.isFinite(receiveCount) || receiveCount < 1) return 1;
+  return Math.floor(receiveCount);
 }
 
 function normalizeAttachmentsForSend(
@@ -263,8 +490,8 @@ function normalizeAttachmentsForSend(
 function getRetryDelaySeconds(
   attributes: Record<string, string> | undefined,
 ): number | null {
-  const receiveCount = Number(attributes?.ApproximateReceiveCount ?? "1");
-  if (!Number.isFinite(receiveCount) || receiveCount <= 1) return null;
+  const receiveCount = getReceiveCount(attributes);
+  if (receiveCount <= 1) return null;
   return Math.min(MAX_SQS_DELAY_SECONDS, 2 ** Math.min(receiveCount, 6));
 }
 

--- a/src/app/api/emails/batch/route.ts
+++ b/src/app/api/emails/batch/route.ts
@@ -3,7 +3,15 @@ import { db } from "@/lib/db";
 import { emails } from "@/lib/db/schema";
 import { normalizeAttachmentsForStorage } from "@/lib/email-attachments";
 import { batchSendEmailSchema } from "@/lib/validation/emails";
-import { createBackgroundJob, publishBackgroundJob } from "@namuh/core";
+import {
+  createBackgroundJob,
+  createTelemetryContext,
+  emitCloudWatchMetric,
+  getTelemetryCarrier,
+  logTelemetry,
+  publishBackgroundJob,
+  recordTelemetryError,
+} from "@namuh/core";
 import { eq } from "drizzle-orm";
 
 // ── Helpers ───────────────────────────────────────────────────────
@@ -15,23 +23,90 @@ function normalizeToArray(
   return Array.isArray(value) ? value : [value];
 }
 
+function jsonWithTelemetry(
+  body: unknown,
+  telemetry: ReturnType<typeof createTelemetryContext>,
+  init?: ResponseInit,
+): Response {
+  const headers = new Headers(init?.headers);
+  headers.set("x-correlation-id", telemetry.correlationId);
+  headers.set("traceparent", telemetry.traceparent);
+  return Response.json(body, { ...init, headers });
+}
+
+function recordBatchMetric(
+  telemetry: ReturnType<typeof createTelemetryContext>,
+  input: {
+    durationMs: number;
+    outcome: "accepted" | "failed" | "unauthorized" | "invalid";
+    count?: number;
+  },
+): void {
+  emitCloudWatchMetric(telemetry, {
+    metrics: [
+      { name: "EmailBatchAccepted", value: input.count ?? 0, unit: "Count" },
+      {
+        name: "EmailBatchAcceptLatency",
+        value: Math.round(input.durationMs),
+        unit: "Milliseconds",
+      },
+    ],
+    dimensions: {
+      Service: "api",
+      Operation: "email.batch_accept",
+      Outcome: input.outcome,
+    },
+  });
+}
+
 // ── POST /api/emails/batch ────────────────────────────────────────
 
 export async function POST(request: Request): Promise<Response> {
+  const telemetry = createTelemetryContext({
+    service: "api",
+    operation: "POST /api/emails/batch",
+    headers: request.headers,
+  });
+  const startedAt = performance.now();
+  logTelemetry("info", "api.request.start", telemetry, {
+    method: "POST",
+    route: "/api/emails/batch",
+  });
+
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth) {
+    recordBatchMetric(telemetry, {
+      durationMs: performance.now() - startedAt,
+      outcome: "unauthorized",
+    });
+    const response = unauthorizedResponse();
+    response.headers.set("x-correlation-id", telemetry.correlationId);
+    response.headers.set("traceparent", telemetry.traceparent);
+    return response;
+  }
 
   let body: unknown;
   try {
     body = await request.json();
   } catch {
-    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+    recordBatchMetric(telemetry, {
+      durationMs: performance.now() - startedAt,
+      outcome: "invalid",
+    });
+    return jsonWithTelemetry({ error: "Invalid JSON body" }, telemetry, {
+      status: 400,
+    });
   }
 
   const result = batchSendEmailSchema.safeParse(body);
   if (!result.success) {
-    return Response.json(
+    recordBatchMetric(telemetry, {
+      durationMs: performance.now() - startedAt,
+      outcome: "invalid",
+    });
+    return jsonWithTelemetry(
       { error: "Validation failed", details: result.error.flatten() },
+      telemetry,
       { status: 422 },
     );
   }
@@ -85,6 +160,7 @@ export async function POST(request: Request): Promise<Response> {
                   type: "email.send",
                   source: "api",
                   emailId: email.id,
+                  trace: getTelemetryCarrier(telemetry),
                 }),
                 {
                   deduplicationId: `email.send:${email.id}`,
@@ -96,6 +172,12 @@ export async function POST(request: Request): Promise<Response> {
                 .update(emails)
                 .set({ status: "failed" })
                 .where(eq(emails.id, email.id));
+              recordTelemetryError(
+                telemetry,
+                "email.batch_accept.queue_publish_failed",
+                error,
+                { email_id: email.id },
+              );
               throw error;
             }
           }
@@ -106,10 +188,36 @@ export async function POST(request: Request): Promise<Response> {
       results.push(...chunkResults);
     }
 
-    return Response.json({ data: results });
+    const durationMs = performance.now() - startedAt;
+    logTelemetry("info", "email.batch_accepted", telemetry, {
+      email_count: results.length,
+      duration_ms: Math.round(durationMs),
+    });
+    recordBatchMetric(telemetry, {
+      durationMs,
+      outcome: "accepted",
+      count: results.length,
+    });
+    return jsonWithTelemetry({ data: results }, telemetry);
   } catch (err) {
     const message =
       err instanceof Error ? err.message : "Failed to send batch emails";
-    return Response.json({ error: message }, { status: 500 });
+    recordTelemetryError(telemetry, "email.batch_accept.failed", err);
+    emitCloudWatchMetric(telemetry, {
+      metrics: [
+        { name: "EmailBatchAcceptFailed", value: 1, unit: "Count" },
+        {
+          name: "EmailBatchAcceptLatency",
+          value: Math.round(performance.now() - startedAt),
+          unit: "Milliseconds",
+        },
+      ],
+      dimensions: {
+        Service: "api",
+        Operation: "email.batch_accept",
+        Outcome: "failed",
+      },
+    });
+    return jsonWithTelemetry({ error: message }, telemetry, { status: 500 });
   }
 }

--- a/src/app/api/emails/route.ts
+++ b/src/app/api/emails/route.ts
@@ -3,7 +3,15 @@ import { db } from "@/lib/db";
 import { emails, templates } from "@/lib/db/schema";
 import { normalizeAttachmentsForStorage } from "@/lib/email-attachments";
 import { sendEmailSchema } from "@/lib/validation/emails";
-import { createBackgroundJob, publishBackgroundJob } from "@namuh/core";
+import {
+  createBackgroundJob,
+  createTelemetryContext,
+  emitCloudWatchMetric,
+  getTelemetryCarrier,
+  logTelemetry,
+  publishBackgroundJob,
+  recordTelemetryError,
+} from "@namuh/core";
 import { and, desc, eq, gt, lt } from "drizzle-orm";
 import type { ZodError } from "zod";
 
@@ -16,19 +24,79 @@ function normalizeToArray(
   return Array.isArray(value) ? value : [value];
 }
 
+function jsonWithTelemetry(
+  body: unknown,
+  telemetry: ReturnType<typeof createTelemetryContext>,
+  init?: ResponseInit,
+): Response {
+  const headers = new Headers(init?.headers);
+  headers.set("x-correlation-id", telemetry.correlationId);
+  headers.set("traceparent", telemetry.traceparent);
+  return Response.json(body, { ...init, headers });
+}
+
+function recordAcceptMetric(
+  telemetry: ReturnType<typeof createTelemetryContext>,
+  input: {
+    durationMs: number;
+    outcome: "queued" | "scheduled" | "failed" | "unauthorized" | "invalid";
+  },
+): void {
+  emitCloudWatchMetric(telemetry, {
+    metrics: [
+      { name: "EmailAccept", value: 1, unit: "Count" },
+      {
+        name: "EmailAcceptLatency",
+        value: Math.round(input.durationMs),
+        unit: "Milliseconds",
+      },
+    ],
+    dimensions: {
+      Service: "api",
+      Operation: "email.accept",
+      Outcome: input.outcome,
+    },
+  });
+}
+
 // ── POST /api/emails ──────────────────────────────────────────────
 
 export async function POST(request: Request): Promise<Response> {
+  const telemetry = createTelemetryContext({
+    service: "api",
+    operation: "POST /api/emails",
+    headers: request.headers,
+  });
+  const startedAt = performance.now();
+  logTelemetry("info", "api.request.start", telemetry, {
+    method: "POST",
+    route: "/api/emails",
+  });
+
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth) {
+    recordAcceptMetric(telemetry, {
+      durationMs: performance.now() - startedAt,
+      outcome: "unauthorized",
+    });
+    const response = unauthorizedResponse();
+    response.headers.set("x-correlation-id", telemetry.correlationId);
+    response.headers.set("traceparent", telemetry.traceparent);
+    return response;
+  }
 
   const idempotencyKey = request.headers.get("idempotency-key");
   if (
     idempotencyKey &&
     (idempotencyKey.length < 1 || idempotencyKey.length > 255)
   ) {
-    return Response.json(
+    recordAcceptMetric(telemetry, {
+      durationMs: performance.now() - startedAt,
+      outcome: "invalid",
+    });
+    return jsonWithTelemetry(
       { error: "Invalid idempotency key length" },
+      telemetry,
       { status: 400 },
     );
   }
@@ -37,13 +105,24 @@ export async function POST(request: Request): Promise<Response> {
   try {
     body = await request.json();
   } catch {
-    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+    recordAcceptMetric(telemetry, {
+      durationMs: performance.now() - startedAt,
+      outcome: "invalid",
+    });
+    return jsonWithTelemetry({ error: "Invalid JSON body" }, telemetry, {
+      status: 400,
+    });
   }
 
   const result = sendEmailSchema.safeParse(body);
   if (!result.success) {
-    return Response.json(
+    recordAcceptMetric(telemetry, {
+      durationMs: performance.now() - startedAt,
+      outcome: "invalid",
+    });
+    return jsonWithTelemetry(
       { error: "Validation failed", details: result.error.flatten() },
+      telemetry,
       { status: 422 },
     );
   }
@@ -56,7 +135,11 @@ export async function POST(request: Request): Promise<Response> {
       where: eq(emails.idempotencyKey, idempotencyKey),
     });
     if (existing) {
-      return Response.json({ id: existing.id }, { status: 409 });
+      recordAcceptMetric(telemetry, {
+        durationMs: performance.now() - startedAt,
+        outcome: "queued",
+      });
+      return jsonWithTelemetry({ id: existing.id }, telemetry, { status: 409 });
     }
   }
 
@@ -78,7 +161,13 @@ export async function POST(request: Request): Promise<Response> {
         where: eq(templates.id, validated.template.id),
       });
       if (!template) {
-        return Response.json({ error: "Template not found" }, { status: 404 });
+        recordAcceptMetric(telemetry, {
+          durationMs: performance.now() - startedAt,
+          outcome: "invalid",
+        });
+        return jsonWithTelemetry({ error: "Template not found" }, telemetry, {
+          status: 404,
+        });
       }
 
       // Validate required variables
@@ -94,11 +183,16 @@ export async function POST(request: Request): Promise<Response> {
 
       for (const requiredVar of requiredVars) {
         if (providedVars[requiredVar] === undefined) {
-          return Response.json(
+          recordAcceptMetric(telemetry, {
+            durationMs: performance.now() - startedAt,
+            outcome: "invalid",
+          });
+          return jsonWithTelemetry(
             {
               error: "Validation failed",
               message: `Missing required template variable: ${requiredVar}`,
             },
+            telemetry,
             { status: 422 },
           );
         }
@@ -152,6 +246,7 @@ export async function POST(request: Request): Promise<Response> {
             type: "email.send",
             source: "api",
             emailId: email.id,
+            trace: getTelemetryCarrier(telemetry),
           }),
           {
             deduplicationId: `email.send:${email.id}`,
@@ -163,14 +258,35 @@ export async function POST(request: Request): Promise<Response> {
           .update(emails)
           .set({ status: "failed" })
           .where(eq(emails.id, email.id));
+        recordTelemetryError(
+          telemetry,
+          "email.accept.queue_publish_failed",
+          error,
+          {
+            email_id: email.id,
+          },
+        );
         throw error;
       }
     }
 
-    return Response.json({ id: email.id });
+    const outcome = shouldQueueNow ? "queued" : "scheduled";
+    const durationMs = performance.now() - startedAt;
+    logTelemetry("info", "email.accepted", telemetry, {
+      email_id: email.id,
+      status: outcome,
+      duration_ms: Math.round(durationMs),
+    });
+    recordAcceptMetric(telemetry, { durationMs, outcome });
+    return jsonWithTelemetry({ id: email.id }, telemetry);
   } catch (err) {
     const message = err instanceof Error ? err.message : "Failed to send email";
-    return Response.json({ error: message }, { status: 500 });
+    recordTelemetryError(telemetry, "email.accept.failed", err);
+    recordAcceptMetric(telemetry, {
+      durationMs: performance.now() - startedAt,
+      outcome: "failed",
+    });
+    return jsonWithTelemetry({ error: message }, telemetry, { status: 500 });
   }
 }
 

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -5,6 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mockSendEmail = vi.hoisted(() => vi.fn());
 const mockPublishBackgroundJob = vi.hoisted(() => vi.fn());
 const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockEmitCloudWatchMetric = vi.hoisted(() => vi.fn());
+const mockLogTelemetry = vi.hoisted(() => vi.fn());
+const mockRecordTelemetryError = vi.hoisted(() => vi.fn());
 const mockDb = vi.hoisted(() => ({
   insert: vi.fn(),
   select: vi.fn(),
@@ -15,13 +18,62 @@ vi.mock("@/lib/ses", () => ({
   sendEmail: mockSendEmail,
 }));
 
-vi.mock("@namuh/core", () => ({
-  createBackgroundJob: (job: Record<string, unknown>) => ({
-    ...job,
-    requestedAt: "2026-04-28T00:00:00.000Z",
-  }),
-  publishBackgroundJob: mockPublishBackgroundJob,
-}));
+vi.mock("@namuh/core", () => {
+  const testTraceparent =
+    "00-11111111111111111111111111111111-2222222222222222-01";
+  const getHeader = (
+    headers: Headers | Record<string, string | undefined> | undefined,
+    key: string,
+  ): string | null => {
+    if (!headers) return null;
+    if ("get" in headers && typeof headers.get === "function") {
+      return headers.get(key);
+    }
+    const match = Object.entries(headers).find(
+      ([headerKey]) => headerKey.toLowerCase() === key.toLowerCase(),
+    );
+    return match?.[1] ?? null;
+  };
+
+  return {
+    createBackgroundJob: (job: Record<string, unknown>) => ({
+      ...job,
+      requestedAt: "2026-04-28T00:00:00.000Z",
+    }),
+    createTelemetryContext: (input: {
+      service: string;
+      operation: string;
+      headers?: Headers | Record<string, string | undefined>;
+      carrier?: { traceparent?: string; correlationId?: string };
+    }) => ({
+      service: input.service,
+      operation: input.operation,
+      traceId: "11111111111111111111111111111111",
+      spanId: "2222222222222222",
+      parentSpanId: null,
+      sampled: true,
+      traceparent:
+        input.carrier?.traceparent ??
+        getHeader(input.headers, "traceparent") ??
+        testTraceparent,
+      correlationId:
+        input.carrier?.correlationId ??
+        getHeader(input.headers, "x-correlation-id") ??
+        "corr-test",
+    }),
+    emitCloudWatchMetric: mockEmitCloudWatchMetric,
+    getTelemetryCarrier: (context: {
+      traceparent: string;
+      correlationId: string;
+    }) => ({
+      traceparent: context.traceparent,
+      correlationId: context.correlationId,
+    }),
+    logTelemetry: mockLogTelemetry,
+    publishBackgroundJob: mockPublishBackgroundJob,
+    recordTelemetryError: mockRecordTelemetryError,
+  };
+});
 
 vi.mock("@/lib/db", () => ({
   db: mockDb,
@@ -107,6 +159,9 @@ describe("POST /api/emails", () => {
     vi.resetModules();
     mockSendEmail.mockReset();
     mockPublishBackgroundJob.mockReset();
+    mockEmitCloudWatchMetric.mockReset();
+    mockLogTelemetry.mockReset();
+    mockRecordTelemetryError.mockReset();
     mockPublishBackgroundJob.mockResolvedValue({
       status: "skipped",
       reason: "queue_url_missing",
@@ -152,6 +207,8 @@ describe("POST /api/emails", () => {
     mockDb.insert = vi.fn().mockReturnValue({ values: valuesMock });
 
     const { POST } = await import("@/app/api/emails/route");
+    const traceparent =
+      "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01";
     const req = makeRequest(
       "POST",
       {
@@ -160,10 +217,16 @@ describe("POST /api/emails", () => {
         subject: "Test Email",
         html: "<p>Hello</p>",
       },
-      { Authorization: "Bearer re_test123" },
+      {
+        Authorization: "Bearer re_test123",
+        "x-correlation-id": "corr-email-test",
+        traceparent,
+      },
     );
     const res = await POST(req);
     expect(res.status).toBe(200);
+    expect(res.headers.get("x-correlation-id")).toBe("corr-email-test");
+    expect(res.headers.get("traceparent")).toBe(traceparent);
     const json = await res.json();
     expect(json).toHaveProperty("id", emailId);
     expect(mockSendEmail).not.toHaveBeenCalled();
@@ -179,6 +242,10 @@ describe("POST /api/emails", () => {
         type: "email.send",
         source: "api",
         emailId,
+        trace: {
+          correlationId: "corr-email-test",
+          traceparent,
+        },
       }),
       expect.objectContaining({
         deduplicationId: `email.send:${emailId}`,
@@ -317,6 +384,9 @@ describe("POST /api/emails/batch", () => {
     vi.resetModules();
     mockSendEmail.mockReset();
     mockPublishBackgroundJob.mockReset();
+    mockEmitCloudWatchMetric.mockReset();
+    mockLogTelemetry.mockReset();
+    mockRecordTelemetryError.mockReset();
     mockPublishBackgroundJob.mockResolvedValue({
       status: "skipped",
       reason: "queue_url_missing",

--- a/tests/background-jobs.test.ts
+++ b/tests/background-jobs.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockSqsSend = vi.hoisted(() => vi.fn());
 const mockEventBridgeSend = vi.hoisted(() => vi.fn());
@@ -29,10 +29,29 @@ describe("background job publisher", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockSqsClient.mockImplementation(() => ({ send: mockSqsSend }));
+    mockEventBridgeClient.mockImplementation(() => ({
+      send: mockEventBridgeSend,
+    }));
+    mockSendMessageCommand.mockImplementation((input) => ({
+      input,
+      type: "SendMessageCommand",
+    }));
+    mockPutEventsCommand.mockImplementation((input) => ({
+      input,
+      type: "PutEventsCommand",
+    }));
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
     process.env.AWS_REGION = "us-east-1";
     process.env.BACKGROUND_JOBS_QUEUE_URL = "";
     process.env.BACKGROUND_JOBS_EVENT_BUS_NAME = "";
     process.env.BACKGROUND_JOBS_REQUIRE_QUEUE = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("skips publishing when no queue URL is configured", async () => {
@@ -91,12 +110,38 @@ describe("background job publisher", () => {
     expect(mockSendMessageCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         QueueUrl: process.env.BACKGROUND_JOBS_QUEUE_URL,
-        MessageBody: JSON.stringify(job),
         DelaySeconds: 900,
+        MessageAttributes: expect.objectContaining({
+          correlationId: expect.objectContaining({
+            DataType: "String",
+            StringValue: expect.any(String),
+          }),
+          traceparent: expect.objectContaining({
+            DataType: "String",
+            StringValue: expect.stringMatching(
+              /^00-[a-f0-9]{32}-[a-f0-9]{16}-0[01]$/,
+            ),
+          }),
+        }),
         MessageDeduplicationId: "delivery-1",
         MessageGroupId: "webhook.dispatch",
       }),
     );
+    const sentBody = JSON.parse(
+      mockSendMessageCommand.mock.calls[0]?.[0]?.MessageBody ?? "{}",
+    );
+    expect(sentBody).toMatchObject({
+      id: job.id,
+      type: job.type,
+      source: job.source,
+      deliveryId: "delivery-1",
+      trace: {
+        correlationId: expect.any(String),
+        traceparent: expect.stringMatching(
+          /^00-[a-f0-9]{32}-[a-f0-9]{16}-0[01]$/,
+        ),
+      },
+    });
     expect(mockPutEventsCommand).toHaveBeenCalledWith({
       Entries: [
         expect.objectContaining({
@@ -121,6 +166,11 @@ describe("background job publisher", () => {
           source: "eventbridge",
           requestedAt: "2026-04-28T00:00:00.000Z",
           limit: 25,
+          trace: {
+            traceparent:
+              "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+            correlationId: "corr-1",
+          },
         }),
       ),
     ).toEqual({
@@ -129,6 +179,10 @@ describe("background job publisher", () => {
       source: "eventbridge",
       requestedAt: "2026-04-28T00:00:00.000Z",
       limit: 25,
+      trace: {
+        traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+        correlationId: "corr-1",
+      },
     });
 
     expect(() => parseBackgroundJob("{}")).toThrow(/id/);

--- a/tests/ingester-ses-route.test.ts
+++ b/tests/ingester-ses-route.test.ts
@@ -6,20 +6,69 @@ const mockWebhookList = vi.fn();
 const mockEnqueue = vi.fn();
 const mockDispatchDelivery = vi.fn();
 const mockPublishBackgroundJob = vi.fn();
+const mockEmitCloudWatchMetric = vi.fn();
+const mockLogTelemetry = vi.fn();
+const mockRecordTelemetryError = vi.fn();
 
-vi.mock("@namuh/core", () => ({
-  createBackgroundJob: (job: Record<string, unknown>) => ({
-    ...job,
-    requestedAt: "2026-04-28T00:00:00.000Z",
-  }),
-  emailEventRepo: {
-    createOrIgnoreDuplicate: mockCreateOrIgnoreDuplicate,
-  },
-  publishBackgroundJob: mockPublishBackgroundJob,
-  webhookRepo: {
-    list: mockWebhookList,
-  },
-}));
+vi.mock("@namuh/core", () => {
+  const testTraceparent =
+    "00-11111111111111111111111111111111-2222222222222222-01";
+  const getHeader = (
+    headers: Record<string, string | undefined> | undefined,
+    key: string,
+  ): string | null => {
+    if (!headers) return null;
+    const match = Object.entries(headers).find(
+      ([headerKey]) => headerKey.toLowerCase() === key.toLowerCase(),
+    );
+    return match?.[1] ?? null;
+  };
+
+  return {
+    createBackgroundJob: (job: Record<string, unknown>) => ({
+      ...job,
+      requestedAt: "2026-04-28T00:00:00.000Z",
+    }),
+    createTelemetryContext: (input: {
+      service: string;
+      operation: string;
+      headers?: Record<string, string | undefined>;
+      carrier?: { traceparent?: string; correlationId?: string };
+    }) => ({
+      service: input.service,
+      operation: input.operation,
+      traceId: "11111111111111111111111111111111",
+      spanId: "2222222222222222",
+      parentSpanId: null,
+      sampled: true,
+      traceparent:
+        input.carrier?.traceparent ??
+        getHeader(input.headers, "traceparent") ??
+        testTraceparent,
+      correlationId:
+        input.carrier?.correlationId ??
+        getHeader(input.headers, "x-correlation-id") ??
+        "corr-ingester-test",
+    }),
+    emailEventRepo: {
+      createOrIgnoreDuplicate: mockCreateOrIgnoreDuplicate,
+    },
+    emitCloudWatchMetric: mockEmitCloudWatchMetric,
+    getTelemetryCarrier: (context: {
+      traceparent: string;
+      correlationId: string;
+    }) => ({
+      traceparent: context.traceparent,
+      correlationId: context.correlationId,
+    }),
+    logTelemetry: mockLogTelemetry,
+    publishBackgroundJob: mockPublishBackgroundJob,
+    recordTelemetryError: mockRecordTelemetryError,
+    webhookRepo: {
+      list: mockWebhookList,
+    },
+  };
+});
 
 vi.mock("hono", () => {
   type Handler = (context: {
@@ -175,6 +224,9 @@ describe("SES SNS ingestion route", () => {
         },
       ],
     });
+    mockEmitCloudWatchMetric.mockReset();
+    mockLogTelemetry.mockReset();
+    mockRecordTelemetryError.mockReset();
 
     vi.stubGlobal(
       "fetch",
@@ -207,6 +259,8 @@ describe("SES SNS ingestion route", () => {
       headers: {
         "content-type": "application/json",
         "x-amz-sns-message-type": "Notification",
+        "x-correlation-id": "corr-ses-test",
+        traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
       },
       body: JSON.stringify(envelope),
     });
@@ -225,6 +279,11 @@ describe("SES SNS ingestion route", () => {
         type: "webhook.dispatch",
         source: "ses-ingest",
         deliveryId: "delivery-1",
+        trace: {
+          correlationId: "corr-ses-test",
+          traceparent:
+            "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+        },
       }),
       expect.objectContaining({
         deduplicationId: "webhook.dispatch:delivery-1",

--- a/tests/observability.test.ts
+++ b/tests/observability.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createChildTelemetryContext,
+  createTelemetryContext,
+  emitCloudWatchMetric,
+  sanitizeTelemetryFields,
+} from "../packages/core/src/observability/telemetry";
+
+describe("observability telemetry helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("accepts incoming W3C trace context and creates child spans on the same trace", () => {
+    const parentTraceparent =
+      "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01";
+
+    const context = createTelemetryContext({
+      service: "api",
+      operation: "POST /api/emails",
+      headers: {
+        traceparent: parentTraceparent,
+        "x-correlation-id": "corr-123",
+      },
+    });
+
+    expect(context.traceId).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    expect(context.parentSpanId).toBe("bbbbbbbbbbbbbbbb");
+    expect(context.correlationId).toBe("corr-123");
+    expect(context.traceparent).toMatch(
+      /^00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-[a-f0-9]{16}-01$/,
+    );
+
+    const child = createChildTelemetryContext(context, {
+      service: "worker",
+      operation: "worker.email.send",
+    });
+
+    expect(child.traceId).toBe(context.traceId);
+    expect(child.parentSpanId).toBe(context.spanId);
+    expect(child.correlationId).toBe("corr-123");
+    expect(child.traceparent).toMatch(
+      /^00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-[a-f0-9]{16}-01$/,
+    );
+  });
+
+  it("redacts PII-bearing fields and hashes email addresses in freeform logs", () => {
+    const sanitized = sanitizeTelemetryFields({
+      Authorization: "Bearer secret-token",
+      apiKey: "re_secret",
+      from: "sender@example.com",
+      metadata: "recipient@example.com clicked",
+      email_id: "email-1",
+      requestBody: "raw payload",
+      nested: {
+        subject: "Account reset",
+      },
+    }) as Record<string, unknown>;
+
+    const serialized = JSON.stringify(sanitized);
+    expect(serialized).not.toContain("secret-token");
+    expect(serialized).not.toContain("re_secret");
+    expect(serialized).not.toContain("sender@example.com");
+    expect(serialized).not.toContain("recipient@example.com");
+    expect(serialized).not.toContain("Account reset");
+    expect(serialized).not.toContain("raw payload");
+    expect(sanitized.email_id).toBe("email-1");
+    expect(serialized).toContain("[redacted:sha256:");
+  });
+
+  it("emits CloudWatch EMF metric records with trace and correlation fields", () => {
+    const infoSpy = vi
+      .spyOn(console, "info")
+      .mockImplementation(() => undefined);
+    const context = createTelemetryContext({
+      service: "worker",
+      operation: "ses.send",
+      correlationId: "corr-metric",
+    });
+
+    emitCloudWatchMetric(context, {
+      metrics: [
+        { name: "SendOutcome", value: 1, unit: "Count" },
+        { name: "SendLatency", value: 42, unit: "Milliseconds" },
+      ],
+      dimensions: {
+        Service: "worker",
+        Operation: "ses.send",
+        Outcome: "sent",
+      },
+      fields: {
+        to: ["recipient@example.com"],
+      },
+    });
+
+    expect(infoSpy).toHaveBeenCalledOnce();
+    const [line] = infoSpy.mock.calls[0] ?? [];
+    const entry = JSON.parse(String(line)) as Record<string, unknown>;
+
+    expect(entry.event).toBe("metric.emf");
+    expect(entry.correlation_id).toBe("corr-metric");
+    expect(entry.trace_id).toBe(context.traceId);
+    expect(entry.SendOutcome).toBe(1);
+    expect(entry.SendLatency).toBe(42);
+    expect(entry.Service).toBe("worker");
+    expect(entry.Operation).toBe("ses.send");
+    expect(entry.Outcome).toBe("sent");
+    expect(JSON.stringify(entry)).not.toContain("recipient@example.com");
+
+    const aws = entry._aws as {
+      CloudWatchMetrics: Array<{
+        Namespace: string;
+        Dimensions: string[][];
+        Metrics: Array<{ Name: string; Unit: string }>;
+      }>;
+    };
+    expect(aws.CloudWatchMetrics[0]).toMatchObject({
+      Namespace: "NamuhSend",
+      Dimensions: [["Service", "Operation", "Outcome"]],
+      Metrics: [
+        { Name: "SendOutcome", Unit: "Count" },
+        { Name: "SendLatency", Unit: "Milliseconds" },
+      ],
+    });
+  });
+});

--- a/tests/queue-worker.test.ts
+++ b/tests/queue-worker.test.ts
@@ -7,11 +7,30 @@ const mockSendEmail = vi.hoisted(() => vi.fn());
 const mockPublishBackgroundJob = vi.hoisted(() => vi.fn());
 const mockDispatchDelivery = vi.hoisted(() => vi.fn());
 const mockDispatchPendingDeliveries = vi.hoisted(() => vi.fn());
+const mockEmitCloudWatchMetric = vi.hoisted(() => vi.fn());
+const mockLogTelemetry = vi.hoisted(() => vi.fn());
+const mockRecordTelemetryError = vi.hoisted(() => vi.fn());
 
 vi.mock("@namuh/core", () => ({
   createBackgroundJob: (job: Record<string, unknown>) => ({
     ...job,
     requestedAt: "2026-04-28T00:00:00.000Z",
+  }),
+  createTelemetryContext: (input: {
+    service: string;
+    operation: string;
+    carrier?: { traceparent?: string; correlationId?: string };
+  }) => ({
+    service: input.service,
+    operation: input.operation,
+    traceId: "11111111111111111111111111111111",
+    spanId: "2222222222222222",
+    parentSpanId: null,
+    sampled: true,
+    traceparent:
+      input.carrier?.traceparent ??
+      "00-11111111111111111111111111111111-2222222222222222-01",
+    correlationId: input.carrier?.correlationId ?? "corr-worker-test",
   }),
   emailProvider: {
     sendEmail: mockSendEmail,
@@ -21,8 +40,28 @@ vi.mock("@namuh/core", () => ({
     findDueScheduled: mockFindDueScheduled,
     update: mockUpdateEmail,
   },
+  emitCloudWatchMetric: mockEmitCloudWatchMetric,
+  finishTelemetrySpan: () => 12,
+  getTelemetryCarrier: (context: {
+    traceparent: string;
+    correlationId: string;
+  }) => ({
+    traceparent: context.traceparent,
+    correlationId: context.correlationId,
+  }),
+  logTelemetry: mockLogTelemetry,
   parseBackgroundJob: (raw: string) => JSON.parse(raw),
   publishBackgroundJob: mockPublishBackgroundJob,
+  recordTelemetryError: mockRecordTelemetryError,
+  startTelemetrySpan: (context: {
+    service: string;
+    operation: string;
+    traceparent: string;
+    correlationId: string;
+  }) => ({
+    context,
+    startedAt: 0,
+  }),
 }));
 
 vi.mock("../packages/ingester/src/dispatcher", () => ({
@@ -109,6 +148,17 @@ describe("QueueWorker", () => {
     });
 
     expect(mockPublishBackgroundJob).toHaveBeenCalledTimes(2);
+    expect(mockPublishBackgroundJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "email.send:email-1",
+        trace: expect.objectContaining({
+          correlationId: "corr-worker-test",
+          traceparent:
+            "00-11111111111111111111111111111111-2222222222222222-01",
+        }),
+      }),
+      expect.any(Object),
+    );
     expect(mockUpdateEmail).toHaveBeenCalledWith("email-1", {
       status: "queued",
     });


### PR DESCRIPTION
## What
- Added a shared telemetry helper in `@namuh/core` for W3C/OpenTelemetry-compatible `traceparent`, correlation IDs, structured JSON logs, PII sanitization, span start/end events, and CloudWatch EMF metrics.
- Instrumented `POST /api/emails`, batch sends, background job publishing, worker polling/execution, SES sends, and SES/SNS ingestion so request and worker paths stay connected through queued jobs.
- Added CloudWatch-visible metrics for accept latency, send latency/outcomes, queue publish/depth, retry count, worker failures, and SES ingest outcomes.
- Documented PII-safe logging rules, metric names, alarms, and an API-to-provider tracing runbook in `docs/observability.md`.

## Why
Issue #18 needs an AWS-first operational observability baseline now that sending is queue-first and multi-service. The first slice keeps the default sink in CloudWatch logs/metrics and avoids introducing a collector or non-AWS dashboard dependency before there is deploy-time collector infrastructure.

## Notes
- This uses W3C/OpenTelemetry-compatible trace context and span logs without adding an OpenTelemetry collector/exporter dependency yet. A later deployment can attach a full SDK/exporter using the same propagated trace carrier.
- Telemetry sanitization redacts known sensitive fields and hashes email-address-shaped freeform strings before log/metric emission.

## Validation
- `make check`
- `make test`
- `bun run build`
- `bun run build:ingester`
- `bun run test -- tests/background-jobs.test.ts tests/observability.test.ts tests/queue-worker.test.ts tests/api-emails.test.ts tests/ingester-ses-route.test.ts`

Closes #18
