### PR TITLE
Rewrite ingester deploy runbook for ECS Fargate

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,14 +254,14 @@ curl -i http://localhost:3015/api/auth/verify \
 # Expect: X-RateLimit-Backend: redis when enabled
 ```
 
-The included `Dockerfile` produces an optimized multi-stage build suitable for any container platform (AWS App Runner, Google Cloud Run, Fly.io, Railway, etc.):
+The included `Dockerfile` produces an optimized multi-stage build suitable for any container platform (AWS ECS Fargate, Google Cloud Run, Fly.io, Railway, etc.):
 
 ```bash
 docker build -t namuh-send .
 docker run -p 3015:8080 --env-file .env namuh-send
 ```
 
-For the split-service App Runner shape, SNS cutover, and ingester log/replay runbook, see [`docs/ingester-deploy.md`](docs/ingester-deploy.md).
+For the ECS Fargate split-service shape, ALB host-based events routing, SNS cutover, and ingester log/replay runbook, see [`docs/ingester-deploy.md`](docs/ingester-deploy.md).
 
 ## Architecture
 

--- a/docs/ingester-deploy.md
+++ b/docs/ingester-deploy.md
@@ -1,6 +1,6 @@
 # Ingester deployment runbook
 
-Issue #70 splits SES/SNS ingestion into its own container and App Runner service so webhook bursts do not contend with the Next.js app.
+The standalone ingester receives SES/SNS events and owns background worker execution so webhook bursts and queued email sends do not contend with the Next.js app. Team production runs the ingester as an AWS ECS Fargate service behind the shared `namuh-alb` Application Load Balancer.
 
 ## Local docker-compose
 
@@ -23,35 +23,72 @@ docker compose ps ingester
 docker compose logs -f ingester
 ```
 
-## Production deploy shape
+## Production ECS Fargate shape
 
-`bash scripts/deploy.sh <image-tag>` now deploys two services:
+Production is AWS ECS Fargate in `us-east-1`:
 
-- app image from `Dockerfile`
-- ingester image from `packages/ingester/Dockerfile`
+- ECS cluster: `namuh`
+- ALB: `namuh-alb`, shared across products with host-based listener rules
+- ECR repos: `<product>-app` and `<product>-ingester`
+- ECS services: `<product>-app` and `<product>-ingester`
+- CloudWatch log groups: `/ecs/<product>-app` and `/ecs/<product>-ingester`
 
-Override names when the real production service or repository names differ from the repo defaults:
+The ALB listener routes by hostname:
 
-```bash
-APP_ECR_REPO=resend-clone \
-APP_RUNNER_SERVICE=resend-clone \
-INGESTER_ECR_REPO=resend-clone-ingester \
-INGESTER_APP_RUNNER_SERVICE=namuh-ingester \
-bash scripts/deploy.sh <image-tag>
+| Host | Target service | Target port |
+| --- | --- | --- |
+| `<product>.namuh.co` | app/dashboard | `8080` |
+| `api.<product>.namuh.co` | app/API | `8080` |
+| `events.<product>.namuh.co` | ingester | `3016` |
+
+For the current Opensend deployment, the ingester public endpoint is:
+
+```text
+https://events.opensend.namuh.co/events/ses
 ```
 
+The Fargate task definition must expose/container-map the ingester on port `3016`, and the `events.<product>.namuh.co` ALB rule must forward to the ingester target group on port `3016`.
+
+## Deploy the ingester
+
+Use `scripts/deploy.sh` rather than a raw `aws ecs update-service`. The Fargate deploy script contract is:
+
+- build `packages/ingester/Dockerfile` for `linux/amd64`
+- push the image to ECR repo `<product>-ingester`
+- force a new deployment of ECS service `<product>-ingester` in cluster `namuh`
+- wait for `aws ecs wait services-stable` before reporting success
+
+Deploy only the ingester:
+
+```bash
+PRODUCT=opensend \
+ECS_CLUSTER=namuh \
+IMAGE_TAG=latest \
+PLATFORM=linux/amd64 \
+bash scripts/deploy.sh ingester
+```
+
+Supported deploy targets:
+
+```bash
+bash scripts/deploy.sh app       # app image + app service redeploy
+bash scripts/deploy.sh ingester  # ingester image + ingester service redeploy
+bash scripts/deploy.sh all       # app + ingester images + both redeploys
+```
+
+The deploy script assumes the ECS services, target groups, listener rules, log groups, ECR repositories, and Secrets Manager wiring already exist. Use this runbook's external residuals checklist when bringing up a new product or debugging a failed deployment.
 
 ## Background job worker
 
-Issues #15/#16 move send/webhook work to AWS-native background jobs. The app publishes jobs to SQS after persisting rows; the ingester service consumes and executes them. Email rows start as `queued`, transition through worker-owned `processing`/`sent`, and get `sent_at` only after SES accepts the message.
+The app publishes jobs to SQS after persisting rows; the ingester service consumes and executes them. Email rows start as `queued`, transition through worker-owned `processing`/`sent`, and get `sent_at` only after SES accepts the message.
 
 Required production environment for both app and ingester:
 
 ```bash
-BACKGROUND_JOBS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/<account>/namuh-send-background
+BACKGROUND_JOBS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/<account>/<product>-background
 BACKGROUND_JOBS_REQUIRE_QUEUE=true
-BACKGROUND_JOBS_EVENT_BUS_NAME=namuh-send-background-jobs # optional lifecycle/event hook bus
-CLOUDWATCH_METRICS_NAMESPACE=NamuhSend # optional EMF namespace override
+BACKGROUND_JOBS_EVENT_BUS_NAME=<product>-background-jobs # optional lifecycle/event hook bus
+CLOUDWATCH_METRICS_NAMESPACE=Opensend # optional EMF namespace override
 ```
 
 Set this only on the ingester worker service when SQS is ready:
@@ -77,7 +114,7 @@ EventBridge scheduling:
 Manual probes:
 
 ```bash
