### PR TITLE
Enforce billing quota gates in send pipeline

### DIFF
--- a/agent_docs/learnings/active/2026-05-02-issue-136-quota-gating-transaction-boundary.md
+++ b/agent_docs/learnings/active/2026-05-02-issue-136-quota-gating-transaction-boundary.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-02
+issue: 136
+type: decision
+promoted_to: null
+---
+
+## Quota reservations belong in the accept transaction
+
+**What:** Email quota gating reserves `usage_periods.emails_sent` with a single conditional `UPDATE ... WHERE emails_sent + N <= limit` and the send routes pass the Drizzle transaction into the quota service before inserting accepted email rows.
+
+**Why:** This keeps concurrent quota checks on the database row instead of an app-level read-then-write window, while preserving the existing post-commit SQS publish boundary so workers only see durable email rows.
+
+**Caveat:** Unit-test doubles assert the conditional update path but do not provide real Postgres row locking; production correctness depends on Postgres row update locking for the `usage_periods` row.

--- a/src/app/api/api-keys/route.ts
+++ b/src/app/api/api-keys/route.ts
@@ -4,6 +4,7 @@ import {
   unauthorizedResponse,
   validateApiKey,
 } from "@/lib/api-auth";
+import { checkApiKeyQuota, quotaExceededResponse } from "@/lib/billing/quota";
 import { db } from "@/lib/db";
 import { apiKeys } from "@/lib/db/schema";
 import { and, desc, lt } from "drizzle-orm";
@@ -90,6 +91,11 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   try {
+    const quota = await checkApiKeyQuota(auth.userId);
+    if (!quota.ok) {
+      return quotaExceededResponse(quota.info);
+    }
+
     const rawKey = `re_${randomUUID().replace(/-/g, "")}`;
     const tokenHash = createHash("sha256").update(rawKey).digest("hex");
     const tokenPreview = `${rawKey.slice(0, 6)}...${rawKey.slice(-4)}`;
@@ -102,6 +108,7 @@ export async function POST(request: Request): Promise<Response> {
         tokenPreview,
         permission: body.permission ?? "full_access",
         domain: body.domain_id ?? null,
+        userId: auth.userId,
       })
       .returning();
 

--- a/src/app/api/domains/route.ts
+++ b/src/app/api/domains/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { checkDomainQuota, quotaExceededResponse } from "@/lib/billing/quota";
 import { db } from "@/lib/db";
 import { domains } from "@/lib/db/schema";
 import { invalidateDomainCaches } from "@/lib/domain-cache";
