### PR TITLE
Surface real failures behind the domain detail 404

### DIFF
--- a/agent_docs/learnings/active/2026-05-02-127-domain-detail-404-root-cause.md
+++ b/agent_docs/learnings/active/2026-05-02-127-domain-detail-404-root-cause.md
@@ -1,0 +1,38 @@
+---
+date: 2026-05-02
+issue: "#127"
+type: mistake
+promoted_to: null
+---
+
+## Don't wrap `notFound()` in a generic catch-all
+
+**What:** `src/app/(dashboard)/domains/[id]/page.tsx` wrapped its Drizzle query
+in `try { ... } catch { notFound() }`. Two distinct failure modes were both
+collapsed to a 404:
+
+1. The route param wasn't a UUID, so Postgres rejected the query with
+   `invalid input syntax for type uuid` — and the catch swallowed it.
+2. Any real DB error (connection drop, schema drift) was also masked as 404,
+   so server logs never surfaced the actual failure.
+
+The result: every `/domains/<id>` link rendered the global 404 page, even
+though the row existed in the same connection used by the list page.
+
+**Why it matters:** Server components should let infrastructure errors bubble
+to Next.js so the framework can render an error boundary or 5xx response.
+`notFound()` is for "the row doesn't exist," not "I couldn't find out
+whether the row exists."
+
+**Fix:** Validate the `[id]` segment with the existing `domainRouteParamsSchema`
+before touching the DB, then run the query without a catch-all. Invalid UUIDs
+produce a clean 404 without ever opening a Postgres transaction; missing
+rows still 404; real DB errors propagate to Next.js' error handling.
+
+**Pattern to reuse:** All other `[id]` server-component routes that import
+`@/lib/validation/domains` (or the matching contact/email/template schemas)
+should follow the same shape. The remaining detail pages
+(`api-keys/[id]`, `emails/[id]`, `audience/contacts/[id]`,
+`logs/[id]`, `templates/[id]`) still pass the raw param straight to a
+`uuid` column — invalid UUIDs there will throw and either 500 or, if a
+catch-all is present, mask the failure as 404. Worth filing follow-ups.

--- a/src/app/(dashboard)/domains/[id]/page.tsx
+++ b/src/app/(dashboard)/domains/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { DomainDetail } from "@/components/domain-detail";
 import { db } from "@/lib/db";
 import { domains } from "@/lib/db/schema";
+import { domainRouteParamsSchema } from "@/lib/validation/domains";
 import { eq } from "drizzle-orm";
 import { notFound } from "next/navigation";
 