-INGESTER_URL="https://<ingester-service-url>"
+INGESTER_URL="https://events.<product>.namuh.co"
 curl -i -X POST "${INGESTER_URL}/jobs/poll" \
   -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
 curl -i -X POST "${INGESTER_URL}/jobs/scheduled-emails" \
@@ -88,13 +125,19 @@ curl -i -X POST "${INGESTER_URL}/jobs/webhooks" \
 
 ## SNS cutover
 
-After the ingester service is live, SES SNS should point at:
+After the Fargate ingester service is healthy behind the ALB, SES SNS should point at the host-based `events` route:
 
 ```text
-https://<ingester-service-url>/events/ses
+https://events.<product>.namuh.co/events/ses
 ```
 
-Do not leave SES pointed at the Next.js app URL once the split is active.
+For Opensend production:
+
+```text
+https://events.opensend.namuh.co/events/ses
+```
+
+Do not leave SES pointed at the Next.js app/API host once the split is active.
 
 ## Observability
 
@@ -102,38 +145,34 @@ The app and ingester emit structured JSON logs, W3C/OpenTelemetry-compatible tra
 
 ## Tail ingester logs
 
-1. Resolve the service id:
+Tail the ECS CloudWatch log group for the ingester service:
 
 ```bash
-SERVICE_NAME=namuh-ingester
-aws apprunner list-services \
+PRODUCT=opensend
+aws logs tail "/ecs/${PRODUCT}-ingester" \
   --region us-east-1 \
-  --query "ServiceSummaryList[?ServiceName=='${SERVICE_NAME}'].ServiceId | [0]" \
-  --output text
+  --since 10m \
+  --follow
 ```
 
-2. Find the CloudWatch log group that App Runner created:
+Check recent ECS service events when a deploy or health check is failing:
 
 ```bash
-SERVICE_NAME=namuh-ingester
-aws logs describe-log-groups \
+PRODUCT=opensend
+aws ecs describe-services \
+  --cluster namuh \
+  --services "${PRODUCT}-ingester" \
   --region us-east-1 \
-  --log-group-name-prefix "/aws/apprunner/${SERVICE_NAME}"
+  --query 'services[0].events[0:10].message' \
+  --output table
 ```
 
-3. Tail the application log group:
+## Replay a missed SES SNS event
+
+The ingester verifies the original SNS signature, so the safe replay path is to resend the exact SNS notification body that AWS originally delivered to the Fargate endpoint.
 
 ```bash
-LOG_GROUP="/aws/apprunner/namuh-ingester/<service-id>/application"
-aws logs tail "${LOG_GROUP}" --region us-east-1 --since 10m --follow
-```
-
-## Force-process a missed SES event
-
-The ingester verifies the original SNS signature, so the safe replay path is to resend the exact SNS notification body that AWS originally delivered.
-
-```bash
-INGESTER_URL="https://<ingester-service-url>/events/ses"
+INGESTER_URL="https://events.<product>.namuh.co/events/ses"
 curl -i "${INGESTER_URL}" \
   -H "Content-Type: text/plain; charset=UTF-8" \
   -H "x-amz-sns-message-type: Notification" \
@@ -144,11 +183,14 @@ curl -i "${INGESTER_URL}" \
 
 ## External residuals
 
-This repo change does not create or mutate external AWS resources on its own. Before production cutover, verify:
+This repo change does not create or mutate external AWS resources on its own. Before production cutover or a new product launch, verify:
 
-- the ingester ECR repository exists
-- the ingester App Runner service has the shared RDS and Secrets Manager wiring
+- the `<product>-ingester` ECR repository exists
+- the `<product>-ingester` ECS service exists in cluster `namuh`
+- the ingester task definition has the same RDS, AWS, Cloudflare, queue, and token secrets as production requires
+- the ALB listener has a host-based rule for `events.<product>.namuh.co`
+- the ingester target group forwards to port `3016` and has a passing health check
 - the SQS queue exists with a redrive policy and DLQ
 - EventBridge schedule/rules exist for scheduled-email and webhook retry scans
 - IAM grants app publish permissions and ingester consume/delete/change-visibility permissions
-- the SES SNS subscription has been updated to the ingester URL
+- the SES SNS subscription has been updated to `https://events.<product>.namuh.co/events/ses`


### PR DESCRIPTION
## Summary
- Rewrites the ingester deploy runbook around the current ECS Fargate + shared ALB production shape.
- Documents the `bash scripts/deploy.sh ingester` path, `events.<product>.namuh.co` host routing, target port `3016`, `/ecs/<product>-ingester` CloudWatch log tailing, and SNS replay endpoint.
- Updates the README deployment pointer away from the stale App Runner split-service wording.

Closes #128

## Changes
- **docs/ingester-deploy.md**: replaces App Runner commands/log-group discovery with ECS Fargate deploy, routing, log, worker-probe, SNS cutover, and replay guidance.
- **README.md**: points operators to the ECS Fargate split-service runbook.

## How to Test
- [x] `rg -n 'App Runner|apprunner|3016|/ecs/|events/ses|jobs/poll|Fargate|ECS' README.md docs/ingester-deploy.md`
- [x] `rg -n 'App Runner|apprunner' README.md docs/ingester-deploy.md` returns no matches
- [x] `git diff --check -- README.md docs/ingester-deploy.md`
- [x] `bun run check`

## Notes
- Docs-only change; no ingester runtime code or AWS resources were changed.
- Live AWS deploy/log tail/SNS replay were not executed.
