### PR TITLE
chore: ECS migrator deploy stage + refresh env docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,70 +1,97 @@
-# Copy this file to .env and fill in your values
+# Copy this file to .env and fill in your values.
 #
-# Required vars are uncommented. Optional vars are commented out.
+# Convention:
+#   - Uncommented lines = required for local dev to work end-to-end.
+#   - Commented lines   = optional, or only needed for specific features /
+#                          staging / production.
 
-# ── Database (required) ──────────────────────────────────────────
-# If you run app/scripts on your host machine, leave this localhost URL as-is.
+# ─────────────────────────────────────────────────────────────────
+# Database (required)
+# ─────────────────────────────────────────────────────────────────
+# If you run app/scripts on your host machine, leave the localhost URL as-is.
 # Docker Compose services use their own internal DATABASE_URL automatically.
 DATABASE_URL=postgresql://opensend:opensend@localhost:5432/opensend
-# If using a remote Postgres (e.g. AWS RDS, Supabase, Neon):
+# Remote Postgres example (RDS / Supabase / Neon):
 # DATABASE_URL=postgresql://user:password@host:5432/dbname
 
-# ── Docker Compose Postgres Password ────────────────────────────
-# Only used by docker compose. Change this in production.
+# Docker Compose Postgres password (compose only). Change in production.
 # POSTGRES_PASSWORD=opensend
-# If port 5432 is already taken on your machine, change both this and DATABASE_URL.
+# If port 5432 is taken on your host, change BOTH this and DATABASE_URL.
 # POSTGRES_PORT=5432
 
-# ── Dashboard Auth (required) ───────────────────────────────────
-# Master key for the dashboard and internal API endpoints.
-# Generate one: node -e "console.log(crypto.randomUUID())"
-DASHBOARD_KEY=
+# ─────────────────────────────────────────────────────────────────
+# Auth (required)
+# ─────────────────────────────────────────────────────────────────
+# Better Auth callback base URL.
+BETTER_AUTH_URL=http://localhost:3015
+# Public URL the frontend uses. Must match BETTER_AUTH_URL for local dev.
+NEXT_PUBLIC_APP_URL=http://localhost:3015
 
-# ── App Port ────────────────────────────────────────────────────
-# Port the app is exposed on (docker compose only). Default: 3015.
+# Google OAuth — create at https://console.cloud.google.com/apis/credentials
+# Authorized redirect URI: ${BETTER_AUTH_URL}/api/auth/callback/google
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# ─────────────────────────────────────────────────────────────────
+# App port (Docker Compose only — Next.js dev server uses bun run dev)
+# ─────────────────────────────────────────────────────────────────
 # PORT=3015
 
-# ── Shared Rate Limiting (recommended for staging/production) ─────
-# RATE_LIMIT_BACKEND=disabled   # local single-process dev default
-# RATE_LIMIT_BACKEND=redis      # required for shared/staging/production instances
-# REDIS_URL=rediss://default:password@your-cache-endpoint:6379
-# Use the TLS-enabled ElastiCache/Redis endpoint (`rediss://...`) when RATE_LIMIT_BACKEND=redis.
-# REDIS_URL also backs API-key auth caching and domain metadata caching.
-
-# ── AWS SES (Email Sending) ─────────────────────────────────────
-# Required for sending emails. Uses ~/.aws/credentials locally,
-# or set these explicitly for Docker / production:
+# ─────────────────────────────────────────────────────────────────
+# AWS SES — email sending (required to actually send mail)
+# ─────────────────────────────────────────────────────────────────
+# Locally these are picked up from ~/.aws/credentials. Set them
+# explicitly for Docker / production.
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=
 # AWS_REGION=us-east-1
 #
 # NOTE: New AWS accounts are in SES *sandbox* mode and can only send
-# to verified email addresses. Request production access in the AWS
-# SES console to send to anyone.
+# to verified addresses. Request production access in the SES console.
 
+# ─────────────────────────────────────────────────────────────────
+# AWS S3 — email attachment storage (required only for attachments)
+# ─────────────────────────────────────────────────────────────────
+# S3_BUCKET_NAME=
 
-# ── AWS Background Jobs (SQS/EventBridge) ───────────────────────
-# Optional for local dev; recommended/required for staging and production send paths.
-# POST /api/emails persists email rows and publishes email.send jobs here.
+# ─────────────────────────────────────────────────────────────────
+# Cloudflare DNS — auto-configure DKIM/SPF/DMARC when adding domains
+# ─────────────────────────────────────────────────────────────────
+# Get a token at https://dash.cloudflare.com/profile/api-tokens
+# CLOUDFLARE_API_TOKEN=
+# CLOUDFLARE_ZONE_ID=
+
+# ─────────────────────────────────────────────────────────────────
+# Rate limiting + cache backend (recommended for staging/production)
+# ─────────────────────────────────────────────────────────────────
+# RATE_LIMIT_BACKEND=memory   # default for single-process dev
+# RATE_LIMIT_BACKEND=redis    # required for shared/staging/production
+# Use the TLS-enabled endpoint (rediss://...) when RATE_LIMIT_BACKEND=redis.
+# REDIS_URL also backs API-key auth caching and domain metadata caching.
+# REDIS_URL=rediss://default:password@your-cache-endpoint:6379
+
+# ─────────────────────────────────────────────────────────────────
+# Background jobs — SQS / EventBridge send pipeline
+# ─────────────────────────────────────────────────────────────────
+# Optional locally. Required for the queued send path in staging/prod.
+# POST /api/emails persists rows and publishes email.send jobs here.
 # Configure the SQS queue with a redrive policy / DLQ for retry exhaustion.
 # BACKGROUND_JOBS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789012/opensend-background
 # BACKGROUND_JOBS_EVENT_BUS_NAME=opensend-background-jobs
 # BACKGROUND_JOBS_REQUIRE_QUEUE=true
 # Set on the ingester/worker process to long-poll SQS.
 # BACKGROUND_WORKER_POLL=true
