### PR TITLE
Pilot API-key thin adapters for control-plane split

### DIFF
--- a/agent_docs/learnings/active/2026-05-02-issue-71-api-keys-thin-adapter.md
+++ b/agent_docs/learnings/active/2026-05-02-issue-71-api-keys-thin-adapter.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-02
+issue: "#71"
+type: pattern
+promoted_to: null
+---
+
+## API keys thin-adapter pilot
+
+**What:** API key route handlers now delegate API-key business rules to `packages/core/src/services/apiKeys.ts` while staying responsible for auth, request parsing, and response mapping.
+
+**Why:** Issue #71 needs proof that Next.js routes can become reusable adapters before moving behavior into `services/api`; API keys are low-risk because they avoid SES, Cloudflare, billing quota, and automation runner coupling.
+
+**Pattern:** Extract service logic with injectable dependencies first, test it independently, then keep the route handler as `auth -> parse -> service call -> HTTP mapping` so a future Hono control-plane adapter can reuse the same service without preserving Next.js internals.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export * from "./webhook-signing";
 export * from "./webhook-events";
 export * from "./services/dns";
 export * from "./services/domain";
+export * from "./services/apiKeys";
 export * from "./services/email";
 export * from "./services/emailProvider";
 export * from "./services/storage";

--- a/packages/core/src/services/apiKeys.ts
+++ b/packages/core/src/services/apiKeys.ts
@@ -1,0 +1,180 @@
+import { createHash, randomUUID } from "node:crypto";
+import { apiKeyRepo } from "../db/repositories/apiKeyRepo";
+import type { apiKeys } from "../db/schema";
+
+type ApiKeyRow = typeof apiKeys.$inferSelect;
+type ApiKeyInsert = typeof apiKeys.$inferInsert;
+
+export type ApiKeyPermission = "full_access" | "sending_access";
+
+export type ApiKeyServiceListItem = Pick<
+  ApiKeyRow,
+  "id" | "name" | "createdAt" | "lastUsedAt"
+>;
+
+export type ApiKeyDetail = Pick<
+  ApiKeyRow,
+  "id" | "name" | "createdAt" | "lastUsedAt"
+>;
+
+export type ApiKeyListResult = {
+  data: ApiKeyServiceListItem[];
+  hasMore: boolean;
+};
+
+export type CreateApiKeyInput = {
+  name: string;
+  permission?: ApiKeyPermission;
+  domainId?: string;
+  userId?: string;
+};
+
+export type CreateApiKeyResult = {
+  id: string;
+  token: string;
+  tokenHash: string;
+};
+
+export type DeleteApiKeyResult = {
+  id: string;
+  tokenHash: string;
+};
+
+export type ApiKeyServiceErrorCode =
+  | "invalid_name"
+  | "name_too_long"
+  | "not_found";
+
+export class ApiKeyServiceError extends Error {
+  constructor(
+    readonly code: ApiKeyServiceErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiKeyServiceError";
+  }
+}
+
+export type ApiKeyRepository = {
+  list(options: { limit?: number; after?: string }): Promise<{
+    data: ApiKeyRow[];
+    hasMore: boolean;
+  }>;
+  create(data: ApiKeyInsert): Promise<ApiKeyRow[]>;
+  findById(id: string): Promise<ApiKeyRow | undefined>;
+  delete(id: string): Promise<Array<{ id: string }>>;
+};
+
+export type ApiKeyServiceDependencies = {
+  repository?: ApiKeyRepository;
+  generateRawKey?: () => string;
+  invalidateAuthCache?: (tokenHash: string) => Promise<void>;
+};
+
+function defaultGenerateRawKey(): string {
+  return `re_${randomUUID().replace(/-/g, "")}`;
+}
+
+function hashApiKey(rawKey: string): string {
+  return createHash("sha256").update(rawKey).digest("hex");
+}
+
+function previewApiKey(rawKey: string): string {
+  return `${rawKey.slice(0, 6)}...${rawKey.slice(-4)}`;
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  return Math.min(Math.max(limit || 20, 1), 100);
+}
+
+export function createApiKeyService({
+  repository = apiKeyRepo,
+  generateRawKey = defaultGenerateRawKey,
+  invalidateAuthCache = async () => {},
+}: ApiKeyServiceDependencies = {}) {
+  return {
+    async listApiKeys(options: {
+      limit?: number;
+      after?: string;
+    }): Promise<ApiKeyListResult> {
+      const result = await repository.list({
+        limit: normalizeLimit(options.limit),
+        after: options.after || undefined,
+      });
+
+      return {
+        data: result.data.map((key) => ({
+          id: key.id,
+          name: key.name,
+          createdAt: key.createdAt,
+          lastUsedAt: key.lastUsedAt,
+        })),
+        hasMore: result.hasMore,
+      };
+    },
+
+    async createApiKey(input: CreateApiKeyInput): Promise<CreateApiKeyResult> {
+      const name = input.name.trim();
+      if (!name) {
+        throw new ApiKeyServiceError("invalid_name", "name is required");
+      }
+
+      if (name.length > 50) {
+        throw new ApiKeyServiceError(
+          "name_too_long",
+          "name must be 50 characters or less",
+        );
+      }
+
+      const rawKey = generateRawKey();
+      const tokenHash = hashApiKey(rawKey);
+      const [created] = await repository.create({
+        name,
+        tokenHash,
+        tokenPreview: previewApiKey(rawKey),
+        permission: input.permission ?? "full_access",
+        domain: input.domainId ?? null,
+        userId: input.userId ?? null,
+      });
+
+      await invalidateAuthCache(created.tokenHash);
+
+      return {
+        id: created.id,
+        token: rawKey,
+        tokenHash: created.tokenHash,
+      };
+    },
+
+    async getApiKey(id: string): Promise<ApiKeyDetail> {
+      const key = await repository.findById(id);
+      if (!key) {
+        throw new ApiKeyServiceError("not_found", "API key not found");
+      }
+
+      return {
+        id: key.id,
+        name: key.name,
+        createdAt: key.createdAt,
+        lastUsedAt: key.lastUsedAt,
+      };
+    },
+
+    async deleteApiKey(id: string): Promise<DeleteApiKeyResult> {
+      const existing = await repository.findById(id);
+      if (!existing) {
+        throw new ApiKeyServiceError("not_found", "API key not found");
+      }
+
+      const [deleted] = await repository.delete(id);
+      await invalidateAuthCache(existing.tokenHash);
+
+      return {
+        id: deleted?.id ?? id,
+        tokenHash: existing.tokenHash,
+      };
+    },
+  };
+}
+
+export const apiKeyService = createApiKeyService();

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -14,4 +14,14 @@ Current endpoints:
 - `GET /healthz` — service/version health metadata
 - `GET /readyz` — static readiness response that does not require AWS, database, queue, or other external credentials
 
