### PR TITLE
Add automation API and event ingestion endpoints

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -37,6 +37,51 @@ export type SendEmailPayload = EmailOptions & {
 };
 export type CreateDomainPayload = DomainOptions;
 
+export interface AutomationStepPayload {
+  key: string;
+  type: "trigger" | "delay" | "send_email" | "end";
+  config?: Record<string, unknown>;
+  position?: number;
+}
+
+export interface AutomationConnectionPayload {
+  from: string;
+  to: string;
+}
+
+export interface CreateAutomationPayload {
+  name?: string;
+  status?: "draft" | "enabled" | "disabled";
+  trigger_event_name?: string;
+  triggerEventName?: string;
+  steps: AutomationStepPayload[];
+  connections?: AutomationConnectionPayload[];
+}
+
+export type UpdateAutomationPayload = Partial<CreateAutomationPayload>;
+
+export interface SendEventPayload {
+  event: string;
+  contact_id?: string;
+  contactId?: string;
+  email?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface CreateEventPayload {
+  name: string;
+  schema?: Record<string, unknown>;
+}
+
+export interface ListOptions {
+  limit?: number;
+  after?: string;
+}
+
+export interface AutomationRunListOptions extends ListOptions {
+  status?: string;
+}
+
 function normalizeBaseUrl(baseUrl?: string): string {
   if (!baseUrl?.trim()) {
     throw new Error("A non-empty baseUrl is required");
@@ -262,11 +307,103 @@ class Contacts {
   }
 }
 
+class Automations {
+  constructor(private readonly http: HttpClient) {}
+
+  async create(
+    payload: CreateAutomationPayload,
+  ): Promise<ApiResponse<unknown>> {
+    return this.http.request<unknown>("POST", "/api/automations", payload);
+  }
+
+  async list(
+    options: ListOptions & { status?: string } = {},
+  ): Promise<ApiResponse<unknown>> {
+    const params = new URLSearchParams();
+    if (options.limit !== undefined) params.set("limit", String(options.limit));
+    if (options.after) params.set("after", options.after);
+    if (options.status) params.set("status", options.status);
+    const query = params.toString();
+    return this.http.request<unknown>(
+      "GET",
+      query ? `/api/automations?${query}` : "/api/automations",
+    );
+  }
+
+  async get(id: string): Promise<ApiResponse<unknown>> {
+    return this.http.request<unknown>("GET", `/api/automations/${id}`);
+  }
+
+  async update(
+    id: string,
+    payload: UpdateAutomationPayload,
+  ): Promise<ApiResponse<unknown>> {
+    return this.http.request<unknown>(
+      "PATCH",
+      `/api/automations/${id}`,
+      payload,
+    );
+  }
+
+  async delete(id: string): Promise<ApiResponse<unknown>> {
+    return this.http.request<unknown>("DELETE", `/api/automations/${id}`);
+  }
+
+  async listRuns(
+    id: string,
+    options: AutomationRunListOptions = {},
+  ): Promise<ApiResponse<unknown>> {
+    const params = new URLSearchParams();
+    if (options.limit !== undefined) params.set("limit", String(options.limit));
+    if (options.after) params.set("after", options.after);
+    if (options.status) params.set("status", options.status);
+    const query = params.toString();
+    return this.http.request<unknown>(
+      "GET",
+      query
+        ? `/api/automations/${id}/runs?${query}`
+        : `/api/automations/${id}/runs`,
+    );
+  }
+
+  async getRun(id: string, runId: string): Promise<ApiResponse<unknown>> {
+    return this.http.request<unknown>(
+      "GET",
+      `/api/automations/${id}/runs/${runId}`,
+    );
+  }
+}
+
+class Events {
+  constructor(private readonly http: HttpClient) {}
+
+  async create(payload: CreateEventPayload): Promise<ApiResponse<unknown>> {
+    return this.http.request<unknown>("POST", "/api/events", payload);
+  }
+
+  async list(options: ListOptions = {}): Promise<ApiResponse<unknown>> {
+    const params = new URLSearchParams();
+    if (options.limit !== undefined) params.set("limit", String(options.limit));
+    if (options.after) params.set("after", options.after);
+    const query = params.toString();
+    return this.http.request<unknown>(
+      "GET",
+      query ? `/api/events?${query}` : "/api/events",
+    );
+  }
+
+  async send(payload: SendEventPayload): Promise<ApiResponse<unknown>> {
+    return this.http.request<unknown>("POST", "/api/events/send", payload);
+  }
+}
+
 class NamuhSend {
   public readonly emails: Emails;
   public readonly domains: Domains;
   public readonly apiKeys: ApiKeys;
   public readonly contacts: Contacts;
+  public readonly automations: Automations;
+  public readonly events: Events;
 
   constructor(apiKey: string, options: SDKOptions) {
     if (!apiKey) {
@@ -279,6 +416,8 @@ class NamuhSend {
     this.domains = new Domains(http);
     this.apiKeys = new ApiKeys(http);
     this.contacts = new Contacts(http);
+    this.automations = new Automations(http);
+    this.events = new Events(http);
   }
 }
 

--- a/src/app/api/automations/[id]/route.ts
+++ b/src/app/api/automations/[id]/route.ts
@@ -1,0 +1,205 @@
+import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { formatAutomation } from "@/lib/automations";
+import { db } from "@/lib/db";
+import { automationSteps, automations } from "@/lib/db/schema";
+import { updateAutomationSchema } from "@/lib/validation/automations";
+import {
+  type AutomationStepInput,
+  AutomationValidationError,
+  automationRepo,
+} from "@namuh/core";
+import { and, asc, eq } from "drizzle-orm";
+
+async function findAutomationForCaller(id: string, userId: string | null) {
+  const conditions = [eq(automations.id, id)];
+  if (userId) conditions.push(eq(automations.userId, userId));
+  return (
+    (await db.query.automations.findFirst({ where: and(...conditions) })) ??
+    null
+  );
+}
+
+async function loadSteps(automationId: string) {
+  return await db
+    .select()
+    .from(automationSteps)
+    .where(eq(automationSteps.automationId, automationId))
+    .orderBy(asc(automationSteps.position));
+}
+
+function toStepInputs(
+  steps: Array<{
+    key: string;
+    type: "trigger" | "delay" | "send_email" | "end";
+    config?: Record<string, unknown>;
+    position?: number;
+  }>,
+): AutomationStepInput[] {
+  return steps.map((step) => ({
+    key: step.key,
+    type: step.type,
+    config: step.config ?? {},
+    position: step.position,
+  }));
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return unauthorizedResponse();
+
+  const { id } = await params;
+  try {
+    const automation = await findAutomationForCaller(id, auth.userId);
+    if (!automation) {
+      return Response.json({ error: "Automation not found" }, { status: 404 });
+    }
+    return Response.json(formatAutomation(automation, await loadSteps(id)));
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to retrieve automation";
+    return Response.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return unauthorizedResponse();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = updateAutomationSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  const { id } = await params;
+  const validated = parsed.data;
+  try {
+    const existing = await findAutomationForCaller(id, auth.userId);
+    if (!existing) {
+      return Response.json({ error: "Automation not found" }, { status: 404 });
+    }
+
+    if (validated.steps) {
+      const normalized = automationRepo.validate({
+        name: validated.name ?? existing.name,
+        status:
+          validated.status ??
+          (existing.status as "draft" | "enabled" | "disabled"),
+        triggerEventName:
+          validated.trigger_event_name ??
+          validated.triggerEventName ??
+          existing.triggerEventName ??
+          undefined,
+        steps: toStepInputs(validated.steps),
+        connections: validated.connections,
+        userId: auth.userId,
+      });
+
+      await db.transaction(async (tx) => {
+        await tx
+          .delete(automationSteps)
+          .where(eq(automationSteps.automationId, existing.id));
+        await tx.insert(automationSteps).values(
+          normalized.steps.map((step) => ({
+            automationId: existing.id,
+            key: step.key,
+            type: step.type,
+            config: step.config,
+            position: step.position ?? 0,
+          })),
+        );
+        await tx
+          .update(automations)
+          .set({
+            name: validated.name ?? existing.name,
+            status: validated.status ?? existing.status,
+            triggerEventName: normalized.triggerEventName,
+            connections: normalized.connections,
+            updatedAt: new Date(),
+          })
+          .where(eq(automations.id, existing.id));
+      });
+    } else {
+      const updates: Partial<typeof automations.$inferInsert> = {};
+      if (validated.name !== undefined) updates.name = validated.name;
+      if (validated.status !== undefined) updates.status = validated.status;
+      if (validated.trigger_event_name !== undefined) {
+        updates.triggerEventName = validated.trigger_event_name;
+      }
+      if (validated.triggerEventName !== undefined) {
+        updates.triggerEventName = validated.triggerEventName;
+      }
+      if (validated.connections !== undefined)
+        updates.connections = validated.connections;
+      if (Object.keys(updates).length > 0) {
+        await automationRepo.update(existing.id, updates);
+      }
+    }
+
+    const refreshed = await findAutomationForCaller(id, auth.userId);
+    if (!refreshed) {
+      return Response.json({ error: "Automation not found" }, { status: 404 });
+    }
+    return Response.json(formatAutomation(refreshed, await loadSteps(id)));
+  } catch (err) {
+    if (err instanceof AutomationValidationError) {
+      return Response.json(
+        { error: err.message, code: err.code },
+        { status: 422 },
+      );
+    }
+    const message =
+      err instanceof Error ? err.message : "Failed to update automation";
+    return Response.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return unauthorizedResponse();
+
+  const { id } = await params;
+  try {
+    const automation = await findAutomationForCaller(id, auth.userId);
+    if (!automation) {
+      return Response.json({ error: "Automation not found" }, { status: 404 });
+    }
+    if (automation.status === "enabled") {
+      return Response.json(
+        {
+          error: "Disable the automation before deleting",
+          code: "automation_enabled",
+        },
+        { status: 409 },
+      );
+    }
+    await automationRepo.delete(automation.id);
+    return Response.json({
+      object: "automation",
+      id: automation.id,
+      deleted: true,
+    });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to delete automation";
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/automations/[id]/runs/[runId]/route.ts
+++ b/src/app/api/automations/[id]/runs/[runId]/route.ts
@@ -1,0 +1,39 @@
+import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { formatRunDetail } from "@/lib/automations";
+import { db } from "@/lib/db";
+import { automationRuns, automations } from "@/lib/db/schema";
+import { and, eq } from "drizzle-orm";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string; runId: string }> },
+): Promise<Response> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return unauthorizedResponse();
+
+  const { id, runId } = await params;
+  try {
+    const ownerConditions = [eq(automations.id, id)];
+    if (auth.userId) ownerConditions.push(eq(automations.userId, auth.userId));
+    const automation = await db.query.automations.findFirst({
+      where: and(...ownerConditions),
+    });
+    if (!automation) {
+      return Response.json({ error: "Automation not found" }, { status: 404 });
+    }
+
+    const run = await db.query.automationRuns.findFirst({
+      where: and(
+        eq(automationRuns.id, runId),
+        eq(automationRuns.automationId, id),
+      ),
+    });
+    if (!run) return Response.json({ error: "Run not found" }, { status: 404 });
+
+    return Response.json(formatRunDetail(run));
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to retrieve automation run";
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/automations/[id]/runs/route.ts
+++ b/src/app/api/automations/[id]/runs/route.ts
@@ -1,0 +1,70 @@
+import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { formatRunListItem, parseRunStatusFilter } from "@/lib/automations";
+import { db } from "@/lib/db";
+import { automationRuns, automations } from "@/lib/db/schema";
+import { listRunsQuerySchema } from "@/lib/validation/automations";
+import { type SQL, and, desc, eq, inArray, lt } from "drizzle-orm";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return unauthorizedResponse();
+
+  const url = new URL(request.url);
+  const parsed = listRunsQuerySchema.safeParse({
+    status: url.searchParams.get("status") ?? undefined,
+    limit: url.searchParams.get("limit") ?? undefined,
+    after: url.searchParams.get("after") ?? undefined,
+  });
+  if (!parsed.success) {
+    return Response.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  const { id } = await params;
+  try {
+    const ownerConditions = [eq(automations.id, id)];
+    if (auth.userId) ownerConditions.push(eq(automations.userId, auth.userId));
+    const automation = await db.query.automations.findFirst({
+      where: and(...ownerConditions),
+    });
+    if (!automation) {
+      return Response.json({ error: "Automation not found" }, { status: 404 });
+    }
+
+    const conditions: SQL[] = [eq(automationRuns.automationId, automation.id)];
+    const statuses = parseRunStatusFilter(parsed.data.status ?? null);
+    if (statuses.length === 1) {
+      conditions.push(eq(automationRuns.status, statuses[0]));
+    } else if (statuses.length > 1) {
+      conditions.push(inArray(automationRuns.status, statuses));
+    }
+    if (parsed.data.after)
+      conditions.push(lt(automationRuns.id, parsed.data.after));
+
+    const limit = parsed.data.limit ?? 25;
+    const rows = await db
+      .select()
+      .from(automationRuns)
+      .where(and(...conditions))
+      .orderBy(desc(automationRuns.createdAt))
+      .limit(limit + 1);
+
+    const hasMore = rows.length > limit;
+    const data = hasMore ? rows.slice(0, limit) : rows;
+
+    return Response.json({
+      object: "list",
+      data: data.map(formatRunListItem),
+      has_more: hasMore,
+    });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to list automation runs";
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/automations/route.ts
+++ b/src/app/api/automations/route.ts
@@ -1,0 +1,109 @@
+import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { formatAutomation, formatAutomationListItem } from "@/lib/automations";
+import { listAutomationsQuerySchema } from "@/lib/validation/automations";
+import { createAutomationSchema } from "@/lib/validation/automations";
+import {
+  type AutomationStepInput,
+  AutomationValidationError,
+  automationRepo,
+} from "@namuh/core";
+
+function toStepInputs(
+  steps: Array<{
+    key: string;
+    type: "trigger" | "delay" | "send_email" | "end";
+    config?: Record<string, unknown>;
+    position?: number;
+  }>,
+): AutomationStepInput[] {
+  return steps.map((step) => ({
+    key: step.key,
+    type: step.type,
+    config: step.config ?? {},
+    position: step.position,
+  }));
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return unauthorizedResponse();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = createAutomationSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  const validated = parsed.data;
+  try {
+    const created = await automationRepo.create({
+      name: validated.name,
+      status: validated.status,
+      triggerEventName:
+        validated.trigger_event_name ?? validated.triggerEventName,
+      steps: toStepInputs(validated.steps),
+      connections: validated.connections,
+      userId: auth.userId,
+    });
+
+    return Response.json(formatAutomation(created.automation, created.steps), {
+      status: 201,
+    });
+  } catch (err) {
+    if (err instanceof AutomationValidationError) {
+      return Response.json(
+        { error: err.message, code: err.code },
+        { status: 422 },
+      );
+    }
+    const message =
+      err instanceof Error ? err.message : "Failed to create automation";
+    return Response.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return unauthorizedResponse();
+
+  const url = new URL(request.url);
+  const parsed = listAutomationsQuerySchema.safeParse({
+    status: url.searchParams.get("status") ?? undefined,
+    limit: url.searchParams.get("limit") ?? undefined,
+    after: url.searchParams.get("after") ?? undefined,
+  });
+  if (!parsed.success) {
+    return Response.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  try {
+    const { data, hasMore } = await automationRepo.list({
+      limit: parsed.data.limit ?? 25,
+      after: parsed.data.after,
+      status: parsed.data.status,
+      userId: auth.userId,
+    });
+
+    return Response.json({
+      object: "list",
+      data: data.map(formatAutomationListItem),
+      has_more: hasMore,
+    });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to list automations";
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,0 +1,95 @@
+import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { formatCustomEvent } from "@/lib/automations";
+import {
+  createCustomEventSchema,
+  listEventsQuerySchema,
+} from "@/lib/validation/events";
+import { AutomationValidationError, customEventRepo } from "@namuh/core";
+
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    err.code === "23505"
+  );
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return unauthorizedResponse();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = createCustomEventSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  try {
+    const event = await customEventRepo.create({
+      name: parsed.data.name,
+      schema: parsed.data.schema ?? null,
+      userId: auth.userId,
+    });
+    return Response.json(formatCustomEvent(event), { status: 201 });
+  } catch (err) {
+    if (err instanceof AutomationValidationError) {
+      return Response.json(
+        { error: err.message, code: err.code },
+        { status: 422 },
+      );
+    }
+    if (isUniqueViolation(err)) {
+      return Response.json(
+        { error: "An event with this name already exists" },
+        { status: 409 },
+      );
+    }
+    const message =
+      err instanceof Error ? err.message : "Failed to create event";
+    return Response.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return unauthorizedResponse();
+
+  const url = new URL(request.url);
+  const parsed = listEventsQuerySchema.safeParse({
+    limit: url.searchParams.get("limit") ?? undefined,
+    after: url.searchParams.get("after") ?? undefined,
+  });
+  if (!parsed.success) {
+    return Response.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  try {
+    const { data, hasMore } = await customEventRepo.list({
+      limit: parsed.data.limit ?? 50,
+      after: parsed.data.after,
+      userId: auth.userId,
+    });
+    return Response.json({
+      object: "list",
+      data: data.map(formatCustomEvent),
+      has_more: hasMore,
+    });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to list events";
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/events/send/route.ts
+++ b/src/app/api/events/send/route.ts
@@ -1,0 +1,109 @@
+import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import {
+  formatCustomEventDelivery,
+  formatRunListItem,
+} from "@/lib/automations";
+import { db } from "@/lib/db";
+import { contacts } from "@/lib/db/schema";
+import { sendEventSchema } from "@/lib/validation/events";
+import {
+  AutomationValidationError,
+  automationRepo,
+  automationRunRepo,
+  customEventDeliveryRepo,
+} from "@namuh/core";
+import { eq } from "drizzle-orm";
+
+async function resolveContactId(input: {
+  contactId?: string;
+  email?: string;
+  userId: string | null;
+}): Promise<string | null> {
+  if (input.contactId) return input.contactId;
+  if (!input.email) return null;
+
+  const normalizedEmail = input.email.toLowerCase().trim();
+  const existing = await db.query.contacts.findFirst({
+    where: eq(contacts.email, normalizedEmail),
+  });
+  if (existing) return existing.id;
+
+  const [created] = await db
+    .insert(contacts)
+    .values({ email: normalizedEmail, userId: input.userId })
+    .returning({ id: contacts.id });
+  return created.id;
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return unauthorizedResponse();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = sendEventSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  const event = parsed.data;
+  const contactId = event.contact_id ?? event.contactId;
+
+  try {
+    const resolvedContactId = await resolveContactId({
+      contactId,
+      email: event.email,
+      userId: auth.userId,
+    });
+    const delivery = await customEventDeliveryRepo.record({
+      eventName: event.event,
+      payload: event.payload ?? {},
+      contactId: resolvedContactId,
+      email: event.email?.toLowerCase().trim() ?? null,
+      userId: auth.userId,
+    });
+
+    const matching = await automationRepo.findEnabledByTriggerEventName(
+      event.event,
+      auth.userId,
+    );
+    const runs = [];
+    for (const automation of matching) {
+      runs.push(
+        await automationRunRepo.createFromTrigger({
+          automationId: automation.id,
+          triggerEventId: delivery.id,
+          contactId: resolvedContactId,
+          userId: auth.userId,
+          initialStepKey: "trigger",
+        }),
+      );
+    }
+
+    return Response.json(
+      {
+        object: "event_delivery",
+        delivery: formatCustomEventDelivery(delivery),
+        automation_runs: runs.map(formatRunListItem),
+      },
+      { status: 202 },
+    );
+  } catch (err) {
+    if (err instanceof AutomationValidationError) {
+      return Response.json(
+        { error: err.message, code: err.code },
+        { status: 422 },
+      );
+    }
+    const message = err instanceof Error ? err.message : "Failed to send event";
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/lib/automations.ts
+++ b/src/lib/automations.ts
@@ -1,0 +1,140 @@
+import type {
+  automationRuns,
+  automationSteps,
+  automations,
+  customEventDeliveries,
+  customEvents,
+} from "@/lib/db/schema";
+
+export type AutomationRow = typeof automations.$inferSelect;
+export type AutomationStepRow = typeof automationSteps.$inferSelect;
+export type AutomationRunRow = typeof automationRuns.$inferSelect;
+export type CustomEventRow = typeof customEvents.$inferSelect;
+export type CustomEventDeliveryRow = typeof customEventDeliveries.$inferSelect;
+
+type StepState = NonNullable<AutomationRunRow["stepStates"]>[string];
+
+export function formatStep(step: AutomationStepRow) {
+  return {
+    id: step.id,
+    key: step.key,
+    type: step.type,
+    config: step.config ?? {},
+    position: step.position,
+  };
+}
+
+export function formatAutomation(
+  automation: AutomationRow,
+  steps: AutomationStepRow[],
+) {
+  const ordered = [...steps].sort((a, b) => a.position - b.position);
+  return {
+    object: "automation" as const,
+    id: automation.id,
+    name: automation.name,
+    status: automation.status,
+    trigger_event_name: automation.triggerEventName,
+    connections: automation.connections ?? [],
+    steps: ordered.map(formatStep),
+    created_at: automation.createdAt,
+    updated_at: automation.updatedAt,
+  };
+}
+
+export function formatAutomationListItem(automation: AutomationRow) {
+  return {
+    object: "automation" as const,
+    id: automation.id,
+    name: automation.name,
+    status: automation.status,
+    trigger_event_name: automation.triggerEventName,
+    created_at: automation.createdAt,
+    updated_at: automation.updatedAt,
+  };
+}
+
+function findFailedStepKey(
+  stepStates: AutomationRunRow["stepStates"],
+): string | null {
+  if (!stepStates) return null;
+  for (const [key, state] of Object.entries(stepStates) as Array<
+    [string, StepState]
+  >) {
+    if (state.status === "failed") return key;
+  }
+  return null;
+}
+
+function durationMs(run: AutomationRunRow): number | null {
+  if (!run.startedAt || !run.completedAt) return null;
+  return Math.max(0, run.completedAt.getTime() - run.startedAt.getTime());
+}
+
+export function formatRunListItem(run: AutomationRunRow) {
+  return {
+    object: "automation_run" as const,
+    id: run.id,
+    automation_id: run.automationId,
+    status: run.status,
+    started_at: run.startedAt,
+    completed_at: run.completedAt,
+    duration_ms: durationMs(run),
+    current_step_key: run.currentStepKey,
+    failed_step_key: findFailedStepKey(run.stepStates),
+    failure_reason: run.failureReason,
+    created_at: run.createdAt,
+  };
+}
+
+export function formatRunDetail(run: AutomationRunRow) {
+  return {
+    object: "automation_run" as const,
+    id: run.id,
+    automation_id: run.automationId,
+    trigger_event_id: run.triggerEventId,
+    contact_id: run.contactId,
+    status: run.status,
+    current_step_key: run.currentStepKey,
+    failed_step_key: findFailedStepKey(run.stepStates),
+    failure_reason: run.failureReason,
+    step_states: run.stepStates ?? {},
+    started_at: run.startedAt,
+    completed_at: run.completedAt,
+    next_step_at: run.nextStepAt,
+    duration_ms: durationMs(run),
+    created_at: run.createdAt,
+    updated_at: run.updatedAt,
+  };
+}
+
+export function parseRunStatusFilter(value: string | null): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+export function formatCustomEvent(event: CustomEventRow) {
+  return {
+    object: "event" as const,
+    id: event.id,
+    name: event.name,
+    schema: event.schema ?? null,
+    created_at: event.createdAt,
+    updated_at: event.updatedAt,
+  };
+}
+
+export function formatCustomEventDelivery(delivery: CustomEventDeliveryRow) {
+  return {
+    object: "event_delivery" as const,
+    id: delivery.id,
+    event: delivery.eventName,
+    contact_id: delivery.contactId,
+    email: delivery.email,
+    payload: delivery.payload,
+    received_at: delivery.receivedAt,
+  };
+}

--- a/src/lib/validation/automations.ts
+++ b/src/lib/validation/automations.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+
+export const automationStatusSchema = z.enum(["draft", "enabled", "disabled"]);
+
+export const automationStepTypeSchema = z.enum([
+  "trigger",
+  "delay",
+  "send_email",
+  "end",
+]);
+
+const automationStepConfigSchema = z.record(z.string(), z.unknown());
+
+export const automationStepSchema = z.object({
+  key: z
+    .string()
+    .min(1)
+    .max(64)
+    .regex(/^[A-Za-z0-9_:-]+$/, "step key may only contain A-Z, 0-9, _, :, -"),
+  type: automationStepTypeSchema,
+  config: automationStepConfigSchema.optional(),
+  position: z.number().int().nonnegative().optional(),
+});
+
+export const automationConnectionSchema = z.object({
+  from: z.string().min(1).max(64),
+  to: z.string().min(1).max(64),
+});
+
+export const createAutomationSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  status: automationStatusSchema.optional(),
+  trigger_event_name: z.string().min(1).max(255).optional(),
+  triggerEventName: z.string().min(1).max(255).optional(),
+  steps: z.array(automationStepSchema).min(1),
+  connections: z.array(automationConnectionSchema).optional(),
+});
+
+export const updateAutomationSchema = z
+  .object({
+    name: z.string().min(1).max(255).optional(),
+    status: automationStatusSchema.optional(),
+    trigger_event_name: z.string().min(1).max(255).optional(),
+    triggerEventName: z.string().min(1).max(255).optional(),
+    steps: z.array(automationStepSchema).min(1).optional(),
+    connections: z.array(automationConnectionSchema).optional(),
+  })
+  .refine((data) => Object.values(data).some((value) => value !== undefined), {
+    message: "at least one updatable field is required",
+  });
+
+export const listAutomationsQuerySchema = z.object({
+  status: automationStatusSchema.optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  after: z.string().min(1).optional(),
+});
+
+export const listRunsQuerySchema = z.object({
+  status: z.string().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  after: z.string().min(1).optional(),
+});
+
+export type CreateAutomationRequest = z.infer<typeof createAutomationSchema>;
+export type UpdateAutomationRequest = z.infer<typeof updateAutomationSchema>;

--- a/src/lib/validation/events.ts
+++ b/src/lib/validation/events.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+const eventNameSchema = z.string().min(1).max(255);
+const uuidSchema = z.string().uuid();
+const emailSchema = z.string().email().min(3).max(512);
+const jsonObjectSchema = z.record(z.string(), z.unknown());
+
+export const createCustomEventSchema = z.object({
+  name: eventNameSchema,
+  schema: jsonObjectSchema.optional(),
+});
+
+export const listEventsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  after: z.string().min(1).optional(),
+});
+
+export const sendEventSchema = z
+  .object({
+    event: eventNameSchema,
+    contact_id: uuidSchema.optional(),
+    contactId: uuidSchema.optional(),
+    email: emailSchema.optional(),
+    payload: jsonObjectSchema.optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (
+      data.contact_id !== undefined &&
+      data.contactId !== undefined &&
+      data.contact_id !== data.contactId
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["contactId"],
+        message: "contactId and contact_id must match when both are provided",
+      });
+      return;
+    }
+
+    const hasContactId =
+      data.contact_id !== undefined || data.contactId !== undefined;
+    const hasEmail = data.email !== undefined;
+
+    if (hasContactId === hasEmail) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: hasEmail ? ["email"] : ["contact_id"],
+        message:
+          "provide exactly one contact identifier: contact_id/contactId or email",
+      });
+    }
+  });
+
+export type CreateCustomEventRequest = z.infer<typeof createCustomEventSchema>;
+export type SendEventRequest = z.infer<typeof sendEventSchema>;

--- a/tests/api-automations-events.test.ts
+++ b/tests/api-automations-events.test.ts
@@ -1,0 +1,369 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockAutomationCreate = vi.hoisted(() => vi.fn());
+const mockAutomationList = vi.hoisted(() => vi.fn());
+const mockAutomationValidate = vi.hoisted(() => vi.fn());
+const mockAutomationDelete = vi.hoisted(() => vi.fn());
+const mockFindEnabledByTriggerEventName = vi.hoisted(() => vi.fn());
+const mockCustomEventCreate = vi.hoisted(() => vi.fn());
+const mockCustomEventList = vi.hoisted(() => vi.fn());
+const mockDeliveryRecord = vi.hoisted(() => vi.fn());
+const mockRunCreateFromTrigger = vi.hoisted(() => vi.fn());
+const mockDbSelect = vi.hoisted(() => vi.fn());
+const mockDbInsert = vi.hoisted(() => vi.fn());
+const mockDbUpdate = vi.hoisted(() => vi.fn());
+const mockDbDelete = vi.hoisted(() => vi.fn());
+const mockDbTransaction = vi.hoisted(() => vi.fn());
+const mockAutomationFindFirst = vi.hoisted(() => vi.fn());
+const mockRunFindFirst = vi.hoisted(() => vi.fn());
+const mockContactFindFirst = vi.hoisted(() => vi.fn());
+
+class TestAutomationValidationError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code = "automation_invalid") {
+    super(message);
+    this.name = "AutomationValidationError";
+    this.code = code;
+  }
+}
+
+function queryRows<T>(rows: T[]) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+    // biome-ignore lint/suspicious/noThenProperty: mocks Drizzle thenable builders
+    then: (resolve: (value: T[]) => unknown) => Promise.resolve(resolve(rows)),
+  };
+}
+
+function insertRows<T>(rows: T[]) {
+  return {
+    values: vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue(rows),
+    }),
+  };
+}
+
+vi.mock("@/lib/api-auth", () => ({
+  validateApiKey: mockValidateApiKey,
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      automations: { findFirst: mockAutomationFindFirst },
+      automationRuns: { findFirst: mockRunFindFirst },
+      contacts: { findFirst: mockContactFindFirst },
+    },
+    select: mockDbSelect,
+    insert: mockDbInsert,
+    update: mockDbUpdate,
+    delete: mockDbDelete,
+    transaction: mockDbTransaction,
+  },
+}));
+
+vi.mock("@namuh/core", () => ({
+  AutomationValidationError: TestAutomationValidationError,
+  automationRepo: {
+    create: mockAutomationCreate,
+    list: mockAutomationList,
+    validate: mockAutomationValidate,
+    delete: mockAutomationDelete,
+    update: mockDbUpdate,
+    findEnabledByTriggerEventName: mockFindEnabledByTriggerEventName,
+  },
+  customEventRepo: {
+    create: mockCustomEventCreate,
+    list: mockCustomEventList,
+  },
+  customEventDeliveryRepo: {
+    record: mockDeliveryRecord,
+  },
+  automationRunRepo: {
+    createFromTrigger: mockRunCreateFromTrigger,
+  },
+}));
+
+vi.mock("drizzle-orm", async () => {
+  const actual = await vi.importActual("drizzle-orm");
+  return {
+    ...actual,
+    eq: vi.fn((...args: unknown[]) => ({ op: "eq", args })),
+    and: vi.fn((...args: unknown[]) => ({ op: "and", args })),
+    asc: vi.fn((col: unknown) => ({ op: "asc", col })),
+    desc: vi.fn((col: unknown) => ({ op: "desc", col })),
+    lt: vi.fn((...args: unknown[]) => ({ op: "lt", args })),
+    inArray: vi.fn((...args: unknown[]) => ({ op: "inArray", args })),
+  };
+});
+
+const auth = {
+  apiKeyId: "key_1",
+  permission: "full_access",
+  domain: null,
+  userId: "user_1",
+};
+const now = new Date("2026-05-02T00:00:00.000Z");
+const automation = {
+  id: "auto_1",
+  name: "Welcome",
+  status: "enabled",
+  triggerEventName: "user.signed_up",
+  connections: [],
+  createdAt: now,
+  updatedAt: now,
+};
+const triggerStep = {
+  id: "step_1",
+  automationId: "auto_1",
+  key: "trigger",
+  type: "trigger",
+  config: { event_name: "user.signed_up" },
+  position: 0,
+  createdAt: now,
+  updatedAt: now,
+};
+const customEvent = {
+  id: "evt_1",
+  name: "user.signed_up",
+  schema: null,
+  createdAt: now,
+  updatedAt: now,
+};
+
+function jsonRequest(url: string, body: unknown, method = "POST") {
+  return new Request(url, {
+    method,
+    headers: {
+      Authorization: "Bearer re_test",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("automation API routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue(auth);
+    mockDbSelect.mockReturnValue(queryRows([triggerStep]));
+  });
+
+  it("returns 401 for missing API auth", async () => {
+    mockValidateApiKey.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/automations/route");
+
+    const response = await GET(new Request("http://localhost/api/automations"));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("creates an automation through zod validation and repository validation", async () => {
+    mockAutomationCreate.mockResolvedValue({
+      automation,
+      steps: [triggerStep],
+    });
+    const { POST } = await import("@/app/api/automations/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/automations", {
+        name: "Welcome",
+        status: "enabled",
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { eventName: "user.signed_up" },
+          },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      id: "auto_1",
+      steps: [{ key: "trigger" }],
+    });
+    expect(mockAutomationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user_1" }),
+    );
+  });
+
+  it("rejects invalid automation create payloads with 422", async () => {
+    const { POST } = await import("@/app/api/automations/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/automations", {
+        steps: [{ key: "x", type: "condition" }],
+      }),
+    );
+
+    expect(response.status).toBe(422);
+  });
+
+  it("lists and retrieves automations", async () => {
+    mockAutomationList.mockResolvedValue({
+      data: [automation],
+      hasMore: false,
+    });
+    mockAutomationFindFirst.mockResolvedValue(automation);
+    const listRoute = await import("@/app/api/automations/route");
+    const detailRoute = await import("@/app/api/automations/[id]/route");
+
+    const list = await listRoute.GET(
+      new Request("http://localhost/api/automations?status=enabled"),
+    );
+    const detail = await detailRoute.GET(
+      new Request("http://localhost/api/automations/auto_1"),
+      { params: Promise.resolve({ id: "auto_1" }) },
+    );
+
+    expect(list.status).toBe(200);
+    expect(detail.status).toBe(200);
+    await expect(detail.json()).resolves.toMatchObject({
+      id: "auto_1",
+      trigger_event_name: "user.signed_up",
+    });
+  });
+});
+
+describe("events API routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue(auth);
+  });
+
+  it("creates and lists custom events", async () => {
+    mockCustomEventCreate.mockResolvedValue(customEvent);
+    mockCustomEventList.mockResolvedValue({
+      data: [customEvent],
+      hasMore: false,
+    });
+    const { POST, GET } = await import("@/app/api/events/route");
+
+    const created = await POST(
+      jsonRequest("http://localhost/api/events", { name: "user.signed_up" }),
+    );
+    const listed = await GET(
+      new Request("http://localhost/api/events", {
+        headers: { Authorization: "Bearer re_test" },
+      }),
+    );
+
+    expect(created.status).toBe(201);
+    expect(listed.status).toBe(200);
+    await expect(created.json()).resolves.toMatchObject({
+      id: "evt_1",
+      name: "user.signed_up",
+    });
+  });
+
+  it("rejects reserved resend event names", async () => {
+    mockCustomEventCreate.mockRejectedValue(
+      new TestAutomationValidationError("reserved", "event_name_reserved"),
+    );
+    const { POST } = await import("@/app/api/events/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/events", { name: "resend:bounced" }),
+    );
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "event_name_reserved",
+    });
+  });
+
+  it("requires exactly one contact identifier when sending events", async () => {
+    const { POST } = await import("@/app/api/events/send/route");
+
+    const none = await POST(
+      jsonRequest("http://localhost/api/events/send", {
+        event: "user.signed_up",
+      }),
+    );
+    const both = await POST(
+      jsonRequest("http://localhost/api/events/send", {
+        event: "user.signed_up",
+        contact_id: "11111111-1111-1111-1111-111111111111",
+        email: "u@example.com",
+      }),
+    );
+
+    expect(none.status).toBe(422);
+    expect(both.status).toBe(422);
+  });
+
+  it("resolves email contacts, records delivery, and fans out one run per matching automation", async () => {
+    mockContactFindFirst.mockResolvedValue(null);
+    mockDbInsert.mockReturnValue(insertRows([{ id: "contact_1" }]));
+    mockDeliveryRecord.mockResolvedValue({
+      id: "delivery_1",
+      eventName: "user.signed_up",
+      contactId: "contact_1",
+      email: "user@example.com",
+      payload: { plan: "pro" },
+      receivedAt: now,
+    });
+    mockFindEnabledByTriggerEventName.mockResolvedValue([
+      { ...automation, id: "auto_1" },
+      { ...automation, id: "auto_2" },
+    ]);
+    mockRunCreateFromTrigger
+      .mockResolvedValueOnce({
+        id: "run_1",
+        automationId: "auto_1",
+        status: "queued",
+        triggerEventId: "delivery_1",
+        contactId: "contact_1",
+        stepStates: {},
+        startedAt: null,
+        completedAt: null,
+        currentStepKey: "trigger",
+        failureReason: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .mockResolvedValueOnce({
+        id: "run_2",
+        automationId: "auto_2",
+        status: "queued",
+        triggerEventId: "delivery_1",
+        contactId: "contact_1",
+        stepStates: {},
+        startedAt: null,
+        completedAt: null,
+        currentStepKey: "trigger",
+        failureReason: null,
+        createdAt: now,
+        updatedAt: now,
+      });
+    const { POST } = await import("@/app/api/events/send/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/events/send", {
+        event: "user.signed_up",
+        email: "USER@example.com",
+        payload: { plan: "pro" },
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    const json = await response.json();
+    expect(json.automation_runs).toHaveLength(2);
+    expect(mockFindEnabledByTriggerEventName).toHaveBeenCalledWith(
+      "user.signed_up",
+      "user_1",
+    );
+    expect(mockRunCreateFromTrigger).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/sdk-client.test.tsx
+++ b/tests/sdk-client.test.tsx
@@ -117,4 +117,51 @@ describe("NamuhSend SDK", () => {
       error: null,
     });
   });
+
+  it("exposes automations and events clients", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ object: "ok" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new NamuhSend("re_test", {
+      baseUrl: "https://api.example.com",
+    });
+
+    await client.automations.create({
+      name: "Welcome",
+      steps: [
+        {
+          key: "trigger",
+          type: "trigger",
+          config: { event_name: "user.signed_up" },
+        },
+      ],
+    });
+    await client.automations.listRuns("auto_1", { status: "queued", limit: 5 });
+    await client.events.send({
+      event: "user.signed_up",
+      email: "user@example.com",
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example.com/api/automations",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.example.com/api/automations/auto_1/runs?limit=5&status=queued",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "https://api.example.com/api/events/send",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Adds public automation control-plane routes for create/list/get/update/delete plus run list/detail endpoints.
- Adds custom event create/list and `/api/events/send` ingestion that resolves/creates contacts by email, records deliveries, and queues one automation run per matching enabled automation.
- Adds SDK `automations` and `events` clients for the new endpoints.

## Tests
- `bunx vitest run tests/api-automations-events.test.ts tests/sdk-client.test.tsx`
- `make check`
- `make test`
- Push guardrail: `bun run check`

## Issue
Refs #117

## Residual risk
- No runner execution is included; queued runs remain for the #118 runner slice.
- No Playwright E2E added because this is an API/SDK-only slice with route-level Vitest coverage.
