### PR TITLE
Add logout control to dashboard sidebar

### DIFF
--- a/agent_docs/learnings/active/2026-04-30-issue-140-sidebar-logout-e2e.md
+++ b/agent_docs/learnings/active/2026-04-30-issue-140-sidebar-logout-e2e.md
@@ -1,0 +1,12 @@
+---
+date: 2026-04-30
+issue: "#140"
+type: decision
+promoted_to: null
+---
+
+## Sidebar logout needs same-origin auth client and Edge-safe page middleware
+
+The dashboard logout control should use Better Auth through the current app origin unless `NEXT_PUBLIC_APP_URL` is explicitly set. Keeping a hardcoded localhost fallback can send sign-out traffic to the wrong port during Playwright/dev runs.
+
+Dashboard page E2E also depends on middleware staying Edge-safe before API rate-limit code runs. Keep Node Redis imports out of the page-route middleware path; only load Redis rate-limit code after an `/api/*` request has opted into the Redis backend.

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { authClient } from "@/lib/auth-client";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { useState } from "react";
 
 const NAV_ITEMS = [
   {
@@ -215,6 +217,35 @@ const NAV_ITEMS = [
 
 export function Sidebar() {
   const pathname = usePathname();
+  const router = useRouter();
+  const { data: session } = authClient.useSession();
+  const [isSigningOut, setIsSigningOut] = useState(false);
+  const [signOutError, setSignOutError] = useState<string | null>(null);
+
+  const userLabel =
+    session?.user.email ?? session?.user.name ?? "Signed in user";
+  const userInitial = userLabel.charAt(0).toUpperCase();
+
+  const handleSignOut = async () => {
+    setIsSigningOut(true);
+    setSignOutError(null);
+
+    try {
+      const result = await authClient.signOut();
+      if (result.error) {
+        setSignOutError(result.error.message ?? "Unable to sign out.");
+        setIsSigningOut(false);
+        return;
+      }
+
+      if (window.location.pathname !== "/auth") {
+        router.push("/auth");
+      }
+    } catch {
+      setSignOutError("Unable to sign out.");
+      setIsSigningOut(false);
+    }
+  };
 
   return (
     <aside className="fixed left-0 top-0 bottom-0 w-[250px] bg-black flex flex-col border-r border-[rgba(176,199,217,0.145)]">
@@ -270,12 +301,41 @@ export function Sidebar() {
       <div className="px-4 py-3 border-t border-[rgba(176,199,217,0.145)]">
         <div className="flex items-center gap-2">
           <div className="w-5 h-5 rounded-full bg-blue-600 flex items-center justify-center text-[10px] font-semibold text-white">
-            J
+            {userInitial}
           </div>
-          <span className="text-[12px] text-[#A1A4A5] truncate">
-            user@example.com
+          <span className="text-[12px] text-[#A1A4A5] truncate flex-1">
+            {userLabel}
           </span>
         </div>
+        {signOutError ? (
+          <p className="mt-2 text-[12px] text-red-400" role="alert">
+            {signOutError}
+          </p>
+        ) : null}
+        <button
+          type="button"
+          onClick={handleSignOut}
+          disabled={isSigningOut}
+          className="mt-3 flex w-full items-center justify-center gap-2 rounded-md border border-[rgba(176,199,217,0.145)] px-3 py-2 text-[13px] font-medium text-[#A1A4A5] transition-colors hover:bg-[rgba(24,25,28,0.5)] hover:text-[#F0F0F0] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-500 disabled:cursor-not-allowed disabled:opacity-50"
+          aria-busy={isSigningOut}
+        >
+          <svg
+            aria-hidden="true"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+            <polyline points="16 17 21 12 16 7" />
+            <line x1="21" x2="9" y1="12" y2="12" />
+          </svg>
+          {isSigningOut ? "Signing out..." : "Sign out"}
+        </button>
       </div>
     </aside>
   );

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,5 +1,5 @@
 import { createAuthClient } from "better-auth/react";
 
 export const authClient = createAuthClient({
-  baseURL: process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000",
+  baseURL: process.env.NEXT_PUBLIC_APP_URL,
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,3 @@
-import {
-  getRateLimitBackend,
-  getTtl,
-  incrCache,
-  isRedisConfigured,
-} from "@/lib/cache/redis";
 import { getSessionCookie } from "better-auth/cookies";
 import { type NextRequest, NextResponse } from "next/server";
 
@@ -12,16 +6,35 @@ type RateCheckResult =
   | { allowed: false; retryAfter: number; status: 429 }
   | { allowed: false; error: string; status: 503 };
 
+type RateLimitBackend = "disabled" | "redis";
+type RateLimitDependencies = typeof import("@/lib/cache/redis");
+
 const RATE_LIMIT_BACKEND_UNAVAILABLE_ERROR =
   "Rate limiting is temporarily unavailable.";
 let hasLoggedRateLimitConfigError = false;
+let hasLoggedUnsupportedRateLimitBackend = false;
+
+function getRateLimitBackend(): RateLimitBackend {
+  const backend = process.env.RATE_LIMIT_BACKEND?.trim().toLowerCase();
+  if (!backend) return "disabled";
+  if (backend === "disabled" || backend === "redis") return backend;
+
+  if (!hasLoggedUnsupportedRateLimitBackend) {
+    hasLoggedUnsupportedRateLimitBackend = true;
+    console.warn(
+      `[rate-limit] Unsupported RATE_LIMIT_BACKEND="${backend}". Falling back to "disabled".`,
+    );
+  }
+  return "disabled";
+}
 
 async function checkRate(
   key: string,
   maxRequests: number,
   windowMs: number,
+  rateLimit: RateLimitDependencies,
 ): Promise<RateCheckResult> {
-  if (!isRedisConfigured()) {
+  if (!rateLimit.isRedisConfigured()) {
     if (!hasLoggedRateLimitConfigError) {
       hasLoggedRateLimitConfigError = true;
       console.error(
@@ -37,7 +50,7 @@ async function checkRate(
 
   const redisKey = `ratelimit:${key}`;
   const windowSeconds = Math.ceil(windowMs / 1000);
-  const count = await incrCache(redisKey, windowSeconds);
+  const count = await rateLimit.incrCache(redisKey, windowSeconds);
 
   if (count === null) {
     return {
@@ -51,7 +64,7 @@ async function checkRate(
     return { allowed: true };
   }
 
-  const ttl = await getTtl(redisKey);
+  const ttl = await rateLimit.getTtl(redisKey);
   return {
     allowed: false,
     retryAfter: ttl && ttl > 0 ? ttl : windowSeconds,
@@ -118,6 +131,8 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next({ headers: responseHeaders });
   }
 
+  const rateLimit = await import("@/lib/cache/redis");
+
   const rawIp =
     request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "";
   const ip = /^[\d.a-fA-F:]+$/.test(rawIp) ? rawIp : "unknown";
@@ -125,7 +140,7 @@ export async function middleware(request: NextRequest) {
   const rateLimitKey = `${ip}:${authKey}:${pathname}`;
 
   const { max, windowMs } = getLimits(pathname, request.method);
-  const result = await checkRate(rateLimitKey, max, windowMs);
+  const result = await checkRate(rateLimitKey, max, windowMs, rateLimit);
 
   if (!result.allowed) {
     return NextResponse.json(

--- a/tests/e2e/sidebar-logout.spec.ts
+++ b/tests/e2e/sidebar-logout.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "@playwright/test";
+
+test("signed-in dashboard user can sign out and protected routes redirect to auth", async ({
+  context,
+  page,
+}) => {
+  await context.addCookies([
+    {
+      name: "better-auth.session_token",
+      value: "e2e-session-token",
+      domain: "localhost",
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+    },
+  ]);
+
+  await page.route("**/api/auth/get-session", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        session: { id: "e2e-session", token: "e2e-session-token" },
+        user: { id: "e2e-user", email: "e2e@example.com", name: "E2E User" },
+      }),
+    });
+  });
+
+  await page.route("**/api/auth/sign-out", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      headers: {
+        "set-cookie":
+          "better-auth.session_token=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax",
+      },
+      body: JSON.stringify({ success: true }),
+    });
+  });
+
+  await page.goto("/emails");
+  await expect(page).toHaveURL(/\/emails/);
+  await expect(page.getByText("e2e@example.com")).toBeVisible();
+
+  await page.getByRole("button", { name: "Sign out" }).click();
+  await expect(
+    page.getByRole("button", { name: "Signing out..." }),
+  ).toBeDisabled();
+  await expect(page).toHaveURL(/\/auth$/);
+  await expect(
+    page.getByRole("heading", { name: "Sign in to namuh" }),
+  ).toBeVisible();
+
+  await page.goto("/emails");
+  await expect(page).toHaveURL(/\/auth$/);
+});

--- a/tests/middleware-rate-limit.test.ts
+++ b/tests/middleware-rate-limit.test.ts
@@ -1,14 +1,12 @@
 import type { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockGetRateLimitBackend = vi.hoisted(() => vi.fn());
 const mockIsRedisConfigured = vi.hoisted(() => vi.fn());
 const mockIncrCache = vi.hoisted(() => vi.fn());
 const mockGetTtl = vi.hoisted(() => vi.fn());
 const mockGetSessionCookie = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/cache/redis", () => ({
-  getRateLimitBackend: mockGetRateLimitBackend,
   isRedisConfigured: mockIsRedisConfigured,
   incrCache: mockIncrCache,
   getTtl: mockGetTtl,
@@ -30,7 +28,7 @@ describe("middleware rate limiting", () => {
     vi.clearAllMocks();
     mockGetSessionCookie.mockReturnValue("session");
     mockIsRedisConfigured.mockReturnValue(true);
-    mockGetRateLimitBackend.mockReturnValue("disabled");
+    process.env.RATE_LIMIT_BACKEND = "disabled";
   });
 
   it("skips API rate limiting when RATE_LIMIT_BACKEND is disabled", async () => {
@@ -45,7 +43,7 @@ describe("middleware rate limiting", () => {
   });
 
   it("enforces Redis-backed limits for API routes", async () => {
-    mockGetRateLimitBackend.mockReturnValue("redis");
+    process.env.RATE_LIMIT_BACKEND = "redis";
     mockIncrCache.mockResolvedValue(1);
 
     const { middleware } = await import("@/middleware");
@@ -67,7 +65,7 @@ describe("middleware rate limiting", () => {
   });
 
   it("returns 429 with Retry-After once the Redis limit is exceeded", async () => {
-    mockGetRateLimitBackend.mockReturnValue("redis");
+    process.env.RATE_LIMIT_BACKEND = "redis";
     mockIncrCache.mockResolvedValue(21);
     mockGetTtl.mockResolvedValue(17);
 
@@ -85,7 +83,7 @@ describe("middleware rate limiting", () => {
   });
 
   it("returns 503 when Redis-backed rate limiting is unavailable", async () => {
-    mockGetRateLimitBackend.mockReturnValue("redis");
+    process.env.RATE_LIMIT_BACKEND = "redis";
     mockIncrCache.mockResolvedValue(null);
 
     const { middleware } = await import("@/middleware");

--- a/tests/sidebar-logout.test.tsx
+++ b/tests/sidebar-logout.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPush, mockSignOut, mockUseSession } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockSignOut: vi.fn(),
+  mockUseSession: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    className,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} className={className} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/emails",
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    signOut: mockSignOut,
+    useSession: mockUseSession,
+  },
+}));
+
+import { Sidebar } from "@/components/sidebar";
+
+type SignOutResult = {
+  data: { success: boolean } | null;
+  error: { message?: string; status: number; statusText: string } | null;
+};
+
+describe("Sidebar logout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          email: "jaeyunha@example.com",
+          name: "Jaeyun Ha",
+        },
+      },
+    });
+  });
+
+  afterEach(cleanup);
+
+  it("renders with a session, signs out, and redirects to auth on success", async () => {
+    let resolveSignOut: (value: SignOutResult) => void = () => undefined;
+    mockSignOut.mockReturnValue(
+      new Promise<SignOutResult>((resolve) => {
+        resolveSignOut = resolve;
+      }),
+    );
+
+    render(<Sidebar />);
+
+    expect(screen.getByText("jaeyunha@example.com")).toBeTruthy();
+    const signOutButton = screen.getByRole("button", { name: "Sign out" });
+
+    await userEvent.click(signOutButton);
+
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+    expect(signOutButton.getAttribute("disabled")).toBe("");
+    expect(signOutButton.getAttribute("aria-busy")).toBe("true");
+    expect(screen.getByRole("button", { name: "Signing out..." })).toBeTruthy();
+
+    resolveSignOut({ data: { success: true }, error: null });
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/auth");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a keyboard-accessible Sign out button to the dashboard sidebar with in-flight disabled/loading state and inline error recovery.
- Call Better Auth `authClient.signOut()` and navigate to `/auth` on success while keeping auth calls same-origin by default.
- Keep dashboard page middleware Edge-safe before API Redis rate-limit handling so protected-route logout E2E can run.
- Add Vitest and Playwright coverage for sidebar logout.

## Verification
- `make check && make test` — passed
- `bun run test:e2e tests/e2e/sidebar-logout.spec.ts` — passed

## Notes
- Playwright uses an authenticated Better Auth session cookie fixture rather than real Google OAuth, since Google OAuth is not suitable for deterministic CI/local E2E.
