### PR TITLE
Add Stripe checkout and portal endpoints

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "redis": "^5.12.1",
+        "stripe": "^22.1.0",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.0",
@@ -1079,6 +1080,8 @@
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "stripe": ["stripe@22.1.0", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw=="],
 
     "strnum": ["strnum@2.2.3", "", {}, "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="],
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "pg": "^8.16.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "redis": "^5.12.1"
+    "redis": "^5.12.1",
+    "stripe": "^22.1.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",

--- a/packages/core/src/db/repositories/stripeCustomerRepo.ts
+++ b/packages/core/src/db/repositories/stripeCustomerRepo.ts
@@ -23,6 +23,20 @@ export const stripeCustomerRepo = {
   async ensureForUser(userId: string, stripeCustomerId: string) {
     const existing = await this.findByUserId(userId);
     if (existing) return existing;
-    return await this.create({ userId, stripeCustomerId });
+
+    const [row] = await db
+      .insert(stripeCustomers)
+      .values({ userId, stripeCustomerId })
+      .onConflictDoNothing({ target: stripeCustomers.userId })
+      .returning();
+    if (row) return row;
+
+    const reloaded = await this.findByUserId(userId);
+    if (!reloaded) {
+      throw new Error(
+        "Stripe customer ensure failed: insert ignored but no row",
+      );
+    }
+    return reloaded;
   },
 };

--- a/src/app/api/billing/checkout/route.ts
+++ b/src/app/api/billing/checkout/route.ts
@@ -1,0 +1,111 @@
+import { getServerSession } from "@/lib/api-auth";
+import { getBillingBackend } from "@/lib/billing";
+import { getStripe } from "@/lib/billing/stripe";
+import { planRepo, stripeCustomerRepo } from "@namuh/core";
+import { NextResponse } from "next/server";
+import type Stripe from "stripe";
+
+interface CheckoutRequestBody {
+  plan_id?: unknown;
+  planId?: unknown;
+}
+
+function getRequestOrigin(request: Request) {
+  return new URL(request.url).origin;
+}
+
+async function readCheckoutBody(request: Request) {
+  try {
+    return (await request.json()) as CheckoutRequestBody;
+  } catch {
+    return null;
+  }
+}
+
+async function ensureStripeCustomer(params: {
+  stripe: Stripe;
+  userId: string;
+  email?: string | null;
+  name?: string | null;
+}) {
+  const existing = await stripeCustomerRepo.findByUserId(params.userId);
+  if (existing) return existing;
+
+  const customer = await params.stripe.customers.create({
+    email: params.email ?? undefined,
+    name: params.name ?? undefined,
+    metadata: {
+      user_id: params.userId,
+    },
+  });
+
+  return await stripeCustomerRepo.ensureForUser(params.userId, customer.id);
+}
+
+export async function POST(request: Request) {
+  if (getBillingBackend() !== "stripe") {
+    return NextResponse.json(
+      { error: "Billing is not enabled" },
+      { status: 404 },
+    );
+  }
+
+  const session = await getServerSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await readCheckoutBody(request);
+  const planId = body?.plan_id ?? body?.planId;
+  if (typeof planId !== "string" || !planId.trim()) {
+    return NextResponse.json({ error: "plan_id is required" }, { status: 400 });
+  }
+
+  const plan = await planRepo.findById(planId.trim());
+  if (!plan || !plan.isPublic) {
+    return NextResponse.json({ error: "Plan not found" }, { status: 404 });
+  }
+
+  if (!plan.stripePriceId) {
+    return NextResponse.json(
+      { error: "Plan is not available for Stripe checkout" },
+      { status: 400 },
+    );
+  }
+
+  const stripe = getStripe();
+  const customer = await ensureStripeCustomer({
+    stripe,
+    userId: session.user.id,
+    email: session.user.email,
+    name: session.user.name,
+  });
+  const origin = getRequestOrigin(request);
+
+  const checkoutSession = await stripe.checkout.sessions.create({
+    mode: "subscription",
+    customer: customer.stripeCustomerId,
+    line_items: [{ price: plan.stripePriceId, quantity: 1 }],
+    success_url: `${origin}/settings/billing?status=success`,
+    cancel_url: `${origin}/settings/billing?status=cancelled`,
+    metadata: {
+      user_id: session.user.id,
+      plan_id: plan.id,
+    },
+    subscription_data: {
+      metadata: {
+        user_id: session.user.id,
+        plan_id: plan.id,
+      },
+    },
+  });
+
+  if (!checkoutSession.url) {
+    return NextResponse.json(
+      { error: "Stripe did not return a checkout URL" },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({ url: checkoutSession.url });
+}

--- a/src/app/api/billing/portal/route.ts
+++ b/src/app/api/billing/portal/route.ts
@@ -1,0 +1,38 @@
+import { getServerSession } from "@/lib/api-auth";
+import { getBillingBackend } from "@/lib/billing";
+import { getStripe } from "@/lib/billing/stripe";
+import { stripeCustomerRepo } from "@namuh/core";
+import { NextResponse } from "next/server";
+
+function getRequestOrigin(request: Request) {
+  return new URL(request.url).origin;
+}
+
+export async function POST(request: Request) {
+  if (getBillingBackend() !== "stripe") {
+    return NextResponse.json(
+      { error: "Billing is not enabled" },
+      { status: 404 },
+    );
+  }
+
+  const session = await getServerSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const customer = await stripeCustomerRepo.findByUserId(session.user.id);
+  if (!customer) {
+    return NextResponse.json(
+      { error: "Stripe customer not found" },
+      { status: 404 },
+    );
+  }
+
+  const portalSession = await getStripe().billingPortal.sessions.create({
+    customer: customer.stripeCustomerId,
+    return_url: `${getRequestOrigin(request)}/settings/billing`,
+  });
+
+  return NextResponse.json({ url: portalSession.url });
+}

--- a/src/lib/billing/stripe.ts
+++ b/src/lib/billing/stripe.ts
@@ -1,0 +1,33 @@
+import Stripe from "stripe";
+
+// Keep this pinned to the API version bundled as Stripe.API_VERSION by stripe@22.1.0.
+export const STRIPE_API_VERSION = "2026-04-22.dahlia" as const;
+
+let cachedClient: Stripe | null = null;
+let cachedFromKey: string | null = null;
+
+export function getStripe(
+  env: Record<string, string | undefined> = process.env,
+): Stripe {
+  const secret = env.STRIPE_SECRET_KEY?.trim();
+  if (!secret) {
+    throw new Error("STRIPE_SECRET_KEY is required to use the Stripe client");
+  }
+
+  if (cachedClient && cachedFromKey === secret) return cachedClient;
+
+  cachedClient = new Stripe(secret, {
+    apiVersion: STRIPE_API_VERSION,
+    typescript: true,
+    appInfo: {
+      name: "opensend",
+    },
+  });
+  cachedFromKey = secret;
+  return cachedClient;
+}
+
+export function __resetStripeForTests() {
+  cachedClient = null;
+  cachedFromKey = null;
+}

--- a/tests/billing-checkout-portal.test.ts
+++ b/tests/billing-checkout-portal.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetServerSession = vi.fn();
+const mockPlanFindById = vi.fn();
+const mockFindCustomerByUserId = vi.fn();
+const mockEnsureCustomerForUser = vi.fn();
+const mockStripeCustomerCreate = vi.fn();
+const mockCheckoutCreate = vi.fn();
+const mockPortalCreate = vi.fn();
+
+vi.mock("@/lib/api-auth", () => ({
+  getServerSession: mockGetServerSession,
+}));
+
+vi.mock("@namuh/core", () => ({
+  planRepo: {
+    findById: mockPlanFindById,
+  },
+  stripeCustomerRepo: {
+    findByUserId: mockFindCustomerByUserId,
+    ensureForUser: mockEnsureCustomerForUser,
+  },
+}));
+
+vi.mock("@/lib/billing/stripe", () => ({
+  getStripe: () => ({
+    customers: { create: mockStripeCustomerCreate },
+    checkout: { sessions: { create: mockCheckoutCreate } },
+    billingPortal: { sessions: { create: mockPortalCreate } },
+  }),
+}));
+
+const testSession = {
+  user: {
+    id: "user_123",
+    email: "owner@example.com",
+    name: "Owner Example",
+  },
+};
+
+function postRequest(path: string, body?: unknown) {
+  return new Request(`https://app.opensend.test${path}`, {
+    method: "POST",
+    body: body === undefined ? undefined : JSON.stringify(body),
+    headers:
+      body === undefined ? undefined : { "content-type": "application/json" },
+  });
+}
+
+async function importCheckoutRoute() {
+  return await import("@/app/api/billing/checkout/route");
+}
+
+async function importPortalRoute() {
+  return await import("@/app/api/billing/portal/route");
+}
+
+describe("billing checkout and portal routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.BILLING_BACKEND = "stripe";
+    process.env.STRIPE_SECRET_KEY = "sk_test_unit";
+    mockGetServerSession.mockResolvedValue(testSession);
+  });
+
+  it("returns 404 when Stripe billing is disabled instead of throwing", async () => {
+    process.env.BILLING_BACKEND = undefined;
+    process.env.STRIPE_SECRET_KEY = undefined;
+    const { POST } = await importCheckoutRoute();
+
+    const response = await POST(
+      postRequest("/api/billing/checkout", { plan_id: "plan_1" }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Billing is not enabled",
+    });
+    expect(mockGetServerSession).not.toHaveBeenCalled();
+  });
+
+  it("auto-creates a Stripe customer and returns the checkout session URL", async () => {
+    mockPlanFindById.mockResolvedValue({
+      id: "plan_pro",
+      isPublic: true,
+      stripePriceId: "price_123",
+    });
+    mockFindCustomerByUserId.mockResolvedValue(undefined);
+    mockStripeCustomerCreate.mockResolvedValue({ id: "cus_new" });
+    mockEnsureCustomerForUser.mockResolvedValue({
+      userId: "user_123",
+      stripeCustomerId: "cus_new",
+    });
+    mockCheckoutCreate.mockResolvedValue({
+      url: "https://checkout.stripe.com/c/pay/cs_test_123",
+    });
+    const { POST } = await importCheckoutRoute();
+
+    const response = await POST(
+      postRequest("/api/billing/checkout", { plan_id: "plan_pro" }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      url: "https://checkout.stripe.com/c/pay/cs_test_123",
+    });
+    expect(mockStripeCustomerCreate).toHaveBeenCalledWith({
+      email: "owner@example.com",
+      name: "Owner Example",
+      metadata: { user_id: "user_123" },
+    });
+    expect(mockEnsureCustomerForUser).toHaveBeenCalledWith(
+      "user_123",
+      "cus_new",
+    );
+    expect(mockCheckoutCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: "cus_new",
+        line_items: [{ price: "price_123", quantity: 1 }],
+        mode: "subscription",
+        success_url:
+          "https://app.opensend.test/settings/billing?status=success",
+        cancel_url:
+          "https://app.opensend.test/settings/billing?status=cancelled",
+      }),
+    );
+  });
+
+  it("returns a checkout URL for an existing Stripe customer", async () => {
+    mockPlanFindById.mockResolvedValue({
+      id: "plan_pro",
+      isPublic: true,
+      stripePriceId: "price_123",
+    });
+    mockFindCustomerByUserId.mockResolvedValue({
+      userId: "user_123",
+      stripeCustomerId: "cus_existing",
+    });
+    mockCheckoutCreate.mockResolvedValue({
+      url: "https://checkout.stripe.com/c/pay/cs_test_existing",
+    });
+    const { POST } = await importCheckoutRoute();
+
+    const response = await POST(
+      postRequest("/api/billing/checkout", { planId: "plan_pro" }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      url: "https://checkout.stripe.com/c/pay/cs_test_existing",
+    });
+    expect(mockStripeCustomerCreate).not.toHaveBeenCalled();
+    expect(mockCheckoutCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ customer: "cus_existing" }),
+    );
+  });
+
+  it("reuses the current user's Stripe customer for the customer portal", async () => {
+    mockFindCustomerByUserId.mockResolvedValue({
+      userId: "user_123",
+      stripeCustomerId: "cus_existing",
+    });
+    mockPortalCreate.mockResolvedValue({
+      url: "https://billing.stripe.com/p/session/test_123",
+    });
+    const { POST } = await importPortalRoute();
+
+    const response = await POST(postRequest("/api/billing/portal"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      url: "https://billing.stripe.com/p/session/test_123",
+    });
+    expect(mockPortalCreate).toHaveBeenCalledWith({
+      customer: "cus_existing",
+      return_url: "https://app.opensend.test/settings/billing",
+    });
+  });
+});

