### PR TITLE
Introduce control-plane API service skeleton

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
 - `packages/core/` — `@namuh/core` — shared DB client, repositories, DTOs, webhook helpers
 - `packages/ingester/` — `@namuh/ingester` — Hono webhook dispatcher for SES/SNS events and scheduled email worker
 - `packages/sdk/` — `namuh-send` — public TypeScript SDK published to npm
+- `services/api/` — `@namuh/api` — Bun + Hono control-plane API skeleton on local port 3026; Next.js `src/app/api` routes remain the public API until later thin-adapter PRs
 - `tests/` — Vitest unit tests
 - `tests/e2e/` — Playwright E2E tests
 - `drizzle/` — generated migration SQL

--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ curl -X POST http://localhost:3015/api/emails \
 
 Open `http://localhost:3015/docs` for the full local API reference.
 
+### Control-plane API skeleton
+
+This repository now includes a dedicated TypeScript control-plane API service skeleton at [`services/api`](./services/api). It runs on Bun + Hono and reserves local development port **3026**:
+
+```bash
+bun run dev:api
+curl http://localhost:3026/healthz
+curl http://localhost:3026/readyz
+```
+
+For now, the Next.js routes under `src/app/api` remain the current public API and own production request handling. The control-plane service only exposes health/readiness endpoints until follow-up thin-adapter PRs move route ownership behind this boundary.
+
 ### TypeScript SDK
 
 ```bash

--- a/agent_docs/learnings/active/2026-05-02-issue-71-control-plane-api-skeleton.md
+++ b/agent_docs/learnings/active/2026-05-02-issue-71-control-plane-api-skeleton.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-02
+issue: "#71"
+type: decision
+promoted_to: null
+---
+
+## Control-plane API skeleton boundary
+
+**What:** Introduced `services/api` as a Bun + Hono workspace with only `/healthz` and `/readyz` endpoints on local port 3026.
+**Why:** Issue #71 needs an independently discoverable control-plane runtime before moving route ownership, but this slice must not change existing Next.js API behavior or depend on the OpenSend package namespace rename.
+**Fix:** Keep `src/app/api` as the current public API until follow-up thin-adapter PRs move route logic behind the control-plane boundary.

--- a/bun.lock
+++ b/bun.lock
@@ -67,6 +67,13 @@
         "typescript": "^5.0.0",
       },
     },
+    "services/api": {
+      "name": "@namuh/api",
+      "version": "0.1.0",
+      "dependencies": {
+        "hono": "^4.12.15",
+      },
+    },
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
@@ -380,6 +387,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@namuh/api": ["@namuh/api@workspace:services/api"],
 
     "@namuh/core": ["@namuh/core@workspace:packages/core"],
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "packageManager": "bun@1.3.8",
-  "workspaces": ["packages/*"],
+  "workspaces": ["packages/*", "services/*"],
   "scripts": {
     "postinstall": "bash scripts/postinstall-star.sh 2>/dev/null || true && node scripts/install-git-hooks.mjs",
     "dev": "next dev --port 3015",
@@ -22,7 +22,10 @@
     "db:generate": "drizzle-kit generate --config drizzle.config.ts",
     "db:migrate": "drizzle-kit migrate --config drizzle.config.ts",
     "db:push": "drizzle-kit push --config drizzle.config.ts",
-    "db:seed": "tsx scripts/seed.ts"
+    "db:seed": "tsx scripts/seed.ts",
+    "dev:api": "bun run --cwd services/api dev",
+    "start:api": "bun run --cwd services/api start",
+    "build:api": "bun run --cwd services/api build"
   },
   "dependencies": {
     "@aws-sdk/client-eventbridge": "^3.1038.0",

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -1,0 +1,17 @@
+# Control-plane API service
+
+`services/api` is the Bun + Hono skeleton for the future OpenSend/Namuh Send control-plane API runtime.
+
+Local development convention:
+
+```bash
+bun run dev:api
+# service listens on http://localhost:3026 by default
+```
+
+Current endpoints:
+
+- `GET /healthz` — service/version health metadata
+- `GET /readyz` — static readiness response that does not require AWS, database, queue, or other external credentials
+
+This service is intentionally a skeleton. The existing Next.js route handlers under `src/app/api` remain the current public API until follow-up thin-adapter PRs move route ownership behind this boundary.

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@namuh/api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "dev": "bun --watch src/server.ts",
+    "start": "bun src/server.ts",
+    "build": "bun build ./src/server.ts --target bun --outfile ./dist/server.js"
+  },
+  "dependencies": {
+    "hono": "^4.12.15"
+  }
+}

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -1,0 +1,47 @@
+import { Hono } from "hono";
+
+export const CONTROL_PLANE_API_SERVICE = "control-plane-api";
+export const CONTROL_PLANE_API_VERSION = "0.1.0";
+
+export type HealthResponse = {
+  ok: true;
+  service: typeof CONTROL_PLANE_API_SERVICE;
+  version: typeof CONTROL_PLANE_API_VERSION;
+};
+
+export type ReadinessResponse = HealthResponse & {
+  ready: true;
+  checks: {
+    config: "ok";
+  };
+};
+
+export function createApp() {
+  const app = new Hono();
+
+  app.get("/healthz", (c) =>
+    c.json({
+      ok: true,
+      service: CONTROL_PLANE_API_SERVICE,
+      version: CONTROL_PLANE_API_VERSION,
+    } satisfies HealthResponse),
+  );
+
+  app.get("/readyz", (c) =>
+    c.json({
+      ok: true,
+      ready: true,
+      service: CONTROL_PLANE_API_SERVICE,
+      version: CONTROL_PLANE_API_VERSION,
+      checks: {
+        config: "ok",
+      },
+    } satisfies ReadinessResponse),
+  );
+
+  return app;
+}
+
+const app = createApp();
+
+export default app;

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -1,0 +1,33 @@
+import app from "./index";
+
+type FetchHandler = typeof app.fetch;
+
+declare const Bun: {
+  env?: Record<string, string | undefined>;
+  serve: (options: {
+    fetch: FetchHandler;
+    hostname: string;
+    port: number;
+  }) => { port: number };
+};
+
+const DEFAULT_PORT = 3026;
+const DEFAULT_HOST = "0.0.0.0";
+
+function parsePort(value: string | undefined): number {
+  if (!value) return DEFAULT_PORT;
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : DEFAULT_PORT;
+}
+
+const port = parsePort(Bun.env?.PORT ?? process.env.PORT);
+const hostname = Bun.env?.HOST ?? process.env.HOST ?? DEFAULT_HOST;
+
+const server = Bun.serve({
+  fetch: app.fetch,
+  hostname,
+  port,
+});
+
+console.log(`control-plane-api listening on http://${hostname}:${server.port}`);

