### PR TITLE
Automations: MVP runner on background jobs

### DIFF
--- a/agent_docs/learnings/active/2026-05-02-118-automation-runner-mvp.md
+++ b/agent_docs/learnings/active/2026-05-02-118-automation-runner-mvp.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-02
+issue: "#118"
+type: decision
+promoted_to: null
+---
+
+## MVP automation runner executes one due step per cron tick
+
+**What:** The runner advances exactly one due step for each automation run per scheduled tick. Delay steps leave the run on the delay key with `status=waiting` and `next_step_at`; a later due tick completes the delay and advances to send.
+**Why:** This matches the existing scheduled worker polling model and avoids sleeping or doing multi-step work inside event ingestion.
+**Fix:** Future step types should preserve this one-step-per-tick contract and add their own waiting/resume state instead of blocking request or cron execution.

--- a/packages/core/src/db/repositories/automationRunRepo.ts
+++ b/packages/core/src/db/repositories/automationRunRepo.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, lt, lte } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, lt, lte } from "drizzle-orm";
 import { AutomationValidationError } from "../../dto/automations";
 import { db } from "../client";
 import { automationRuns, automations } from "../schema";
@@ -95,15 +95,13 @@ export const automationRunRepo = {
           lte(automationRuns.nextStepAt, cursor),
           statuses.length === 1
             ? eq(automationRuns.status, statuses[0])
-            : undefined,
+            : inArray(automationRuns.status, statuses),
         ),
       )
       .orderBy(asc(automationRuns.nextStepAt))
       .limit(limit);
 