-# Protects /jobs/* endpoints when set on the ingester.
+
+# ─────────────────────────────────────────────────────────────────
+# Ingester / cron auth tokens
+# ─────────────────────────────────────────────────────────────────
+# Shared secret between the app and the ingester service for /jobs/* calls.
 # INGESTER_JOB_TOKEN=
+# Bearer token required by /api/cron/* scheduled-email endpoints.
+# CRON_AUTH_TOKEN=
 
-# ── Observability (CloudWatch EMF / structured logs) ─────────────
-# Optional namespace override for emitted CloudWatch Embedded Metric Format logs.
+# ─────────────────────────────────────────────────────────────────
+# Observability
+# ─────────────────────────────────────────────────────────────────
+# Override the CloudWatch Embedded Metric Format namespace (default: Opensend).
 # CLOUDWATCH_METRICS_NAMESPACE=Opensend
-
-# ── AWS S3 (File Storage) ───────────────────────────────────────
-# Bucket for email attachments and assets. Required for attachment support.
-# S3_BUCKET_NAME=
-
-# ── Cloudflare DNS (optional) ───────────────────────────────────
-# Enables auto-configure of DKIM/SPF/DMARC records when adding domains.
-# Get a token at: https://dash.cloudflare.com/profile/api-tokens
-# CLOUDFLARE_API_TOKEN=
-# CLOUDFLARE_ZONE_ID=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,8 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
 - `bun run dev` — Next.js dev server on port 3015
 - `bun run build` — production build
 - `bun run db:generate` — Drizzle migration files
-- `bun run db:migrate` — apply migrations
+- `bun run db:migrate` — apply migrations for the configured `DATABASE_URL`
+- `bash scripts/deploy.sh migrate` — team prod: build/push the migrator image and run an ECS one-off migration task only
 - `bun run db:push` — push schema (dev)
 - `bun run db:seed` — seed sample data
 - `docker compose up -d` — full stack with Postgres + auto-migration
@@ -71,7 +72,7 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
   - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` — SES + S3
   - `S3_BUCKET_NAME` — email attachment storage
   - Google OAuth client credentials for Better Auth
-- **Deployment**: Docker Compose is the reference deploy. Team production uses `bash scripts/deploy.sh` (service name, URL, and ECR details live in local memory).
+- **Deployment**: Docker Compose is the reference deploy. Team production uses `bash scripts/deploy.sh` (ECS/Fargate); `app`, `ingester`, and `all` run migrations before service redeploy, and `migrate` runs migrations only.
 
 ## Security — Secrets Management
 - **Never hardcode** passwords, tokens, or API keys in scripts or source.
@@ -94,10 +95,11 @@ Team prod runs on **ECS Fargate**, not App Runner. App Runner deployment is depr
   - `events.<product>.namuh.co` → ingester target group (port 3016)
 - **ACM cert** has SANs for `namuh.co`, `*.namuh.co`, `*.opensend.namuh.co`. Add new SANs and re-validate when adding products.
 - **DNS authoritative on Cloudflare**, NOT Route53. Zone `namuh.co` ID = `182dba68b02c180d4eb127eb0b025284`. Always use the Cloudflare API for namuh.co records. Do not create Route53 hosted zones for it.
-- **Deploy**: `bash scripts/deploy.sh [app|ingester|all]` — builds, pushes to ECR, force-redeploys ECS service, waits until stable.
-- **ECR repos**: `<product>-app`, `<product>-ingester`. **ECS services**: `<product>-app`, `<product>-ingester`. **Log groups**: `/ecs/<product>-app`, `/ecs/<product>-ingester`.
+- **Deploy**: `bash scripts/deploy.sh [app|ingester|all|migrate]` — builds/pushes images, runs the migrator ECS task before app/ingester redeploys, force-redeploys selected ECS services, waits until stable. Use `migrate` alone for DB-only repairs.
+- **ECR repos**: `<product>-app`, `<product>-ingester`. The app repo also carries the `<tag>-migrator` image built from the Dockerfile `migrator` target. **ECS services**: `<product>-app`, `<product>-ingester`. **Log groups**: `/ecs/<product>-app`, `/ecs/<product>-ingester`.
 
 ## Production Gotchas (must-know)
+- **Run prod migrations before redeploying app code that expects new columns**: `scripts/deploy.sh` now does this automatically, but never bypass it with a raw `aws ecs update-service` after schema changes. Use `bash scripts/deploy.sh migrate` for DB-only fixes. The migrator image runs `src/lib/db/migrate.ts` via the Drizzle migrator API; avoid switching back to `drizzle-kit migrate` without re-testing in ECS. If a dashboard list page works but a detail page 404s, suspect swallowed DB/schema errors before assuming a missing route.
 - **Cloudflare zone ID secret was wrong historically**: `resend-clone/cloudflare/zone-id` previously pointed at the wrong zone (`foreverbrowsing.com`), causing both ACM validation CNAMEs and customer DKIM auto-setup records to be silently written to the wrong zone. Fixed 2026-04-30; verify the secret value matches the namuh.co zone ID before trusting `cloudflare.ts` output.
 - **Docker build platform**: Fargate is `linux/amd64`. M-chip Macs default to `arm64`, which silently produces tasks that fail to start. Always `docker buildx build --platform linux/amd64 ... --push`.
 - **`bun install` in containers needs `--ignore-scripts`**: postinstall calls `node scripts/install-git-hooks.mjs` which is not present at the `deps` Dockerfile stage. Without `--ignore-scripts` the build fails.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,8 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
 - `bun run dev` — Next.js dev server on port 3015
 - `bun run build` — production build
 - `bun run db:generate` — Drizzle migration files
-- `bun run db:migrate` — apply migrations
+- `bun run db:migrate` — apply migrations for the configured `DATABASE_URL`
+- `bash scripts/deploy.sh migrate` — team prod: build/push the migrator image and run an ECS one-off migration task only
 - `bun run db:push` — push schema (dev)
 - `bun run db:seed` — seed sample data
 - `docker compose up -d` — full stack with Postgres + auto-migration
@@ -71,14 +72,14 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
   - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` — SES + S3
   - `S3_BUCKET_NAME` — email attachment storage
   - Google OAuth client credentials for Better Auth