-This service is intentionally a skeleton. The existing Next.js route handlers under `src/app/api` remain the current public API until follow-up thin-adapter PRs move route ownership behind this boundary.
+This service is intentionally a skeleton. The existing Next.js route handlers under `src/app/api` remain the current public API until follow-up route-move/thin-adapter PRs move route ownership behind this boundary.
+
+## Thin-adapter pilot pattern
+
+The API keys route family is the first narrow thin-adapter pilot for issue #71:
+
+- `src/app/api/api-keys/**/route.ts` owns only request authorization, JSON/query/route-param parsing, service invocation, and HTTP response mapping.
+- `packages/core/src/services/apiKeys.ts` owns API-key business rules: pagination bounds, create validation, token generation/hash/preview construction, repository orchestration, not-found semantics, and cache-invalidation hook invocation.
+- The service accepts explicit dependencies, so behavior can be unit-tested without a Next.js request object and later reused by the Hono control-plane runtime.
+
+Follow-up route moves should preserve this split before adding Hono handlers: keep public API shape stable, move business logic into core or a service layer, then let each runtime provide only an adapter.

--- a/src/app/api/api-keys/[id]/route.ts
+++ b/src/app/api/api-keys/[id]/route.ts
@@ -3,9 +3,22 @@ import {
   unauthorizedResponse,
   validateApiKey,
 } from "@/lib/api-auth";
