### PR TITLE
Fix deprecated Zod flatten usage in emails route

### DIFF
--- a/src/app/api/emails/route.ts
+++ b/src/app/api/emails/route.ts
@@ -13,7 +13,7 @@ import {
   recordTelemetryError,
 } from "@namuh/core";
 import { and, desc, eq, gt, lt } from "drizzle-orm";
-import type { ZodError } from "zod";
+import { type ZodError, flattenError } from "zod";
 
 // ── Helpers ───────────────────────────────────────────────────────
 
@@ -121,7 +121,7 @@ export async function POST(request: Request): Promise<Response> {
       outcome: "invalid",
     });
     return jsonWithTelemetry(
-      { error: "Validation failed", details: result.error.flatten() },
+      { error: "Validation failed", details: flattenError(result.error) },
       telemetry,
       { status: 422 },
     );
@@ -395,5 +395,5 @@ export async function DELETE(request: Request): Promise<Response> {
 
 // Error fallback for Zod (kept explicit for strict typing in route handlers)
 export function formatZodError(error: ZodError): Record<string, unknown> {
-  return error.flatten();
+  return flattenError(error);
 }

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -173,7 +173,7 @@ describe("POST /api/emails", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns 422 when required fields are missing", async () => {
+  it("returns 422 with flattened validation details when required fields are missing", async () => {
     const { POST } = await import("@/app/api/emails/route");
     const req = makeRequest(
       "POST",
@@ -183,7 +183,16 @@ describe("POST /api/emails", () => {
     const res = await POST(req);
     expect(res.status).toBe(422);
     const json = await res.json();
-    expect(json).toHaveProperty("error");
+    expect(json).toEqual({
+      error: "Validation failed",
+      details: {
+        formErrors: [],
+        fieldErrors: {
+          to: [expect.any(String)],
+          subject: [expect.any(String)],
+        },
+      },
+    });
   });
 
   it("returns 422 when from is missing", async () => {


### PR DESCRIPTION
## Summary
- Replace deprecated ZodError#flatten() calls in /api/emails with zod flattenError().
- Preserve the existing Validation failed response shape with details.formErrors and details.fieldErrors.
- Strengthen invalid-payload coverage for missing required email fields.

## Verification
- bun run vitest run tests/api-emails.test.ts
- make check && make test

Closes #125