-    if (statuses.length <= 1) return rows;
-    const allowed = new Set(statuses);
-    return rows.filter((row) => allowed.has(row.status));
+    return rows;
   },
 
   async update(id: string, data: Partial<typeof automationRuns.$inferInsert>) {

--- a/packages/core/src/dto/automations.ts
+++ b/packages/core/src/dto/automations.ts
@@ -201,7 +201,7 @@ const UNIT_TO_SECONDS: Record<string, number> = {
   weeks: 604800,
 };
 
-export function parseDurationToSeconds(input: string): number {
+function parseDurationSecondsRaw(input: string): number {
   if (typeof input !== "string") {
     throw new AutomationValidationError(
       "delay duration must be a string",
@@ -227,7 +227,11 @@ export function parseDurationToSeconds(input: string): number {
     );
   }
 
-  const seconds = Math.round(amount * factor);
+  return Math.round(amount * factor);
+}
+
+export function parseDurationToSeconds(input: string): number {
+  const seconds = parseDurationSecondsRaw(input);
   if (seconds > MAX_DELAY_SECONDS) {
     throw new AutomationValidationError(
       `delay duration "${input}" exceeds the ${MAX_DELAY_DAYS}-day cap`,
@@ -235,6 +239,10 @@ export function parseDurationToSeconds(input: string): number {
     );
   }
   return seconds;
+}
+
+export function parseDurationToCappedSeconds(input: string): number {
+  return Math.min(parseDurationSecondsRaw(input), MAX_DELAY_SECONDS);
 }
 
 export function normalizeDelayConfig(

--- a/packages/core/src/services/email.ts
+++ b/packages/core/src/services/email.ts
@@ -20,6 +20,7 @@ export class EmailService {
     scheduledAt?: Date | null;
     topicId?: string | null;
     idempotencyKey?: string | null;
+    userId?: string | null;
   }) {
     // Check idempotency if key provided
     if (params.idempotencyKey) {
@@ -48,6 +49,7 @@ export class EmailService {
       scheduledAt: params.scheduledAt,
       topicId: params.topicId,
       idempotencyKey: params.idempotencyKey,
+      userId: params.userId,
     });
 
     if (shouldQueueNow) {

--- a/src/app/api/internal/cron/process-scheduled/route.ts
+++ b/src/app/api/internal/cron/process-scheduled/route.ts
@@ -1,3 +1,4 @@
+import { processScheduledAutomations } from "@/lib/workers/automation-runner";
 import { processScheduledBroadcasts } from "@/lib/workers/broadcast-sender";
 import { processScheduledEmails } from "@/lib/workers/scheduled-emails";
 import { NextResponse } from "next/server";
@@ -18,15 +19,17 @@ export async function GET(request: Request) {
   }
 
   try {
-    const [emailResult, broadcastResult] = await Promise.all([
+    const [emailResult, broadcastResult, automationResult] = await Promise.all([
       processScheduledEmails(),
       processScheduledBroadcasts(),
+      processScheduledAutomations(),
     ]);
 
     return NextResponse.json({
       ok: true,
       emails: emailResult,
       broadcasts: broadcastResult,
+      automations: automationResult,
     });
   } catch (error) {
     console.error("Cron: Scheduled processing failed:", error);

--- a/src/lib/workers/automation-runner.ts
+++ b/src/lib/workers/automation-runner.ts
@@ -1,0 +1,619 @@
+import { db } from "@/lib/db";
+import {
+  type AutomationConnection,
+  type AutomationStepStateEntry,
+  type automationRuns,
+  automationSteps,
+  automations,
+  contacts,
+  customEventDeliveries,
+  templates,
+} from "@/lib/db/schema";
+import {
+  automationRunRepo,
+  emailService,
+  parseDurationToCappedSeconds,
+} from "@namuh/core";
+import { asc, eq } from "drizzle-orm";
+
+type AutomationRun = typeof automationRuns.$inferSelect;
+type Automation = typeof automations.$inferSelect;
+type AutomationStep = typeof automationSteps.$inferSelect;
+type CustomEventDelivery = typeof customEventDeliveries.$inferSelect;
+type Contact = typeof contacts.$inferSelect;
+type Template = typeof templates.$inferSelect;
+
+type StepStates = Record<string, AutomationStepStateEntry>;
+
+type RunnerSendEmailInput = {
+  from: string;
+  to: string[];
+  subject: string;
+  html?: string;
+  text?: string;
+  replyTo?: string[];
+  tags?: Array<{ name: string; value: string }>;
+  idempotencyKey?: string | null;
+  userId?: string | null;
+};
+
+export interface AutomationRunnerDeps {
+  now: () => Date;
+  getAutomation: (id: string) => Promise<Automation | null>;
+  listSteps: (automationId: string) => Promise<AutomationStep[]>;
+  getDelivery: (id: string) => Promise<CustomEventDelivery | null>;
+  getContact: (id: string) => Promise<Contact | null>;
+  getTemplate: (id: string) => Promise<Template | null>;
+  sendEmail: (input: RunnerSendEmailInput) => Promise<{ id: string }>;
+  updateRun: (
+    id: string,
+    data: Partial<typeof automationRuns.$inferInsert>,
+  ) => Promise<AutomationRun | null>;
+}
+
+export interface ProcessScheduledAutomationsResult {
+  processed: number;
+  advanced: number;
+  failed: number;
+  skipped: number;
+}
+
+const defaultDeps: AutomationRunnerDeps = {
+  now: () => new Date(),
+  async getAutomation(id) {
+    return (
+      (await db.query.automations.findFirst({
+        where: eq(automations.id, id),
+      })) ?? null
+    );
+  },
+  async listSteps(automationId) {
+    return await db
+      .select()
+      .from(automationSteps)
+      .where(eq(automationSteps.automationId, automationId))
+      .orderBy(asc(automationSteps.position));
+  },
+  async getDelivery(id) {
+    return (
+      (await db.query.customEventDeliveries.findFirst({
+        where: eq(customEventDeliveries.id, id),
+      })) ?? null
+    );
+  },
+  async getContact(id) {
+    return (
+      (await db.query.contacts.findFirst({ where: eq(contacts.id, id) })) ??
+      null
+    );
+  },
+  async getTemplate(id) {
+    return (
+      (await db.query.templates.findFirst({ where: eq(templates.id, id) })) ??
+      null
+    );
+  },
+  async sendEmail(input) {
+    return await emailService.send(input);
+  },
+  async updateRun(id, data) {
+    const [updated] = await automationRunRepo.update(id, data);
+    return updated ?? null;
+  },
+};
+
+function iso(date: Date): string {
+  return date.toISOString();
+}
+
+function cloneStepStates(run: AutomationRun): StepStates {
+  return { ...(run.stepStates ?? {}) };
+}
+
+function setStepState(
+  states: StepStates,
+  key: string,
+  patch: AutomationStepStateEntry,
+): StepStates {
+  return {
+    ...states,
+    [key]: {
+      ...(states[key] ?? { status: "pending" }),
+      ...patch,
+    },
+  };
+}
+
+function findStep(
+  steps: AutomationStep[],
+  key: string | null,
+): AutomationStep | null {
+  if (key) return steps.find((step) => step.key === key) ?? null;
+  return steps.find((step) => step.type === "trigger") ?? steps[0] ?? null;
+}
+
+function nextStepKey(
+  automation: Automation,
+  steps: AutomationStep[],
+  currentKey: string,
+): string | null {
+  const connections = (automation.connections ?? []) as AutomationConnection[];
+  const connected = connections.find((edge) => edge.from === currentKey)?.to;
+  if (connected && steps.some((step) => step.key === connected)) {
+    return connected;
+  }
+
+  const ordered = [...steps].sort((a, b) => a.position - b.position);
+  const currentIndex = ordered.findIndex((step) => step.key === currentKey);
+  if (currentIndex < 0) return null;
+  return ordered[currentIndex + 1]?.key ?? null;
+}
+
+async function advanceRun(
+  deps: AutomationRunnerDeps,
+  run: AutomationRun,
+  automation: Automation,
+  steps: AutomationStep[],
+  step: AutomationStep,
+  states: StepStates,
+  now: Date,
+  output?: Record<string, unknown>,
+) {
+  const nextKey = nextStepKey(automation, steps, step.key);
+  const completedStates = setStepState(states, step.key, {
+    status: "completed",
+    completedAt: iso(now),
+    ...(output ? { output } : {}),
+  });
+
+  const startedAtPatch =
+    step.type === "trigger" && !run.startedAt ? { startedAt: now } : {};
+
+  if (!nextKey) {
+    return await deps.updateRun(run.id, {
+      status: "completed",
+      currentStepKey: null,
+      stepStates: completedStates,
+      completedAt: now,
+      nextStepAt: null,
+      failureReason: null,
+      ...startedAtPatch,
+    });
+  }
+
+  return await deps.updateRun(run.id, {
+    status: "queued",
+    currentStepKey: nextKey,
+    stepStates: completedStates,
+    nextStepAt: now,
+    failureReason: null,
+    ...startedAtPatch,
+  });
+}
+
+async function failRun(
+  deps: AutomationRunnerDeps,
+  run: AutomationRun,
+  stepKey: string,
+  states: StepStates,
+  now: Date,
+  reason: string,
+) {
+  const failedStates = setStepState(states, stepKey, {
+    status: "failed",
+    completedAt: iso(now),
+    error: reason,
+  });
+  return await deps.updateRun(run.id, {
+    status: "failed",
+    currentStepKey: stepKey,
+    stepStates: failedStates,
+    completedAt: now,
+    nextStepAt: null,
+    failureReason: reason,
+  });
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function getPath(source: unknown, path: string[]): unknown {
+  let current = source;
+  for (const part of path) {
+    if (typeof current !== "object" || current === null || !(part in current)) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+function buildVariableContext(
+  delivery: CustomEventDelivery | null,
+  contact: Contact,
+): Record<string, unknown> {
+  const eventPayload = delivery?.payload ?? {};
+  const customProperties = contact.customProperties ?? {};
+  const contactContext: Record<string, unknown> = {
+    id: contact.id,
+    email: contact.email,
+    first_name: contact.firstName ?? "",
+    firstName: contact.firstName ?? "",
+    last_name: contact.lastName ?? "",
+    lastName: contact.lastName ?? "",
+    unsubscribed: contact.unsubscribed,
+    custom_properties: customProperties,
+    customProperties,
+  };
+
+  return {
+    ...(typeof eventPayload === "object" && eventPayload !== null
+      ? eventPayload
+      : {}),
+    ...customProperties,
+    email: contact.email,
+    first_name: contact.firstName ?? "",
+    firstName: contact.firstName ?? "",
+    last_name: contact.lastName ?? "",
+    lastName: contact.lastName ?? "",
+    event: eventPayload,
+    contact: contactContext,
+  };
+}
+
+function resolveReference(
+  value: unknown,
+  context: Record<string, unknown>,
+): unknown {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  const directPath = /^(event|contact)\.([A-Za-z0-9_.-]+)$/.exec(trimmed);
+  if (directPath) {
+    return getPath(context[directPath[1]], directPath[2].split("."));
+  }
+  return value.replace(/{{\s*([^}]+?)\s*}}/g, (_match, token: string) => {
+    const path = token.trim().split(".");
+    const resolved = getPath(context, path);
+    return resolved === undefined || resolved === null ? "" : String(resolved);
+  });
+}
+
+function renderTemplate(
+  content: string | null,
+  variables: Record<string, unknown>,
+) {
+  let rendered = content ?? "";
+  for (const [key, value] of Object.entries(variables)) {
+    if (typeof value === "object") continue;
+    rendered = rendered.replace(
+      new RegExp(
+        `{{\\s*${key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*}}`,
+        "g",
+      ),
+      value === undefined || value === null ? "" : String(value),
+    );
+  }
+  return rendered;
+}
+
+function normalizeReplyTo(value: string | null): string[] | undefined {
+  return value ? [value] : undefined;
+}
+
+function getSendEmailConfig(step: AutomationStep): {
+  templateId: string | null;
+  variables: Record<string, unknown>;
+  from: string | null;
+  subject: string | null;
+  replyTo: string | null;
+} {
+  const config = step.config ?? {};
+  const template =
+    typeof config.template === "object" && config.template !== null
+      ? (config.template as Record<string, unknown>)
+      : {};
+  const variables =
+    typeof template.variables === "object" && template.variables !== null
+      ? (template.variables as Record<string, unknown>)
+      : {};
+  return {
+    templateId: readString(template.id),
+    variables,
+    from: readString(config.from),
+    subject: readString(config.subject),
+    replyTo: readString(config.reply_to),
+  };
+}
+
+async function processSendEmailStep(
+  deps: AutomationRunnerDeps,
+  run: AutomationRun,
+  automation: Automation,
+  steps: AutomationStep[],
+  step: AutomationStep,
+  states: StepStates,
+  now: Date,
+) {
+  if (!run.contactId) {
+    return await failRun(
+      deps,
+      run,
+      step.key,
+      states,
+      now,
+      "send_email requires a contact",
+    );
+  }
+
+  const contact = await deps.getContact(run.contactId);
+  if (!contact) {
+    return await failRun(deps, run, step.key, states, now, "contact not found");
+  }
+
+  if (contact.unsubscribed) {
+    const nextKey = nextStepKey(automation, steps, step.key);
+    const skippedStates = setStepState(states, step.key, {
+      status: "skipped",
+      startedAt: states[step.key]?.startedAt ?? iso(now),
+      completedAt: iso(now),
+      output: { reason: "contact_unsubscribed", contact_id: contact.id },
+    });
+    if (!nextKey) {
+      return await deps.updateRun(run.id, {
+        status: "completed",
+        currentStepKey: null,
+        stepStates: skippedStates,
+        completedAt: now,
+        nextStepAt: null,
+        failureReason: null,
+      });
+    }
+    return await deps.updateRun(run.id, {
+      status: "queued",
+      currentStepKey: nextKey,
+      stepStates: skippedStates,
+      nextStepAt: now,
+      failureReason: null,
+    });
+  }
+
+  const config = getSendEmailConfig(step);
+  if (!config.templateId) {
+    return await failRun(
+      deps,
+      run,
+      step.key,
+      states,
+      now,
+      "send_email step missing template id",
+    );
+  }
+
+  const template = await deps.getTemplate(config.templateId);
+  if (!template || template.status !== "published") {
+    return await failRun(
+      deps,
+      run,
+      step.key,
+      states,
+      now,
+      "send_email template is missing or unpublished",
+    );
+  }
+
+  const delivery = run.triggerEventId
+    ? await deps.getDelivery(run.triggerEventId)
+    : null;
+  const context = buildVariableContext(delivery, contact);
+  const explicitVariables = Object.fromEntries(
+    Object.entries(config.variables).map(([key, value]) => [
+      key,
+      resolveReference(value, context),
+    ]),
+  );
+  const variables = { ...context, ...explicitVariables };
+  const from = String(
+    resolveReference(config.from ?? template.from ?? "", context) ?? "",
+  ).trim();
+  const subjectSource = config.subject ?? template.subject ?? "";
+  const subject = renderTemplate(
+    String(resolveReference(subjectSource, context) ?? ""),
+    variables,
+  ).trim();
+  const replyTo = String(
+    resolveReference(config.replyTo ?? template.replyTo ?? "", context) ?? "",
+  ).trim();
+
+  if (!from) {
+    return await failRun(
+      deps,
+      run,
+      step.key,
+      states,
+      now,
+      "send_email from address is missing",
+    );
+  }
+  if (!subject) {
+    return await failRun(
+      deps,
+      run,
+      step.key,
+      states,
+      now,
+      "send_email subject is missing",
+    );
+  }
+
+  const email = await deps.sendEmail({
+    from,
+    to: [contact.email],
+    subject,
+    html: renderTemplate(template.html, variables),
+    text: renderTemplate(template.text, variables),
+    replyTo: normalizeReplyTo(replyTo),
+    tags: [
+      { name: "automation_id", value: automation.id },
+      { name: "automation_run_id", value: run.id },
+    ],
+    idempotencyKey: `automation:${run.id}:${step.key}`,
+    userId: run.userId ?? automation.userId ?? null,
+  });
+
+  return await advanceRun(deps, run, automation, steps, step, states, now, {
+    email_id: email.id,
+  });
+}
+
+export async function processAutomationRunStep(
+  run: AutomationRun,
+  deps: AutomationRunnerDeps = defaultDeps,
+): Promise<AutomationRun | null> {
+  const now = deps.now();
+  const automation = await deps.getAutomation(run.automationId);
+  if (!automation) {
+    return await deps.updateRun(run.id, {
+      status: "failed",
+      completedAt: now,
+      nextStepAt: null,
+      failureReason: "automation not found",
+    });
+  }
+
+  const steps = await deps.listSteps(run.automationId);
+  const step = findStep(steps, run.currentStepKey);
+  if (!step) {
+    return await deps.updateRun(run.id, {
+      status: "completed",
+      currentStepKey: null,
+      completedAt: now,
+      nextStepAt: null,
+    });
+  }
+
+  const states = setStepState(cloneStepStates(run), step.key, {
+    status: "running",
+    startedAt: run.stepStates?.[step.key]?.startedAt ?? iso(now),
+  });
+
+  try {
+    if (step.type === "trigger") {
+      return await advanceRun(deps, run, automation, steps, step, states, now);
+    }
+
+    if (step.type === "delay") {
+      const existing = run.stepStates?.[step.key];
+      if (existing?.status === "waiting") {
+        return await advanceRun(
+          deps,
+          run,
+          automation,
+          steps,
+          step,
+          states,
+          now,
+        );
+      }
+
+      const duration = readString(step.config?.duration);
+      if (!duration) {
+        return await failRun(
+          deps,
+          run,
+          step.key,
+          states,
+          now,
+          "delay duration is missing",
+        );
+      }
+      const seconds = parseDurationToCappedSeconds(duration);
+      const scheduledFor = new Date(now.getTime() + seconds * 1000);
+      const waitingStates = setStepState(states, step.key, {
+        status: "waiting",
+        scheduledFor: iso(scheduledFor),
+      });
+      return await deps.updateRun(run.id, {
+        status: "waiting",
+        currentStepKey: step.key,
+        stepStates: waitingStates,
+        nextStepAt: scheduledFor,
+        failureReason: null,
+      });
+    }
+
+    if (step.type === "send_email") {
+      return await processSendEmailStep(
+        deps,
+        run,
+        automation,
+        steps,
+        step,
+        states,
+        now,
+      );
+    }
+
+    if (step.type === "end") {
+      const completedStates = setStepState(states, step.key, {
+        status: "completed",
+        completedAt: iso(now),
+      });
+      return await deps.updateRun(run.id, {
+        status: "completed",
+        currentStepKey: null,
+        stepStates: completedStates,
+        completedAt: now,
+        nextStepAt: null,
+        failureReason: null,
+      });
+    }
+
+    return await failRun(
+      deps,
+      run,
+      step.key,
+      states,
+      now,
+      `unsupported automation step type: ${step.type}`,
+    );
+  } catch (error) {
+    const reason =
+      error instanceof Error ? error.message : "automation step failed";
+    return await failRun(deps, run, step.key, states, now, reason);
+  }
+}
+
+export async function processScheduledAutomations(
+  options: { limit?: number; now?: Date } = {},
+): Promise<ProcessScheduledAutomationsResult> {
+  const now = options.now ?? new Date();
+  const due = await automationRunRepo.listDue({
+    limit: options.limit ?? 50,
+    statuses: ["queued", "waiting"],
+    before: now,
+  });
+
+  const result: ProcessScheduledAutomationsResult = {
+    processed: due.length,
+    advanced: 0,
+    failed: 0,
+    skipped: 0,
+  };
+
+  for (const run of due) {
+    const updated = await processAutomationRunStep(run, {
+      ...defaultDeps,
+      now: () => now,
+    });
+    if (updated?.status === "failed") result.failed += 1;
+    else if (updated) result.advanced += 1;
+
+    const states = updated?.stepStates ?? {};
+    if (Object.values(states).some((state) => state.status === "skipped")) {
+      result.skipped += 1;
+    }
+  }
+
+  return result;
+}

--- a/tests/automation-runner.test.ts
+++ b/tests/automation-runner.test.ts
@@ -1,0 +1,287 @@
+import type {
+  automationRuns,
+  automationSteps,
+  automations,
+  contacts,
+  customEventDeliveries,
+  templates,
+} from "@/lib/db/schema";
+import type { AutomationRunnerDeps } from "@/lib/workers/automation-runner";
+import { describe, expect, it, vi } from "vitest";
+
+type AutomationRun = typeof automationRuns.$inferSelect;
+type Automation = typeof automations.$inferSelect;
+type AutomationStep = typeof automationSteps.$inferSelect;
+type Contact = typeof contacts.$inferSelect;
+type Template = typeof templates.$inferSelect;
+type Delivery = typeof customEventDeliveries.$inferSelect;
+
+const now = new Date("2026-05-02T00:00:00.000Z");
+const automation: Automation = {
+  id: "11111111-1111-1111-1111-111111111111",
+  name: "Welcome",
+  status: "enabled",
+  triggerEventName: "user.signed_up",
+  connections: [
+    { from: "trigger", to: "delay" },
+    { from: "delay", to: "send" },
+    { from: "send", to: "end" },
+  ],
+  createdAt: now,
+  updatedAt: now,
+  document: null,
+  userId: "user_1",
+};
+const steps: AutomationStep[] = [
+  {
+    id: "21111111-1111-1111-1111-111111111111",
+    automationId: automation.id,
+    key: "trigger",
+    type: "trigger",
+    config: { event_name: "user.signed_up" },
+    position: 0,
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: "21111111-1111-1111-1111-111111111112",
+    automationId: automation.id,
+    key: "delay",
+    type: "delay",
+    config: { duration: "2 hours" },
+    position: 1,
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: "21111111-1111-1111-1111-111111111113",
+    automationId: automation.id,
+    key: "send",
+    type: "send_email",
+    config: {
+      template: {
+        id: "31111111-1111-1111-1111-111111111111",
+        variables: { plan: "event.plan" },
+      },
+      subject: "Welcome {{contact.first_name}} to {{event.plan}}",
+    },
+    position: 2,
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: "21111111-1111-1111-1111-111111111114",
+    automationId: automation.id,
+    key: "end",
+    type: "end",
+    config: {},
+    position: 3,
+    createdAt: now,
+    updatedAt: now,
+  },
+];
+const delivery: Delivery = {
+  id: "41111111-1111-1111-1111-111111111111",
+  eventName: "user.signed_up",
+  contactId: "51111111-1111-1111-1111-111111111111",
+  email: "user@example.com",
+  payload: { plan: "pro" },
+  receivedAt: now,
+  userId: "user_1",
+};
+const contact: Contact = {
+  id: "51111111-1111-1111-1111-111111111111",
+  email: "user@example.com",
+  firstName: "Ada",
+  lastName: "Lovelace",
+  unsubscribed: false,
+  customProperties: {},
+  segments: [],
+  topicSubscriptions: [],
+  createdAt: now,
+  document: null,
+  userId: "user_1",
+};
+const template: Template = {
+  id: "31111111-1111-1111-1111-111111111111",
+  name: "Welcome",
+  alias: null,
+  status: "published",
+  subject: "Welcome {{first_name}}",
+  from: "sender@example.com",
+  replyTo: "reply@example.com",
+  previewText: null,
+  html: "<p>{{first_name}} picked {{plan}}</p>",
+  text: "{{first_name}} picked {{plan}}",
+  variables: [{ name: "plan", required: true }],
+  currentVersionId: null,
+  publishedAt: now,
+  hasUnpublishedVersions: false,
+  createdAt: now,
+  document: null,
+  userId: "user_1",
+};
+
+function run(overrides: Partial<AutomationRun> = {}): AutomationRun {
+  return {
+    id: "61111111-1111-1111-1111-111111111111",
+    automationId: automation.id,
+    triggerEventId: delivery.id,
+    contactId: contact.id,
+    status: "queued",
+    currentStepKey: "trigger",
+    stepStates: {},
+    startedAt: null,
+    completedAt: null,
+    nextStepAt: now,
+    failureReason: null,
+    createdAt: now,
+    updatedAt: now,
+    userId: "user_1",
+    ...overrides,
+  };
+}
+
+function deps(overrides: Partial<AutomationRunnerDeps> = {}) {
+  const updates: Array<Partial<AutomationRun>> = [];
+  const sendEmail = vi.fn().mockResolvedValue({ id: "email_1" });
+  const base: AutomationRunnerDeps = {
+    now: () => now,
+    getAutomation: vi.fn().mockResolvedValue(automation),
+    listSteps: vi.fn().mockResolvedValue(steps),
+    getDelivery: vi.fn().mockResolvedValue(delivery),
+    getContact: vi.fn().mockResolvedValue(contact),
+    getTemplate: vi.fn().mockResolvedValue(template),
+    sendEmail,
+    updateRun: vi.fn(async (_id, data) => {
+      updates.push(data as Partial<AutomationRun>);
+      return { ...run(), ...data } as AutomationRun;
+    }),
+    ...overrides,
+  };
+  return { deps: base, updates, sendEmail };
+}
+
+describe("automation runner", () => {
+  it("advances trigger then schedules delay next_step_at without sleeping", async () => {
+    const { processAutomationRunStep } = await import(
+      "@/lib/workers/automation-runner"
+    );
+    const setup = deps();
+
+    await processAutomationRunStep(run(), setup.deps);
+    expect(setup.updates[0]).toMatchObject({
+      status: "queued",
+      currentStepKey: "delay",
+    });
+
+    await processAutomationRunStep(
+      run({
+        currentStepKey: "delay",
+        stepStates: setup.updates[0]?.stepStates,
+      }),
+      setup.deps,
+    );
+
+    expect(setup.updates[1]).toMatchObject({
+      status: "waiting",
+      currentStepKey: "delay",
+      nextStepAt: new Date("2026-05-02T02:00:00.000Z"),
+    });
+    expect(setup.updates[1]?.stepStates?.delay).toMatchObject({
+      status: "waiting",
+      scheduledFor: "2026-05-02T02:00:00.000Z",
+    });
+  });
+
+  it("resumes a due delayed run and calls the email publishing boundary", async () => {
+    const { processAutomationRunStep } = await import(
+      "@/lib/workers/automation-runner"
+    );
+    const setup = deps();
+
+    await processAutomationRunStep(
+      run({
+        currentStepKey: "delay",
+        status: "waiting",
+        stepStates: {
+          delay: { status: "waiting", scheduledFor: now.toISOString() },
+        },
+      }),
+      setup.deps,
+    );
+    await processAutomationRunStep(
+      run({
+        currentStepKey: "send",
+        stepStates: setup.updates[0]?.stepStates,
+      }),
+      setup.deps,
+    );
+
+    expect(setup.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "sender@example.com",
+        to: ["user@example.com"],
+        subject: "Welcome Ada to pro",
+        html: "<p>Ada picked pro</p>",
+        tags: [
+          { name: "automation_id", value: automation.id },
+          {
+            name: "automation_run_id",
+            value: "61111111-1111-1111-1111-111111111111",
+          },
+        ],
+      }),
+    );
+    expect(setup.updates[1]).toMatchObject({
+      status: "queued",
+      currentStepKey: "end",
+    });
+    expect(setup.updates[1]?.stepStates?.send.output).toEqual({
+      email_id: "email_1",
+    });
+  });
+
+  it("fails missing or unpublished templates with a step-level error", async () => {
+    const { processAutomationRunStep } = await import(
+      "@/lib/workers/automation-runner"
+    );
+    const setup = deps({
+      getTemplate: vi.fn().mockResolvedValue({ ...template, status: "draft" }),
+    });
+
+    await processAutomationRunStep(run({ currentStepKey: "send" }), setup.deps);
+
+    expect(setup.sendEmail).not.toHaveBeenCalled();
+    expect(setup.updates[0]).toMatchObject({
+      status: "failed",
+      currentStepKey: "send",
+      failureReason: "send_email template is missing or unpublished",
+    });
+    expect(setup.updates[0]?.stepStates?.send).toMatchObject({
+      status: "failed",
+      error: "send_email template is missing or unpublished",
+    });
+  });
+
+  it("skips send_email for unsubscribed contacts", async () => {
+    const { processAutomationRunStep } = await import(
+      "@/lib/workers/automation-runner"
+    );
+    const setup = deps({
+      getContact: vi.fn().mockResolvedValue({ ...contact, unsubscribed: true }),
+    });
+
+    await processAutomationRunStep(run({ currentStepKey: "send" }), setup.deps);
+
+    expect(setup.sendEmail).not.toHaveBeenCalled();
+    expect(setup.updates[0]).toMatchObject({
+      status: "queued",
+      currentStepKey: "end",
+    });
+    expect(setup.updates[0]?.stepStates?.send).toMatchObject({
+      status: "skipped",
+      output: { reason: "contact_unsubscribed", contact_id: contact.id },
+    });
+  });
+});

--- a/tests/cron-process-scheduled.test.ts
+++ b/tests/cron-process-scheduled.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mockProcessScheduledAutomations = vi.hoisted(() => vi.fn());
+const mockProcessScheduledBroadcasts = vi.hoisted(() => vi.fn());
+const mockProcessScheduledEmails = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/workers/automation-runner", () => ({
+  processScheduledAutomations: mockProcessScheduledAutomations,
+}));
+vi.mock("@/lib/workers/broadcast-sender", () => ({
+  processScheduledBroadcasts: mockProcessScheduledBroadcasts,
+}));
+vi.mock("@/lib/workers/scheduled-emails", () => ({
+  processScheduledEmails: mockProcessScheduledEmails,
+}));
+
+describe("process-scheduled cron route", () => {
+  it("includes automation runner summary next to emails and broadcasts", async () => {
+    vi.resetModules();
+    mockProcessScheduledEmails.mockResolvedValue({ processed: 1, enqueued: 1 });
+    mockProcessScheduledBroadcasts.mockResolvedValue({ processed: 2 });
+    mockProcessScheduledAutomations.mockResolvedValue({
+      processed: 3,
+      advanced: 2,
+      failed: 1,
+      skipped: 0,
+    });
+
+    const { GET } = await import(
+      "@/app/api/internal/cron/process-scheduled/route"
+    );
+    const response = await GET(
+      new Request("http://localhost/api/internal/cron/process-scheduled"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      emails: { processed: 1, enqueued: 1 },
+      broadcasts: { processed: 2 },
+      automations: { processed: 3, advanced: 2, failed: 1, skipped: 0 },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add the MVP automation runner on the scheduled cron path, advancing one deterministic due step per run tick for `trigger`, `delay`, `send_email`, and `end`.
- Persist step-level running/waiting/completed/skipped/failed state, capped delay `next_step_at`, run failures, and unsubscribed-contact skips.
- Resolve send_email contacts, published templates, event/contact variables, and enqueue through the existing durable email service with automation tags/idempotency.
- Include `automations` in the internal scheduled cron response alongside existing email and broadcast summaries.

## Tests
- `bun run test tests/automation-runner.test.ts tests/cron-process-scheduled.test.ts tests/api-automations-events.test.ts`
- `make check`
- `make test`

## Issues
Closes #118
Refs #57

## Residual risks
- Runner intentionally supports only the MVP step types; condition/wait/contact/segment actions remain out of scope for later issues.
- No distributed lock beyond the existing scheduled worker pattern; idempotent email keys reduce duplicate send risk for repeated send_email ticks.
- Variable resolution is intentionally simple for MVP (`event.*`, `contact.*`, and scalar template variables), not a full templating language.
