### PR TITLE
Rename packages and docs to OpenSend namespace

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,8 +47,8 @@ DASHBOARD_KEY=
 # Optional for local dev; recommended/required for staging and production send paths.
 # POST /api/emails persists email rows and publishes email.send jobs here.
 # Configure the SQS queue with a redrive policy / DLQ for retry exhaustion.
-# BACKGROUND_JOBS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789012/namuh-send-background
-# BACKGROUND_JOBS_EVENT_BUS_NAME=namuh-send-background-jobs
+# BACKGROUND_JOBS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789012/opensend-background
+# BACKGROUND_JOBS_EVENT_BUS_NAME=opensend-background-jobs
 # BACKGROUND_JOBS_REQUIRE_QUEUE=true
 # Set on the ingester/worker process to long-poll SQS.
 # BACKGROUND_WORKER_POLL=true
@@ -57,7 +57,7 @@ DASHBOARD_KEY=
 
 # ── Observability (CloudWatch EMF / structured logs) ─────────────
 # Optional namespace override for emitted CloudWatch Embedded Metric Format logs.
-# CLOUDWATCH_METRICS_NAMESPACE=NamuhSend
+# CLOUDWATCH_METRICS_NAMESPACE=OpenSend
 
 # ── AWS S3 (File Storage) ───────────────────────────────────────
 # Bucket for email attachments and assets. Required for attachment support.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
-# Namuh Send
+# OpenSend
 
 ## What This Is
 Open-source, self-hostable email platform. REST API, TypeScript SDK, React email templates, domain verification (DKIM/SPF/DMARC), webhooks, broadcasts, contacts/segments/topics, and a full admin dashboard. Resend-compatible surface that runs on your own AWS SES quota.
 
-- Repo: `github.com/namuh-eng/namuh-send`
+- Repo: `github.com/namuh-eng/opensend`
 - License: Elastic License 2.0 (ELv2)
 - Primary deploy: Docker Compose (Dockerfile is multi-stage and runs on App Runner, Cloud Run, Fly, Railway, etc.)
 
@@ -27,10 +27,10 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
   - `src/components/` — React UI components
   - `src/lib/` — `auth.ts`, `auth-client.ts`, `api-auth.ts`, `db/`, `ses.ts`, `s3.ts`, `cloudflare.ts`, `webhook-signing.ts`, `date-range.ts`
   - `src/middleware.ts` — per-route rate limiting
-- `packages/core/` — `@namuh/core` — shared DB client, repositories, DTOs, webhook helpers
-- `packages/ingester/` — `@namuh/ingester` — Hono webhook dispatcher for SES/SNS events and scheduled email worker
-- `packages/sdk/` — `namuh-send` — public TypeScript SDK published to npm
-- `services/api/` — `@namuh/api` — Bun + Hono control-plane API skeleton on local port 3026; Next.js `src/app/api` routes remain the public API until later thin-adapter PRs
+- `packages/core/` — `@opensend/core` — shared DB client, repositories, DTOs, webhook helpers
+- `packages/ingester/` — `@opensend/ingester` — Hono webhook dispatcher for SES/SNS events and scheduled email worker
+- `packages/sdk/` — `@opensend/sdk` — public TypeScript SDK published to npm
+- `services/api/` — `@opensend/api` — Bun + Hono control-plane API skeleton on local port 3026; Next.js `src/app/api` routes remain the public API until later thin-adapter PRs
 - `tests/` — Vitest unit tests
 - `tests/e2e/` — Playwright E2E tests
 - `drizzle/` — generated migration SQL

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,9 @@
-# Namuh Send
+# OpenSend
 
 ## What This Is
 Open-source, self-hostable email platform. REST API, TypeScript SDK, React email templates, domain verification (DKIM/SPF/DMARC), webhooks, broadcasts, contacts/segments/topics, and a full admin dashboard. Resend-compatible surface that runs on your own AWS SES quota.
 
-- Repo: `github.com/namuh-eng/namuh-send`
+- Repo: `github.com/namuh-eng/opensend`
 - License: Elastic License 2.0 (ELv2)
 - Primary deploy: Docker Compose (Dockerfile is multi-stage and runs on App Runner, Cloud Run, Fly, Railway, etc.)
 
@@ -27,9 +27,9 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
   - `src/components/` — React UI components
   - `src/lib/` — `auth.ts`, `auth-client.ts`, `api-auth.ts`, `db/`, `ses.ts`, `s3.ts`, `cloudflare.ts`, `webhook-signing.ts`, `date-range.ts`
   - `src/middleware.ts` — per-route rate limiting
-- `packages/core/` — `@namuh/core` — shared DB client, repositories, DTOs, webhook helpers
-- `packages/ingester/` — `@namuh/ingester` — Hono webhook dispatcher for SES/SNS events and scheduled email worker
-- `packages/sdk/` — `namuh-send` — public TypeScript SDK published to npm
+- `packages/core/` — `@opensend/core` — shared DB client, repositories, DTOs, webhook helpers
+- `packages/ingester/` — `@opensend/ingester` — Hono webhook dispatcher for SES/SNS events and scheduled email worker
+- `packages/sdk/` — `@opensend/sdk` — public TypeScript SDK published to npm
 - `tests/` — Vitest unit tests
 - `tests/e2e/` — Playwright E2E tests
 - `drizzle/` — generated migration SQL

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 # Contributing
 