-- **Deployment**: Docker Compose is the reference deploy. Team production uses `bash scripts/deploy.sh` for both the Next.js app and the standalone ingester service (service name, URL, and any non-default ECR details can be overridden via environment variables if local memory differs from the repo defaults).
+- **Deployment**: Docker Compose is the reference deploy. Team production uses `bash scripts/deploy.sh` for the Next.js app and standalone ingester on ECS/Fargate; `app`, `ingester`, and `all` run migrations before service redeploy, and `migrate` runs migrations only.
 - **Ingester cutover**: SES SNS should point at `https://<ingester-service-url>/events/ses`, not the app URL. See `docs/ingester-deploy.md` for the split-service runbook, CloudWatch log tailing, and replay instructions.
 
 ## Security — Secrets Management
 - **Never hardcode** passwords, tokens, or API keys in scripts or source.
 - **Contributors / local dev**: use `.env` (gitignored).
 - **Team production**: secrets live in **AWS Secrets Manager** (region `us-east-1`). Ask Jaeyun or Ashley for the current secret IDs and access.
-- **Shared service wiring**: both the app and the ingester must receive the same database/credential secrets; keep the actual secret IDs external to the repo and inject them through the ECS task definition (`secrets` block, referenced via Secrets Manager ARN).
+- **Shared service wiring**: app, ingester, and migrator ECS tasks must receive the same database/credential secrets; keep the actual secret IDs external to the repo and inject them through the ECS task definition (`secrets` block, referenced via Secrets Manager ARN).
 - Retrieve at runtime:
   ```bash
   aws secretsmanager get-secret-value --secret-id <id> --region us-east-1 --query SecretString --output text
@@ -96,10 +97,11 @@ Team prod runs on **ECS Fargate**, not App Runner. App Runner deployment is depr
   - `events.<product>.namuh.co` → ingester target group (port 3016)
 - **ACM cert** has SANs for `namuh.co`, `*.namuh.co`, `*.opensend.namuh.co`. Add new SANs and re-validate when adding products.
 - **DNS authoritative on Cloudflare**, NOT Route53. Zone `namuh.co` ID = `182dba68b02c180d4eb127eb0b025284`. Always use the Cloudflare API for namuh.co records. Do not create Route53 hosted zones for it.
-- **Deploy**: `bash scripts/deploy.sh [app|ingester|all]` — builds, pushes to ECR, force-redeploys ECS service, waits until stable.
-- **ECR repos**: `<product>-app`, `<product>-ingester`. **ECS services**: `<product>-app`, `<product>-ingester`. **Log groups**: `/ecs/<product>-app`, `/ecs/<product>-ingester`.
+- **Deploy**: `bash scripts/deploy.sh [app|ingester|all|migrate]` — builds/pushes images, runs the migrator ECS task before app/ingester redeploys, force-redeploys selected ECS services, waits until stable. Use `migrate` alone for DB-only repairs.
+- **ECR repos**: `<product>-app`, `<product>-ingester`. The app repo also carries the `<tag>-migrator` image built from the Dockerfile `migrator` target. **ECS services**: `<product>-app`, `<product>-ingester`. **Log groups**: `/ecs/<product>-app`, `/ecs/<product>-ingester`.
 
 ## Production Gotchas (must-know)
+- **Run prod migrations before redeploying app code that expects new columns**: `scripts/deploy.sh` now does this automatically, but never bypass it with a raw `aws ecs update-service` after schema changes. Use `bash scripts/deploy.sh migrate` for DB-only fixes. The migrator image runs `src/lib/db/migrate.ts` via the Drizzle migrator API; avoid switching back to `drizzle-kit migrate` without re-testing in ECS. If a dashboard list page works but a detail page 404s, suspect swallowed DB/schema errors before assuming a missing route.
 - **Cloudflare zone ID secret was wrong historically**: `resend-clone/cloudflare/zone-id` previously pointed at the wrong zone (`foreverbrowsing.com`), causing both ACM validation CNAMEs and customer DKIM auto-setup records to be silently written to the wrong zone. Fixed 2026-04-30; verify the secret value matches the namuh.co zone ID before trusting `cloudflare.ts` output.
 - **Docker build platform**: Fargate is `linux/amd64`. M-chip Macs default to `arm64`, which silently produces tasks that fail to start. Always `docker buildx build --platform linux/amd64 ... --push`.
 - **`bun install` in containers needs `--ignore-scripts`**: postinstall calls `node scripts/install-git-hooks.mjs` which is not present at the `deps` Dockerfile stage. Without `--ignore-scripts` the build fails.

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY drizzle ./drizzle
 COPY drizzle.config.ts ./
 COPY src/lib/db/schema.ts ./src/lib/db/schema.ts
+COPY src/lib/db/migrate.ts ./src/lib/db/migrate.ts
 COPY package.json ./
-CMD ["bunx", "drizzle-kit", "migrate", "--config", "drizzle.config.ts"]
+CMD ["bun", "src/lib/db/migrate.ts"]
 
 # Production app
 FROM base AS runner

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ docker compose up -d
 That's it. Open **http://localhost:3015** and sign in with Google (configure `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` in `.env`).
 
 > The `migrate` service runs database migrations automatically on first boot. Compose also launches the standalone ingester on port `3016` (`http://localhost:3016/health`) for SES/SNS events and background workers.