@@ -14,24 +15,24 @@ export default async function DomainDetailPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-
-  type DomainRow = typeof domains.$inferSelect;
-  let domain: DomainRow;
-  try {
-    const rows = await db
-      .select()
-      .from(domains)
-      .where(eq(domains.id, id))
-      .limit(1);
-
-    if (rows.length === 0) {
-      notFound();
-    }
-    domain = rows[0];
-  } catch {
+  const parsedParams = domainRouteParamsSchema.safeParse(await params);
+  if (!parsedParams.success) {
     notFound();
   }
+
+  const { id } = parsedParams.data;
+
+  const rows = await db
+    .select()
+    .from(domains)
+    .where(eq(domains.id, id))
+    .limit(1);
+
+  if (rows.length === 0) {
+    notFound();
+  }
+
+  const domain = rows[0];
 
   const events: DomainEvent[] = [];
   events.push({

--- a/tests/domain-detail-page.test.tsx
+++ b/tests/domain-detail-page.test.tsx
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const notFoundCalls = vi.hoisted(() => ({ count: 0 }));
+const mockNotFound = vi.hoisted(() =>
+  vi.fn(() => {
+    notFoundCalls.count += 1;
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+);
+
+const limitMock = vi.hoisted(() => vi.fn());
+const whereMock = vi.hoisted(() => vi.fn(() => ({ limit: limitMock })));
+const fromMock = vi.hoisted(() => vi.fn(() => ({ where: whereMock })));
+const selectMock = vi.hoisted(() => vi.fn(() => ({ from: fromMock })));
+
+vi.mock("@/lib/db", () => ({
+  db: { select: selectMock },
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: mockNotFound,
+}));
+
+vi.mock("@/components/domain-detail", () => ({
+  DomainDetail: ({ domain }: { domain: { id: string } }) => (
+    <div data-testid="domain-detail">{domain.id}</div>
+  ),
+}));
+
+const VALID_UUID = "11111111-1111-4111-8111-111111111111";
+
+async function importPage() {
+  const mod = await import("@/app/(dashboard)/domains/[id]/page");
+  return mod.default;
+}
+
+describe("DomainDetailPage server component", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    notFoundCalls.count = 0;
+    mockNotFound.mockClear();
+    selectMock.mockClear();
+    fromMock.mockClear();
+    whereMock.mockClear();
+    limitMock.mockReset();
+  });
+
+  it("calls notFound for non-UUID ids without hitting the database", async () => {
+    const Page = await importPage();
+    await expect(
+      Page({ params: Promise.resolve({ id: "not-a-uuid" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(mockNotFound).toHaveBeenCalledTimes(1);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it("calls notFound when the row is missing", async () => {
+    limitMock.mockResolvedValueOnce([]);
+
+    const Page = await importPage();
+    await expect(
+      Page({ params: Promise.resolve({ id: VALID_UUID }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(mockNotFound).toHaveBeenCalledTimes(1);
+    expect(selectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates database errors instead of masking them as 404", async () => {
+    const dbError = new Error("invalid input syntax for type uuid");
+    limitMock.mockRejectedValueOnce(dbError);
+
+    const Page = await importPage();
+    await expect(
+      Page({ params: Promise.resolve({ id: VALID_UUID }) }),
+    ).rejects.toBe(dbError);
+
+    expect(mockNotFound).not.toHaveBeenCalled();
+  });
+
+  it("renders DomainDetail when the row exists", async () => {
+    limitMock.mockResolvedValueOnce([
+      {
+        id: VALID_UUID,
+        name: "example.com",
+        status: "verified",
+        region: "us-east-1",
+        trackClicks: false,
+        trackOpens: false,
+        tls: "opportunistic",
+        records: [],
+        createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      },
+    ]);
+
+    const Page = await importPage();
+    const result = await Page({
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+
+    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(result).toBeTruthy();
+    expect(result.props.domain.id).toBe(VALID_UUID);
+    expect(result.props.domain.events[0].type).toBe("domain_added");
+    expect(
+      result.props.domain.events.map((e: { type: string }) => e.type),
+    ).toContain("domain_verified");
+  });
+});


### PR DESCRIPTION
## Summary
- Validate `/domains/[id]` with the existing `domainRouteParamsSchema` so non-UUID segments cleanly hit `notFound()` without ever opening a Postgres transaction.
- Drop the silent `try { ... } catch { notFound() }` around the Drizzle query so real DB errors propagate to Next.js error handling instead of being masked as 404.
- Add focused regression coverage for the four behaviors: invalid UUID, missing row, propagated DB error, and the happy path.

## Root cause
`src/app/(dashboard)/domains/[id]/page.tsx` ran `db.select().from(domains).where(eq(domains.id, id))` and wrapped the whole thing in `try { ... } catch { notFound() }`. That catch swallowed Postgres' `invalid input syntax for type uuid` error (and any other infra failure) and rendered the global 404 — so every detail link looked broken even when the row existed in the same connection used by `/domains`.

## Test plan
- [x] `bunx vitest run tests/domain-detail-page.test.tsx`
- [x] `make check`
- [x] `make test` (566 pass)
- [ ] Production deploy verification — not run from this session
- [ ] Playwright `tests/e2e/domain-detail.spec.ts` — needs the dev server running on port 3015

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)