--- a/tests/api-service-health.test.ts
+++ b/tests/api-service-health.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import app, {
+  CONTROL_PLANE_API_SERVICE,
+  CONTROL_PLANE_API_VERSION,
+} from "../services/api/src/index";
+
+describe("control-plane API health endpoints", () => {
+  it("returns production-shaped health metadata", async () => {
+    const response = await app.request("http://localhost/healthz");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      service: CONTROL_PLANE_API_SERVICE,
+      version: CONTROL_PLANE_API_VERSION,
+    });
+  });
+
+  it("returns readiness without requiring external credentials", async () => {
+    const response = await app.request("http://localhost/readyz");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      ready: true,
+      service: CONTROL_PLANE_API_SERVICE,
+      version: CONTROL_PLANE_API_VERSION,
+      checks: {
+        config: "ok",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `services/api` as a Bun + Hono workspace for the future control-plane API runtime.
- Exposes production-shaped skeleton endpoints: `GET /healthz` and `GET /readyz` with service/version/readiness metadata and no live external credential requirements.
- Wires monorepo discovery via `services/*` workspace coverage plus `dev:api`, `start:api`, and `build:api` scripts using the issue #71 port convention of `3026`.
- Documents that this is a skeleton only: existing Next.js `src/app/api` routes remain the current public API until follow-up route-move/thin-adapter PRs.

## Tests
- `bunx vitest run tests/api-service-health.test.ts`
- `bun run build:api`
- `make check`
- `bunx vitest run --exclude tests/postinstall-star.test.ts` — 74 files / 613 tests passed
- Attempted `make test`; it is blocked by existing `tests/postinstall-star.test.ts` interactive child-process failures (4 cases exiting 1 after timeout), unrelated to `services/api`.

## Issue
Parent: #71

## Skeleton-only note
This PR does not move any `src/app/api` route handlers and does not change current dashboard/API runtime behavior. Route moves and thin adapters are follow-up work under the #71 architecture split.

## Residual risks
- `services/api` currently has only health/readiness endpoints; real control-plane auth, persistence, queue publishing, and route adapters are intentionally not implemented yet.
- The service package keeps the current staging namespace (`@namuh/api`) and does not depend on the #153/#154 OpenSend namespace rename.
- Full `make test` remains red locally because of the existing postinstall-star interactive harness failure noted above.