+>
+> Outside Docker Compose, migrations are not automatic unless your deploy path
+> runs the migrator. Team ECS/Fargate production uses `bash scripts/deploy.sh`,
+> which runs a one-off migrator task before service redeploys.
 
 ## Features
 
@@ -191,11 +195,25 @@ New AWS accounts start in SES **sandbox mode** — emails can only be sent to ve
 For production, we recommend:
 
 - **Database**: Use a managed PostgreSQL (AWS RDS, Supabase, Neon, etc.) instead of the Docker Compose Postgres
+- **Migrations**: Run committed Drizzle migrations before deploying app code that expects new columns. The Dockerfile has a `migrator` target that runs `src/lib/db/migrate.ts`; team ECS deploys run it automatically via `bash scripts/deploy.sh`.
 - **Reverse proxy**: Put Nginx or Caddy in front for TLS termination
 - **Secrets**: Store credentials in your cloud provider's secrets manager
 - **Rate limiting**: Use a shared Redis/ElastiCache instance instead of the disabled local default
 - **Background jobs**: Use SQS with a redrive policy/DLQ, plus EventBridge to trigger scheduled-email and webhook retry scans
 - **Observability**: Emit structured JSON logs, trace/correlation headers, and CloudWatch EMF metrics for send and worker flows
+
+Team production on AWS ECS/Fargate:
+
+```bash
+bash scripts/deploy.sh migrate   # DB-only migration/repair
+bash scripts/deploy.sh app       # app image + migrations + app redeploy
+bash scripts/deploy.sh ingester  # ingester image + migrations + ingester redeploy
+bash scripts/deploy.sh all       # app + ingester images + migrations + both redeploys
+```
+
+If a list page works but a detail page shows 404 after a deploy, check for
+schema drift before assuming a missing Next.js route. A server component may be
+catching a database error and rendering `notFound()`.
 
 ### Shared rate limiting (staging/production)
 

--- a/docs/ingester-deploy.md
+++ b/docs/ingester-deploy.md
@@ -1,6 +1,6 @@
 # Ingester deployment runbook
 
-Issue #70 splits SES/SNS ingestion into its own container and App Runner service so webhook bursts do not contend with the Next.js app.
+Issue #70 splits SES/SNS ingestion into its own container and ECS/Fargate service so webhook bursts do not contend with the Next.js app.
 
 ## Local docker-compose
 
@@ -25,21 +25,36 @@ docker compose logs -f ingester
 
 ## Production deploy shape
 
-`bash scripts/deploy.sh <image-tag>` now deploys two services:
+Team production runs on AWS ECS/Fargate behind the shared `namuh` ALB.
+`bash scripts/deploy.sh` deploys two long-running services and a one-off
+migrator task:
 
 - app image from `Dockerfile`
+- migrator image from the `Dockerfile` `migrator` target, pushed to the app ECR repo as `<tag>-migrator`
 - ingester image from `packages/ingester/Dockerfile`
 
-Override names when the real production service or repository names differ from the repo defaults:
+Supported targets:
 
 ```bash
-APP_ECR_REPO=resend-clone \
-APP_RUNNER_SERVICE=resend-clone \
-INGESTER_ECR_REPO=resend-clone-ingester \
-INGESTER_APP_RUNNER_SERVICE=opensend-ingester \
-bash scripts/deploy.sh <image-tag>
+bash scripts/deploy.sh migrate   # DB-only migration/repair
+bash scripts/deploy.sh app       # app image + migrations + app service redeploy
+bash scripts/deploy.sh ingester  # ingester image + migrations + ingester service redeploy
+bash scripts/deploy.sh all       # app + ingester images + migrations + both redeploys
 ```
 
