### PR TITLE
Fix webhook event type drift

### DIFF
--- a/agent_docs/learnings/active/2026-05-01-126-webhook-event-types.md
+++ b/agent_docs/learnings/active/2026-05-01-126-webhook-event-types.md
@@ -1,0 +1,10 @@
+---
+date: 2026-05-01
+issue: 126
+type: decision
+promoted_to: null
+---
+
+# Webhook event type source of truth
+
+Webhook subscriptions should use the fully-qualified event names emitted in webhook payloads, not raw internal email event names. The shared source of truth is `SUPPORTED_WEBHOOK_EVENT_TYPES` in `packages/core/src/webhook-events.ts`; API validation, dashboard rendering, and ingester dispatch matching should derive from that constant so unsupported names like `delivered`, `email.unknown`, or `*` do not silently drift.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export * from "./auth/api-auth";
 export * from "./auth/rate-limiter";
 export * from "./dto";
 export * from "./webhook-signing";
+export * from "./webhook-events";
 export * from "./services/dns";
 export * from "./services/domain";
 export * from "./services/email";

--- a/packages/core/src/webhook-events.ts
+++ b/packages/core/src/webhook-events.ts
@@ -1,0 +1,35 @@
+export const SUPPORTED_WEBHOOK_EVENT_TYPES = [
+  "email.sent",
+  "email.delivered",
+  "email.bounced",
+  "email.complained",
+  "email.delivery_delayed",
+  "email.opened",
+  "email.clicked",
+  "email.failed",
+] as const;
+
+export type SupportedWebhookEventType =
+  (typeof SUPPORTED_WEBHOOK_EVENT_TYPES)[number];
+
+export const SUPPORTED_WEBHOOK_EVENT_TYPE_SET: ReadonlySet<string> = new Set(
+  SUPPORTED_WEBHOOK_EVENT_TYPES,
+);
+
+export function isSupportedWebhookEventType(
+  value: string,
+): value is SupportedWebhookEventType {
+  return SUPPORTED_WEBHOOK_EVENT_TYPE_SET.has(value);
+}
+
+export function toWebhookEventType(
+  eventType: string,
+): SupportedWebhookEventType | null {
+  const webhookEventType = eventType.includes(".")
+    ? eventType
+    : `email.${eventType}`;
+
+  return isSupportedWebhookEventType(webhookEventType)
+    ? webhookEventType
+    : null;
+}

--- a/packages/ingester/src/dispatcher.ts
+++ b/packages/ingester/src/dispatcher.ts
@@ -1,6 +1,7 @@
 import {
   emailEventRepo,
   signWebhookPayload,
+  toWebhookEventType,
   webhookDeliveryRepo,
   webhookRepo,
 } from "@namuh/core";