--- a/tests/e2e/billing-checkout.spec.ts
+++ b/tests/e2e/billing-checkout.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+const sessionCookie = process.env.BILLING_E2E_SESSION_COOKIE;
+const planId = process.env.BILLING_E2E_PLAN_ID;
+const canRunStripeCheckoutE2E =
+  process.env.BILLING_BACKEND === "stripe" &&
+  Boolean(process.env.STRIPE_SECRET_KEY) &&
+  Boolean(sessionCookie) &&
+  Boolean(planId);
+
+test.describe("Billing checkout endpoint", () => {
+  test.skip(
+    !canRunStripeCheckoutE2E,
+    "Set BILLING_BACKEND=stripe, STRIPE_SECRET_KEY, BILLING_E2E_SESSION_COOKIE, and BILLING_E2E_PLAN_ID to run live Stripe checkout E2E.",
+  );
+
+  test("returns a Stripe Checkout URL", async ({ request }) => {
+    const response = await request.post("/api/billing/checkout", {
+      headers: { cookie: sessionCookie ?? "" },
+      data: { plan_id: planId },
+    });
+
+    expect(response.ok()).toBe(true);
+    const body = (await response.json()) as { url?: string };
+    expect(body.url).toBeTruthy();
+    expect(new URL(body.url ?? "").hostname).toBe("checkout.stripe.com");
+  });
+});