+Override names when production service or repository names differ from repo defaults:
+
+```bash
+PRODUCT=opensend \
+ECS_CLUSTER=namuh \
+IMAGE_TAG=latest \
+PLATFORM=linux/amd64 \
+bash scripts/deploy.sh all
+```
+
+Do not bypass the script with a raw `aws ecs update-service` after schema
+changes. The script runs migrations before service redeploys so app code does
+not start against an older database schema.
 
 ## Background job worker
 
@@ -102,30 +117,21 @@ The app and ingester emit structured JSON logs, W3C/OpenTelemetry-compatible tra
 
 ## Tail ingester logs
 
-1. Resolve the service id:
+Tail the ECS CloudWatch log group:
 
 ```bash
-SERVICE_NAME=opensend-ingester
-aws apprunner list-services \
-  --region us-east-1 \
-  --query "ServiceSummaryList[?ServiceName=='${SERVICE_NAME}'].ServiceId | [0]" \
-  --output text
+aws logs tail /ecs/opensend-ingester --region us-east-1 --since 10m --follow
 ```
 
-2. Find the CloudWatch log group that App Runner created:
+Check recent ECS service events:
 
 ```bash
-SERVICE_NAME=opensend-ingester
-aws logs describe-log-groups \
+aws ecs describe-services \
+  --cluster namuh \
+  --services opensend-ingester \
   --region us-east-1 \
-  --log-group-name-prefix "/aws/apprunner/${SERVICE_NAME}"
-```
-
-3. Tail the application log group:
-
-```bash
-LOG_GROUP="/aws/apprunner/opensend-ingester/<service-id>/application"
-aws logs tail "${LOG_GROUP}" --region us-east-1 --since 10m --follow
+  --query 'services[0].events[0:10].message' \
+  --output table
 ```
 
 ## Force-process a missed SES event
@@ -147,7 +153,7 @@ curl -i "${INGESTER_URL}" \
 This repo change does not create or mutate external AWS resources on its own. Before production cutover, verify:
 
 - the ingester ECR repository exists
-- the ingester App Runner service has the shared RDS and Secrets Manager wiring
+- the app, ingester, and migrator ECS tasks have shared RDS and Secrets Manager wiring
 - the SQS queue exists with a redrive policy and DLQ
 - EventBridge schedule/rules exist for scheduled-email and webhook retry scans
 - IAM grants app publish permissions and ingester consume/delete/change-visibility permissions