-import { db } from "@/lib/db";
-import { apiKeys } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { ApiKeyServiceError, createApiKeyService } from "@opensend/core";
+
+function apiKeyService() {
+  return createApiKeyService({
+    invalidateAuthCache: invalidateApiKeyAuthCache,
+  });
+}
+
+function mapServiceError(err: unknown, fallback: string): Response {
+  if (err instanceof ApiKeyServiceError) {
+    return Response.json({ error: err.message }, { status: 404 });
+  }
+
+  const message = err instanceof Error ? err.message : fallback;
+  return Response.json({ error: message }, { status: 500 });
+}
 
 export async function GET(
   request: Request,
@@ -18,15 +31,7 @@ export async function GET(
 
   const { id } = await params;
   try {
-    const [key] = await db
-      .select()
-      .from(apiKeys)
-      .where(eq(apiKeys.id, id))
-      .limit(1);
-
-    if (!key) {
-      return Response.json({ error: "API key not found" }, { status: 404 });
-    }
+    const key = await apiKeyService().getApiKey(id);
 
     return Response.json({
       object: "api_key",
@@ -36,9 +41,7 @@ export async function GET(
       last_used_at: key.lastUsedAt,
     });
   } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to get API key";
-    return Response.json({ error: message }, { status: 500 });
+    return mapServiceError(err, "Failed to get API key");
   }
 }
 
@@ -53,27 +56,10 @@ export async function DELETE(
 
   const { id } = await params;
   try {
-    const [existing] = await db
-      .select({ tokenHash: apiKeys.tokenHash })
-      .from(apiKeys)
-      .where(eq(apiKeys.id, id))
-      .limit(1);
-
-    if (!existing) {
-      return Response.json({ error: "API key not found" }, { status: 404 });
-    }
-
-    const [deleted] = await db
-      .delete(apiKeys)
-      .where(eq(apiKeys.id, id))
-      .returning({ id: apiKeys.id });
-
-    await invalidateApiKeyAuthCache(existing.tokenHash);
+    await apiKeyService().deleteApiKey(id);
 
     return new Response(null, { status: 200 });
   } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to delete API key";
-    return Response.json({ error: message }, { status: 500 });
+    return mapServiceError(err, "Failed to delete API key");
   }
 }

--- a/src/app/api/api-keys/route.ts
+++ b/src/app/api/api-keys/route.ts
@@ -1,13 +1,50 @@
-import { createHash, randomUUID } from "node:crypto";
 import {
   invalidateApiKeyAuthCache,
   unauthorizedResponse,
   validateApiKey,
 } from "@/lib/api-auth";
 import { checkApiKeyQuota, quotaExceededResponse } from "@/lib/billing/quota";