-Thanks for your interest in contributing to Namuh Send!
+Thanks for your interest in contributing to OpenSend!
 
 ## Setup
 
 **Quick start** (requires Docker + [Bun](https://bun.sh)):
 
 ```bash
-git clone https://github.com/namuh-eng/namuh-send.git
-cd namuh-send
+git clone https://github.com/namuh-eng/opensend.git
+cd opensend
 cp .env.example .env
 make setup    # ensures DASHBOARD_KEY exists, starts Postgres, installs deps, pushes schema, seeds DB
 make dev      # http://localhost:3015
@@ -30,7 +30,7 @@ curl -X POST http://localhost:3015/api/emails \
   -d '{
     "from": "hello@example.com",
     "to": ["test@example.com"],
-    "subject": "Hello from namuh-send",
+    "subject": "Hello from OpenSend",
     "text": "It works!"
   }'
 ```
@@ -79,7 +79,7 @@ The hooks are versioned in `.githooks/`, so everyone on the repo gets the same g
 
 AWS credentials are **not required** for local development — without them, emails are logged to the console and the full API flow still works. When you're ready to actually send emails, configure `~/.aws/credentials` via `aws configure`.
 
-New AWS accounts start in SES **sandbox mode** — you can only send to verified addresses. This is an AWS limitation, not a Namuh Send bug. See [AWS SES docs](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) to request production access.
+New AWS accounts start in SES **sandbox mode** — you can only send to verified addresses. This is an AWS limitation, not an OpenSend bug. See [AWS SES docs](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) to request production access.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <p align="center">
-  <h1 align="center">Namuh Send</h1>
+  <h1 align="center">OpenSend</h1>
   <p align="center">
     Open-source email infrastructure for developers.
     <br />
     Send transactional emails, manage domains, build broadcasts — all self-hosted.
   </p>
   <p align="center">
-    <a href="https://github.com/namuh-eng/namuh-send/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-ELv2-blue" alt="License" /></a>
-    <a href="https://github.com/namuh-eng/namuh-send/stargazers"><img src="https://img.shields.io/github/stars/namuh-eng/namuh-send?style=social" alt="GitHub Stars" /></a>
-    <a href="https://github.com/namuh-eng/namuh-send/issues"><img src="https://img.shields.io/github/issues/namuh-eng/namuh-send" alt="Issues" /></a>
+    <a href="https://github.com/namuh-eng/opensend/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-ELv2-blue" alt="License" /></a>
+    <a href="https://github.com/namuh-eng/opensend/stargazers"><img src="https://img.shields.io/github/stars/namuh-eng/opensend?style=social" alt="GitHub Stars" /></a>
+    <a href="https://github.com/namuh-eng/opensend/issues"><img src="https://img.shields.io/github/issues/namuh-eng/opensend" alt="Issues" /></a>
   </p>
 </p>
 
@@ -21,14 +21,14 @@
 </p>
 
 <p align="center">
-  <img src="docs/assets/screenshot-dashboard.png" alt="Namuh Send Dashboard" width="800" />
+  <img src="docs/assets/screenshot-dashboard.png" alt="OpenSend Dashboard" width="800" />
 </p>
 
 ---
 
-## What is Namuh Send?
+## What is OpenSend?
 
-Namuh Send is a **self-hostable email platform** that gives you the same developer experience as Resend — REST API, TypeScript SDK, React email templates, domain verification, webhooks, and a full dashboard — running on your own infrastructure.
+OpenSend is a **self-hostable email platform** that gives you the same developer experience as Resend — REST API, TypeScript SDK, React email templates, domain verification, webhooks, and a full dashboard — running on your own infrastructure.
 
 **Use it if you want:**
 - Full control over your email infrastructure
@@ -38,11 +38,11 @@ Namuh Send is a **self-hostable email platform** that gives you the same develop
 
 ## One-Click Deploy
 
-The fastest way to get Namuh Send running:
+The fastest way to get OpenSend running:
 
 ```bash
-git clone https://github.com/namuh-eng/namuh-send.git
-cd namuh-send
+git clone https://github.com/namuh-eng/opensend.git
+cd opensend
 cp .env.example .env
 # Edit .env — set DASHBOARD_KEY (required); AWS credentials are only needed for real email sending
 docker compose up -d
@@ -55,7 +55,7 @@ That's it. Open **http://localhost:3015** and enter your dashboard key.
 ## Features
 
 - **REST API** — Send emails via a simple POST request with API key auth
-- **TypeScript SDK** — [`namuh-send`](./packages/sdk) npm package with full type safety
+- **TypeScript SDK** — [`@opensend/sdk`](./packages/sdk) npm package with full type safety
 - **React Email Templates** — Pass React components via the SDK's `react` prop
 - **Domain Verification** — DKIM, SPF, DMARC auto-configured via Cloudflare DNS
 - **API Key Management** — `full_access` and `sending_access` permission scopes
@@ -79,7 +79,7 @@ curl -X POST http://localhost:3015/api/emails \
   -d '{
     "from": "hello@yourdomain.com",
     "to": ["recipient@example.com"],
-    "subject": "Hello from Namuh Send",
+    "subject": "Hello from OpenSend",
     "html": "<h1>It works!</h1>"
   }'
 ```
@@ -101,20 +101,20 @@ For now, the Next.js routes under `src/app/api` remain the current public API an
 ### TypeScript SDK
 
 ```bash
-bun add namuh-send
+bun add @opensend/sdk
 ```
 
 ```typescript
-import { NamuhSend } from "namuh-send";
+import { OpenSend } from "@opensend/sdk";
 
-const client = new NamuhSend("YOUR_API_KEY", {
+const client = new OpenSend("YOUR_API_KEY", {
   baseUrl: "https://your-deployment.example.com",
 });
 
 const { data } = await client.emails.send({
   from: "hello@yourdomain.com",
   to: "recipient@example.com",
-  subject: "Hello from Namuh Send",
+  subject: "Hello from OpenSend",
   html: "<h1>It works!</h1>",
 });
 
@@ -134,8 +134,8 @@ Full SDK docs: [`packages/sdk/README.md`](./packages/sdk/README.md)
 ### Docker Compose (recommended)
 
 ```bash
-git clone https://github.com/namuh-eng/namuh-send.git
-cd namuh-send
+git clone https://github.com/namuh-eng/opensend.git
+cd opensend
 cp .env.example .env
 ```
 
@@ -159,7 +159,7 @@ CLOUDFLARE_ZONE_ID=your-zone-id
 S3_BUCKET_NAME=your-bucket             # For email attachments
 BACKGROUND_JOBS_QUEUE_URL=...          # Optional locally; required for async production sending
 BACKGROUND_WORKER_POLL=true            # Set on the ingester worker when SQS is configured
-CLOUDWATCH_METRICS_NAMESPACE=NamuhSend  # Optional CloudWatch EMF namespace override
+CLOUDWATCH_METRICS_NAMESPACE=OpenSend  # Optional CloudWatch EMF namespace override
 ```
 
 `.env.example` keeps `DATABASE_URL` on `localhost` for host-run commands like `bun run dev` and `bun run db:push`. Docker Compose injects its own internal `postgres` hostname for the containerized app and migration services.
@@ -177,8 +177,8 @@ This starts PostgreSQL, runs migrations, launches the app, and launches the stan
 If you prefer running without Docker (requires [Bun](https://bun.sh)):
 
 ```bash
-git clone https://github.com/namuh-eng/namuh-send.git
-cd namuh-send
+git clone https://github.com/namuh-eng/opensend.git
+cd opensend
 bun install
 cp .env.example .env
 # Edit .env — set DASHBOARD_KEY (required). Leave DATABASE_URL as localhost unless you're using another Postgres instance.
@@ -195,7 +195,7 @@ To suppress the optional GitHub star prompt during install, use `SKIP_STAR_PROMP
 
 New AWS accounts start in SES **sandbox mode** — emails can only be sent to verified addresses. To send to anyone:
 
-1. Verify a sender domain in the Namuh Send dashboard
+1. Verify a sender domain in the OpenSend dashboard
 2. Request production access in [AWS SES Console](https://console.aws.amazon.com/ses/) → Account dashboard → Request production access
 
 ### Production Deployment
@@ -211,7 +211,7 @@ For production, we recommend:
 
 ### Shared rate limiting (staging/production)
 
-Namuh Send now treats API rate limiting as an explicit runtime contract:
+OpenSend now treats API rate limiting as an explicit runtime contract:
 
 - `RATE_LIMIT_BACKEND=disabled` skips API rate limiting entirely. This is the default for local single-process development only.
 - `RATE_LIMIT_BACKEND=redis` enables the middleware-backed shared limiter. If Redis is misconfigured or unavailable, API requests fail with `503` instead of silently falling back to per-process memory.
@@ -243,7 +243,7 @@ Local dev remains Docker-friendly if no queue is configured: publishes are logge
 
 ### Observability
 
-Email accept and worker flows emit structured JSON logs with `x-correlation-id`, W3C/OpenTelemetry-compatible `traceparent`, sanitized span events, and CloudWatch EMF metrics for accept latency, send outcomes, queue depth, retries, and worker failures. Set `CLOUDWATCH_METRICS_NAMESPACE` to override the default `NamuhSend` namespace.
+Email accept and worker flows emit structured JSON logs with `x-correlation-id`, W3C/OpenTelemetry-compatible `traceparent`, sanitized span events, and CloudWatch EMF metrics for accept latency, send outcomes, queue depth, retries, and worker failures. Set `CLOUDWATCH_METRICS_NAMESPACE` to override the default `OpenSend` namespace.
 
 See [`docs/observability.md`](docs/observability.md) for PII-safe logging rules, metric names, alarms, and the runbook for tracing an email from API acceptance to SES/provider result.
 
@@ -269,8 +269,8 @@ curl -i http://localhost:3015/api/auth/verify \
 The included `Dockerfile` produces an optimized multi-stage build suitable for any container platform (AWS ECS Fargate, Google Cloud Run, Fly.io, Railway, etc.):
 
 ```bash
-docker build -t namuh-send .
-docker run -p 3015:8080 --env-file .env namuh-send
+docker build -t opensend .
+docker run -p 3015:8080 --env-file .env opensend
 ```
 
 For the ECS Fargate split-service shape, ALB host-based events routing, SNS cutover, and ingester log/replay runbook, see [`docs/ingester-deploy.md`](docs/ingester-deploy.md).
@@ -284,7 +284,7 @@ src/
 ├── lib/          # Core services: db, ses, s3, cloudflare
 └── types/        # TypeScript type definitions
 packages/
-└── sdk/          # Published TypeScript SDK (namuh-send)
+└── sdk/          # Published TypeScript SDK (@opensend/sdk)
 tests/
 ├── *.test.ts     # Unit tests (Vitest)
 └── e2e/          # E2E tests (Playwright)
@@ -350,7 +350,7 @@ We welcome contributions! See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup ins
 
 ## License
 
-[Elastic License 2.0](./LICENSE) — free to use, modify, and self-host. The only restriction: you cannot offer Namuh Send as a hosted email service to third parties.
+[Elastic License 2.0](./LICENSE) — free to use, modify, and self-host. The only restriction: you cannot offer OpenSend as a hosted email service to third parties.
 
 ---
 

--- a/agent_docs/learnings/active/2026-04-28-67-sdk-core-dto-packaging.md
+++ b/agent_docs/learnings/active/2026-04-28-67-sdk-core-dto-packaging.md
@@ -11,4 +11,4 @@ promoted_to: null
 
 **Why:** A thin publishable SDK should not duplicate request/response shapes in `packages/sdk/src/index.ts`, but it also cannot ship declaration files that reference a private workspace package consumers do not install.
 
-**Fix:** Keep SDK DTOs in `@namuh/core`, import them by source path inside the monorepo, and compile the DTO source into `packages/sdk/dist/core/...` alongside the SDK declaration output.
+**Fix:** Keep SDK DTOs in `@opensend/core`, import them by source path inside the monorepo, and compile the DTO source into `packages/sdk/dist/core/...` alongside the SDK declaration output.

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 0,
   "workspaces": {
     "": {
-      "name": "namuh-send",
+      "name": "opensend",
       "dependencies": {
         "@aws-sdk/client-eventbridge": "^3.1038.0",
         "@aws-sdk/client-s3": "^3.1019.0",
@@ -53,22 +53,22 @@
       },
     },
     "packages/core": {
-      "name": "@namuh/core",
+      "name": "@opensend/core",
       "version": "0.1.0",
     },
     "packages/ingester": {
-      "name": "@namuh/ingester",
+      "name": "@opensend/ingester",
       "version": "0.1.0",
     },
     "packages/sdk": {
-      "name": "namuh-send",
+      "name": "@opensend/sdk",
       "version": "1.0.0",
       "devDependencies": {
         "typescript": "^5.0.0",
       },
     },
     "services/api": {
-      "name": "@namuh/api",
+      "name": "@opensend/api",
       "version": "0.1.0",
       "dependencies": {
         "hono": "^4.12.15",
@@ -388,11 +388,11 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@namuh/api": ["@namuh/api@workspace:services/api"],
+    "@opensend/api": ["@opensend/api@workspace:services/api"],
 
-    "@namuh/core": ["@namuh/core@workspace:packages/core"],
+    "@opensend/core": ["@opensend/core@workspace:packages/core"],
 
-    "@namuh/ingester": ["@namuh/ingester@workspace:packages/ingester"],
+    "@opensend/ingester": ["@opensend/ingester@workspace:packages/ingester"],
 
     "@next/env": ["@next/env@16.2.1", "", {}, "sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg=="],
 
@@ -940,7 +940,7 @@
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
-    "namuh-send": ["namuh-send@workspace:packages/sdk"],
+    "@opensend/sdk": ["@opensend/sdk@workspace:packages/sdk"],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,12 +1,12 @@
 # Observability runbook
 
-Namuh Send emits an AWS-first observability baseline for the email accept and delivery flow. The implementation uses structured JSON logs, W3C/OpenTelemetry-compatible `traceparent` propagation, and CloudWatch Embedded Metric Format (EMF) records so the same application logs can drive CloudWatch Logs and Metrics.
+OpenSend emits an AWS-first observability baseline for the email accept and delivery flow. The implementation uses structured JSON logs, W3C/OpenTelemetry-compatible `traceparent` propagation, and CloudWatch Embedded Metric Format (EMF) records so the same application logs can drive CloudWatch Logs and Metrics.
 
 ## Telemetry model
 
 Every instrumented request/job has:
 
-- `correlation_id` — stable identifier for support/debugging. API callers can provide `x-correlation-id`; otherwise Namuh Send derives one from the trace id.
+- `correlation_id` — stable identifier for support/debugging. API callers can provide `x-correlation-id`; otherwise OpenSend derives one from the trace id.
 - `trace_id`, `span_id`, `parent_span_id`, `traceparent`, `tracestate` — W3C trace context fields that keep API, SQS, worker, SES, and webhook jobs connected.
 - `event` — machine-readable log event such as `email.accepted`, `queue.publish`, `worker.email.send`, or `ses.event.received`.
 - low-cardinality metric dimensions only: `Service`, `Operation`, `Outcome`, `JobType`, and `EventType`.
@@ -24,7 +24,7 @@ Do not log raw email content or recipient data. The shared telemetry sanitizer e
 
 ## CloudWatch metrics
 
-Metrics are emitted as EMF JSON log records in the `NamuhSend` namespace by default. Override with `CLOUDWATCH_METRICS_NAMESPACE` when an environment needs a distinct namespace.
+Metrics are emitted as EMF JSON log records in the `OpenSend` namespace by default. Override with `CLOUDWATCH_METRICS_NAMESPACE` when an environment needs a distinct namespace.
 
 | Area | Metrics | Dimensions |
 | --- | --- | --- |

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "namuh-send",
+  "name": "opensend",
   "version": "0.1.0",
   "private": true,
   "packageManager": "bun@1.3.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@namuh/core",
+  "name": "@opensend/core",
   "version": "0.1.0",
   "private": true,
   "main": "src/index.ts",

--- a/packages/core/src/jobs/background-jobs.ts
+++ b/packages/core/src/jobs/background-jobs.ts
@@ -15,7 +15,7 @@ import {
 } from "../observability/telemetry";
 
 const MAX_SQS_DELAY_SECONDS = 900;
-const BACKGROUND_JOB_EVENT_SOURCE = "namuh-send.background-jobs";
+const BACKGROUND_JOB_EVENT_SOURCE = "opensend.background-jobs";
 
 export type BackgroundJobType =
   | "email.send"

--- a/packages/core/src/observability/telemetry.ts
+++ b/packages/core/src/observability/telemetry.ts
@@ -4,7 +4,7 @@ const TRACE_ID_BYTES = 16;
 const SPAN_ID_BYTES = 8;
 const TRACE_FLAGS_SAMPLED = "01";
 const TRACEPARENT_VERSION = "00";
-const DEFAULT_NAMESPACE = "NamuhSend";
+const DEFAULT_NAMESPACE = "OpenSend";
 const MAX_SANITIZE_DEPTH = 4;
 
 const TRACEPARENT_PATTERN =

--- a/packages/ingester/package.json
+++ b/packages/ingester/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@namuh/ingester",
+  "name": "@opensend/ingester",
   "version": "0.1.0",
   "private": true,
   "main": "src/index.ts",

--- a/packages/ingester/src/dispatcher.ts
+++ b/packages/ingester/src/dispatcher.ts
@@ -4,7 +4,7 @@ import {
   toWebhookEventType,
   webhookDeliveryRepo,
   webhookRepo,
-} from "@namuh/core";
+} from "@opensend/core";
 
 const DEFAULT_RETRY_DELAYS_SECONDS = [10, 60, 300, 1800, 7200, 21600, 86400];
 const DEFAULT_TIMEOUT_MS = 5_000;

--- a/packages/ingester/src/index.ts
+++ b/packages/ingester/src/index.ts
@@ -10,7 +10,7 @@ import {
   recordTelemetryError,
   toWebhookEventType,
   webhookRepo,
-} from "@namuh/core";
+} from "@opensend/core";
 import { Hono } from "hono";
 import { webhookDispatcher } from "./dispatcher";
 import { queueWorker } from "./queue-worker";

--- a/packages/ingester/src/queue-worker.ts
+++ b/packages/ingester/src/queue-worker.ts
@@ -20,7 +20,7 @@ import {
   publishBackgroundJob,
   recordTelemetryError,
   startTelemetrySpan,
-} from "@namuh/core";
+} from "@opensend/core";
 import { webhookDispatcher } from "./dispatcher";
 
 const DEFAULT_MAX_MESSAGES = 5;

--- a/packages/ingester/src/server.ts
+++ b/packages/ingester/src/server.ts
@@ -15,12 +15,12 @@ const server = Bun.serve({
   port,
 });
 
-console.log(`namuh-ingester listening on http://${hostname}:${server.port}`);
+console.log(`opensend-ingester listening on http://${hostname}:${server.port}`);
 
 if (
   (Bun.env.BACKGROUND_WORKER_POLL ?? process.env.BACKGROUND_WORKER_POLL) ===
   "true"
 ) {
   queueWorker.start();
-  console.log("namuh-ingester background job polling enabled");
+  console.log("opensend-ingester background job polling enabled");
 }

--- a/packages/ingester/src/stripe-webhook.ts
+++ b/packages/ingester/src/stripe-webhook.ts
@@ -15,8 +15,8 @@ import {
   stripeCustomerRepo,
   stripeEventRepo,
   subscriptionRepo,
-} from "@namuh/core";
-import { db, user } from "@namuh/core";
+} from "@opensend/core";
+import { db, user } from "@opensend/core";
 import { eq } from "drizzle-orm";
 
 export type StripeWebhookOutcome =

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,19 +1,19 @@
-# namuh-send
+# @opensend/sdk
 
-TypeScript SDK for the Namuh Send email API.
+TypeScript SDK for the OpenSend email API.
 
 ## Installation
 
 ```bash
-bun add namuh-send
+bun add @opensend/sdk
 ```
 
 ## Getting Started
 
 ```typescript
-import { NamuhSend } from "namuh-send";
+import { OpenSend } from "@opensend/sdk";
 
-const client = new NamuhSend("re_your_api_key", {
+const client = new OpenSend("re_your_api_key", {
   baseUrl: "https://your-deployment.example.com",
 });
 ```
@@ -133,7 +133,7 @@ The SDK is publish-ready and does not assume a local dev server. Pass your
 deployment origin explicitly:
 
 ```typescript
-const client = new NamuhSend("re_your_api_key", {
+const client = new OpenSend("re_your_api_key", {
   baseUrl: "https://api.your-deployment.example.com",
 });
 ```

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "namuh-send",
+  "name": "@opensend/sdk",
   "version": "1.0.0",
-  "description": "TypeScript SDK for the Namuh Send email API",
+  "description": "TypeScript SDK for the OpenSend email API",
   "main": "dist/sdk/src/index.js",
   "types": "dist/sdk/src/index.d.ts",
   "exports": {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -397,7 +397,7 @@ class Events {
   }
 }
 
-class NamuhSend {
+class OpenSend {
   public readonly emails: Emails;
   public readonly domains: Domains;
   public readonly apiKeys: ApiKeys;
@@ -421,7 +421,7 @@ class NamuhSend {
   }
 }
 
-export { NamuhSend };
+export { OpenSend };
 export type {
   SDKOptions,
   ApiResponse,

--- a/scripts/install-git-hooks.mjs
+++ b/scripts/install-git-hooks.mjs
@@ -33,4 +33,4 @@ execFileSync("git", ["config", "core.hooksPath", ".githooks"], {
   stdio: "ignore",
 });
 
-console.log("✓ Installed Namuh Send git hooks (.githooks)");
+console.log("✓ Installed OpenSend git hooks (.githooks)");

--- a/scripts/postinstall-star.sh
+++ b/scripts/postinstall-star.sh
@@ -3,8 +3,8 @@
 # ABOUTME: Three guard gates (skip flag/env, TTY, gh auth). Never fails the install.
 
 OWNER="namuh-eng"
-REPO="namuh-send"
-PROJECT="namuh-send"
+REPO="opensend"
+PROJECT="opensend"
 
 main() {
   # --- Guard Gate 1: Skip flags ---
@@ -14,7 +14,7 @@ main() {
     fi
   done
 
-  if [ "${SKIP_STAR_PROMPT:-}" = "1" ] || [ "${NAMUH_SEND_SKIP_STAR_PROMPT:-}" = "1" ]; then
+  if [ "${SKIP_STAR_PROMPT:-}" = "1" ] || [ "${OPENSEND_SKIP_STAR_PROMPT:-}" = "1" ]; then
     return 0
   fi
 

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@namuh/api",
+  "name": "@opensend/api",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -15,13 +15,13 @@ export default function DashboardLayout({
         <div className="flex-1 p-6">{children}</div>
         <footer className="flex items-center justify-end gap-4 border-t border-[rgba(176,199,217,0.145)] px-6 py-3">
           <a
-            href="mailto:feedback@example.com?subject=Namuh%20Send%20Feedback"
+            href="mailto:feedback@example.com?subject=OpenSend%20Feedback"
             className="text-[13px] text-[#A1A4A5] transition-colors hover:text-[#F0F0F0]"
           >
             Feedback
           </a>
           <a
-            href="mailto:help@example.com?subject=Namuh%20Send%20Help"
+            href="mailto:help@example.com?subject=OpenSend%20Help"
             className="text-[13px] text-[#A1A4A5] transition-colors hover:text-[#F0F0F0]"
           >
             Help

--- a/src/app/(dashboard)/webhooks/page.tsx
+++ b/src/app/(dashboard)/webhooks/page.tsx
@@ -1,7 +1,7 @@
 import { WebhooksList } from "@/components/webhooks-list";
 import { db } from "@/lib/db";
 import { webhooks } from "@/lib/db/schema";
-import { SUPPORTED_WEBHOOK_EVENT_TYPES } from "@namuh/core/src/webhook-events";
+import { SUPPORTED_WEBHOOK_EVENT_TYPES } from "@opensend/core/src/webhook-events";
 import { desc } from "drizzle-orm";
 
 export default async function WebhooksPage() {

--- a/src/app/api/automations/[id]/route.ts
+++ b/src/app/api/automations/[id]/route.ts
@@ -7,7 +7,7 @@ import {
   type AutomationStepInput,
   AutomationValidationError,
   automationRepo,
-} from "@namuh/core";
+} from "@opensend/core";
 import { and, asc, eq } from "drizzle-orm";
 
 async function findAutomationForCaller(id: string, userId: string | null) {

--- a/src/app/api/automations/route.ts
+++ b/src/app/api/automations/route.ts
@@ -6,7 +6,7 @@ import {
   type AutomationStepInput,
   AutomationValidationError,
   automationRepo,
-} from "@namuh/core";
+} from "@opensend/core";
 
 function toStepInputs(
   steps: Array<{

--- a/src/app/api/billing/checkout/route.ts
+++ b/src/app/api/billing/checkout/route.ts
@@ -1,7 +1,7 @@
 import { getServerSession } from "@/lib/api-auth";
 import { getBillingBackend } from "@/lib/billing";
 import { getStripe } from "@/lib/billing/stripe";
-import { planRepo, stripeCustomerRepo } from "@namuh/core";
+import { planRepo, stripeCustomerRepo } from "@opensend/core";
 import { NextResponse } from "next/server";
 import type Stripe from "stripe";
 

--- a/src/app/api/billing/portal/route.ts
+++ b/src/app/api/billing/portal/route.ts
@@ -1,7 +1,7 @@
 import { getServerSession } from "@/lib/api-auth";
 import { getBillingBackend } from "@/lib/billing";
 import { getStripe } from "@/lib/billing/stripe";
-import { stripeCustomerRepo } from "@namuh/core";
+import { stripeCustomerRepo } from "@opensend/core";
 import { NextResponse } from "next/server";
 
 function getRequestOrigin(request: Request) {

--- a/src/app/api/emails/batch/route.ts
+++ b/src/app/api/emails/batch/route.ts
@@ -11,7 +11,7 @@ import {
   logTelemetry,
   publishBackgroundJob,
   recordTelemetryError,
-} from "@namuh/core";
+} from "@opensend/core";
 import { eq } from "drizzle-orm";
 
 // ── Helpers ───────────────────────────────────────────────────────

--- a/src/app/api/emails/route.ts
+++ b/src/app/api/emails/route.ts
@@ -11,7 +11,7 @@ import {
   logTelemetry,
   publishBackgroundJob,
   recordTelemetryError,
-} from "@namuh/core";
+} from "@opensend/core";
 import { and, desc, eq, gt, lt } from "drizzle-orm";
 import { type ZodError, flattenError } from "zod";
 

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -4,7 +4,7 @@ import {
   createCustomEventSchema,
   listEventsQuerySchema,
 } from "@/lib/validation/events";
-import { AutomationValidationError, customEventRepo } from "@namuh/core";
+import { AutomationValidationError, customEventRepo } from "@opensend/core";
 
 function isUniqueViolation(err: unknown): boolean {
   return (

--- a/src/app/api/events/send/route.ts
+++ b/src/app/api/events/send/route.ts
@@ -11,7 +11,7 @@ import {
   automationRepo,
   automationRunRepo,
   customEventDeliveryRepo,
-} from "@namuh/core";
+} from "@opensend/core";
 import { eq } from "drizzle-orm";
 
 async function resolveContactId(input: {

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -21,7 +21,7 @@ export default function AuthPage() {
             n
           </div>
           <h1 className="text-xl font-semibold text-[#F0F0F0]">
-            Sign in to namuh
+            Sign in to OpenSend
           </h1>
           <p className="text-[13px] text-[#A1A4A5] mt-1">
             Continue with your Google account

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -22,7 +22,7 @@ const API_GROUPS: EndpointGroup[] = [
         method: "POST",
         path: "/api/emails",
         description: "Send an email",
-        curl: `curl -X POST https://api.namuh-send.com/api/emails \\
+        curl: `curl -X POST https://api.opensend.com/api/emails \\
   -H "Authorization: Bearer re_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -36,21 +36,21 @@ const API_GROUPS: EndpointGroup[] = [
         method: "GET",
         path: "/api/emails",
         description: "List all emails with pagination",
-        curl: `curl https://api.namuh-send.com/api/emails \\
+        curl: `curl https://api.opensend.com/api/emails \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
       {
         method: "GET",
         path: "/api/emails/:id",
         description: "Retrieve a specific email by ID",
-        curl: `curl https://api.namuh-send.com/api/emails/EMAIL_ID \\
+        curl: `curl https://api.opensend.com/api/emails/EMAIL_ID \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
       {
         method: "POST",
         path: "/api/emails/batch",
         description: "Send a batch of emails",
-        curl: `curl -X POST https://api.namuh-send.com/api/emails/batch \\
+        curl: `curl -X POST https://api.opensend.com/api/emails/batch \\
   -H "Authorization: Bearer re_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '[
@@ -67,7 +67,7 @@ const API_GROUPS: EndpointGroup[] = [
         method: "POST",
         path: "/api/domains",
         description: "Add a new domain",
-        curl: `curl -X POST https://api.namuh-send.com/api/domains \\
+        curl: `curl -X POST https://api.opensend.com/api/domains \\
   -H "Authorization: Bearer re_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{ "name": "mail.example.com" }'`,
@@ -76,28 +76,28 @@ const API_GROUPS: EndpointGroup[] = [
         method: "GET",
         path: "/api/domains",
         description: "List all domains",
-        curl: `curl https://api.namuh-send.com/api/domains \\
+        curl: `curl https://api.opensend.com/api/domains \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
       {
         method: "GET",
         path: "/api/domains/:id",
         description: "Retrieve a domain by ID",
-        curl: `curl https://api.namuh-send.com/api/domains/DOMAIN_ID \\
+        curl: `curl https://api.opensend.com/api/domains/DOMAIN_ID \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
       {
         method: "DELETE",
         path: "/api/domains/:id",
         description: "Delete a domain",
-        curl: `curl -X DELETE https://api.namuh-send.com/api/domains/DOMAIN_ID \\
+        curl: `curl -X DELETE https://api.opensend.com/api/domains/DOMAIN_ID \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
       {
         method: "POST",
         path: "/api/domains/:id/auto-configure",
         description: "Auto-configure DNS records for a domain",
-        curl: `curl -X POST https://api.namuh-send.com/api/domains/DOMAIN_ID/auto-configure \\
+        curl: `curl -X POST https://api.opensend.com/api/domains/DOMAIN_ID/auto-configure \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
     ],
@@ -109,7 +109,7 @@ const API_GROUPS: EndpointGroup[] = [
         method: "POST",
         path: "/api/api-keys",
         description: "Create a new API key",
-        curl: `curl -X POST https://api.namuh-send.com/api/api-keys \\
+        curl: `curl -X POST https://api.opensend.com/api/api-keys \\
   -H "Authorization: Bearer re_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{ "name": "Production Key" }'`,
@@ -118,14 +118,14 @@ const API_GROUPS: EndpointGroup[] = [
         method: "GET",
         path: "/api/api-keys",
         description: "List all API keys",
-        curl: `curl https://api.namuh-send.com/api/api-keys \\
+        curl: `curl https://api.opensend.com/api/api-keys \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
       {
         method: "DELETE",
         path: "/api/api-keys/:id",
         description: "Delete an API key",
-        curl: `curl -X DELETE https://api.namuh-send.com/api/api-keys/KEY_ID \\
+        curl: `curl -X DELETE https://api.opensend.com/api/api-keys/KEY_ID \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
     ],
@@ -137,7 +137,7 @@ const API_GROUPS: EndpointGroup[] = [
         method: "POST",
         path: "/api/templates",
         description: "Create a new template",
-        curl: `curl -X POST https://api.namuh-send.com/api/templates \\
+        curl: `curl -X POST https://api.opensend.com/api/templates \\
   -H "Authorization: Bearer re_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{ "name": "Welcome Email", "html": "<p>Welcome {{name}}</p>" }'`,
@@ -146,21 +146,21 @@ const API_GROUPS: EndpointGroup[] = [
         method: "GET",
         path: "/api/templates",
         description: "List all templates",
-        curl: `curl https://api.namuh-send.com/api/templates \\
+        curl: `curl https://api.opensend.com/api/templates \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
       {
         method: "GET",
         path: "/api/templates/:id",
         description: "Retrieve a template by ID",
-        curl: `curl https://api.namuh-send.com/api/templates/TEMPLATE_ID \\
+        curl: `curl https://api.opensend.com/api/templates/TEMPLATE_ID \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
       {
         method: "PATCH",
         path: "/api/templates/:id",
         description: "Update a template",
-        curl: `curl -X PATCH https://api.namuh-send.com/api/templates/TEMPLATE_ID \\
+        curl: `curl -X PATCH https://api.opensend.com/api/templates/TEMPLATE_ID \\
   -H "Authorization: Bearer re_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{ "name": "Updated Template" }'`,
@@ -169,7 +169,7 @@ const API_GROUPS: EndpointGroup[] = [
         method: "DELETE",
         path: "/api/templates/:id",
         description: "Delete a template",
-        curl: `curl -X DELETE https://api.namuh-send.com/api/templates/TEMPLATE_ID \\
+        curl: `curl -X DELETE https://api.opensend.com/api/templates/TEMPLATE_ID \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
     ],
@@ -181,7 +181,7 @@ const API_GROUPS: EndpointGroup[] = [
         method: "POST",
         path: "/api/contacts",
         description: "Create a new contact",
-        curl: `curl -X POST https://api.namuh-send.com/api/contacts \\
+        curl: `curl -X POST https://api.opensend.com/api/contacts \\
   -H "Authorization: Bearer re_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{ "email": "user@example.com", "first_name": "Jane" }'`,
@@ -190,7 +190,7 @@ const API_GROUPS: EndpointGroup[] = [
         method: "GET",
         path: "/api/contacts",
         description: "List all contacts",
-        curl: `curl https://api.namuh-send.com/api/contacts \\
+        curl: `curl https://api.opensend.com/api/contacts \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
     ],
@@ -202,7 +202,7 @@ const API_GROUPS: EndpointGroup[] = [
         method: "POST",
         path: "/api/broadcasts",
         description: "Create a new broadcast",
-        curl: `curl -X POST https://api.namuh-send.com/api/broadcasts \\
+        curl: `curl -X POST https://api.opensend.com/api/broadcasts \\
   -H "Authorization: Bearer re_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{ "name": "March Newsletter" }'`,
@@ -211,14 +211,14 @@ const API_GROUPS: EndpointGroup[] = [
         method: "GET",
         path: "/api/broadcasts",
         description: "List all broadcasts",
-        curl: `curl https://api.namuh-send.com/api/broadcasts \\
+        curl: `curl https://api.opensend.com/api/broadcasts \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
       {
         method: "GET",
         path: "/api/broadcasts/:id",
         description: "Retrieve a broadcast by ID",
-        curl: `curl https://api.namuh-send.com/api/broadcasts/BROADCAST_ID \\
+        curl: `curl https://api.opensend.com/api/broadcasts/BROADCAST_ID \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
     ],
@@ -230,7 +230,7 @@ const API_GROUPS: EndpointGroup[] = [
         method: "POST",
         path: "/api/segments",
         description: "Create a new segment",
-        curl: `curl -X POST https://api.namuh-send.com/api/segments \\
+        curl: `curl -X POST https://api.opensend.com/api/segments \\
   -H "Authorization: Bearer re_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{ "name": "Active Users" }'`,
@@ -239,7 +239,7 @@ const API_GROUPS: EndpointGroup[] = [
         method: "GET",
         path: "/api/segments",
         description: "List all segments",
-        curl: `curl https://api.namuh-send.com/api/segments \\
+        curl: `curl https://api.opensend.com/api/segments \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
     ],
@@ -251,7 +251,7 @@ const API_GROUPS: EndpointGroup[] = [
         method: "POST",
         path: "/api/topics",
         description: "Create a new topic",
-        curl: `curl -X POST https://api.namuh-send.com/api/topics \\
+        curl: `curl -X POST https://api.opensend.com/api/topics \\
   -H "Authorization: Bearer re_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{ "name": "Product Updates" }'`,
@@ -260,7 +260,7 @@ const API_GROUPS: EndpointGroup[] = [
         method: "GET",
         path: "/api/topics",
         description: "List all topics",
-        curl: `curl https://api.namuh-send.com/api/topics \\
+        curl: `curl https://api.opensend.com/api/topics \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
     ],
@@ -272,7 +272,7 @@ const API_GROUPS: EndpointGroup[] = [
         method: "POST",
         path: "/api/properties",
         description: "Create a new property",
-        curl: `curl -X POST https://api.namuh-send.com/api/properties \\
+        curl: `curl -X POST https://api.opensend.com/api/properties \\
   -H "Authorization: Bearer re_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{ "name": "plan", "type": "string" }'`,
@@ -281,7 +281,7 @@ const API_GROUPS: EndpointGroup[] = [
         method: "GET",
         path: "/api/properties",
         description: "List all properties",
-        curl: `curl https://api.namuh-send.com/api/properties \\
+        curl: `curl https://api.opensend.com/api/properties \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
     ],
@@ -364,7 +364,7 @@ export default function DocsPage() {
             All endpoints require a Bearer token in the Authorization header.
             Base URL:{" "}
             <code className="px-1.5 py-0.5 bg-[rgba(24,25,28,0.88)] border border-[rgba(176,199,217,0.145)] rounded text-[13px] text-[#F0F0F0] font-mono">
-              https://api.namuh-send.com
+              https://api.opensend.com
             </code>
           </p>
         </div>

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -36,7 +36,7 @@ const FEATURES: Array<{ title: string; body: string }> = [
   },
   {
     title: "TypeScript SDK",
-    body: "First-class `namuh-send` package on npm with typed payloads, retries, and idempotency keys.",
+    body: "First-class `@opensend/sdk` package on npm with typed payloads, retries, and idempotency keys.",
   },
   {
     title: "Domain verification",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Namuh Send",
+  title: "OpenSend",
   description: "Email API for developers",
 };
 

--- a/src/app/unsubscribe/[contactId]/page.tsx
+++ b/src/app/unsubscribe/[contactId]/page.tsx
@@ -69,7 +69,7 @@ export default function UnsubscribePage() {
 
         <div className="mt-12 pt-6 border-t border-white/[0.04]">
           <p className="text-[10px] text-zinc-600 uppercase tracking-widest font-medium">
-            Powered by Namuh Send
+            Powered by OpenSend
           </p>
         </div>
       </div>

--- a/src/components/settings-page.tsx
+++ b/src/components/settings-page.tsx
@@ -34,7 +34,7 @@ function isUsageData(value: unknown): value is UsageData {
 }
 
 const SMTP_CREDENTIALS = [
-  { label: "Host", value: "smtp.namuh-send.com" },
+  { label: "Host", value: "smtp.opensend.com" },
   { label: "Port", value: "465" },
   { label: "Username", value: "resend" },
   { label: "Password", value: "YOUR_API_KEY" },
@@ -152,7 +152,7 @@ export function SettingsPage() {
               EXAMPLE CONFIGURATION
             </p>
             <pre className="text-[13px] text-[#F0F0F0] font-mono whitespace-pre-wrap">
-              {`SMTP_HOST=smtp.namuh-send.com
+              {`SMTP_HOST=smtp.opensend.com
 SMTP_PORT=465
 SMTP_USER=resend
 SMTP_PASS=re_YOUR_API_KEY`}
@@ -208,7 +208,7 @@ SMTP_PASS=re_YOUR_API_KEY`}
                   Successfully unsubscribed
                 </div>
                 <p className="text-gray-400 text-xs mt-6">
-                  Powered by Namuh Send
+                  Powered by OpenSend
                 </p>
               </div>
             </div>

--- a/src/components/webhooks-list.tsx
+++ b/src/components/webhooks-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { StatusBadge } from "@/components/status-badge";
-import type { SupportedWebhookEventType } from "@namuh/core/src/webhook-events";
+import type { SupportedWebhookEventType } from "@opensend/core/src/webhook-events";
 
 interface Webhook {
   id: string;

--- a/src/lib/billing/index.ts
+++ b/src/lib/billing/index.ts
@@ -1,4 +1,4 @@
-import type { BillingBackend } from "@namuh/core";
+import type { BillingBackend } from "@opensend/core";
 
 const STRIPE_REQUIRED_KEYS = ["STRIPE_SECRET_KEY"] as const;
 

--- a/src/lib/ses.ts
+++ b/src/lib/ses.ts
@@ -22,7 +22,7 @@ const useDevStub = process.env.NODE_ENV === "development" && !hasAwsCredentials;
 
 if (useDevStub) {
   console.log(
-    "[namuh-send] AWS credentials not found — emails will be logged to console instead of sent via SES.",
+    "[opensend] AWS credentials not found — emails will be logged to console instead of sent via SES.",
   );
 }
 

--- a/src/lib/validation/webhooks.ts
+++ b/src/lib/validation/webhooks.ts
@@ -1,7 +1,7 @@
 import {
   SUPPORTED_WEBHOOK_EVENT_TYPES,
   type SupportedWebhookEventType,
-} from "@namuh/core/src/webhook-events";
+} from "@opensend/core/src/webhook-events";
 import { z } from "zod";
 
 export const webhookStatusSchema = z.enum(["active", "disabled"]);

--- a/src/lib/workers/scheduled-emails.ts
+++ b/src/lib/workers/scheduled-emails.ts
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db";
 import { emails } from "@/lib/db/schema";
-import { createBackgroundJob, publishBackgroundJob } from "@namuh/core";
+import { createBackgroundJob, publishBackgroundJob } from "@opensend/core";
 import { and, eq, lte } from "drizzle-orm";
 
 /**

--- a/tests/api-automations-events.test.ts
+++ b/tests/api-automations-events.test.ts
@@ -69,7 +69,7 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-vi.mock("@namuh/core", () => ({
+vi.mock("@opensend/core", () => ({
   AutomationValidationError: TestAutomationValidationError,
   automationRepo: {
     create: mockAutomationCreate,

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -18,7 +18,7 @@ vi.mock("@/lib/ses", () => ({
   sendEmail: mockSendEmail,
 }));
 
-vi.mock("@namuh/core", () => {
+vi.mock("@opensend/core", () => {
   const testTraceparent =
     "00-11111111111111111111111111111111-2222222222222222-01";
   const getHeader = (

--- a/tests/background-jobs.test.ts
+++ b/tests/background-jobs.test.ts
@@ -79,7 +79,7 @@ describe("background job publisher", () => {
   it("publishes SQS jobs and optional EventBridge lifecycle events", async () => {
     process.env.BACKGROUND_JOBS_QUEUE_URL =
       "https://sqs.us-east-1.amazonaws.com/123/background.fifo";
-    process.env.BACKGROUND_JOBS_EVENT_BUS_NAME = "namuh-send-jobs";
+    process.env.BACKGROUND_JOBS_EVENT_BUS_NAME = "opensend-jobs";
     mockSqsSend.mockResolvedValue({ MessageId: "sqs-message-1" });
     mockEventBridgeSend.mockResolvedValue({ Entries: [{ EventId: "evt-1" }] });
 
@@ -145,8 +145,8 @@ describe("background job publisher", () => {
     expect(mockPutEventsCommand).toHaveBeenCalledWith({
       Entries: [
         expect.objectContaining({
-          EventBusName: "namuh-send-jobs",
-          Source: "namuh-send.background-jobs",
+          EventBusName: "opensend-jobs",
+          Source: "opensend.background-jobs",
           DetailType: "webhook.dispatch",
         }),
       ],

--- a/tests/billing-checkout-portal.test.ts
+++ b/tests/billing-checkout-portal.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/lib/api-auth", () => ({
   getServerSession: mockGetServerSession,
 }));
 
-vi.mock("@namuh/core", () => ({
+vi.mock("@opensend/core", () => ({
   planRepo: {
     findById: mockPlanFindById,
   },

--- a/tests/e2e/sidebar-logout.spec.ts
+++ b/tests/e2e/sidebar-logout.spec.ts
@@ -48,7 +48,7 @@ test("signed-in dashboard user can sign out and protected routes redirect to aut
   ).toBeDisabled();
   await expect(page).toHaveURL(/\/auth$/);
   await expect(
-    page.getByRole("heading", { name: "Sign in to namuh" }),
+    page.getByRole("heading", { name: "Sign in to OpenSend" }),
   ).toBeVisible();
 
   await page.goto("/emails");

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -71,11 +71,11 @@ test("footer exposes feedback, help, and docs links", async ({ page }) => {
   await expect(footer).toBeVisible();
   await expect(footer.getByRole("link", { name: "Feedback" })).toHaveAttribute(
     "href",
-    "mailto:feedback@foreverbrowsing.com?subject=Namuh%20Send%20Feedback",
+    "mailto:feedback@foreverbrowsing.com?subject=OpenSend%20Feedback",
   );
   await expect(footer.getByRole("link", { name: "Help" })).toHaveAttribute(
     "href",
-    "mailto:help@foreverbrowsing.com?subject=Namuh%20Send%20Help",
+    "mailto:help@foreverbrowsing.com?subject=OpenSend%20Help",
   );
   await expect(footer.getByRole("link", { name: "Docs" })).toHaveAttribute(
     "href",

--- a/tests/ingester-ses-route.test.ts
+++ b/tests/ingester-ses-route.test.ts
@@ -10,7 +10,7 @@ const mockEmitCloudWatchMetric = vi.fn();
 const mockLogTelemetry = vi.fn();
 const mockRecordTelemetryError = vi.fn();
 
-vi.mock("@namuh/core", () => {
+vi.mock("@opensend/core", () => {
   const testTraceparent =
     "00-11111111111111111111111111111111-2222222222222222-01";
   const getHeader = (

--- a/tests/observability.test.ts
+++ b/tests/observability.test.ts
@@ -115,7 +115,7 @@ describe("observability telemetry helpers", () => {
       }>;
     };
     expect(aws.CloudWatchMetrics[0]).toMatchObject({
-      Namespace: "NamuhSend",
+      Namespace: "OpenSend",
       Dimensions: [["Service", "Operation", "Outcome"]],
       Metrics: [
         { Name: "SendOutcome", Unit: "Count" },

--- a/tests/postinstall-star.test.ts
+++ b/tests/postinstall-star.test.ts
@@ -59,7 +59,7 @@ describe("postinstall-star", () => {
     // Tests that want the skip behavior set the var explicitly via `env`.
     const {
       SKIP_STAR_PROMPT: _skip,
-      NAMUH_SEND_SKIP_STAR_PROMPT: _nskip,
+      OPENSEND_SKIP_STAR_PROMPT: _oskip,
       ...inherited
     } = process.env;
     try {
@@ -67,7 +67,7 @@ describe("postinstall-star", () => {
         env: { ...inherited, ...env },
         input,
         encoding: "utf-8",
-        timeout: 5000,
+        timeout: 30000,
       });
       return { stdout, exitCode: 0 };
     } catch (err: unknown) {
@@ -94,10 +94,10 @@ describe("postinstall-star", () => {
     expect(result.stdout).toBe("");
   });
 
-  it("exits 0 when NAMUH_SEND_SKIP_STAR_PROMPT=1", () => {
+  it("exits 0 when OPENSEND_SKIP_STAR_PROMPT=1", () => {
     const result = run({
       env: {
-        NAMUH_SEND_SKIP_STAR_PROMPT: "1",
+        OPENSEND_SKIP_STAR_PROMPT: "1",
         __FORCE_INTERACTIVE: "1",
         GH_CMD: fakeGhOk,
       },

--- a/tests/queue-worker.test.ts
+++ b/tests/queue-worker.test.ts
@@ -11,7 +11,7 @@ const mockEmitCloudWatchMetric = vi.hoisted(() => vi.fn());
 const mockLogTelemetry = vi.hoisted(() => vi.fn());
 const mockRecordTelemetryError = vi.hoisted(() => vi.fn());
 
-vi.mock("@namuh/core", () => ({
+vi.mock("@opensend/core", () => ({
   createBackgroundJob: (job: Record<string, unknown>) => ({
     ...job,
     requestedAt: "2026-04-28T00:00:00.000Z",

--- a/tests/sdk-client.test.tsx
+++ b/tests/sdk-client.test.tsx
@@ -1,13 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { NamuhSend } from "../packages/sdk/src";
+import { OpenSend } from "../packages/sdk/src";
 
-describe("NamuhSend SDK", () => {
+describe("OpenSend SDK", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
   it("requires an explicit baseUrl", () => {
-    expect(() => new NamuhSend("re_test", {} as never)).toThrow(
+    expect(() => new OpenSend("re_test", {} as never)).toThrow(
       "A non-empty baseUrl is required",
     );
   });
@@ -22,7 +22,7 @@ describe("NamuhSend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new NamuhSend("re_test", {
+    const client = new OpenSend("re_test", {
       baseUrl: "https://api.example.com/",
     });
 
@@ -58,7 +58,7 @@ describe("NamuhSend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new NamuhSend("re_test", {
+    const client = new OpenSend("re_test", {
       baseUrl: "https://api.example.com",
     });
 
@@ -87,7 +87,7 @@ describe("NamuhSend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new NamuhSend("re_test", {
+    const client = new OpenSend("re_test", {
       baseUrl: "https://api.example.com",
     });
 
@@ -106,7 +106,7 @@ describe("NamuhSend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new NamuhSend("re_test", {
+    const client = new OpenSend("re_test", {
       baseUrl: "https://api.example.com",
     });
 
@@ -128,7 +128,7 @@ describe("NamuhSend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new NamuhSend("re_test", {
+    const client = new OpenSend("re_test", {
       baseUrl: "https://api.example.com",
     });
 

--- a/tests/stripe-webhook.test.ts
+++ b/tests/stripe-webhook.test.ts
@@ -1,7 +1,7 @@
 import {
   type ParsedStripeInvoice,
   generateStripeSignatureHeader,
-} from "@namuh/core";
+} from "@opensend/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { StripeWebhookProcessor } from "../packages/ingester/src/stripe-webhook";
 

--- a/tests/webhook-dispatcher.test.ts
+++ b/tests/webhook-dispatcher.test.ts
@@ -8,7 +8,7 @@ const mockFindWebhookById = vi.fn();
 const mockFindEventById = vi.fn();
 const mockSignWebhookPayload = vi.fn();
 
-vi.mock("@namuh/core", () => ({
+vi.mock("@opensend/core", () => ({
   emailEventRepo: {
     findById: mockFindEventById,
   },

--- a/tests/webhook-event-types.test.tsx
+++ b/tests/webhook-event-types.test.tsx
@@ -3,7 +3,7 @@ import {
   createWebhookSchema,
   updateWebhookSchema,
 } from "@/lib/validation/webhooks";
-import { SUPPORTED_WEBHOOK_EVENT_TYPES } from "@namuh/core/src/webhook-events";
+import { SUPPORTED_WEBHOOK_EVENT_TYPES } from "@opensend/core/src/webhook-events";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 


### PR DESCRIPTION
## Summary
- Renames workspace/package identity to OpenSend: root `opensend`, `@opensend/core`, `@opensend/ingester`, and `@opensend/sdk`.
- Updates internal imports, mocks, SDK docs/examples, app/docs copy, AGENTS/CLAUDE, lockfile workspace entries, and user-facing OpenSend naming.
- Documents the SDK package decision as scoped `@opensend/sdk` and keeps this PR to namespace cleanup before deeper #71 architecture work.

## Tests
- `make check && make test`
- Push guardrails: changed-file check, full-project typecheck, changed-file Biome lint

## Issue
Closes #153
Parent: #71

## Residual risk
- Historical notes still mention old Namuh Send URLs/names where they record past work; current package/import identity no longer uses `@namuh/core`, `@namuh/ingester`, or `namuh-send`.
- Some deployed/infrastructure names still include `namuh` because they are existing org/domain/database identifiers, not package namespace changes.
- This is only namespace/package cleanup before the broader #71 architecture work; it does not move routes, introduce services/api, or refactor runtime boundaries.