--- a/drizzle/0006_repair_domain_columns.sql
+++ b/drizzle/0006_repair_domain_columns.sql
@@ -1,0 +1,90 @@
+CREATE TABLE IF NOT EXISTS "contact_properties" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"key" varchar(255) NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"type" varchar(50) DEFAULT 'string' NOT NULL,
+	"fallback_value" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"document" jsonb,
+	"user_id" text
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "email_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"email_id" uuid NOT NULL REFERENCES "public"."emails"("id"),
+	"source_id" varchar(255),
+	"type" varchar(50) NOT NULL,
+	"payload" jsonb NOT NULL,
+	"received_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "received_emails" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"from" varchar(512) NOT NULL,
+	"to" jsonb NOT NULL,
+	"subject" text NOT NULL,
+	"html" text,
+	"text" text,
+	"status" varchar(50) DEFAULT 'received' NOT NULL,
+	"attachments" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"user_id" text
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "webhook_deliveries" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"webhook_id" uuid NOT NULL REFERENCES "public"."webhooks"("id") ON DELETE cascade,
+	"event_id" uuid NOT NULL REFERENCES "public"."email_events"("id"),
+	"attempt" integer DEFAULT 1 NOT NULL,
+	"status_code" integer,
+	"response_body" text,
+	"status" varchar(50) DEFAULT 'pending' NOT NULL,
+	"attempted_at" timestamp with time zone,
+	"next_retry_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "broadcasts" ADD COLUMN IF NOT EXISTS "text" text;
+--> statement-breakpoint
+ALTER TABLE "domains" ADD COLUMN IF NOT EXISTS "custom_return_path" varchar(255);
+--> statement-breakpoint
+ALTER TABLE "domains" ADD COLUMN IF NOT EXISTS "tracking_subdomain" varchar(255);
+--> statement-breakpoint
+ALTER TABLE "domains" ADD COLUMN IF NOT EXISTS "capabilities" jsonb;
+--> statement-breakpoint
+ALTER TABLE "emails" ADD COLUMN IF NOT EXISTS "topic_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "emails" ADD COLUMN IF NOT EXISTS "idempotency_key" varchar(255);
+--> statement-breakpoint
+ALTER TABLE "emails" ADD COLUMN IF NOT EXISTS "sent_at" timestamp with time zone;
+--> statement-breakpoint
+ALTER TABLE "logs" ADD COLUMN IF NOT EXISTS "api_key_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "templates" ADD COLUMN IF NOT EXISTS "current_version_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "templates" ADD COLUMN IF NOT EXISTS "published_at" timestamp with time zone;
+--> statement-breakpoint
+ALTER TABLE "templates" ADD COLUMN IF NOT EXISTS "has_unpublished_versions" boolean DEFAULT true NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "webhooks" ADD COLUMN IF NOT EXISTS "signing_secret" varchar(255);
+--> statement-breakpoint
+ALTER TABLE "email_events" ADD COLUMN IF NOT EXISTS "source_id" varchar(255);
+--> statement-breakpoint
+ALTER TABLE "session" ADD COLUMN IF NOT EXISTS "ip_address" text;
+--> statement-breakpoint
+ALTER TABLE "session" ADD COLUMN IF NOT EXISTS "user_agent" text;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "contact_properties_key_idx" ON "contact_properties" USING btree ("key");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "email_events_email_id_idx" ON "email_events" USING btree ("email_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "email_events_source_id_idx" ON "email_events" USING btree ("source_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "received_emails_created_at_idx" ON "received_emails" USING btree ("created_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "webhook_deliveries_webhook_id_idx" ON "webhook_deliveries" USING btree ("webhook_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "webhook_deliveries_status_idx" ON "webhook_deliveries" USING btree ("status");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "emails_idempotency_key_idx" ON "emails" USING btree ("idempotency_key");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1777939200000,
       "tag": "0005_session_better_auth_fields",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1777939200001,
+      "tag": "0006_repair_domain_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,6 +6,7 @@
 #   bash scripts/deploy.sh                  # both app and ingester
 #   bash scripts/deploy.sh app              # just the app
 #   bash scripts/deploy.sh ingester         # just the ingester
+#   bash scripts/deploy.sh migrate          # just run database migrations
 #
 # Requires: docker (with buildx), aws CLI, AWS creds with ECR + ECS permissions.
 # Assumes infra has been bootstrapped (see scripts/aws-bootstrap.sh).
@@ -29,8 +30,14 @@ ECR_BASE="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
 
 APP_REPO="${PRODUCT}-app"
 APP_SERVICE="${PRODUCT}-app"
+APP_CONTAINER_NAME="${APP_CONTAINER_NAME:-${PRODUCT}-app}"
 APP_DOCKERFILE="${APP_DOCKERFILE:-Dockerfile}"
 APP_TARGET="${APP_TARGET:-runner}"
+APP_MIGRATOR_TARGET="${APP_MIGRATOR_TARGET:-migrator}"
+MIGRATOR_IMAGE_TAG="${MIGRATOR_IMAGE_TAG:-${IMAGE_TAG}-migrator}"
+MIGRATOR_TASK_FAMILY="${MIGRATOR_TASK_FAMILY:-${PRODUCT}-migrator}"
+APP_LOG_GROUP="${APP_LOG_GROUP:-/ecs/${APP_SERVICE}}"
+APP_LOG_STREAM_PREFIX="${APP_LOG_STREAM_PREFIX:-app}"
 
 ING_REPO="${PRODUCT}-ingester"
 ING_SERVICE="${PRODUCT}-ingester"
@@ -50,8 +57,8 @@ ecr_login() {
 }
 
 build_and_push() {
-  local repo="$1" dockerfile="$2" target="${3:-}"
-  local image="${ECR_BASE}/${repo}:${IMAGE_TAG}"
+  local repo="$1" dockerfile="$2" target="${3:-}" tag="${4:-${IMAGE_TAG}}"
+  local image="${ECR_BASE}/${repo}:${tag}"
 
   info "→ Build & push ${repo}"
   echo "  image:      ${image}"
@@ -65,6 +72,178 @@ build_and_push() {
 
   docker "${args[@]}"
   ok "  pushed ${image}"
+}
+
+app_task_definition() {
+  aws ecs describe-services \
+    --cluster "${CLUSTER}" \
+    --services "${APP_SERVICE}" \
+    --region "${AWS_REGION}" \
+    --query 'services[0].taskDefinition' \
+    --output text
+}
+
+write_service_network_configuration() {
+  local output_file="$1"
+
+  aws ecs describe-services \
+    --cluster "${CLUSTER}" \
+    --services "${APP_SERVICE}" \
+    --region "${AWS_REGION}" \
+    --query 'services[0].networkConfiguration' \
+    --output json > "${output_file}"
+}
+
+write_migrator_task_definition() {
+  local base_task_definition="$1" migrator_image="$2" output_file="$3"
+  local base_task_file
+  base_task_file="$(mktemp)"
+
+  aws ecs describe-task-definition \
+    --task-definition "${base_task_definition}" \
+    --region "${AWS_REGION}" \
+    --query 'taskDefinition' \
+    --output json > "${base_task_file}"
+
+  python3 - "${base_task_file}" "${migrator_image}" "${MIGRATOR_TASK_FAMILY}" "${APP_CONTAINER_NAME}" > "${output_file}" <<'PY'
+import copy
+import json
+import sys
+
+base_task_file, migrator_image, family, container_name = sys.argv[1:5]
+with open(base_task_file, "r", encoding="utf-8") as handle:
+    task = json.load(handle)
+
+allowed_task_keys = [
+    "taskRoleArn",
+    "executionRoleArn",
+    "networkMode",
+    "volumes",
+    "placementConstraints",
+    "requiresCompatibilities",
+    "cpu",
+    "memory",
+    "runtimePlatform",
+    "ephemeralStorage",
+    "proxyConfiguration",
+    "inferenceAccelerators",
+    "pidMode",
+    "ipcMode",
+]
+
+definition = {"family": family}
+for key in allowed_task_keys:
+    value = task.get(key)
+    if value not in (None, [], {}):
+        definition[key] = value
+
+containers = task.get("containerDefinitions") or []
+selected = next(
+    (container for container in containers if container.get("name") == container_name),
+    containers[0] if containers else None,
+)
+if selected is None:
+    raise SystemExit("base task definition has no containers")
+
+migrator = copy.deepcopy(selected)
+migrator["image"] = migrator_image
+migrator["essential"] = True
+
+# The migration image has its own CMD. App serving concerns should not leak into
+# the one-off task because health checks and ports can race a short-lived job.
+for key in ("command", "entryPoint", "portMappings", "healthCheck"):
+    migrator.pop(key, None)
+
+definition["containerDefinitions"] = [migrator]
+json.dump(definition, sys.stdout)
+PY
+}
+
+register_migrator_task_definition() {
+  local migrator_image="$1" base_task_definition task_file
+  base_task_definition="$(app_task_definition)"
+  task_file="$(mktemp)"
+
+  write_migrator_task_definition "${base_task_definition}" "${migrator_image}" "${task_file}"
+
+  aws ecs register-task-definition \
+    --cli-input-json "file://${task_file}" \
+    --region "${AWS_REGION}" \
+    --query 'taskDefinition.taskDefinitionArn' \
+    --output text
+}
+
+show_migrator_logs() {
+  local task_arn="$1"
+  local task_id="${task_arn##*/}"
+  local log_stream="${APP_LOG_STREAM_PREFIX}/${APP_CONTAINER_NAME}/${task_id}"
+
+  aws logs get-log-events \
+    --log-group-name "${APP_LOG_GROUP}" \
+    --log-stream-name "${log_stream}" \
+    --region "${AWS_REGION}" \
+    --query 'events[].message' \
+    --output text 2>/dev/null || true
+}
+
+run_migrations() {
+  local migrator_image="${ECR_BASE}/${APP_REPO}:${MIGRATOR_IMAGE_TAG}"
+  local network_file run_output task_arn exit_code stopped_reason
+
+  build_and_push "${APP_REPO}" "${APP_DOCKERFILE}" "${APP_MIGRATOR_TARGET}" "${MIGRATOR_IMAGE_TAG}"
+
+  info "→ Register ECS migrator task definition"
+  local migrator_task_definition
+  migrator_task_definition="$(register_migrator_task_definition "${migrator_image}")"
+  ok "  registered ${migrator_task_definition}"
+
+  network_file="$(mktemp)"
+  write_service_network_configuration "${network_file}"
+
+  info "→ Run database migrations"
+  run_output="$(aws ecs run-task \
+    --cluster "${CLUSTER}" \
+    --task-definition "${migrator_task_definition}" \
+    --launch-type FARGATE \
+    --network-configuration "file://${network_file}" \
+    --region "${AWS_REGION}" \
+    --query '{task:tasks[0].taskArn,failures:failures}' \
+    --output json)"
+
+  task_arn="$(python3 -c 'import json, sys; print(json.load(sys.stdin).get("task") or "")' <<< "${run_output}")"
+  if [[ -z "${task_arn}" ]]; then
+    err "  migration task failed to start:"
+    echo "${run_output}" >&2
+    exit 1
+  fi
+
+  echo "  task: ${task_arn}"
+  aws ecs wait tasks-stopped \
+    --cluster "${CLUSTER}" \
+    --tasks "${task_arn}" \
+    --region "${AWS_REGION}"
+
+  exit_code="$(aws ecs describe-tasks \
+    --cluster "${CLUSTER}" \
+    --tasks "${task_arn}" \
+    --region "${AWS_REGION}" \
+    --query 'tasks[0].containers[0].exitCode' \
+    --output text)"
+  stopped_reason="$(aws ecs describe-tasks \
+    --cluster "${CLUSTER}" \
+    --tasks "${task_arn}" \
+    --region "${AWS_REGION}" \
+    --query 'tasks[0].stoppedReason' \
+    --output text)"
+
+  if [[ "${exit_code}" != "0" ]]; then
+    err "  migration task failed (exit ${exit_code}): ${stopped_reason}"
+    show_migrator_logs "${task_arn}" >&2
+    exit 1
+  fi
+
+  show_migrator_logs "${task_arn}" || true
+  ok "  migrations complete"
 }
 
 redeploy() {
@@ -101,12 +280,10 @@ wait_stable() {
 
 deploy_app() {
   build_and_push "${APP_REPO}" "${APP_DOCKERFILE}" "${APP_TARGET}"
-  redeploy "${APP_SERVICE}"
 }
 
 deploy_ingester() {
   build_and_push "${ING_REPO}" "${ING_DOCKERFILE}" ""
-  redeploy "${ING_SERVICE}"
 }
 
 target="${1:-all}"
@@ -116,15 +293,25 @@ ecr_login
 case "${target}" in
   app)
     deploy_app
+    run_migrations
+    redeploy "${APP_SERVICE}"
     wait_stable "${APP_SERVICE}"
     ;;
   ingester)
     deploy_ingester
+    run_migrations
+    redeploy "${ING_SERVICE}"
     wait_stable "${ING_SERVICE}"
+    ;;
+  migrate)
+    run_migrations
     ;;
   all)
     deploy_app
     deploy_ingester