@@ -69,10 +70,14 @@ export class WebhookDispatcher {
     const attemptNumber = delivery.attempt + 1;
     const timestamp = Math.floor(attemptedAt.getTime() / 1000).toString();
     const msgId = `whd_${delivery.id}_${attemptNumber}`;
-    const eventType =
-      typeof event.type === "string" && event.type.includes(".")
-        ? event.type
-        : `email.${event.type}`;
+    const eventType = toWebhookEventType(String(event.type));
+    if (!eventType) {
+      return await this.markTerminal(
+        delivery,
+        `Unsupported webhook event type: ${String(event.type)}`,
+      );
+    }
+
     const body = JSON.stringify({
       id: msgId,
       type: eventType,

--- a/packages/ingester/src/index.ts
+++ b/packages/ingester/src/index.ts
@@ -7,6 +7,7 @@ import {
   logTelemetry,
   publishBackgroundJob,
   recordTelemetryError,
+  toWebhookEventType,
   webhookRepo,
 } from "@namuh/core";
 import { Hono } from "hono";
@@ -145,16 +146,15 @@ app.post("/events/ses", async (c) => {
       },
     });
 
+    const webhookEventType = toWebhookEventType(event.type);
+    if (!webhookEventType) {
+      return c.text("OK");
+    }
+
     const { data: hooks } = await webhookRepo.list({ limit: 100 });
     for (const hook of hooks) {
       const types = hook.eventTypes as string[];
-      const webhookEventType = `email.${event.type}`;
-      if (
-        hook.status === "active" &&
-        (types.includes("*") ||
-          types.includes(event.type) ||
-          types.includes(webhookEventType))
-      ) {
+      if (hook.status === "active" && types.includes(webhookEventType)) {
         const delivery = await webhookDispatcher.enqueue(hook.id, event.id);
         await publishBackgroundJob(
           createBackgroundJob({

--- a/src/app/(dashboard)/webhooks/page.tsx
+++ b/src/app/(dashboard)/webhooks/page.tsx
@@ -1,6 +1,7 @@
 import { WebhooksList } from "@/components/webhooks-list";
 import { db } from "@/lib/db";
 import { webhooks } from "@/lib/db/schema";
+import { SUPPORTED_WEBHOOK_EVENT_TYPES } from "@namuh/core/src/webhook-events";
 import { desc } from "drizzle-orm";
 
 export default async function WebhooksPage() {
@@ -20,7 +21,10 @@ export default async function WebhooksPage() {
   return (
     <div>
       <h1 className="text-2xl font-semibold text-[#F0F0F0]">Webhooks</h1>
-      <WebhooksList webhooks={data} />
+      <WebhooksList
+        supportedEventTypes={[...SUPPORTED_WEBHOOK_EVENT_TYPES]}
+        webhooks={data}
+      />
     </div>
   );
 }

--- a/src/app/api/webhooks/[id]/route.ts
+++ b/src/app/api/webhooks/[id]/route.ts
@@ -1,6 +1,7 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { webhooks } from "@/lib/db/schema";
+import { updateWebhookSchema } from "@/lib/validation/webhooks";
 import { eq } from "drizzle-orm";
 
 export async function GET(
@@ -47,34 +48,38 @@ export async function PATCH(
 
   const { id } = await params;
 
-  let body: {
-    endpoint?: string;
-    url?: string;
-    events?: string[];
-    event_types?: string[];
-    status?: string;
-    active?: boolean;
-  };
+  let body: unknown;
   try {
     body = await request.json();
   } catch {
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
+  const result = updateWebhookSchema.safeParse(body);
+  if (!result.success) {
+    return Response.json(
+      { error: "Validation failed", details: result.error.flatten() },
+      { status: 422 },
+    );
+  }
+
   try {
+    const validated = result.data;
     const updateData: Record<string, unknown> = {};
-    if (body.endpoint !== undefined) updateData.url = body.endpoint;
-    if (body.url !== undefined) updateData.url = body.url;
+    if (validated.endpoint !== undefined) updateData.url = validated.endpoint;
+    if (validated.url !== undefined) updateData.url = validated.url;
 
-    if (body.events !== undefined) updateData.eventTypes = body.events;
-    if (body.event_types !== undefined)
-      updateData.eventTypes = body.event_types;
+    if (validated.events !== undefined)
+      updateData.eventTypes = validated.events;
+    if (validated.event_types !== undefined)
+      updateData.eventTypes = validated.event_types;
 
-    // Support "active" (boolean) and "status" ("enabled"/"disabled")
-    if (body.status !== undefined) {
-      updateData.status = body.status === "enabled" ? "active" : "inactive";
-    } else if (body.active !== undefined) {
-      updateData.status = body.active ? "active" : "inactive";
+    // Support "active" (boolean) and "status" ("enabled"/"disabled").
+    if (validated.status !== undefined) {
+      updateData.status =
+        validated.status === "enabled" ? "active" : "disabled";
+    } else if (validated.active !== undefined) {
+      updateData.status = validated.active ? "active" : "disabled";
     }
 
     const [updated] = await db

--- a/src/components/webhooks-list.tsx
+++ b/src/components/webhooks-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { StatusBadge } from "@/components/status-badge";
+import type { SupportedWebhookEventType } from "@namuh/core/src/webhook-events";
 
 interface Webhook {
   id: string;
@@ -10,9 +11,42 @@ interface Webhook {
   createdAt: string;
 }
 
-export function WebhooksList({ webhooks }: { webhooks: Webhook[] }) {
+function formatEventType(eventType: string): string {
+  return eventType
+    .replace(/^email\./, "")
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export function WebhooksList({
+  supportedEventTypes,
+  webhooks,
+}: {
+  supportedEventTypes: SupportedWebhookEventType[];
+  webhooks: Webhook[];
+}) {
   return (
-    <div className="mt-8">
+    <div className="mt-8 space-y-6">
+      <section className="rounded-lg border border-white/5 bg-black p-6">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-white/40">
+          Supported events
+        </h2>
+        <div
+          className="mt-4 flex flex-wrap gap-2"
+          aria-label="Supported webhook events"
+        >
+          {supportedEventTypes.map((eventType) => (
+            <span
+              key={eventType}
+              className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 text-xs text-[#F0F0F0]"
+            >
+              {eventType}
+            </span>
+          ))}
+        </div>
+      </section>
+
       <div className="overflow-hidden rounded-lg border border-white/5 bg-black">
         <table className="min-w-full divide-y divide-white/5">
           <thead>
@@ -43,7 +77,14 @@ export function WebhooksList({ webhooks }: { webhooks: Webhook[] }) {
                   />
                 </td>
                 <td className="px-6 py-4 text-sm text-white/40">
-                  {webhook.eventTypes.join(", ")}
+                  {webhook.eventTypes
+                    .filter((eventType) =>
+                      supportedEventTypes.includes(
+                        eventType as SupportedWebhookEventType,
+                      ),
+                    )
+                    .map((eventType) => formatEventType(eventType))
+                    .join(", ")}
                 </td>
                 <td className="whitespace-nowrap px-6 py-4 text-sm text-white/40">
                   {new Date(webhook.createdAt).toLocaleDateString()}

--- a/src/lib/validation/webhooks.ts
+++ b/src/lib/validation/webhooks.ts
@@ -1,13 +1,26 @@
+import {
+  SUPPORTED_WEBHOOK_EVENT_TYPES,
+  type SupportedWebhookEventType,
+} from "@namuh/core/src/webhook-events";
 import { z } from "zod";
 
 export const webhookStatusSchema = z.enum(["active", "disabled"]);
+
+const supportedWebhookEventTypeSchema = z.enum(SUPPORTED_WEBHOOK_EVENT_TYPES, {
+  message: "Unsupported webhook event type",
+});
+
+const webhookEventTypesSchema = z
+  .array(supportedWebhookEventTypeSchema)
+  .min(1)
+  .transform((events) => Array.from(new Set(events)));
 
 export const createWebhookSchema = z
   .object({
     endpoint: z.string().url().max(2048).optional(),
     url: z.string().url().max(2048).optional(),
-    events: z.array(z.string()).min(1).optional(),
-    event_types: z.array(z.string()).min(1).optional(),
+    events: webhookEventTypesSchema.optional(),
+    event_types: webhookEventTypesSchema.optional(),
   })
   .refine(
     (data) => (data.endpoint || data.url) && (data.events || data.event_types),
@@ -19,10 +32,12 @@ export const createWebhookSchema = z
 export const updateWebhookSchema = z.object({
   endpoint: z.string().url().max(2048).optional(),
   url: z.string().url().max(2048).optional(),
-  events: z.array(z.string()).min(1).optional(),
-  event_types: z.array(z.string()).min(1).optional(),
+  events: webhookEventTypesSchema.optional(),
+  event_types: webhookEventTypesSchema.optional(),
   status: z.enum(["enabled", "disabled"]).optional(),
+  active: z.boolean().optional(),
 });
 
 export type CreateWebhookRequest = z.infer<typeof createWebhookSchema>;
 export type UpdateWebhookRequest = z.infer<typeof updateWebhookSchema>;
+export type WebhookEventType = SupportedWebhookEventType;

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -862,6 +862,45 @@ describe("route smoke coverage", () => {
     expect(deleteJson.deleted).toBe(true);
   });
 
+  it("rejects unsupported webhook event types in create and update routes", async () => {
+    const listRoute = await import("@/app/api/webhooks/route");
+    const detailRoute = await import("@/app/api/webhooks/[id]/route");
+
+    mockInsert.mockClear();
+    const createRes = await listRoute.POST(
+      makeNextRequest("http://localhost/api/webhooks", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          endpoint: "https://example.com/webhook",
+          events: ["email.unknown"],
+        }),
+      }),
+    );
+
+    expect(createRes.status).toBe(422);
+    expect(mockInsert).not.toHaveBeenCalled();
+
+    mockUpdate.mockClear();
+    const patchRes = await detailRoute.PATCH(
+      makeNextRequest("http://localhost/api/webhooks/wh-1", {
+        method: "PATCH",
+        headers: {
+          authorization: "Bearer token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ event_types: ["delivered"] }),
+      }),
+      { params: Promise.resolve({ id: "wh-1" }) },
+    );
+
+    expect(patchRes.status).toBe(422);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it("covers broadcasts and templates detail routes with happy path and 404s", async () => {
     const broadcastsRoute = await import("@/app/api/broadcasts/[id]/route");
     const templatesRoute = await import("@/app/api/templates/[id]/route");

--- a/tests/ingester-ses-route.test.ts
+++ b/tests/ingester-ses-route.test.ts
@@ -64,6 +64,23 @@ vi.mock("@namuh/core", () => {
     logTelemetry: mockLogTelemetry,
     publishBackgroundJob: mockPublishBackgroundJob,
     recordTelemetryError: mockRecordTelemetryError,
+    toWebhookEventType: (eventType: string) => {
+      const candidate = eventType.includes(".")
+        ? eventType
+        : `email.${eventType}`;
+      return [
+        "email.sent",
+        "email.delivered",
+        "email.bounced",
+        "email.complained",
+        "email.delivery_delayed",
+        "email.opened",
+        "email.clicked",
+        "email.failed",
+      ].includes(candidate)
+        ? candidate
+        : null;
+    },
     webhookRepo: {
       list: mockWebhookList,
     },

--- a/tests/webhook-dispatcher.test.ts
+++ b/tests/webhook-dispatcher.test.ts
@@ -13,6 +13,23 @@ vi.mock("@namuh/core", () => ({
     findById: mockFindEventById,
   },
   signWebhookPayload: mockSignWebhookPayload,
+  toWebhookEventType: (eventType: string) => {
+    const candidate = eventType.includes(".")
+      ? eventType
+      : `email.${eventType}`;
+    return [
+      "email.sent",
+      "email.delivered",
+      "email.bounced",
+      "email.complained",
+      "email.delivery_delayed",
+      "email.opened",
+      "email.clicked",
+      "email.failed",
+    ].includes(candidate)
+      ? candidate
+      : null;
+  },
   webhookDeliveryRepo: {
     create: mockCreate,
     findById: mockFindById,
@@ -138,6 +155,50 @@ describe("WebhookDispatcher", () => {
       }),
     );
     expect(result).toMatchObject({ status: "success", attempt: 1 });
+  });
+
+  it("marks unsupported event types terminal without sending", async () => {
+    mockFindById.mockResolvedValue({
+      id: "delivery-unsupported",
+      webhookId: "hook-unsupported",
+      eventId: "event-unsupported",
+      attempt: 0,
+      status: "pending",
+    });
+    mockFindWebhookById.mockResolvedValue({
+      id: "hook-unsupported",
+      url: "https://example.com/webhook",
+      status: "active",
+      signingSecret: "whsec_test_secret",
+    });
+    mockFindEventById.mockResolvedValue({
+      id: "event-unsupported",
+      type: "domain.updated",
+      payload: {},
+    });
+    const fetchMock = vi.fn();
+    mockUpdate.mockImplementation(async (_id, data) => ({
+      id: "delivery-unsupported",
+      ...data,
+    }));
+
+    const { WebhookDispatcher } = await import(
+      "../packages/ingester/src/dispatcher"
+    );
+    const dispatcher = new WebhookDispatcher({ fetchImpl: fetchMock });
+
+    const result = await dispatcher.dispatchDelivery("delivery-unsupported");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mockUpdate).toHaveBeenCalledWith(
+      "delivery-unsupported",
+      expect.objectContaining({
+        status: "failed",
+        responseBody: "Unsupported webhook event type: domain.updated",
+        nextRetryAt: null,
+      }),
+    );
+    expect(result).toMatchObject({ status: "failed" });
   });
 
   it("schedules the first retry after a failed response", async () => {

--- a/tests/webhook-event-types.test.tsx
+++ b/tests/webhook-event-types.test.tsx
@@ -1,0 +1,61 @@
+import { WebhooksList } from "@/components/webhooks-list";
+import {
+  createWebhookSchema,
+  updateWebhookSchema,
+} from "@/lib/validation/webhooks";
+import { SUPPORTED_WEBHOOK_EVENT_TYPES } from "@namuh/core/src/webhook-events";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+describe("webhook event type support", () => {
+  it("accepts every shared supported webhook event type for create and update", () => {
+    expect(
+      createWebhookSchema.safeParse({
+        endpoint: "https://example.com/webhooks",
+        events: [...SUPPORTED_WEBHOOK_EVENT_TYPES],
+      }).success,
+    ).toBe(true);
+
+    expect(
+      updateWebhookSchema.safeParse({
+        event_types: [...SUPPORTED_WEBHOOK_EVENT_TYPES],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects unsupported webhook event names", () => {
+    expect(
+      createWebhookSchema.safeParse({
+        endpoint: "https://example.com/webhooks",
+        events: ["email.delivered", "email.unknown"],
+      }).success,
+    ).toBe(false);
+
+    expect(
+      updateWebhookSchema.safeParse({
+        events: ["delivered"],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("renders dashboard event labels from the shared supported set", () => {
+    render(
+      <WebhooksList
+        supportedEventTypes={[...SUPPORTED_WEBHOOK_EVENT_TYPES]}
+        webhooks={[
+          {
+            id: "wh-1",
+            url: "https://example.com/webhook",
+            status: "active",
+            eventTypes: ["email.delivered", "email.unknown"],
+            createdAt: "2026-04-23T00:00:00.000Z",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("email.delivered")).toBeTruthy();
+    expect(screen.getByText("Delivered")).toBeTruthy();
+    expect(screen.queryByText("email.unknown")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `SUPPORTED_WEBHOOK_EVENT_TYPES` as the shared contract for webhook event names OpenSend emits.
- Validates webhook create/update payloads against the shared contract and rejects unsupported names.
- Routes dashboard webhook rendering and ingester matching/dispatch payload typing through the shared event contract.
- Adds route, validation/UI, ingester matching, and dispatcher regression coverage.

## Verification
- `bun run test tests/webhook-event-types.test.tsx tests/webhook-dispatcher.test.ts tests/ingester-ses-route.test.ts tests/api-auth-date-range-routes.test.ts` — 4 files passed, 31 tests passed.
- `bun run typecheck` — passed.
- `bun run lint` — passed.
- `make check && make test` — passed; 64 files passed, 562 tests passed.

## Playwright
Skipped. This change affects API validation, shared constants, dashboard static rendering, and ingester subscription matching; there is no webhook create/edit browser flow in the current dashboard for Playwright to exercise without inventing unrelated UI scope.
