### PR TITLE
Add public OpenSend landing page at /landing

### DIFF
--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -1,0 +1,275 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+const GITHUB_URL = "https://github.com/namuh-eng/opensend";
+const DOCS_URL = "/docs";
+const HOSTED_SIGNIN_URL = "/auth";
+const SELF_HOST_URL = `${GITHUB_URL}#self-host`;
+
+export const metadata: Metadata = {
+  title: "OpenSend — Open-source email API you can self-host",
+  description:
+    "OpenSend is an open-source, self-hostable email platform with a Resend-compatible API, a TypeScript SDK, broadcasts, contacts, and a full dashboard. Run it on your own AWS SES quota, or use the hosted version.",
+  openGraph: {
+    title: "OpenSend — Open-source email API you can self-host",
+    description:
+      "Open-source, ELv2 email platform with a Resend-compatible API, SDK, dashboard, domain verification, and webhooks. Self-host on your own AWS SES, or use the hosted version.",
+    type: "website",
+    url: "https://opensend.namuh.co",
+    siteName: "OpenSend",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "OpenSend — Open-source email API you can self-host",
+    description:
+      "Open-source, ELv2 email platform with a Resend-compatible API, SDK, and dashboard.",
+  },
+  alternates: {
+    canonical: "https://opensend.namuh.co/landing",
+  },
+};
+
+const FEATURES: Array<{ title: string; body: string }> = [
+  {
+    title: "Resend-compatible API",
+    body: "Drop-in REST API for transactional and broadcast email. Move existing integrations over without rewriting payloads.",
+  },
+  {
+    title: "TypeScript SDK",
+    body: "First-class `namuh-send` package on npm with typed payloads, retries, and idempotency keys.",
+  },
+  {
+    title: "Domain verification",
+    body: "DKIM, SPF, and DMARC are auto-configured through Cloudflare. Verify domains in minutes, not hours.",
+  },
+  {
+    title: "Contacts, segments, broadcasts",
+    body: "Manage your audience, segment by properties or topics, and send broadcasts from a real dashboard.",
+  },
+  {
+    title: "Webhooks with HMAC signing",
+    body: "Svix-compatible webhook headers with HMAC signatures for delivery, opens, clicks, bounces, and complaints.",
+  },
+  {
+    title: "Runs on your AWS SES quota",
+    body: "Bring your own SES account. Your sending reputation, your data, your cost — no vendor lock-in.",
+  },
+];
+
+export default function LandingPage() {
+  return (
+    <div className="min-h-screen bg-black text-[#F0F0F0]">
+      <header className="border-b border-[rgba(176,199,217,0.145)]">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <Link
+            href="/landing"
+            className="flex items-center gap-2 text-[14px] font-semibold tracking-tight"
+          >
+            <span className="flex h-7 w-7 items-center justify-center rounded-md bg-purple-600 text-[13px] font-semibold text-white">
+              o
+            </span>
+            OpenSend
+          </Link>
+          <nav className="flex items-center gap-5 text-[13px] text-[#A1A4A5]">
+            <Link
+              href={DOCS_URL}
+              className="transition-colors hover:text-[#F0F0F0]"
+            >
+              Docs
+            </Link>
+            <a
+              href={GITHUB_URL}
+              className="transition-colors hover:text-[#F0F0F0]"
+              rel="noreferrer noopener"
+              target="_blank"
+            >
+              GitHub
+            </a>
+            <Link
+              href={HOSTED_SIGNIN_URL}
+              data-testid="nav-sign-in"
+              className="rounded-md bg-white px-3 py-1.5 text-[13px] font-medium text-black transition-colors hover:bg-gray-200"
+            >
+              Sign in
+            </Link>
+          </nav>
+        </div>
+      </header>
+
+      <main>
+        <section className="mx-auto max-w-6xl px-6 py-24">
+          <div className="max-w-3xl">
+            <p className="mb-4 text-[12px] font-medium uppercase tracking-widest text-[#A1A4A5]">
+              Open source · ELv2 · Self-hostable
+            </p>
+            <h1 className="text-4xl font-semibold leading-tight tracking-tight text-[#F0F0F0] sm:text-5xl">
+              The open-source email API you can self-host.
+            </h1>
+            <p className="mt-6 max-w-2xl text-[16px] leading-relaxed text-[#A1A4A5]">
+              OpenSend is a Resend-compatible email platform with a REST API,
+              TypeScript SDK, broadcasts, contacts, and a full dashboard. Run it
+              on your own AWS SES quota, or use the hosted version we run for
+              you.
+            </p>
+            <div className="mt-10 flex flex-wrap items-center gap-3">
+              <a
+                href={SELF_HOST_URL}
+                data-testid="cta-self-host"
+                rel="noreferrer noopener"
+                target="_blank"
+                className="inline-flex items-center gap-2 rounded-md bg-white px-4 py-2.5 text-[14px] font-medium text-black transition-colors hover:bg-gray-200"
+              >
+                Self-host with Docker
+              </a>
+              <Link
+                href={HOSTED_SIGNIN_URL}
+                data-testid="cta-hosted"
+                className="inline-flex items-center gap-2 rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] px-4 py-2.5 text-[14px] font-medium text-[#F0F0F0] transition-colors hover:border-[rgba(176,199,217,0.3)]"
+              >
+                Use the hosted version
+              </Link>
+              <a
+                href={GITHUB_URL}
+                data-testid="cta-github"
+                rel="noreferrer noopener"
+                target="_blank"
+                className="inline-flex items-center gap-2 rounded-md px-4 py-2.5 text-[14px] font-medium text-[#A1A4A5] transition-colors hover:text-[#F0F0F0]"
+              >
+                Star on GitHub →
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section
+          aria-labelledby="features-heading"
+          className="border-t border-[rgba(176,199,217,0.145)]"
+        >
+          <div className="mx-auto max-w-6xl px-6 py-20">
+            <h2
+              id="features-heading"
+              className="text-[11px] font-medium uppercase tracking-widest text-[#A1A4A5]"
+            >
+              What's in the box
+            </h2>
+            <p className="mt-3 max-w-2xl text-2xl font-semibold tracking-tight text-[#F0F0F0]">
+              Everything you need to send production email — without the vendor
+              lock-in.
+            </p>
+            <ul className="mt-12 grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-[rgba(176,199,217,0.145)] bg-[rgba(176,199,217,0.145)] sm:grid-cols-2 lg:grid-cols-3">
+              {FEATURES.map((feature) => (
+                <li key={feature.title} className="bg-black p-6">
+                  <h3 className="text-[14px] font-semibold text-[#F0F0F0]">
+                    {feature.title}
+                  </h3>
+                  <p className="mt-2 text-[13px] leading-relaxed text-[#A1A4A5]">
+                    {feature.body}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section
+          aria-labelledby="self-host-heading"
+          className="border-t border-[rgba(176,199,217,0.145)]"
+        >
+          <div className="mx-auto grid max-w-6xl gap-10 px-6 py-20 lg:grid-cols-2 lg:gap-16">
+            <div>
+              <h2
+                id="self-host-heading"
+                className="text-2xl font-semibold tracking-tight text-[#F0F0F0]"
+              >
+                Self-host in one command
+              </h2>
+              <p className="mt-4 text-[14px] leading-relaxed text-[#A1A4A5]">
+                OpenSend ships as a multi-stage Dockerfile and{" "}
+                <code className="rounded bg-[rgba(24,25,28,0.88)] px-1.5 py-0.5 font-mono text-[13px] text-[#F0F0F0]">
+                  docker-compose.yml
+                </code>{" "}
+                with auto-migration. Bring your own AWS SES credentials and
+                Postgres — your data stays on your infrastructure.
+              </p>
+              <div className="mt-6 flex flex-wrap gap-3">
+                <a
+                  href={SELF_HOST_URL}
+                  rel="noreferrer noopener"
+                  target="_blank"
+                  className="inline-flex items-center gap-2 rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] px-4 py-2.5 text-[14px] font-medium text-[#F0F0F0] transition-colors hover:border-[rgba(176,199,217,0.3)]"
+                >
+                  Self-host instructions
+                </a>
+                <Link
+                  href={DOCS_URL}
+                  className="inline-flex items-center gap-2 rounded-md px-4 py-2.5 text-[14px] font-medium text-[#A1A4A5] transition-colors hover:text-[#F0F0F0]"
+                >
+                  Read the API docs →
+                </Link>
+              </div>
+            </div>
+            <pre className="overflow-x-auto rounded-lg border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] p-5 font-mono text-[13px] leading-relaxed text-[#F0F0F0]">
+              <code>{`git clone https://github.com/namuh-eng/opensend
+cd opensend
+cp .env.example .env
+docker compose up -d`}</code>
+            </pre>
+          </div>
+        </section>
+
+        <section
+          aria-labelledby="hosted-heading"
+          className="border-t border-[rgba(176,199,217,0.145)]"
+        >
+          <div className="mx-auto flex max-w-6xl flex-col items-start gap-6 px-6 py-20 lg:flex-row lg:items-center lg:justify-between">
+            <div className="max-w-xl">
+              <h2
+                id="hosted-heading"
+                className="text-2xl font-semibold tracking-tight text-[#F0F0F0]"
+              >
+                Don't want to run it yourself?
+              </h2>
+              <p className="mt-3 text-[14px] leading-relaxed text-[#A1A4A5]">
+                Use the hosted version of OpenSend. We handle the SES
+                deliverability, monitoring, and upgrades — you keep the same
+                API.
+              </p>
+            </div>
+            <Link
+              href={HOSTED_SIGNIN_URL}
+              data-testid="cta-hosted-bottom"
+              className="inline-flex items-center gap-2 rounded-md bg-white px-4 py-2.5 text-[14px] font-medium text-black transition-colors hover:bg-gray-200"
+            >
+              Get started with hosted
+            </Link>
+          </div>
+        </section>
+      </main>
+
+      <footer className="border-t border-[rgba(176,199,217,0.145)]">
+        <div className="mx-auto flex max-w-6xl flex-col items-start justify-between gap-4 px-6 py-8 sm:flex-row sm:items-center">
+          <p className="text-[12px] text-[#A1A4A5]">
+            © {new Date().getFullYear()} OpenSend · Licensed under Elastic
+            License 2.0
+          </p>
+          <div className="flex flex-wrap items-center gap-5 text-[13px] text-[#A1A4A5]">
+            <Link href={DOCS_URL} className="hover:text-[#F0F0F0]">
+              Docs
+            </Link>
+            <a
+              href={GITHUB_URL}
+              rel="noreferrer noopener"
+              target="_blank"
+              className="hover:text-[#F0F0F0]"
+            >
+              GitHub
+            </a>
+            <Link href={HOSTED_SIGNIN_URL} className="hover:text-[#F0F0F0]">
+              Sign in
+            </Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -109,9 +109,11 @@ export async function middleware(request: NextRequest) {
 
   // Protect non-API page routes with session check
   if (!pathname.startsWith("/api/")) {
-    // Allow auth page and static assets
+    // Allow auth page, public landing page, and static assets
     if (
       pathname === "/auth" ||
+      pathname === "/landing" ||
+      pathname.startsWith("/landing/") ||
       pathname.startsWith("/_next/") ||
       pathname.startsWith("/favicon")
     ) {

--- a/tests/e2e/landing-page.spec.ts
+++ b/tests/e2e/landing-page.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Landing page", () => {
+  test("renders public hero, features, and CTAs without auth redirect", async ({
+    page,
+  }) => {
+    await page.goto("/landing");
+    await expect(page).toHaveURL(/\/landing$/);
+    await expect(
+      page.getByRole("heading", { level: 1, name: /open-source email API/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /What's in the box/i }),
+    ).toBeVisible();
+  });
+
+  test("self-host CTA points at the OpenSend GitHub repo", async ({ page }) => {
+    await page.goto("/landing");
+    const selfHost = page.getByTestId("cta-self-host");
+    await expect(selfHost).toBeVisible();
+    const href = await selfHost.getAttribute("href");
+    expect(href).toContain("github.com/namuh-eng/opensend");
+  });
+
+  test("hosted CTA navigates to the auth page", async ({ page }) => {
+    await page.goto("/landing");
+    await page.getByTestId("cta-hosted").click();
+    await expect(page).toHaveURL(/\/auth$/);
+  });
+
+  test("docs link from landing footer goes to /docs", async ({ page }) => {
+    await page.goto("/landing");
+    const docsLink = page.locator("footer").getByRole("link", { name: "Docs" });
+    await expect(docsLink).toHaveAttribute("href", "/docs");
+  });
+});

--- a/tests/landing-page.test.tsx
+++ b/tests/landing-page.test.tsx
@@ -1,0 +1,81 @@
+import LandingPage, { metadata } from "@/app/landing/page";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(cleanup);
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: { href: string; children: React.ReactNode }) => (
+    <a href={typeof href === "string" ? href : String(href)} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("Landing page metadata", () => {
+  it("exposes a marketing-friendly title and description", () => {
+    expect(metadata.title).toMatch(/OpenSend/);
+    expect(typeof metadata.description).toBe("string");
+    expect((metadata.description as string).length).toBeGreaterThan(40);
+  });
+
+  it("declares OpenGraph + canonical metadata for SEO", () => {
+    expect(metadata.openGraph?.title).toMatch(/OpenSend/);
+    expect(metadata.openGraph?.url).toBe("https://opensend.namuh.co");
+    expect(metadata.alternates?.canonical).toBe(
+      "https://opensend.namuh.co/landing",
+    );
+  });
+});
+
+describe("Landing page route", () => {
+  it("renders the hero headline", () => {
+    render(<LandingPage />);
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading.textContent).toMatch(/open-source email API/i);
+  });
+
+  it("renders all required marketing CTAs", () => {
+    render(<LandingPage />);
+
+    const selfHost = screen
+      .getAllByText(/self-host/i)
+      .find((el) => el.getAttribute("data-testid") === "cta-self-host");
+    expect(selfHost?.getAttribute("href")).toMatch(/github\.com/);
+
+    const hosted = screen.getByTestId("cta-hosted");
+    expect(hosted.getAttribute("href")).toBe("/auth");
+
+    const github = screen.getByTestId("cta-github");
+    expect(github.getAttribute("href")).toMatch(/github\.com/);
+  });
+
+  it("links to docs and GitHub from header navigation", () => {
+    render(<LandingPage />);
+    const docsLinks = screen.getAllByRole("link", { name: "Docs" });
+    expect(docsLinks.some((el) => el.getAttribute("href") === "/docs")).toBe(
+      true,
+    );
+
+    const githubLinks = screen.getAllByRole("link", { name: "GitHub" });
+    expect(
+      githubLinks.some((el) =>
+        (el.getAttribute("href") ?? "").includes("github.com"),
+      ),
+    ).toBe(true);
+  });
+
+  it("renders a footer with copyright and license attribution", () => {
+    render(<LandingPage />);
+    expect(screen.getByText(/Elastic License 2\.0/i)).toBeDefined();
+  });
+
+  it("includes a self-host quickstart code block", () => {
+    render(<LandingPage />);
+    expect(screen.getByText(/docker compose up -d/i)).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a public, additive marketing/landing route at `/landing` inside the existing Next.js app — no separate deployment, no new framework, reuses the existing Tailwind palette.
- Includes hero, "what's in the box" feature grid, self-host quickstart (Docker), hosted CTA, GitHub CTA, docs link, footer with ELv2 attribution, and basic SEO metadata (title, description, OpenGraph, Twitter, canonical).
- Middleware update: `/landing` (and `/landing/*`) are added to the unauthenticated allowlist next to `/auth`, `/_next/`, and `/favicon`. Dashboard auth gating is unchanged.

Closes #138.

## Smallest safe assumptions (please confirm — issue is `spec-needed`)
The issue is intentionally light on spec, so this PR makes only the smallest assumptions needed to be additive and routing-safe. **@jaeyunha** — please weigh in on these before we promote past staging:

1. **Route choice — `/landing`, not `/`.** The bare `/` route currently `redirect()`s to `/emails` (`src/app/page.tsx:1` and `src/app/(dashboard)/page.tsx:1`). Replacing that would change the dashboard entry point and break the existing `home page redirects to emails` smoke test. So this PR adds `/landing` and **does not touch `/`**. The follow-up routing/product decision (does `opensend.namuh.co` map to landing-at-root, with the dashboard moved under a different path; or split via host-based routing in middleware; or something else?) is deferred to a separate PR.
2. **Single deployment, not a separate site.** Per the brief, this lives in the existing app. No new infra.
3. **Marketing copy.** Uses "OpenSend" (matches the `opensend.namuh.co` subdomain and the `github.com/namuh-eng/opensend` repo) rather than the historical "Namuh Send" string still present in `src/app/layout.tsx`. Open to changing the user-facing brand if product wants.
4. **CTAs.** Self-host points at `https://github.com/namuh-eng/opensend#self-host`, hosted points at `/auth`, GitHub points at the repo. No analytics/tracking added — none was specified.

## What's in the box
- `src/app/landing/page.tsx` — server component, server-rendered `metadata`.
- `src/middleware.ts` — adds `/landing` + `/landing/*` to the public allowlist.
- `tests/landing-page.test.tsx` — Vitest coverage of route rendering, required CTAs, header/footer links, and the metadata contract.
- `tests/e2e/landing-page.spec.ts` — Playwright smoke for hero, self-host CTA, hosted CTA → `/auth`, docs link.

## Test plan
- [x] `make check` — typecheck + Biome lint/format clean
- [x] `make test` — 586 unit tests pass (incl. 7 new landing-page tests)
- [ ] `make test-e2e` — Playwright smoke (CI / reviewer to run; requires `bun run dev` on :3015)
- [ ] Manual: visit `/landing` unauthenticated and confirm no redirect to `/auth`
- [ ] Manual: visit any other dashboard route unauthenticated and confirm redirect to `/auth` is unchanged

## Why this is safe to merge to staging
- Additive: one new route, one new line in middleware allowlist. No existing route, layout, or component is modified.
- Routing-safe: dashboard root, `/auth`, `/docs`, `/unsubscribe/*`, and every existing `(dashboard)` page behave identically.
- Green: typecheck + lint + 586 unit tests pass locally.

If any of the assumptions above are wrong, holding for **@jaeyunha** to make the routing/product call before merge.