@@ -34,6 +35,11 @@ export async function POST(request: Request) {
   try {
     const validated = result.data;
     const domainName = validated.name.toLowerCase();
+
+    const quota = await checkDomainQuota(auth.userId);
+    if (!quota.ok) {
+      return quotaExceededResponse(quota.info);
+    }
 
     const identity = await createDomainIdentity(domainName);
 
@@ -78,6 +84,7 @@ export async function POST(request: Request) {
         trackingSubdomain: validated.tracking_subdomain || null,
         tls: validated.tls,
         capabilities: validated.capabilities || defaultCapabilities,
+        userId: auth.userId,
       })
       .returning();
 

--- a/src/app/api/emails/batch/route.ts
+++ b/src/app/api/emails/batch/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { quotaExceededResponse, reserveEmailQuota } from "@/lib/billing/quota";
 import { db } from "@/lib/db";
 import { emails } from "@/lib/db/schema";
 import { normalizeAttachmentsForStorage } from "@/lib/email-attachments";
@@ -114,79 +115,121 @@ export async function POST(request: Request): Promise<Response> {
   const validatedItems = result.data;
 
   try {
-    // Send emails with controlled concurrency (5 at a time)
-    const CONCURRENCY = 5;
+    const reservation = await db.transaction(async (tx) => {
+      // Quota gate: reserve the entire batch atomically in the same transaction
+      // that persists all accepted rows. If the batch would overrun, no rows are
+      // inserted and the whole request returns 402.
+      const quota = await reserveEmailQuota(
+        auth.userId,
+        validatedItems.length,
+        new Date(),
+        process.env,
+        tx,
+      );
+      if (!quota.ok) {
+        return quota;
+      }
+      const persisted: Array<{ id: string; shouldQueueNow: boolean }> = [];
+
+      for (const item of validatedItems) {
+        const to = normalizeToArray(item.to) as string[];
+        const cc = normalizeToArray(item.cc);
+        const bcc = normalizeToArray(item.bcc);
+        const replyTo = normalizeToArray(item.reply_to);
+        const scheduledAt = item.scheduled_at
+          ? new Date(item.scheduled_at)
+          : null;
+
+        const shouldQueueNow = !scheduledAt || scheduledAt <= new Date();
+
+        const [email] = await tx
+          .insert(emails)
+          .values({
+            from: item.from,
+            to,
+            cc: cc ?? [],
+            bcc: bcc ?? [],
+            replyTo: replyTo ?? [],
+            subject: item.subject,
+            html: item.html ?? "",
+            text: item.text ?? "",
+            tags: item.tags ?? [],
+            headers: (item.headers as Record<string, string>) ?? {},
+            attachments: normalizeAttachmentsForStorage(item.attachments),
+            status: shouldQueueNow ? "queued" : "scheduled",
+            scheduledAt: scheduledAt,
+            topicId: item.topic_id || null,
+            userId: auth.userId,
+          })
+          .returning({ id: emails.id });
+
+        persisted.push({ id: email.id, shouldQueueNow });
+      }
+
+      return { ok: true as const, emails: persisted };
+    });
+
+    if (!reservation.ok) {
+      logTelemetry("info", "email.batch_quota_exceeded", telemetry, {
+        plan: reservation.info.plan,
+        limit: reservation.info.limit,
+        used: reservation.info.used,
+        requested: validatedItems.length,
+      });
+      recordBatchMetric(telemetry, {
+        durationMs: performance.now() - startedAt,
+        outcome: "invalid",
+      });
+      return quotaExceededResponse(reservation.info, {
+        headers: {
+          "x-correlation-id": telemetry.correlationId,
+          traceparent: telemetry.traceparent,
+        },
+      });
+    }
+
     const results: Array<{ id: string }> = [];
+    const CONCURRENCY = 5;
+    const queuedEmails = reservation.emails.filter(
+      (email) => email.shouldQueueNow,
+    );
 
-    for (let i = 0; i < validatedItems.length; i += CONCURRENCY) {
-      const chunk = validatedItems.slice(i, i + CONCURRENCY);
-      const chunkResults = await Promise.all(
-        chunk.map(async (item) => {
-          const to = normalizeToArray(item.to) as string[];
-          const cc = normalizeToArray(item.cc);
-          const bcc = normalizeToArray(item.bcc);
-          const replyTo = normalizeToArray(item.reply_to);
-          const scheduledAt = item.scheduled_at
-            ? new Date(item.scheduled_at)
-            : null;
-
-          const shouldQueueNow = !scheduledAt || scheduledAt <= new Date();
-
-          const [email] = await db
-            .insert(emails)
-            .values({
-              from: item.from,
-              to,
-              cc: cc ?? [],
-              bcc: bcc ?? [],
-              replyTo: replyTo ?? [],
-              subject: item.subject,
-              html: item.html ?? "",
-              text: item.text ?? "",
-              tags: item.tags ?? [],
-              headers: (item.headers as Record<string, string>) ?? {},
-              attachments: normalizeAttachmentsForStorage(item.attachments),
-              status: shouldQueueNow ? "queued" : "scheduled",
-              scheduledAt: scheduledAt,
-              topicId: item.topic_id || null,
-            })
-            .returning({ id: emails.id });
-
-          if (shouldQueueNow) {
-            try {
-              await publishBackgroundJob(
-                createBackgroundJob({
-                  id: `email.send:${email.id}`,
-                  type: "email.send",
-                  source: "api",
-                  emailId: email.id,
-                  trace: getTelemetryCarrier(telemetry),
-                }),
-                {
-                  deduplicationId: `email.send:${email.id}`,
-                  groupId: "email.send",
-                },
-              );
-            } catch (error) {
-              await db
-                .update(emails)
-                .set({ status: "failed" })
-                .where(eq(emails.id, email.id));
-              recordTelemetryError(
-                telemetry,
-                "email.batch_accept.queue_publish_failed",
-                error,
-                { email_id: email.id },
-              );
-              throw error;
-            }
+    for (let i = 0; i < queuedEmails.length; i += CONCURRENCY) {
+      const chunk = queuedEmails.slice(i, i + CONCURRENCY);
+      await Promise.all(
+        chunk.map(async (email) => {
+          try {
+            await publishBackgroundJob(
+              createBackgroundJob({
+                id: `email.send:${email.id}`,
+                type: "email.send",
+                source: "api",
+                emailId: email.id,
+                trace: getTelemetryCarrier(telemetry),
+              }),
+              {
+                deduplicationId: `email.send:${email.id}`,
+                groupId: "email.send",
+              },
+            );
+          } catch (error) {
+            await db
+              .update(emails)
+              .set({ status: "failed" })
+              .where(eq(emails.id, email.id));
+            recordTelemetryError(
+              telemetry,
+              "email.batch_accept.queue_publish_failed",
+              error,
+              { email_id: email.id },
+            );
+            throw error;
           }
-
-          return { id: email.id };
         }),
       );
-      results.push(...chunkResults);
     }
+
+    results.push(...reservation.emails.map((email) => ({ id: email.id })));
 
     const durationMs = performance.now() - startedAt;
     logTelemetry("info", "email.batch_accepted", telemetry, {

--- a/src/app/api/emails/route.ts
+++ b/src/app/api/emails/route.ts
@@ -1,4 +1,9 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import {
+  quotaExceededResponse,
+  releaseEmailQuota,
+  reserveEmailQuota,
+} from "@/lib/billing/quota";
 import { db } from "@/lib/db";
 import { emails, templates } from "@/lib/db/schema";
 import { normalizeAttachmentsForStorage } from "@/lib/email-attachments";
@@ -151,6 +156,7 @@ export async function POST(request: Request): Promise<Response> {
     ? new Date(validated.scheduled_at)
     : null;
 
+  let quotaReserved = false;
   try {
     let finalHtml = validated.html || "";
     let finalSubject = validated.subject;
@@ -215,41 +221,78 @@ export async function POST(request: Request): Promise<Response> {
 
     const shouldQueueNow = !scheduledAt || scheduledAt <= new Date();
 
-    // Store in DB before publishing async work so the worker has a durable row.
-    const [email] = await db
-      .insert(emails)
-      .values({
-        from: validated.from,
-        to,
-        cc: cc ?? [],
-        bcc: bcc ?? [],
-        replyTo: replyTo ?? [],
-        subject: finalSubject,
-        html: finalHtml,
-        text: validated.text ?? "",
-        tags: validated.tags ?? [],
-        headers: (validated.headers as Record<string, string>) ?? {},
-        attachments: normalizeAttachmentsForStorage(validated.attachments),
-        status: shouldQueueNow ? "queued" : "scheduled",
-        scheduledAt: scheduledAt,
-        topicId: validated.topic_id || null,
-        idempotencyKey: idempotencyKey,
-        userId: auth.userId, // Link to the user who owns the API key
-      })
-      .returning({ id: emails.id });
+    // Quota gate: post-validation and committed in the same transaction as the
+    // durable email row. SQS publish remains after commit so workers can read it.
+    const email = await db.transaction(async (tx) => {
+      const quota = await reserveEmailQuota(
+        auth.userId,
+        1,
+        new Date(),
+        process.env,
+        tx,
+      );
+      if (!quota.ok) {
+        return quota;
+      }
+      quotaReserved = !quota.bypassed;
+
+      const [created] = await tx
+        .insert(emails)
+        .values({
+          from: validated.from,
+          to,
+          cc: cc ?? [],
+          bcc: bcc ?? [],
+          replyTo: replyTo ?? [],
+          subject: finalSubject,
+          html: finalHtml,
+          text: validated.text ?? "",
+          tags: validated.tags ?? [],
+          headers: (validated.headers as Record<string, string>) ?? {},
+          attachments: normalizeAttachmentsForStorage(validated.attachments),
+          status: shouldQueueNow ? "queued" : "scheduled",
+          scheduledAt: scheduledAt,
+          topicId: validated.topic_id || null,
+          idempotencyKey: idempotencyKey,
+          userId: auth.userId, // Link to the user who owns the API key
+        })
+        .returning({ id: emails.id });
+
+      return { ok: true as const, email: created };
+    });
+
+    if (!email.ok) {
+      logTelemetry("info", "email.quota_exceeded", telemetry, {
+        plan: email.info.plan,
+        limit: email.info.limit,
+        used: email.info.used,
+      });
+      recordAcceptMetric(telemetry, {
+        durationMs: performance.now() - startedAt,
+        outcome: "invalid",
+      });
+      return quotaExceededResponse(email.info, {
+        headers: {
+          "x-correlation-id": telemetry.correlationId,
+          traceparent: telemetry.traceparent,
+        },
+      });
+    }
+
+    const createdEmail = email.email;
 
     if (shouldQueueNow) {
       try {
         await publishBackgroundJob(
           createBackgroundJob({
-            id: `email.send:${email.id}`,
+            id: `email.send:${createdEmail.id}`,
             type: "email.send",
             source: "api",
-            emailId: email.id,
+            emailId: createdEmail.id,
             trace: getTelemetryCarrier(telemetry),
           }),
           {
-            deduplicationId: `email.send:${email.id}`,
+            deduplicationId: `email.send:${createdEmail.id}`,
             groupId: "email.send",
           },
         );
@@ -257,13 +300,13 @@ export async function POST(request: Request): Promise<Response> {
         await db
           .update(emails)
           .set({ status: "failed" })
-          .where(eq(emails.id, email.id));
+          .where(eq(emails.id, createdEmail.id));
         recordTelemetryError(
           telemetry,
           "email.accept.queue_publish_failed",
           error,
           {
-            email_id: email.id,
+            email_id: createdEmail.id,
           },
         );
         throw error;
@@ -273,12 +316,13 @@ export async function POST(request: Request): Promise<Response> {
     const outcome = shouldQueueNow ? "queued" : "scheduled";
     const durationMs = performance.now() - startedAt;
     logTelemetry("info", "email.accepted", telemetry, {
-      email_id: email.id,
+      email_id: createdEmail.id,
       status: outcome,
       duration_ms: Math.round(durationMs),
     });
     recordAcceptMetric(telemetry, { durationMs, outcome });
-    return jsonWithTelemetry({ id: email.id }, telemetry);
+    quotaReserved = false;
+    return jsonWithTelemetry({ id: createdEmail.id }, telemetry);
   } catch (err) {
     const message = err instanceof Error ? err.message : "Failed to send email";
     recordTelemetryError(telemetry, "email.accept.failed", err);
@@ -286,6 +330,9 @@ export async function POST(request: Request): Promise<Response> {
       durationMs: performance.now() - startedAt,
       outcome: "failed",
     });
+    if (quotaReserved) {
+      await releaseEmailQuota(auth.userId, 1);
+    }
     return jsonWithTelemetry({ error: message }, telemetry, { status: 500 });
   }
 }

--- a/src/lib/billing/quota.ts
+++ b/src/lib/billing/quota.ts
@@ -1,0 +1,359 @@
+import { db } from "@/lib/db";
+import {
+  apiKeys,
+  domains,
+  plans,
+  subscriptions,
+  usagePeriods,
+} from "@/lib/db/schema";
+import { FREE_PLAN_SLUG } from "@opensend/core";
+import { and, count, eq, sql } from "drizzle-orm";
+import { getBillingBackend } from "./index";
+
+type BillingDb = Pick<typeof db, "insert" | "query" | "select" | "update">;
+
+const PAST_DUE_GRACE_MS = 3 * 24 * 60 * 60 * 1000;
+const UPGRADE_URL = "/dashboard/billing";
+
+const ACTIVE_STATUSES = new Set(["active", "trialing", "past_due"]);
+
+export type QuotaResource = "emails" | "domains" | "api_keys";
+
+export interface QuotaExceededInfo {
+  resource: QuotaResource;
+  plan: string;
+  limit: number;
+  used: number;
+  upgrade_url: string;
+}
+
+export type QuotaResult =
+  | { ok: true; bypassed: boolean }
+  | { ok: false; info: QuotaExceededInfo };
+
+interface PlanLike {
+  slug: string;
+  monthlyEmailQuota: number;
+  maxDomains: number;
+  maxApiKeys: number;
+}
+
+interface PlanContext {
+  plan: PlanLike;
+  periodStart: Date;
+  periodEnd: Date;
+}
+
+function startOfMonthUtc(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
+}
+
+function startOfNextMonthUtc(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 1));
+}
+
+function isBillingDisabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return getBillingBackend(env) === "disabled";
+}
+
+function blockedInfo(
+  resource: QuotaResource,
+  plan = "past_due",
+): QuotaExceededInfo {
+  return {
+    resource,
+    plan,
+    limit: 0,
+    used: 0,
+    upgrade_url: UPGRADE_URL,
+  };
+}
+
+async function ensureFreePlan(database: BillingDb): Promise<PlanLike> {
+  const [created] = await database
+    .insert(plans)
+    .values({
+      slug: FREE_PLAN_SLUG,
+      name: "Free",
+      monthlyPriceCents: 0,
+      monthlyEmailQuota: 3000,
+      maxDomains: 1,
+      maxApiKeys: 3,
+      isPublic: true,
+    })
+    .onConflictDoNothing({ target: plans.slug })
+    .returning();
+
+  if (created) return created;
+
+  const existing = await database.query.plans.findFirst({
+    where: eq(plans.slug, FREE_PLAN_SLUG),
+  });
+  if (!existing) {
+    throw new Error("Free plan ensure failed: insert ignored but no row");
+  }
+  return existing;
+}
+
+async function loadPlanContext(
+  userId: string,
+  now: Date,
+  database: BillingDb,
+): Promise<PlanContext | "blocked"> {
+  const sub = await database.query.subscriptions.findFirst({
+    where: eq(subscriptions.userId, userId),
+  });
+
+  if (sub && ACTIVE_STATUSES.has(sub.status)) {
+    if (sub.status === "past_due") {
+      const periodEnd = sub.currentPeriodEnd;
+      if (
+        !periodEnd ||
+        now.getTime() - periodEnd.getTime() > PAST_DUE_GRACE_MS
+      ) {
+        return "blocked";
+      }
+    }
+
+    const plan = await database.query.plans.findFirst({
+      where: eq(plans.id, sub.planId),
+    });
+
+    if (plan) {
+      return {
+        plan,
+        periodStart: sub.currentPeriodStart ?? startOfMonthUtc(now),
+        periodEnd: sub.currentPeriodEnd ?? startOfNextMonthUtc(now),
+      };
+    }
+  }
+
+  const freePlan = await ensureFreePlan(database);
+  return {
+    plan: freePlan,
+    periodStart: startOfMonthUtc(now),
+    periodEnd: startOfNextMonthUtc(now),
+  };
+}
+
+async function ensureUsagePeriod(
+  userId: string,
+  periodStart: Date,
+  periodEnd: Date,
+  database: BillingDb,
+): Promise<{ id: string; emailsSent: number }> {
+  const existing = await database.query.usagePeriods.findFirst({
+    where: and(
+      eq(usagePeriods.userId, userId),
+      eq(usagePeriods.periodStart, periodStart),
+    ),
+  });
+  if (existing) return existing;
+
+  const [created] = await database
+    .insert(usagePeriods)
+    .values({ userId, periodStart, periodEnd, emailsSent: 0 })
+    .onConflictDoNothing({
+      target: [usagePeriods.userId, usagePeriods.periodStart],
+    })
+    .returning();
+  if (created) return created;
+
+  const reread = await database.query.usagePeriods.findFirst({
+    where: and(
+      eq(usagePeriods.userId, userId),
+      eq(usagePeriods.periodStart, periodStart),
+    ),
+  });
+  if (!reread) throw new Error("Failed to ensure usage_periods row");
+  return reread;
+}
+
+/**
+ * Atomically reserve `delta` units of monthly email quota for `userId`.
+ *
+ * Implementation note: a single SQL `UPDATE ... WHERE emails_sent + delta <= quota`
+ * is the source of truth for atomicity. Concurrent workers race on the same row
+ * and at most one transaction commits an over-quota state — Postgres row locking
+ * prevents the read-then-write window that mutex-style approaches leave open.
+ *
+ * Pass a Drizzle transaction as `database` when the reservation must commit with
+ * the accepted email rows. Test doubles may omit true row locking; the SQL shape
+ * is the production concurrency boundary.
+ */
+export async function reserveEmailQuota(
+  userId: string | null | undefined,
+  delta: number,
+  now: Date = new Date(),
+  env: Record<string, string | undefined> = process.env,
+  database: BillingDb = db,
+): Promise<QuotaResult> {
+  if (delta <= 0) return { ok: true, bypassed: true };
+  if (isBillingDisabled(env)) return { ok: true, bypassed: true };
+  if (!userId) return { ok: true, bypassed: true };
+
+  const ctx = await loadPlanContext(userId, now, database);
+  if (ctx === "blocked") {
+    return { ok: false, info: blockedInfo("emails") };
+  }
+
+  await ensureUsagePeriod(userId, ctx.periodStart, ctx.periodEnd, database);
+
+  const updated = await database
+    .update(usagePeriods)
+    .set({
+      emailsSent: sql`${usagePeriods.emailsSent} + ${delta}`,
+      lastIncrementAt: now,
+    })
+    .where(
+      and(
+        eq(usagePeriods.userId, userId),
+        eq(usagePeriods.periodStart, ctx.periodStart),
+        sql`${usagePeriods.emailsSent} + ${delta} <= ${ctx.plan.monthlyEmailQuota}`,
+      ),
+    )
+    .returning({ emailsSent: usagePeriods.emailsSent });
+
+  if (updated.length === 0) {
+    const current = await database.query.usagePeriods.findFirst({
+      where: and(
+        eq(usagePeriods.userId, userId),
+        eq(usagePeriods.periodStart, ctx.periodStart),
+      ),
+    });
+    return {
+      ok: false,
+      info: {
+        resource: "emails",
+        plan: ctx.plan.slug,
+        limit: ctx.plan.monthlyEmailQuota,
+        used: current?.emailsSent ?? 0,
+        upgrade_url: UPGRADE_URL,
+      },
+    };
+  }
+
+  return { ok: true, bypassed: false };
+}
+
+/**
+ * Best-effort decrement to compensate a previously reserved unit when the
+ * downstream accept operation fails after reservation. Never throws.
+ */
+export async function releaseEmailQuota(
+  userId: string | null | undefined,
+  delta: number,
+  now: Date = new Date(),
+  env: Record<string, string | undefined> = process.env,
+  database: BillingDb = db,
+): Promise<void> {
+  if (delta <= 0 || !userId || isBillingDisabled(env)) return;
+
+  try {
+    const ctx = await loadPlanContext(userId, now, database);
+    if (ctx === "blocked") return;
+    await database
+      .update(usagePeriods)
+      .set({
+        emailsSent: sql`GREATEST(${usagePeriods.emailsSent} - ${delta}, 0)`,
+      })
+      .where(
+        and(
+          eq(usagePeriods.userId, userId),
+          eq(usagePeriods.periodStart, ctx.periodStart),
+        ),
+      );
+  } catch {
+    // best-effort; never throw from release path
+  }
+}
+
+export async function checkDomainQuota(
+  userId: string | null | undefined,
+  now: Date = new Date(),
+  env: Record<string, string | undefined> = process.env,
+  database: BillingDb = db,
+): Promise<QuotaResult> {
+  if (isBillingDisabled(env)) return { ok: true, bypassed: true };
+  if (!userId) return { ok: true, bypassed: true };
+
+  const ctx = await loadPlanContext(userId, now, database);
+  if (ctx === "blocked") {
+    return { ok: false, info: blockedInfo("domains") };
+  }
+
+  const [row] = await database
+    .select({ value: count() })
+    .from(domains)
+    .where(eq(domains.userId, userId));
+
+  const used = Number(row?.value ?? 0);
+  if (used >= ctx.plan.maxDomains) {
+    return {
+      ok: false,
+      info: {
+        resource: "domains",
+        plan: ctx.plan.slug,
+        limit: ctx.plan.maxDomains,
+        used,
+        upgrade_url: UPGRADE_URL,
+      },
+    };
+  }
+  return { ok: true, bypassed: false };
+}
+
+export async function checkApiKeyQuota(
+  userId: string | null | undefined,
+  now: Date = new Date(),
+  env: Record<string, string | undefined> = process.env,
+  database: BillingDb = db,
+): Promise<QuotaResult> {
+  if (isBillingDisabled(env)) return { ok: true, bypassed: true };
+  if (!userId) return { ok: true, bypassed: true };
+
+  const ctx = await loadPlanContext(userId, now, database);
+  if (ctx === "blocked") {
+    return { ok: false, info: blockedInfo("api_keys") };
+  }
+
+  const [row] = await database
+    .select({ value: count() })
+    .from(apiKeys)
+    .where(eq(apiKeys.userId, userId));
+
+  const used = Number(row?.value ?? 0);
+  if (used >= ctx.plan.maxApiKeys) {
+    return {
+      ok: false,
+      info: {
+        resource: "api_keys",
+        plan: ctx.plan.slug,
+        limit: ctx.plan.maxApiKeys,
+        used,
+        upgrade_url: UPGRADE_URL,
+      },
+    };
+  }
+  return { ok: true, bypassed: false };
+}
+
+export function quotaExceededResponse(
+  info: QuotaExceededInfo,
+  init?: ResponseInit,
+): Response {
+  const headers = new Headers(init?.headers);
+  return Response.json(
+    {
+      error: "quota_exceeded",
+      resource: info.resource,
+      limit: info.limit,
+      used: info.used,
+      plan: info.plan,
+      upgrade_url: info.upgrade_url,
+    },
+    { ...init, status: 402, headers },
+  );
+}

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -12,6 +12,9 @@ const mockDb = vi.hoisted(() => ({
   insert: vi.fn(),
   select: vi.fn(),
   query: vi.fn(),
+  transaction: vi.fn(async (callback: (tx: typeof mockDb) => unknown) =>
+    callback(mockDb),
+  ),
 }));
 
 vi.mock("@/lib/ses", () => ({
@@ -162,6 +165,9 @@ describe("POST /api/emails", () => {
     mockEmitCloudWatchMetric.mockReset();
     mockLogTelemetry.mockReset();
     mockRecordTelemetryError.mockReset();
+    mockDb.transaction.mockImplementation(
+      async (callback: (tx: typeof mockDb) => unknown) => callback(mockDb),
+    );
     mockPublishBackgroundJob.mockResolvedValue({
       status: "skipped",
       reason: "queue_url_missing",
@@ -396,6 +402,9 @@ describe("POST /api/emails/batch", () => {
     mockEmitCloudWatchMetric.mockReset();
     mockLogTelemetry.mockReset();
     mockRecordTelemetryError.mockReset();
+    mockDb.transaction.mockImplementation(
+      async (callback: (tx: typeof mockDb) => unknown) => callback(mockDb),
+    );
     mockPublishBackgroundJob.mockResolvedValue({
       status: "skipped",
       reason: "queue_url_missing",

--- a/tests/billing-quota.test.ts
+++ b/tests/billing-quota.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockDb = vi.hoisted(() => ({
+  insert: vi.fn(),
+  query: {
+    plans: { findFirst: vi.fn() },
+    subscriptions: { findFirst: vi.fn() },
+    usagePeriods: { findFirst: vi.fn() },
+  },
+  select: vi.fn(),
+  update: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockDb,
+}));
+
+const stripeEnv = {
+  BILLING_BACKEND: "stripe",
+  STRIPE_SECRET_KEY: "sk_test_quota",
+};
+
+const now = new Date("2026-05-15T12:00:00.000Z");
+const plan = {
+  id: "plan-free",
+  slug: "free",
+  monthlyEmailQuota: 3,
+  maxDomains: 1,
+  maxApiKeys: 2,
+};
+const subscription = {
+  userId: "user-1",
+  planId: "plan-free",
+  status: "active",
+  currentPeriodStart: new Date("2026-05-01T00:00:00.000Z"),
+  currentPeriodEnd: new Date("2026-06-01T00:00:00.000Z"),
+};
+
+function mockUsagePeriod(emailsSent: number) {
+  mockDb.query.usagePeriods.findFirst.mockResolvedValue({
+    id: "usage-1",
+    emailsSent,
+  });
+}
+
+function mockEmailReserveUpdate(result: Array<{ emailsSent: number }>) {
+  const returning = vi.fn().mockResolvedValue(result);
+  const where = vi.fn().mockReturnValue({ returning });
+  const set = vi.fn().mockReturnValue({ where });
+  mockDb.update.mockReturnValue({ set });
+  return { returning, set, where };
+}
+
+function mockPlanContext() {
+  mockDb.query.subscriptions.findFirst.mockResolvedValue(subscription);
+  mockDb.query.plans.findFirst.mockResolvedValue(plan);
+}
+
+function mockCount(value: number) {
+  const where = vi.fn().mockResolvedValue([{ value }]);
+  const from = vi.fn().mockReturnValue({ where });
+  mockDb.select.mockReturnValue({ from });
+}
+
+describe("billing quota enforcement", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockDb.insert.mockReset();
+    mockDb.query.plans.findFirst.mockReset();
+    mockDb.query.subscriptions.findFirst.mockReset();
+    mockDb.query.usagePeriods.findFirst.mockReset();
+    mockDb.select.mockReset();
+    mockDb.update.mockReset();
+  });
+
+  it("bypasses quota checks when billing is disabled or Stripe config is absent", async () => {
+    const { reserveEmailQuota } = await import("@/lib/billing/quota");
+
+    await expect(
+      reserveEmailQuota("user-1", 99, now, { BILLING_BACKEND: "disabled" }),
+    ).resolves.toEqual({ ok: true, bypassed: true });
+    await expect(
+      reserveEmailQuota("user-1", 99, now, { BILLING_BACKEND: "stripe" }),
+    ).resolves.toEqual({ ok: true, bypassed: true });
+    expect(mockDb.query.subscriptions.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("allows sends under quota and uses one conditional UPDATE for the increment", async () => {
+    mockPlanContext();
+    mockUsagePeriod(1);
+    const update = mockEmailReserveUpdate([{ emailsSent: 2 }]);
+
+    const { reserveEmailQuota } = await import("@/lib/billing/quota");
+    const result = await reserveEmailQuota("user-1", 1, now, stripeEnv);
+
+    expect(result).toEqual({ ok: true, bypassed: false });
+    expect(mockDb.update).toHaveBeenCalledTimes(1);
+    expect(update.set).toHaveBeenCalledWith(
+      expect.objectContaining({ lastIncrementAt: now }),
+    );
+    expect(update.returning).toHaveBeenCalledWith(
+      expect.objectContaining({ emailsSent: expect.anything() }),
+    );
+  });
+
+  it("allows the boundary send and rejects the next reservation with structured 402 info", async () => {
+    mockPlanContext();
+    mockUsagePeriod(2);
+    mockEmailReserveUpdate([{ emailsSent: 3 }]);
+
+    const { reserveEmailQuota } = await import("@/lib/billing/quota");
+    await expect(
+      reserveEmailQuota("user-1", 1, now, stripeEnv),
+    ).resolves.toEqual({ ok: true, bypassed: false });
+
+    mockEmailReserveUpdate([]);
+    mockDb.query.usagePeriods.findFirst.mockResolvedValue({
+      id: "usage-1",
+      emailsSent: 3,
+    });
+
+    await expect(
+      reserveEmailQuota("user-1", 1, now, stripeEnv),
+    ).resolves.toEqual({
+      ok: false,
+      info: {
+        resource: "emails",
+        plan: "free",
+        limit: 3,
+        used: 3,
+        upgrade_url: "/dashboard/billing",
+      },
+    });
+  });
+
+  it("rejects a batch overrun without partially reserving quota", async () => {
+    mockPlanContext();
+    mockUsagePeriod(1);
+    mockEmailReserveUpdate([]);
+
+    const { reserveEmailQuota } = await import("@/lib/billing/quota");
+    const result = await reserveEmailQuota("user-1", 3, now, stripeEnv);
+
+    expect(result).toEqual({
+      ok: false,
+      info: {
+        resource: "emails",
+        plan: "free",
+        limit: 3,
+        used: 1,
+        upgrade_url: "/dashboard/billing",
+      },
+    });
+  });
+
+  it("creates the current monthly usage period lazily", async () => {
+    mockPlanContext();
+    mockDb.query.usagePeriods.findFirst
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValue({ id: "usage-1", emailsSent: 0 });
+    mockDb.insert.mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflictDoNothing: vi.fn().mockReturnValue({
+          returning: vi
+            .fn()
+            .mockResolvedValue([{ id: "usage-1", emailsSent: 0 }]),
+        }),
+      }),
+    });
+    mockEmailReserveUpdate([{ emailsSent: 1 }]);
+
+    const { reserveEmailQuota } = await import("@/lib/billing/quota");
+    await expect(
+      reserveEmailQuota("user-1", 1, now, stripeEnv),
+    ).resolves.toEqual({ ok: true, bypassed: false });
+
+    const values = mockDb.insert.mock.results[0]?.value.values;
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        periodStart: subscription.currentPeriodStart,
+        periodEnd: subscription.currentPeriodEnd,
+        emailsSent: 0,
+      }),
+    );
+  });
+
+  it("gates domain and API key counts against active plan limits", async () => {
+    mockPlanContext();
+    mockCount(1);
+
+    const { checkApiKeyQuota, checkDomainQuota } = await import(
+      "@/lib/billing/quota"
+    );
+
+    await expect(checkDomainQuota("user-1", now, stripeEnv)).resolves.toEqual({
+      ok: false,
+      info: {
+        resource: "domains",
+        plan: "free",
+        limit: 1,
+        used: 1,
+        upgrade_url: "/dashboard/billing",
+      },
+    });
+
+    mockCount(1);
+    await expect(checkApiKeyQuota("user-1", now, stripeEnv)).resolves.toEqual({
+      ok: true,
+      bypassed: false,
+    });
+  });
+});

--- a/tests/quota-routes.test.ts
+++ b/tests/quota-routes.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockReserveEmailQuota = vi.hoisted(() => vi.fn());
+const mockCheckDomainQuota = vi.hoisted(() => vi.fn());
+const mockCheckApiKeyQuota = vi.hoisted(() => vi.fn());
+const mockCreateDomainIdentity = vi.hoisted(() => vi.fn());
+const mockDb = vi.hoisted(() => ({
+  insert: vi.fn(),
+  transaction: vi.fn(async (callback: (tx: typeof mockDb) => unknown) =>
+    callback(mockDb),
+  ),
+}));
+
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("@/lib/api-auth", () => ({
+  validateApiKey: mockValidateApiKey,
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+vi.mock("@/lib/billing/quota", () => ({
+  reserveEmailQuota: mockReserveEmailQuota,
+  checkDomainQuota: mockCheckDomainQuota,
+  checkApiKeyQuota: mockCheckApiKeyQuota,
+  releaseEmailQuota: vi.fn(),
+  quotaExceededResponse: (info: {
+    resource: string;
+    limit: number;
+    used: number;
+    plan: string;
+    upgrade_url: string;
+  }) => Response.json({ error: "quota_exceeded", ...info }, { status: 402 }),
+}));
+vi.mock("@/lib/ses", () => ({
+  createDomainIdentity: mockCreateDomainIdentity,
+}));
+vi.mock("@/lib/domain-cache", () => ({
+  invalidateDomainCaches: vi.fn(),
+}));
+vi.mock("@opensend/core", async () => {
+  const actual =
+    await vi.importActual<typeof import("@opensend/core")>("@opensend/core");
+  return {
+    ...actual,
+    createTelemetryContext: () => ({
+      correlationId: "corr-quota",
+      traceparent: "00-11111111111111111111111111111111-2222222222222222-01",
+    }),
+    emitCloudWatchMetric: vi.fn(),
+    logTelemetry: vi.fn(),
+    recordTelemetryError: vi.fn(),
+  };
+});
+
+const auth = {
+  apiKeyId: "key-1",
+  userId: "user-1",
+  permission: "full_access",
+  domainId: null,
+};
+const quotaInfo = {
+  resource: "emails",
+  limit: 3,
+  used: 3,
+  plan: "free",
+  upgrade_url: "/dashboard/billing",
+};
+
+function jsonRequest(url: string, body: unknown): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer re_test",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("quota route gates", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockValidateApiKey.mockResolvedValue(auth);
+    mockReserveEmailQuota.mockReset();
+    mockCheckDomainQuota.mockReset();
+    mockCheckApiKeyQuota.mockReset();
+    mockCreateDomainIdentity.mockReset();
+    mockDb.insert.mockReset();
+    mockDb.transaction.mockImplementation(
+      async (callback: (tx: typeof mockDb) => unknown) => callback(mockDb),
+    );
+  });
+
+  it("returns 402 from POST /api/emails after payload validation and before insert", async () => {
+    mockReserveEmailQuota.mockResolvedValue({ ok: false, info: quotaInfo });
+    const { POST } = await import("@/app/api/emails/route");
+
+    const res = await POST(
+      jsonRequest("http://localhost:3015/api/emails", {
+        from: "sender@example.com",
+        to: ["user@example.com"],
+        subject: "Quota",
+        html: "<p>Quota</p>",
+      }),
+    );
+
+    expect(res.status).toBe(402);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "quota_exceeded",
+      limit: 3,
+      used: 3,
+      plan: "free",
+      upgrade_url: "/dashboard/billing",
+    });
+    expect(mockReserveEmailQuota).toHaveBeenCalledWith(
+      "user-1",
+      1,
+      expect.any(Date),
+      process.env,
+      mockDb,
+    );
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it("returns 402 from POST /api/emails/batch when the batch would overrun quota", async () => {
+    mockReserveEmailQuota.mockResolvedValue({ ok: false, info: quotaInfo });
+    const { POST } = await import("@/app/api/emails/batch/route");
+
+    const res = await POST(
+      jsonRequest("http://localhost:3015/api/emails/batch", [
+        {
+          from: "sender@example.com",
+          to: ["one@example.com"],
+          subject: "One",
+          html: "<p>One</p>",
+        },
+        {
+          from: "sender@example.com",
+          to: ["two@example.com"],
+          subject: "Two",
+          html: "<p>Two</p>",
+        },
+      ]),
+    );
+
+    expect(res.status).toBe(402);
+    expect(mockReserveEmailQuota).toHaveBeenCalledWith(
+      "user-1",
+      2,
+      expect.any(Date),
+      process.env,
+      mockDb,
+    );
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it("returns 402 from POST /api/domains before creating an SES identity", async () => {
+    mockCheckDomainQuota.mockResolvedValue({
+      ok: false,
+      info: { ...quotaInfo, resource: "domains", limit: 1, used: 1 },
+    });
+    const { POST } = await import("@/app/api/domains/route");
+
+    const res = await POST(
+      jsonRequest("http://localhost:3015/api/domains", {
+        name: "example.com",
+        region: "us-east-1",
+      }),
+    );
+
+    expect(res.status).toBe(402);
+    expect(mockCheckDomainQuota).toHaveBeenCalledWith("user-1");
+    expect(mockCreateDomainIdentity).not.toHaveBeenCalled();
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it("returns 402 from POST /api/api-keys before inserting a key", async () => {
+    mockCheckApiKeyQuota.mockResolvedValue({
+      ok: false,
+      info: { ...quotaInfo, resource: "api_keys", limit: 2, used: 2 },
+    });
+    const { POST } = await import("@/app/api/api-keys/route");
+
+    const res = await POST(
+      jsonRequest("http://localhost:3015/api/api-keys", { name: "extra" }),
+    );
+
+    expect(res.status).toBe(402);
+    expect(mockCheckApiKeyQuota).toHaveBeenCalledWith("user-1");
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a billing quota service that bypasses self-hosted disabled billing and enforces active plan limits for emails, domains, and API keys when Stripe billing is enabled.
- Gates `POST /api/emails` and `POST /api/emails/batch` after payload validation and before accept persistence/SQS publish, returning structured `402 quota_exceeded` responses.
- Gates `POST /api/domains` and `POST /api/api-keys` before external side effects/inserts, and records owner `userId` on created domains/API keys.
- Adds focused unit and route coverage for disabled-billing bypass, under/boundary/reject-next quota behavior, lazy usage periods, batch overruns, and 402 route gates.

## Tests
- `bun run test tests/billing-quota.test.ts tests/quota-routes.test.ts tests/api-emails.test.ts`
- `make check`
- `make check && make test` after rebasing onto current `origin/staging` (79 files / 639 tests passed)
- Push guardrail: full-project typecheck + changed-file Biome lint passed

## Issue
Closes #136
Parent: #132

## Residual risks
- Playwright dashboard surfacing for send-button 402 handling was not run; dashboard billing UI is tracked separately in #137.
- Unit tests assert the conditional `UPDATE ... WHERE emails_sent + N <= limit` path, but true concurrent row-lock behavior depends on production Postgres semantics rather than Vitest doubles.
- Batch rows are committed before SQS publish, matching the existing durable-row-before-worker pattern; publish failures still follow existing failed-status handling rather than rolling back accepted rows.
