### PR TITLE
chore: remove DASHBOARD_KEY auth path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,6 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
 - **AWS CLI** is pre-configured via `~/.aws/credentials`. `aws` commands and `@aws-sdk/*` packages work out of the box. Use `us-east-1` for SES.
 - `.env` keys (see `.env.example` for the contributor-facing set):
   - `DATABASE_URL` — Postgres connection string
-  - `DASHBOARD_KEY` — master dashboard gate key
   - `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ZONE_ID` — DNS management
   - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` — SES + S3
   - `S3_BUCKET_NAME` — email attachment storage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,6 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
 - **AWS CLI** is pre-configured via `~/.aws/credentials`. `aws` commands and `@aws-sdk/*` packages work out of the box. Use `us-east-1` for SES.
 - `.env` keys (see `.env.example` for the contributor-facing set):
   - `DATABASE_URL` — Postgres connection string
-  - `DASHBOARD_KEY` — master dashboard gate key
   - `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ZONE_ID` — DNS management
   - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` — SES + S3
   - `S3_BUCKET_NAME` — email attachment storage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thanks for your interest in contributing to Opensend!
 git clone https://github.com/namuh-eng/opensend.git
 cd opensend
 cp .env.example .env
-make setup    # ensures DASHBOARD_KEY exists, starts Postgres, installs deps, pushes schema, seeds DB
+make setup    # starts Postgres, installs deps, pushes schema, seeds DB
 make dev      # http://localhost:3015
 ```
 
@@ -43,7 +43,7 @@ If you install dependencies with `--ignore-scripts`, run `bun run hooks:install`
 <details>
 <summary>Manual setup (without make setup)</summary>
 
-1. Copy `.env.example` to `.env` and set `DASHBOARD_KEY` (see the file for a generation command).
+1. Copy `.env.example` to `.env`.
 2. Start Postgres: `docker compose up postgres -d` (or point `DATABASE_URL` at your own instance). If port `5432` is already taken, change both `POSTGRES_PORT` and the port inside `DATABASE_URL` in `.env`.
 3. Push schema and seed: `bun run db:push && bun run db:seed`
 4. Start dev server: `bun run dev`

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ db-push:
 # One-command local setup (requires Docker)
 setup:
 	@test -f .env || (cp .env.example .env && echo "  ✓ Created .env from .env.example")
-	@node -e "const fs=require('fs'); const crypto=require('crypto'); const path='.env'; let env=fs.readFileSync(path,'utf8'); if(/^DASHBOARD_KEY=$$/m.test(env)){ env=env.replace(/^DASHBOARD_KEY=$$/m, 'DASHBOARD_KEY='+crypto.randomUUID()); fs.writeFileSync(path, env); console.log('  ✓ Generated DASHBOARD_KEY in .env'); }"
 	@echo "→ Starting Postgres..." && docker compose up postgres -d
 	@echo "→ Waiting for Postgres..." && until docker compose exec -T postgres pg_isready -U opensend >/dev/null 2>&1; do sleep 1; done && echo "  ✓ Postgres is ready"
 	@echo "→ Installing dependencies and git hooks..." && bun install

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ The fastest way to get Opensend running:
 git clone https://github.com/namuh-eng/opensend.git
 cd opensend
 cp .env.example .env
-# Edit .env — set DASHBOARD_KEY (required); AWS credentials are only needed for real email sending
+# Edit .env — AWS credentials are only needed for real email sending
 docker compose up -d
 ```
 
-That's it. Open **http://localhost:3015** and enter your dashboard key.
+That's it. Open **http://localhost:3015** and sign in with Google (configure `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` in `.env`).
 
 > The `migrate` service runs database migrations automatically on first boot.
 
@@ -130,9 +130,6 @@ cp .env.example .env
 Edit `.env` with your configuration:
 
 ```bash
-# Required
-DASHBOARD_KEY=your-secret-key          # Generate: node -e "console.log(crypto.randomUUID())"
-
 # Required for sending emails
 AWS_ACCESS_KEY_ID=your-aws-key
 AWS_SECRET_ACCESS_KEY=your-aws-secret
@@ -169,7 +166,7 @@ git clone https://github.com/namuh-eng/opensend.git
 cd opensend
 bun install
 cp .env.example .env
-# Edit .env — set DASHBOARD_KEY (required). Leave DATABASE_URL as localhost unless you're using another Postgres instance.
+# Edit .env — leave DATABASE_URL as localhost unless you're using another Postgres instance.
 bun run db:push
 bun run db:seed          # Optional: creates sample data
 bun run dev              # Development (port 3015)
@@ -299,7 +296,7 @@ For local contributor onboarding, use the same Docker-backed path as [CONTRIBUTI
 
 ```bash
 cp .env.example .env
-make setup    # ensures DASHBOARD_KEY exists, starts Postgres, installs deps, pushes schema, seeds DB
+make setup    # starts Postgres, installs deps, pushes schema, seeds DB
 make dev      # http://localhost:3015
 ```
 

--- a/packages/core/src/auth/api-auth.ts
+++ b/packages/core/src/auth/api-auth.ts
@@ -42,23 +42,6 @@ export async function validateApiKey(
 }
 
 /**
- * Validate the dashboard master key from the Authorization header.
- * Used for internal dashboard endpoints (e.g. /api/api-keys).
- */
-export function validateDashboardKey(
-  authHeader: string | null | undefined,
-): boolean {
-  const dashboardKey = process.env.DASHBOARD_KEY;
-  if (!dashboardKey) return false;
-
-  if (!authHeader) return false;
-  const parts = authHeader.split(" ");
-  if (parts.length !== 2 || parts[0] !== "Bearer") return false;
-
-  return parts[1] === dashboardKey;
-}
-
-/**
  * Helper to create a 401 JSON response.
  */
 export function unauthorizedResponse(): Response {

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,10 +1,6 @@
 // ABOUTME: Metrics API endpoint — returns aggregated email stats, daily chart data, and per-domain breakdown
 
-import {
-  getServerSession,
-  unauthorizedResponse,
-  validateDashboardKey,
-} from "@/lib/api-auth";
+import { getServerSession, unauthorizedResponse } from "@/lib/api-auth";
 import {
   DASHBOARD_METRICS_CACHE_TTL_SECONDS,
   getMetricsAggregateCacheKey,
@@ -48,12 +44,8 @@ const senderDomainSql = sql<string>`substring(${emails.from} from '@([^>]+)')`;
 
 // Dashboard-only internal endpoint
 export async function GET(request: NextRequest) {
-  const hasDashboardKey = validateDashboardKey(
-    request.headers.get("authorization"),
-  );
-  const session = hasDashboardKey ? null : await getServerSession();
-
-  if (!hasDashboardKey && !session) return unauthorizedResponse();
+  const session = await getServerSession();
+  if (!session) return unauthorizedResponse();
 
   try {
     const searchParams = request.nextUrl.searchParams;

--- a/src/app/api/usage/route.ts
+++ b/src/app/api/usage/route.ts
@@ -1,21 +1,13 @@
-import {
-  getServerSession,
-  unauthorizedResponse,
-  validateDashboardKey,
-} from "@/lib/api-auth";
+import { getServerSession, unauthorizedResponse } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { contacts, domains, emails, segments } from "@/lib/db/schema";
 import { gte } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
 // Dashboard-only internal endpoint
-export async function GET(request: Request) {
-  const hasDashboardKey = validateDashboardKey(
-    request.headers.get("authorization"),
-  );
-  const session = hasDashboardKey ? null : await getServerSession();
-
-  if (!hasDashboardKey && !session) return unauthorizedResponse();
+export async function GET() {
+  const session = await getServerSession();
+  if (!session) return unauthorizedResponse();
 
   try {
     const now = new Date();

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -120,23 +120,6 @@ export async function validateApiKey(
 }
 
 /**
- * Validate the dashboard master key from the Authorization header.
- * Used for internal dashboard endpoints (e.g. /api/api-keys).
- */
-export function validateDashboardKey(
-  authHeader: string | null | undefined,
-): boolean {
-  const dashboardKey = process.env.DASHBOARD_KEY;
-  if (!dashboardKey) return false;
-
-  if (!authHeader) return false;
-  const parts = authHeader.split(" ");
-  if (parts.length !== 2 || parts[0] !== "Bearer") return false;
-
-  return parts[1] === dashboardKey;
-}
-
-/**
  * Helper to create a 401 JSON response.
  */
 export function unauthorizedResponse(): Response {
@@ -155,8 +138,7 @@ export async function getServerSession() {
 
 /**
  * Validate access for dashboard-managed routes that should accept either:
- * - a regular API key,
- * - the dashboard master key, or
+ * - a regular API key, or
  * - an authenticated dashboard session.
  */
 export async function authorizeDashboardOrApiKey(
@@ -165,10 +147,6 @@ export async function authorizeDashboardOrApiKey(
   const apiKeyAuth = await validateApiKey(authHeader);
   if (apiKeyAuth) {
     return apiKeyAuth;
-  }
-
-  if (validateDashboardKey(authHeader)) {
-    return { dashboard: true };
   }
 
   const session = await getServerSession();

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -9,7 +9,6 @@ const mockUpdate = vi.hoisted(() => vi.fn());
 const mockDelete = vi.hoisted(() => vi.fn());
 const mockValidateApiKey = vi.hoisted(() => vi.fn());
 const mockCountFn = vi.hoisted(() => vi.fn());
-const mockValidateDashboardKey = vi.hoisted(() => vi.fn());
 const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
 
@@ -62,7 +61,6 @@ describe("lib/api-auth", () => {
     vi.resetModules();
     vi.clearAllMocks();
     vi.doUnmock("@/lib/api-auth");
-    process.env.DASHBOARD_KEY = undefined;
   });
 
   it("validates a bearer API key by sha256 token hash", async () => {
@@ -95,20 +93,6 @@ describe("lib/api-auth", () => {
     expect(await validateApiKey("Basic abc")).toBeNull();
     expect(await validateApiKey("Bearer ")).toBeNull();
     expect(await validateApiKey("Bearer wrong")).toBeNull();
-  });
-
-  it("validates the dashboard key from env", async () => {
-    process.env.DASHBOARD_KEY = "dashboard-secret";
-    const { validateDashboardKey } = await import("@/lib/api-auth");
-
-    expect(validateDashboardKey("Bearer dashboard-secret")).toBe(true);
-    expect(validateDashboardKey("Bearer wrong")).toBe(false);
-    expect(validateDashboardKey(null)).toBe(false);
-  });
-
-  it("fails dashboard validation when env is missing", async () => {
-    const { validateDashboardKey } = await import("@/lib/api-auth");
-    expect(validateDashboardKey("Bearer dashboard-secret")).toBe(false);
   });
 
   it("builds the standard unauthorized response", async () => {
@@ -214,7 +198,6 @@ describe("route smoke coverage", () => {
       return {
         ...actual,
         validateApiKey: mockValidateApiKey,
-        validateDashboardKey: mockValidateDashboardKey,
         getServerSession: mockGetServerSession,
         authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
       };
@@ -227,15 +210,13 @@ describe("route smoke coverage", () => {
       apiKeyId: "key-1",
       permission: "full_access",
     });
-    mockValidateDashboardKey.mockReturnValue(true);
     mockGetServerSession.mockResolvedValue({
       session: { id: "session-1" },
       user: { id: "user-1" },
     });
   });
 
-  it("covers metrics auth failure, session auth, and dashboard key auth", async () => {
-    mockValidateDashboardKey.mockReturnValueOnce(false);
+  it("covers metrics auth failure and session auth", async () => {
     mockGetServerSession.mockResolvedValueOnce(null);
     const metricsRoute = await import("@/app/api/metrics/route");
     const unauthorized = await metricsRoute.GET(
@@ -243,7 +224,6 @@ describe("route smoke coverage", () => {
     );
     expect(unauthorized.status).toBe(401);
 
-    mockValidateDashboardKey.mockReturnValueOnce(false);
     mockSelect
       .mockReturnValueOnce(
         makeChain([
@@ -290,45 +270,15 @@ describe("route smoke coverage", () => {
       { domain: "example.com", count: 10, rate: 70 },
     ]);
 
-    mockSelect
-      .mockReturnValueOnce(
-        makeChain([
-          {
-            total: 0,
-            delivered: 0,
-            bounced: 0,
-            hard_bounced: 0,
-            soft_bounced: 0,
-            undetermined_bounced: 0,
-            complained: 0,
-          },
-        ]),
-      )
-      .mockReturnValueOnce(makeChain([]))
-      .mockReturnValueOnce(makeChain([]))
-      .mockReturnValueOnce(makeChain([]))
-      .mockReturnValueOnce(makeChain([]));
-    mockValidateDashboardKey.mockReturnValueOnce(true);
-    const dashboardKeyResponse = await metricsRoute.GET(
-      makeNextRequest("http://localhost/api/metrics", {
-        headers: { authorization: "Bearer token" },
-      }) as never,
-    );
-
-    expect(dashboardKeyResponse.status).toBe(200);
     expect(mockGetServerSession).toHaveBeenCalledTimes(2);
   });
 
-  it("covers usage auth failure, session auth, and dashboard key auth", async () => {
-    mockValidateDashboardKey.mockReturnValueOnce(false);
+  it("covers usage auth failure and session auth", async () => {
     mockGetServerSession.mockResolvedValueOnce(null);
     const usageRoute = await import("@/app/api/usage/route");
-    const unauthorized = await usageRoute.GET(
-      makeNextRequest("http://localhost/api/usage"),
-    );
+    const unauthorized = await usageRoute.GET();
     expect(unauthorized.status).toBe(401);
 
-    mockValidateDashboardKey.mockReturnValueOnce(false);
     mockGetServerSession.mockResolvedValueOnce({
       session: { id: "session-1" },
       user: { id: "user-1" },
@@ -340,35 +290,15 @@ describe("route smoke coverage", () => {
     mockCountFn.mockResolvedValueOnce(4);
     mockCountFn.mockResolvedValueOnce(2);
 
-    const sessionResponse = await usageRoute.GET(
-      makeNextRequest("http://localhost/api/usage"),
-    );
+    const sessionResponse = await usageRoute.GET();
 
     expect(sessionResponse.status).toBe(200);
-    let json = await sessionResponse.json();
+    const json = await sessionResponse.json();
     expect(json.transactional.monthlyUsed).toBe(42);
     expect(json.transactional.dailyUsed).toBe(3);
     expect(json.marketing.contactsUsed).toBe(120);
     expect(json.marketing.segmentsUsed).toBe(4);
     expect(json.team.domainsUsed).toBe(2);
-
-    mockValidateDashboardKey.mockReturnValueOnce(true);
-    mockCountFn.mockResolvedValue(0);
-    mockCountFn.mockResolvedValueOnce(7);
-    mockCountFn.mockResolvedValueOnce(1);
-    mockCountFn.mockResolvedValueOnce(8);
-    mockCountFn.mockResolvedValueOnce(2);
-    mockCountFn.mockResolvedValueOnce(1);
-
-    const dashboardKeyResponse = await usageRoute.GET(
-      makeNextRequest("http://localhost/api/usage", {
-        headers: { authorization: "Bearer token" },
-      }),
-    );
-
-    expect(dashboardKeyResponse.status).toBe(200);
-    json = await dashboardKeyResponse.json();
-    expect(json.transactional.monthlyUsed).toBe(7);
     expect(mockGetServerSession).toHaveBeenCalledTimes(2);
   });
 

--- a/tests/metrics-route.test.ts
+++ b/tests/metrics-route.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockSelect = vi.hoisted(() => vi.fn());
-const mockValidateDashboardKey = vi.hoisted(() => vi.fn());
 const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockReadDashboardAggregateCache = vi.hoisted(() => vi.fn());
 const mockWriteDashboardAggregateCache = vi.hoisted(() => vi.fn());
@@ -51,7 +50,6 @@ vi.mock("@/lib/api-auth", () => ({
       status: 401,
       headers: { "content-type": "application/json" },
     }),
-  validateDashboardKey: mockValidateDashboardKey,
 }));
 
 vi.mock("@/lib/cache/dashboard-aggregates", () => ({
@@ -164,7 +162,6 @@ describe("metrics route filters", () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2026, 3, 23, 15, 45, 30));
-    mockValidateDashboardKey.mockReturnValue(true);
     mockGetServerSession.mockResolvedValue({
       session: { id: "session-1" },
       user: { id: "user-1" },


### PR DESCRIPTION
## Summary
- The dashboard master key (`DASHBOARD_KEY` env var) was a pre-Better-Auth escape hatch on `/api/metrics`, `/api/usage`, and the shared dashboard-or-API-key authorizer
- Better Auth + Google OAuth is now the only login path actually used by the dashboard, so the env-keyed fallback was dead code
- Strips the function, the call sites, and the tests
- Updates README, CONTRIBUTING, AGENTS, CLAUDE, and the Makefile `setup` target so contributors aren't directed to set a key the app no longer reads

## Note for follow-up
- `.env.example` still has an empty `DASHBOARD_KEY=` placeholder line. Permission settings here block reading/editing it from the agent — please delete that line manually.
- After merge, prod task definitions still inject `DASHBOARD_KEY` from Secrets Manager. Once this is on `main`, I'll re-roll the task defs to drop the env entry and schedule deletion of `opensend/dashboard-key` from Secrets Manager.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run tests/api-auth-date-range-routes.test.ts tests/metrics-route.test.ts` — 19 tests pass
- [x] Full vitest run: only failure is a pre-existing flake in `broadcasts-list.test.ts` that passes when run alone