+    run_migrations
+    redeploy "${APP_SERVICE}"
+    redeploy "${ING_SERVICE}"
     wait_stable "${APP_SERVICE}" &
     APP_PID=$!
     wait_stable "${ING_SERVICE}" &
@@ -138,7 +325,7 @@ case "${target}" in
     fi
     ;;
   *)
-    err "Unknown target: ${target} (expected: app | ingester | all)"
+    err "Unknown target: ${target} (expected: app | ingester | migrate | all)"
     exit 2
     ;;
 esac

--- a/src/lib/db/migrate.ts
+++ b/src/lib/db/migrate.ts
@@ -1,0 +1,36 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+import { Pool } from "pg";
+
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  console.error("[migrate] DATABASE_URL is required.");
+  process.exit(1);
+}
+
+const pool = new Pool({
+  connectionString,
+  ssl: connectionString.includes("amazonaws.com")
+    ? { rejectUnauthorized: false }
+    : undefined,
+});
+
+try {
+  await migrate(drizzle(pool), { migrationsFolder: "./drizzle" });
+  console.log("[migrate] Migrations complete.");
+} catch (error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  const code =
+    error && typeof error === "object" && "code" in error
+      ? String(error.code)
+      : undefined;
+
+  console.error(
+    "[migrate] Migration failed.",
+    JSON.stringify({ code, message }),
+  );
+  process.exitCode = 1;
+} finally {
+  await pool.end();
+}

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -29,6 +29,14 @@ describe("deploy-001: ECS Fargate deployment configuration", () => {
     expect(dockerfile).toContain("ENV PORT=8080");
   });
 