-import { db } from "@/lib/db";
-import { apiKeys } from "@/lib/db/schema";
-import { and, desc, lt } from "drizzle-orm";
+import {
+  type ApiKeyPermission,
+  ApiKeyServiceError,
+  createApiKeyService,
+} from "@opensend/core";
+
+function apiKeyService() {
+  return createApiKeyService({
+    invalidateAuthCache: invalidateApiKeyAuthCache,
+  });
+}
+
+function mapServiceError(err: unknown, fallback: string): Response {
+  if (err instanceof ApiKeyServiceError) {
+    const status = err.code === "not_found" ? 404 : 422;
+    return Response.json({ error: err.message }, { status });
+  }
+
+  const message = err instanceof Error ? err.message : fallback;
+  return Response.json({ error: message }, { status: 500 });
+}
+
+function parseCreateApiKeyBody(body: unknown): {
+  name: string;
+  permission?: ApiKeyPermission;
+  domainId?: string;
+} {
+  const data = body && typeof body === "object" ? body : {};
+  const record = data as Record<string, unknown>;
+  const permission = record.permission;
+  const domainId = record.domain_id;
+
+  return {
+    name: typeof record.name === "string" ? record.name : "",
+    permission:
+      permission === "full_access" || permission === "sending_access"
+        ? permission
+        : undefined,
+    domainId: typeof domainId === "string" ? domainId : undefined,
+  };
+}
 
 export async function GET(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
@@ -16,54 +53,25 @@ export async function GET(request: Request): Promise<Response> {
   }
 
   const url = new URL(request.url);
-  const limit = Math.min(
-    Math.max(Number(url.searchParams.get("limit")) || 20, 1),
-    100,
-  );
+  const limit = Number(url.searchParams.get("limit")) || 20;
   const after = url.searchParams.get("after") || "";
 
   try {
-    const conditions = [];
-    if (after) {
-      conditions.push(lt(apiKeys.id, after));
-    }
-
-    const results = await db
-      .select({
-        id: apiKeys.id,
-        name: apiKeys.name,
-        createdAt: apiKeys.createdAt,
-        lastUsedAt: apiKeys.lastUsedAt,
-      })
-      .from(apiKeys)
-      .where(conditions.length > 0 ? and(...conditions) : undefined)
-      .orderBy(desc(apiKeys.id))
-      .limit(limit + 1);
-
-    const hasMore = results.length > limit;
-    const dataRows = hasMore ? results.slice(0, limit) : results;
+    const result = await apiKeyService().listApiKeys({ limit, after });
 
     return Response.json({
       object: "list",
-      data: dataRows.map((k) => ({
-        id: k.id,
-        name: k.name,
-        created_at: k.createdAt,
-        last_used_at: k.lastUsedAt,
+      data: result.data.map((key) => ({
+        id: key.id,
+        name: key.name,
+        created_at: key.createdAt,
+        last_used_at: key.lastUsedAt,
       })),
-      has_more: hasMore,
+      has_more: result.hasMore,
     });
   } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to list API keys";
-    return Response.json({ error: message }, { status: 500 });
+    return mapServiceError(err, "Failed to list API keys");
   }
-}
-
-interface CreateApiKeyBody {
-  name: string;
-  permission?: "full_access" | "sending_access";
-  domain_id?: string;
 }
 
 export async function POST(request: Request): Promise<Response> {
@@ -72,22 +80,11 @@ export async function POST(request: Request): Promise<Response> {
     return unauthorizedResponse();
   }
 
-  let body: CreateApiKeyBody;
+  let body: unknown;
   try {
     body = await request.json();
   } catch {
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
-  if (!body.name || body.name.trim().length === 0) {
-    return Response.json({ error: "name is required" }, { status: 422 });
-  }
-
-  if (body.name.trim().length > 50) {
-    return Response.json(
-      { error: "name must be 50 characters or less" },
-      { status: 422 },
-    );
   }
 
   try {
@@ -96,34 +93,19 @@ export async function POST(request: Request): Promise<Response> {
       return quotaExceededResponse(quota.info);
     }
 
-    const rawKey = `re_${randomUUID().replace(/-/g, "")}`;
-    const tokenHash = createHash("sha256").update(rawKey).digest("hex");
-    const tokenPreview = `${rawKey.slice(0, 6)}...${rawKey.slice(-4)}`;
-
-    const [created] = await db
-      .insert(apiKeys)
-      .values({
-        name: body.name.trim(),
-        tokenHash,
-        tokenPreview,
-        permission: body.permission ?? "full_access",
-        domain: body.domain_id ?? null,
-        userId: auth.userId,
-      })
-      .returning();
-
-    await invalidateApiKeyAuthCache(created.tokenHash);
+    const created = await apiKeyService().createApiKey({
+      ...parseCreateApiKeyBody(body),
+      userId: auth.userId ?? undefined,
+    });
 
     return Response.json(
       {
         id: created.id,
-        token: rawKey,
+        token: created.token,
       },
       { status: 201 },
     );
   } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to create API key";
-    return Response.json({ error: message }, { status: 500 });
+    return mapServiceError(err, "Failed to create API key");
   }
 }

--- a/tests/api-key-service.test.ts
+++ b/tests/api-key-service.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ApiKeyRepository,
+  type ApiKeyServiceError,
+  createApiKeyService,
+} from "../packages/core/src/services/apiKeys";
+
+type ApiKeyRow = Awaited<ReturnType<ApiKeyRepository["findById"]>> & {};
+
+type ApiKeyInsert = Parameters<ApiKeyRepository["create"]>[0];
+
+function apiKeyRow(overrides: Partial<ApiKeyRow> = {}): ApiKeyRow {
+  return {
+    id: "key-1",
+    name: "Primary",
+    tokenHash: "hash-1",
+    tokenPreview: "re_123...abcd",
+    permission: "full_access",
+    domain: null,
+    lastUsedAt: null,
+    createdAt: new Date("2026-05-02T00:00:00.000Z"),
+    document: null,
+    userId: null,
+    ...overrides,
+  };
+}
+
+function createRepository(overrides: Partial<ApiKeyRepository> = {}) {
+  const repository: ApiKeyRepository = {
+    async list() {
+      return { data: [], hasMore: false };
+    },
+    async create(data: ApiKeyInsert) {
+      return [apiKeyRow({ tokenHash: data.tokenHash })];
+    },
+    async findById() {
+      return apiKeyRow();
+    },
+    async delete(id: string) {
+      return [{ id }];
+    },
+    ...overrides,
+  };
+
+  return repository;
+}
+
+describe("api key service", () => {
+  it("creates an API key with trimmed name, hashed token, preview, and cache invalidation", async () => {
+    let inserted: ApiKeyInsert | null = null;
+    const invalidateAuthCache = vi.fn<(_: string) => Promise<void>>();
+    const repository = createRepository({
+      async create(data) {
+        inserted = data;
+        return [apiKeyRow({ id: "created-key", tokenHash: data.tokenHash })];
+      },
+    });
+
+    const service = createApiKeyService({
+      repository,
+      generateRawKey: () => "re_1234567890abcdef",
+      invalidateAuthCache,
+    });
+
+    const result = await service.createApiKey({
+      name: "  Primary  ",
+      permission: "sending_access",
+      domainId: "domain-1",
+    });
+
+    expect(result).toEqual({
+      id: "created-key",
+      token: "re_1234567890abcdef",
+      tokenHash:
+        "437645b2b0886d92d681fba33b3096bc45cea50aed15a8a812a15fbb7082a49c",
+    });
+    expect(inserted).toMatchObject({
+      name: "Primary",
+      tokenHash:
+        "437645b2b0886d92d681fba33b3096bc45cea50aed15a8a812a15fbb7082a49c",
+      tokenPreview: "re_123...cdef",
+      permission: "sending_access",
+      domain: "domain-1",
+    });
+    expect(invalidateAuthCache).toHaveBeenCalledWith(result.tokenHash);
+  });
+
+  it("rejects blank and overlong API key names before persistence", async () => {
+    const create = vi.fn<ApiKeyRepository["create"]>();
+    const service = createApiKeyService({
+      repository: createRepository({ create }),
+    });
+
+    await expect(service.createApiKey({ name: "   " })).rejects.toMatchObject({
+      code: "invalid_name",
+      message: "name is required",
+    } satisfies Partial<ApiKeyServiceError>);
+
+    await expect(
+      service.createApiKey({ name: "x".repeat(51) }),
+    ).rejects.toMatchObject({
+      code: "name_too_long",
+      message: "name must be 50 characters or less",
+    } satisfies Partial<ApiKeyServiceError>);
+
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("lists with normalized pagination and maps only public list fields", async () => {
+    let listOptions: { limit?: number; after?: string } | null = null;
+    const service = createApiKeyService({
+      repository: createRepository({
+        async list(options) {
+          listOptions = options;
+          return {
+            data: [apiKeyRow({ id: "key-2", name: "Secondary" })],
+            hasMore: true,
+          };
+        },
+      }),
+    });
+
+    const result = await service.listApiKeys({ limit: 500, after: "key-3" });
+
+    expect(listOptions).toEqual({ limit: 100, after: "key-3" });
+    expect(result).toEqual({
+      data: [
+        {
+          id: "key-2",
+          name: "Secondary",
+          createdAt: new Date("2026-05-02T00:00:00.000Z"),
+          lastUsedAt: null,
+        },
+      ],
+      hasMore: true,
+    });
+  });
+
+  it("returns not_found for get and delete misses", async () => {
+    const service = createApiKeyService({
+      repository: createRepository({
+        async findById() {
+          return undefined;
+        },
+      }),
+    });
+
+    await expect(service.getApiKey("missing")).rejects.toMatchObject({
+      code: "not_found",
+      message: "API key not found",
+    } satisfies Partial<ApiKeyServiceError>);
+    await expect(service.deleteApiKey("missing")).rejects.toMatchObject({
+      code: "not_found",
+      message: "API key not found",
+    } satisfies Partial<ApiKeyServiceError>);
+  });
+});

--- a/tests/broadcasts-list.test.ts
+++ b/tests/broadcasts-list.test.ts
@@ -312,12 +312,8 @@ describe("BroadcastsList", () => {
 
     const statusTrigger = screen.getByText("All Statuses");
     fireEvent.click(statusTrigger);
-    await waitFor(() => {
-      expect(screen.getAllByRole("menuitem", { name: "Draft" })).toHaveLength(
-        1,
-      );
-    });
-    fireEvent.click(screen.getAllByRole("menuitem", { name: "Draft" })[0]);
+    const draftOption = await screen.findByRole("menuitem", { name: "Draft" });
+    fireEvent.click(draftOption);
     await waitFor(() => {
       expect(mockRouter.replace).toHaveBeenCalledWith(
         expect.stringContaining("status=draft"),

--- a/tests/cache-invalidation-routes.test.ts
+++ b/tests/cache-invalidation-routes.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockValidateApiKey = vi.hoisted(() => vi.fn());
 const mockInvalidateApiKeyAuthCache = vi.hoisted(() => vi.fn());
+const mockCreateApiKey = vi.hoisted(() => vi.fn());
+const mockDeleteApiKey = vi.hoisted(() => vi.fn());
 const mockGetCachedDomainById = vi.hoisted(() => vi.fn());
 const mockGetCachedDomainIdentity = vi.hoisted(() => vi.fn());
 const mockInvalidateDomainCaches = vi.hoisted(() => vi.fn());
@@ -19,6 +21,14 @@ const mockDb = vi.hoisted(() => ({
   insert: vi.fn(),
   update: vi.fn(),
   delete: vi.fn(),
+}));
+
+vi.mock("@opensend/core", () => ({
+  ApiKeyServiceError: class ApiKeyServiceError extends Error {},
+  createApiKeyService: () => ({
+    createApiKey: mockCreateApiKey,
+    deleteApiKey: mockDeleteApiKey,
+  }),
 }));
 
 vi.mock("@/lib/api-auth", () => ({
@@ -73,13 +83,11 @@ describe("cache invalidation routes", () => {
     });
   });
 
-  it("invalidates new api-key auth entries after create", async () => {
-    mockDb.insert.mockReturnValue({
-      values: vi.fn().mockReturnValue({
-        returning: vi
-          .fn()
-          .mockResolvedValue([{ id: "created-key", tokenHash: "hash-123" }]),
-      }),
+  it("delegates api-key create through the thin adapter", async () => {
+    mockCreateApiKey.mockResolvedValue({
+      id: "created-key",
+      token: "re_created",
+      tokenHash: "hash-123",
     });
 
     const route = await import("@/app/api/api-keys/route");
@@ -95,7 +103,16 @@ describe("cache invalidation routes", () => {
     );
 
     expect(response.status).toBe(201);
-    expect(mockInvalidateApiKeyAuthCache).toHaveBeenCalledWith("hash-123");
+    await expect(response.json()).resolves.toEqual({
+      id: "created-key",
+      token: "re_created",
+    });
+    expect(mockCreateApiKey).toHaveBeenCalledWith({
+      name: "Primary",
+      permission: undefined,
+      domainId: undefined,
+      userId: "user-1",
+    });
   });
 
   it("invalidates domain caches after create", async () => {
@@ -142,19 +159,8 @@ describe("cache invalidation routes", () => {
     });
   });
 
-  it("invalidates cached api-key auth entries on delete", async () => {
-    mockDb.select.mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ tokenHash: "hash-456" }]),
-        }),
-      }),
-    });
-    mockDb.delete.mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        returning: vi.fn().mockResolvedValue([{ id: "key-1" }]),
-      }),
-    });
+  it("delegates api-key delete through the thin adapter", async () => {
+    mockDeleteApiKey.mockResolvedValue({ id: "key-1", tokenHash: "hash-456" });
 
     const route = await import("@/app/api/api-keys/[id]/route");
     const response = await route.DELETE(new Request("http://localhost"), {
@@ -162,7 +168,7 @@ describe("cache invalidation routes", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(mockInvalidateApiKeyAuthCache).toHaveBeenCalledWith("hash-456");
+    expect(mockDeleteApiKey).toHaveBeenCalledWith("key-1");
   });
 
   it("invalidates domain caches after patch", async () => {


### PR DESCRIPTION
## Summary
- Chosen route family: `api-keys` (`src/app/api/api-keys/**/route.ts`).
- Extracts API-key business logic into `packages/core/src/services/apiKeys.ts` with injectable dependencies for repository, token generation, and auth-cache invalidation.
- Keeps the Next.js handlers as thin adapters: API-key authorization, request/query/param parsing, service call, and HTTP response mapping.
- Documents the pilot pattern in `services/api/README.md` and records the project learning for later route moves.

## Why this slice
API keys are a low-risk #71 pilot because they have bounded CRUD/list behavior, existing focused tests, no SES/Cloudflare/provider calls, no send-quota overlap with #136, and no automation dashboard/runner overlap with #119. This proves the adapter boundary without turning the parent architecture tracker into a giant refactor.

## Behavior / API shape
- Preserves existing response shapes for list/create/get/delete.
- Preserves `full_access` authorization requirement.
- Preserves API-key auth cache invalidation by injecting the cache hook into the core service.
- Does not move any routes into `services/api` in this PR.

## Tests
- `bun run test tests/api-key-service.test.ts tests/cache-invalidation-routes.test.ts`
- `make check`
- `make test` — 78 files / 633 tests passed
- Push guardrails also passed: changed-file check, full-project typecheck, changed-file Biome lint.

## Issue
Parent: #71

## Residual risks
- `services/api` remains skeleton-only; Hono adapters are intentionally left for follow-up PRs.
- API-key routes now depend on the exported core service, but the public API remains served by Next.js until the control-plane runtime is ready.
- Playwright E2E was not run because this slice is service/route-boundary focused and Vitest coverage exercises the changed behavior.

## Merge note
Please review against `staging`; do not merge until the parent #71 sequencing is confirmed.