### PR DESCRIPTION
## Summary
- Add a singleton Stripe SDK helper pinned to `stripe@22.1.0`'s bundled API version (`2026-04-22.dahlia`).
- Add `POST /api/billing/checkout` behind `BILLING_BACKEND=stripe` + session auth; it resolves the requested plan, idempotently ensures a Stripe customer row, and returns a Stripe Checkout URL with the required success/cancel URLs.
- Add `POST /api/billing/portal` behind the same billing/session gates; it reuses the current user's stored Stripe customer and returns a Customer Portal URL.
- Harden `stripeCustomerRepo.ensureForUser` with the existing unique user constraint to avoid duplicate DB rows on repeated customer creation attempts.

## Tests
- [x] `bunx vitest run tests/billing-checkout-portal.test.ts tests/billing-flag.test.ts tests/billing-plan-repo.test.ts tests/billing-schema.test.ts`
- [x] `make check`
- [x] `make test`
- [x] `bun run test:e2e -- tests/e2e/billing-checkout.spec.ts` (locally skipped because live Stripe/session env is not set)

## Issue
Closes #134.

## Residual risk
- The live Stripe Checkout Playwright assertion requires CI/local env to provide `BILLING_BACKEND=stripe`, `STRIPE_SECRET_KEY`, `BILLING_E2E_SESSION_COOKIE`, and `BILLING_E2E_PLAN_ID`; without those it intentionally skips.
- This slice does not reconcile subscriptions, process webhooks, enforce quota, or add UI entry points; those remain follow-up issue scope.