+  it("Dockerfile includes a migration runner image", () => {
+    const dockerfile = readFileSync(join(root, "Dockerfile"), "utf-8");
+    expect(dockerfile).toContain("FROM base AS migrator");
+    expect(dockerfile).toContain("COPY drizzle ./drizzle");
+    expect(dockerfile).toContain("COPY src/lib/db/migrate.ts");
+    expect(dockerfile).toContain('CMD ["bun", "src/lib/db/migrate.ts"]');
+  });
+
   it("deploy script builds, pushes, and force-redeploys ECS services", () => {
     const scriptPath = join(root, "scripts", "deploy.sh");
     expect(existsSync(scriptPath)).toBe(true);
@@ -39,6 +47,45 @@ describe("deploy-001: ECS Fargate deployment configuration", () => {
     expect(script).toContain("aws ecs update-service");
     expect(script).toContain("--force-new-deployment");
     expect(script).toContain("aws ecs wait services-stable");
+  });
+
+  it("deploy script runs migrations before ECS service redeploys", () => {
+    const script = readFileSync(join(root, "scripts", "deploy.sh"), "utf-8");
+    expect(script).toContain("bash scripts/deploy.sh migrate");
+    expect(script).toContain("APP_MIGRATOR_TARGET");
+    expect(script).toContain("aws ecs register-task-definition");
+    expect(script).toContain("aws ecs run-task");
+
+    const allDeployBlock = script.slice(
+      script.indexOf("  all)"),
+      script.indexOf("  *)"),
+    );
+    expect(allDeployBlock.indexOf("run_migrations")).toBeGreaterThan(-1);
+    expect(allDeployBlock.indexOf("redeploy")).toBeGreaterThan(-1);
+    expect(allDeployBlock.indexOf("run_migrations")).toBeLessThan(
+      allDeployBlock.indexOf("redeploy"),
+    );
+  });
+
+  it("has an idempotent repair migration for production domain columns", () => {
+    const migration = readFileSync(
+      join(root, "drizzle", "0006_repair_domain_columns.sql"),
+      "utf-8",
+    );
+    expect(migration).toContain('CREATE TABLE IF NOT EXISTS "email_events"');
+    expect(migration).toContain('CREATE TABLE IF NOT EXISTS "received_emails"');
+    expect(migration).toContain(
+      'CREATE TABLE IF NOT EXISTS "webhook_deliveries"',
+    );
+    expect(migration).toContain(
+      'ADD COLUMN IF NOT EXISTS "custom_return_path"',
+    );
+    expect(migration).toContain(
+      'ADD COLUMN IF NOT EXISTS "tracking_subdomain"',
+    );
+    expect(migration).toContain('ADD COLUMN IF NOT EXISTS "capabilities"');
+    expect(migration).toContain('ADD COLUMN IF NOT EXISTS "sent_at"');
+    expect(migration).toContain("CREATE UNIQUE INDEX IF NOT EXISTS");
   });
 
   it("package.json has build scripts for the app and ingester", () => {


### PR DESCRIPTION
## Summary
- Add a one-off ECS migrator task that runs committed Drizzle migrations before app/ingester service redeploys, so schema lands before code that expects it (`scripts/deploy.sh`, new `src/lib/db/migrate.ts`, Dockerfile `migrator` target, repair migration `drizzle/0006_repair_domain_columns.sql`).
- Strip the obsolete `DASHBOARD_KEY` block from `.env.example` and add the missing required Better Auth + Google OAuth vars (`BETTER_AUTH_URL`, `NEXT_PUBLIC_APP_URL`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`) plus `CRON_AUTH_TOKEN`. Reorganized into clear required/optional sections.
- Refresh CLAUDE.md / AGENTS.md / README.md / docs/ingester-deploy.md to document the migrator command and ECS Fargate flow.

## Test plan
- [x] `make check` (typecheck + Biome) green via push hook
- [ ] Manual: `bash scripts/deploy.sh migrate` runs the migrator task to completion against staging
- [ ] Manual: `bash scripts/deploy.sh app` runs the migrator before redeploy and the service reaches steady state