### PR TITLE
Add dashboard billing and pricing UI

### DIFF
--- a/agent_docs/learnings/active/2026-05-02-137-vitest-workspace-aliases.md
+++ b/agent_docs/learnings/active/2026-05-02-137-vitest-workspace-aliases.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-02
+issue: "#137"
+type: pattern
+promoted_to: null
+---
+
+## Vitest needs explicit workspace aliases for package imports
+
+**What:** The app and tests import `@opensend/core` and deep package paths, but Vitest does not always resolve Bun workspace package links consistently during route-test transforms.
+**Why:** Full `make test` can fail on package imports even when TypeScript and Next can resolve them after `bun install`.
+**Fix:** Keep explicit Vitest aliases for `@opensend/core` and any used deep imports (for example `@opensend/core/src/webhook-events`) in `vitest.config.ts`, with deep aliases ordered before the package root alias.

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,6 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { Sidebar } from "@/components/sidebar";
+import { isBillingEnabled } from "@/lib/billing";
 import Link from "next/link";
 
 export default function DashboardLayout({
@@ -8,9 +9,10 @@ export default function DashboardLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const billingEnabled = isBillingEnabled();
   return (
     <div className="flex min-h-screen">
-      <Sidebar />
+      <Sidebar billingEnabled={billingEnabled} />
       <main className="ml-[250px] flex min-h-screen flex-1 flex-col">
         <div className="flex-1 p-6">{children}</div>
         <footer className="flex items-center justify-end gap-4 border-t border-[rgba(176,199,217,0.145)] px-6 py-3">

--- a/src/app/(dashboard)/pricing/page.tsx
+++ b/src/app/(dashboard)/pricing/page.tsx
@@ -1,0 +1,57 @@
+import { PricingGrid } from "@/components/billing/pricing-grid";
+import { getServerSession } from "@/lib/api-auth";
+import { isBillingEnabled } from "@/lib/billing";
+import { listPublicPlans, loadBillingSummary } from "@/lib/billing/summary";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+export default async function PricingPage() {
+  if (!isBillingEnabled()) {
+    notFound();
+  }
+
+  const session = await getServerSession();
+  if (!session?.user?.id) {
+    redirect("/auth");
+  }
+
+  const [plans, summary] = await Promise.all([
+    listPublicPlans(),
+    loadBillingSummary(session.user.id),
+  ]);
+
+  return (
+    <div className="space-y-6" data-testid="pricing-page">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-[#F0F0F0]">Plans</h1>
+          <p className="mt-1 text-[13px] text-[#A1A4A5]">
+            Pick the plan that fits your sending volume. You can upgrade or
+            downgrade at any time.
+          </p>
+        </div>
+        <Link
+          href="/settings/billing"
+          className="rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] px-3 py-1.5 text-[13px] font-medium text-[#F0F0F0] transition-colors hover:bg-[rgba(24,25,28,1)]"
+        >
+          Back to billing
+        </Link>
+      </div>
+
+      <PricingGrid
+        plans={plans.map((plan) => ({
+          id: plan.id,
+          slug: plan.slug,
+          name: plan.name,
+          monthlyPriceCents: plan.monthlyPriceCents,
+          monthlyEmailQuota: plan.monthlyEmailQuota,
+          maxDomains: plan.maxDomains,
+          maxApiKeys: plan.maxApiKeys,
+        }))}
+        currentPlanId={summary?.plan.id ?? null}
+      />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/billing/page.tsx
+++ b/src/app/(dashboard)/settings/billing/page.tsx
@@ -1,0 +1,65 @@
+import {
+  BillingView,
+  type BillingViewSummary,
+} from "@/components/billing/billing-view";
+import { getServerSession } from "@/lib/api-auth";
+import { isBillingEnabled } from "@/lib/billing";
+import { loadBillingSummary } from "@/lib/billing/summary";
+import { notFound, redirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+export default async function BillingSettingsPage() {
+  if (!isBillingEnabled()) {
+    notFound();
+  }
+
+  const session = await getServerSession();
+  if (!session?.user?.id) {
+    redirect("/auth");
+  }
+
+  const summary = await loadBillingSummary(session.user.id);
+  if (!summary) {
+    return (
+      <div className="space-y-3">
+        <h1 className="text-2xl font-semibold text-[#F0F0F0]">Billing</h1>
+        <p className="text-[14px] text-[#A1A4A5]">
+          No plan record was found. Run the database seed to create the Free
+          plan.
+        </p>
+      </div>
+    );
+  }
+
+  const initial: BillingViewSummary = {
+    plan: {
+      id: summary.plan.id,
+      slug: summary.plan.slug,
+      name: summary.plan.name,
+      monthlyPriceCents: summary.plan.monthlyPriceCents,
+      monthlyEmailQuota: summary.plan.monthlyEmailQuota,
+      maxDomains: summary.plan.maxDomains,
+      maxApiKeys: summary.plan.maxApiKeys,
+    },
+    subscription: summary.subscription
+      ? {
+          id: summary.subscription.id,
+          status: summary.subscription.status,
+          currentPeriodStart: summary.subscription.currentPeriodStart,
+          currentPeriodEnd: summary.subscription.currentPeriodEnd,
+          cancelAtPeriodEnd: summary.subscription.cancelAtPeriodEnd,
+        }
+      : null,
+    usage: {
+      emails: summary.usage.emails,
+      domains: summary.usage.domains,
+      apiKeys: summary.usage.apiKeys,
+      periodStart: summary.usage.periodStart,
+      periodEnd: summary.usage.periodEnd,
+      hasUsagePeriod: summary.usage.hasUsagePeriod,
+    },
+  };
+
+  return <BillingView initial={initial} />;
+}

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -1,5 +1,6 @@
 import { SettingsPage as SettingsPageClient } from "@/components/settings-page";
+import { isBillingEnabled } from "@/lib/billing";
 
 export default function SettingsPage() {
-  return <SettingsPageClient />;
+  return <SettingsPageClient billingEnabled={isBillingEnabled()} />;
 }

--- a/src/app/api/billing/plans/route.ts
+++ b/src/app/api/billing/plans/route.ts
@@ -1,0 +1,35 @@
+import { isBillingEnabled } from "@/lib/billing";
+import { listPublicPlans } from "@/lib/billing/summary";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  if (!isBillingEnabled()) {
+    return NextResponse.json(
+      { error: "Billing is not enabled" },
+      { status: 404 },
+    );
+  }
+
+  try {
+    const plans = await listPublicPlans();
+    return NextResponse.json({
+      object: "list",
+      data: plans.map((plan) => ({
+        object: "plan",
+        id: plan.id,
+        slug: plan.slug,
+        name: plan.name,
+        monthly_price_cents: plan.monthlyPriceCents,
+        monthly_email_quota: plan.monthlyEmailQuota,
+        max_domains: plan.maxDomains,
+        max_api_keys: plan.maxApiKeys,
+      })),
+    });
+  } catch (error) {
+    console.error("Failed to list public plans:", error);
+    return NextResponse.json(
+      { error: "Failed to list plans" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/billing/summary/route.ts
+++ b/src/app/api/billing/summary/route.ts
@@ -1,0 +1,65 @@
+import { getServerSession, unauthorizedResponse } from "@/lib/api-auth";
+import { isBillingEnabled } from "@/lib/billing";
+import { loadBillingSummary } from "@/lib/billing/summary";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  if (!isBillingEnabled()) {
+    return NextResponse.json(
+      { error: "Billing is not enabled" },
+      { status: 404 },
+    );
+  }
+
+  const session = await getServerSession();
+  if (!session?.user?.id) return unauthorizedResponse();
+
+  try {
+    const summary = await loadBillingSummary(session.user.id);
+    if (!summary) {
+      return NextResponse.json(
+        {
+          error:
+            "No plan available. Run database seed to create the Free plan.",
+        },
+        { status: 503 },
+      );
+    }
+
+    return NextResponse.json({
+      object: "billing_summary",
+      plan: {
+        id: summary.plan.id,
+        slug: summary.plan.slug,
+        name: summary.plan.name,
+        monthly_price_cents: summary.plan.monthlyPriceCents,
+        monthly_email_quota: summary.plan.monthlyEmailQuota,
+        max_domains: summary.plan.maxDomains,
+        max_api_keys: summary.plan.maxApiKeys,
+      },
+      subscription: summary.subscription
+        ? {
+            id: summary.subscription.id,
+            status: summary.subscription.status,
+            current_period_start: summary.subscription.currentPeriodStart,
+            current_period_end: summary.subscription.currentPeriodEnd,
+            cancel_at_period_end: summary.subscription.cancelAtPeriodEnd,
+          }
+        : null,
+      usage: {
+        emails: summary.usage.emails,
+        domains: summary.usage.domains,
+        api_keys: summary.usage.apiKeys,
+        period_start: summary.usage.periodStart,
+        period_end: summary.usage.periodEnd,
+        has_usage_period: summary.usage.hasUsagePeriod,
+      },
+    });
+  } catch (error) {
+    console.error("Failed to load billing summary:", error);
+    return NextResponse.json(
+      { error: "Failed to load billing summary" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/billing/billing-view.tsx
+++ b/src/components/billing/billing-view.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { CurrentPlanCard } from "@/components/billing/current-plan-card";
+import { UsageCard } from "@/components/billing/usage-card";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+export interface BillingViewSummary {
+  plan: {
+    id: string;
+    slug: string;
+    name: string;
+    monthlyPriceCents: number;
+    monthlyEmailQuota: number;
+    maxDomains: number;
+    maxApiKeys: number;
+  };
+  subscription: {
+    id: string;
+    status: string;
+    currentPeriodStart: string | null;
+    currentPeriodEnd: string | null;
+    cancelAtPeriodEnd: boolean;
+  } | null;
+  usage: {
+    emails: { used: number | null; limit: number };
+    domains: { used: number; limit: number };
+    apiKeys: { used: number; limit: number };
+    periodStart: string | null;
+    periodEnd: string | null;
+    hasUsagePeriod: boolean;
+  };
+}
+
+interface SummaryEnvelope {
+  plan: {
+    id: string;
+    slug: string;
+    name: string;
+    monthly_price_cents: number;
+    monthly_email_quota: number;
+    max_domains: number;
+    max_api_keys: number;
+  };
+  subscription: {
+    id: string;
+    status: string;
+    current_period_start: string | null;
+    current_period_end: string | null;
+    cancel_at_period_end: boolean;
+  } | null;
+  usage: {
+    emails: { used: number | null; limit: number };
+    domains: { used: number; limit: number };
+    api_keys: { used: number; limit: number };
+    period_start: string | null;
+    period_end: string | null;
+    has_usage_period: boolean;
+  };
+}
+
+function isSummaryEnvelope(value: unknown): value is SummaryEnvelope {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.plan === "object" &&
+    v.plan !== null &&
+    typeof v.usage === "object" &&
+    v.usage !== null
+  );
+}
+
+function adaptEnvelope(envelope: SummaryEnvelope): BillingViewSummary {
+  return {
+    plan: {
+      id: envelope.plan.id,
+      slug: envelope.plan.slug,
+      name: envelope.plan.name,
+      monthlyPriceCents: envelope.plan.monthly_price_cents,
+      monthlyEmailQuota: envelope.plan.monthly_email_quota,
+      maxDomains: envelope.plan.max_domains,
+      maxApiKeys: envelope.plan.max_api_keys,
+    },
+    subscription: envelope.subscription
+      ? {
+          id: envelope.subscription.id,
+          status: envelope.subscription.status,
+          currentPeriodStart: envelope.subscription.current_period_start,
+          currentPeriodEnd: envelope.subscription.current_period_end,
+          cancelAtPeriodEnd: envelope.subscription.cancel_at_period_end,
+        }
+      : null,
+    usage: {
+      emails: envelope.usage.emails,
+      domains: envelope.usage.domains,
+      apiKeys: envelope.usage.api_keys,
+      periodStart: envelope.usage.period_start,
+      periodEnd: envelope.usage.period_end,
+      hasUsagePeriod: envelope.usage.has_usage_period,
+    },
+  };
+}
+
+interface BillingViewProps {
+  initial: BillingViewSummary;
+}
+
+export function BillingView({ initial }: BillingViewProps) {
+  const [summary, setSummary] = useState<BillingViewSummary>(initial);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function refresh() {
+      try {
+        const response = await fetch("/api/billing/summary", {
+          credentials: "same-origin",
+        });
+        if (!response.ok) return;
+        const data: unknown = await response.json();
+        if (!cancelled && isSummaryEnvelope(data)) {
+          setSummary(adaptEnvelope(data));
+        }
+      } catch {
+        // best-effort refetch; keep server-rendered state
+      }
+    }
+
+    function onFocus() {
+      void refresh();
+    }
+
+    window.addEventListener("focus", onFocus);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("focus", onFocus);
+    };
+  }, []);
+
+  return (
+    <div className="space-y-6" data-testid="billing-view">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-[#F0F0F0]">Billing</h1>
+          <p className="mt-1 text-[13px] text-[#A1A4A5]">
+            Review your current plan, usage, and billing details.
+          </p>
+        </div>
+        <Link
+          href="/pricing"
+          className="rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] px-3 py-1.5 text-[13px] font-medium text-[#F0F0F0] transition-colors hover:bg-[rgba(24,25,28,1)]"
+          data-testid="view-plans-link"
+        >
+          View plans
+        </Link>
+      </div>
+
+      <CurrentPlanCard
+        plan={summary.plan}
+        subscription={summary.subscription}
+      />
+
+      <UsageCard
+        data={{
+          emails: summary.usage.emails,
+          domains: summary.usage.domains,
+          apiKeys: summary.usage.apiKeys,
+          periodStart: summary.usage.periodStart,
+          periodEnd: summary.usage.periodEnd,
+          hasUsagePeriod: summary.usage.hasUsagePeriod,
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/billing/current-plan-card.tsx
+++ b/src/components/billing/current-plan-card.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+
+interface PlanInfo {
+  name: string;
+  slug: string;
+  monthlyPriceCents: number;
+}
+
+interface SubscriptionInfo {
+  status: string;
+  currentPeriodEnd: string | null;
+  cancelAtPeriodEnd: boolean;
+}
+
+interface CurrentPlanCardProps {
+  plan: PlanInfo;
+  subscription: SubscriptionInfo | null;
+}
+
+function formatPrice(cents: number) {
+  if (cents === 0) return "Free";
+  return `$${(cents / 100).toFixed(0)} / mo`;
+}
+
+function formatStatus(status: string) {
+  return status.replace(/_/g, " ");
+}
+
+function formatPeriodEnd(value: string | null) {
+  if (!value) return null;
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    }).format(new Date(value));
+  } catch {
+    return null;
+  }
+}
+
+export function CurrentPlanCard({ plan, subscription }: CurrentPlanCardProps) {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const periodEnd = formatPeriodEnd(subscription?.currentPeriodEnd ?? null);
+
+  const handleManage = async () => {
+    setPending(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/billing/portal", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
+
+      const data: unknown = await response.json().catch(() => null);
+
+      if (response.ok && data && typeof data === "object" && "url" in data) {
+        const url = (data as { url: unknown }).url;
+        if (typeof url === "string") {
+          window.location.href = url;
+          return;
+        }
+      }
+
+      const message =
+        data &&
+        typeof data === "object" &&
+        "message" in data &&
+        typeof (data as { message: unknown }).message === "string"
+          ? (data as { message: string }).message
+          : "Manage Billing is unavailable.";
+      setError(message);
+      setPending(false);
+    } catch {
+      setError("Manage Billing is unavailable.");
+      setPending(false);
+    }
+  };
+
+  return (
+    <div
+      className="rounded-lg border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.6)] p-6"
+      data-testid="billing-current-plan-card"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-[16px] font-semibold text-[#F0F0F0]">
+            Current plan
+          </h2>
+          <div className="mt-2 flex items-baseline gap-3">
+            <span
+              className="text-[22px] font-semibold text-[#F0F0F0]"
+              data-testid="current-plan-name"
+            >
+              {plan.name}
+            </span>
+            <span className="text-[14px] text-[#A1A4A5]">
+              {formatPrice(plan.monthlyPriceCents)}
+            </span>
+          </div>
+          <div className="mt-3 flex flex-wrap items-center gap-2 text-[12px]">
+            <span
+              className="rounded-full border border-[rgba(176,199,217,0.145)] px-2 py-0.5 capitalize text-[#A1A4A5]"
+              data-testid="current-plan-status"
+            >
+              {subscription ? formatStatus(subscription.status) : "Free tier"}
+            </span>
+            {subscription?.cancelAtPeriodEnd ? (
+              <span
+                className="rounded-full bg-amber-500/15 px-2 py-0.5 text-amber-300"
+                data-testid="cancel-at-period-end-badge"
+              >
+                Cancels at period end
+              </span>
+            ) : null}
+            {periodEnd ? (
+              <span className="text-[#A1A4A5]" data-testid="current-period-end">
+                Renews {periodEnd}
+              </span>
+            ) : null}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={handleManage}
+          disabled={pending}
+          className="rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] px-3 py-1.5 text-[13px] font-medium text-[#F0F0F0] transition-colors hover:bg-[rgba(24,25,28,1)] disabled:cursor-not-allowed disabled:opacity-50"
+          data-testid="manage-billing-button"
+        >
+          {pending ? "Opening…" : "Manage Billing"}
+        </button>
+      </div>
+      {error ? (
+        <p className="mt-4 text-[12px] text-amber-300" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/billing/pricing-grid.tsx
+++ b/src/components/billing/pricing-grid.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState } from "react";
+
+export interface PricingPlan {
+  id: string;
+  slug: string;
+  name: string;
+  monthlyPriceCents: number;
+  monthlyEmailQuota: number;
+  maxDomains: number;
+  maxApiKeys: number;
+}
+
+interface PricingGridProps {
+  plans: PricingPlan[];
+  currentPlanId: string | null;
+}
+
+function formatPrice(cents: number) {
+  if (cents === 0) return "Free";
+  return `$${(cents / 100).toFixed(0)}`;
+}
+
+function formatNumber(n: number) {
+  return n.toLocaleString("en-US");
+}
+
+export function PricingGrid({ plans, currentPlanId }: PricingGridProps) {
+  const [pendingPlanId, setPendingPlanId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (plans.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-[rgba(176,199,217,0.145)] p-12 text-center text-[14px] text-[#A1A4A5]">
+        No public plans available. Run database seed to load the default plan
+        catalogue.
+      </div>
+    );
+  }
+
+  const handleUpgrade = async (planId: string) => {
+    setPendingPlanId(planId);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/billing/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ plan_id: planId }),
+      });
+
+      const data: unknown = await response.json().catch(() => null);
+
+      if (response.ok && data && typeof data === "object" && "url" in data) {
+        const url = (data as { url: unknown }).url;
+        if (typeof url === "string") {
+          window.location.href = url;
+          return;
+        }
+      }
+
+      const message =
+        data &&
+        typeof data === "object" &&
+        "message" in data &&
+        typeof (data as { message: unknown }).message === "string"
+          ? (data as { message: string }).message
+          : "Upgrade is unavailable right now.";
+      setError(message);
+    } catch {
+      setError("Upgrade is unavailable right now.");
+    } finally {
+      setPendingPlanId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4" data-testid="pricing-grid">
+      <div className="grid gap-4 md:grid-cols-3">
+        {plans.map((plan) => {
+          const isCurrent = plan.id === currentPlanId;
+          const isPending = pendingPlanId === plan.id;
+          return (
+            <article
+              key={plan.id}
+              className={`flex flex-col rounded-lg border p-6 ${
+                isCurrent
+                  ? "border-purple-500/60 bg-[rgba(88,28,135,0.12)]"
+                  : "border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.6)]"
+              }`}
+              data-testid={`pricing-card-${plan.slug}`}
+              data-current={isCurrent ? "true" : undefined}
+            >
+              <header className="mb-4 flex items-baseline justify-between">
+                <h3 className="text-[18px] font-semibold text-[#F0F0F0]">
+                  {plan.name}
+                </h3>
+                {isCurrent ? (
+                  <span
+                    className="rounded-full bg-purple-500/20 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-purple-200"
+                    data-testid={`pricing-card-${plan.slug}-current-badge`}
+                  >
+                    Current Plan
+                  </span>
+                ) : null}
+              </header>
+              <div className="mb-4">
+                <span className="text-[28px] font-semibold text-[#F0F0F0]">
+                  {formatPrice(plan.monthlyPriceCents)}
+                </span>
+                {plan.monthlyPriceCents > 0 ? (
+                  <span className="ml-1 text-[13px] text-[#A1A4A5]">
+                    / month
+                  </span>
+                ) : null}
+              </div>
+              <ul className="mb-6 flex-1 space-y-2 text-[13px] text-[#A1A4A5]">
+                <li>{formatNumber(plan.monthlyEmailQuota)} emails / month</li>
+                <li>
+                  {formatNumber(plan.maxDomains)}{" "}
+                  {plan.maxDomains === 1 ? "domain" : "domains"}
+                </li>
+                <li>
+                  {formatNumber(plan.maxApiKeys)} API{" "}
+                  {plan.maxApiKeys === 1 ? "key" : "keys"}
+                </li>
+              </ul>
+              <button
+                type="button"
+                disabled={isCurrent || isPending}
+                onClick={() => handleUpgrade(plan.id)}
+                className="rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] px-3 py-2 text-[13px] font-medium text-[#F0F0F0] transition-colors hover:bg-[rgba(24,25,28,1)] disabled:cursor-not-allowed disabled:opacity-50"
+                data-testid={`pricing-card-${plan.slug}-upgrade`}
+              >
+                {isCurrent
+                  ? "Current plan"
+                  : isPending
+                    ? "Opening checkout…"
+                    : "Upgrade"}
+              </button>
+            </article>
+          );
+        })}
+      </div>
+      {error ? (
+        <p
+          className="text-[13px] text-amber-300"
+          role="alert"
+          data-testid="pricing-grid-error"
+        >
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/billing/usage-card.tsx
+++ b/src/components/billing/usage-card.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import {
+  type UsageMetric,
+  formatUsagePercent,
+  getProgressBarPercent,
+  getUsageThreshold,
+} from "@/lib/billing/usage";
+
+type KnownUsageMetric = UsageMetric;
+type MaybeKnownUsageMetric = { used: number | null; limit: number };
+
+function thresholdColor(threshold: ReturnType<typeof getUsageThreshold>) {
+  if (threshold === "critical") return "bg-red-500";
+  if (threshold === "warn") return "bg-amber-500";
+  return "bg-blue-500";
+}
+
+function formatNumber(value: number) {
+  return value.toLocaleString("en-US");
+}
+
+interface UsageRowProps {
+  label: string;
+  metric: KnownUsageMetric;
+  testId?: string;
+}
+
+function UsageRow({ label, metric, testId }: UsageRowProps) {
+  const threshold = getUsageThreshold(metric);
+  const percent = getProgressBarPercent(metric);
+
+  return (
+    <div className="space-y-2" data-testid={testId}>
+      <div className="flex items-center justify-between text-[13px]">
+        <span className="text-[#A1A4A5]">{label}</span>
+        <span className="font-medium text-[#F0F0F0]">
+          {formatNumber(metric.used)} / {formatNumber(metric.limit)}
+          <span
+            className="ml-2 text-[12px] text-[#A1A4A5]"
+            data-testid={testId ? `${testId}-percent` : undefined}
+          >
+            {formatUsagePercent(metric)}
+          </span>
+        </span>
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-[rgba(176,199,217,0.145)]">
+        <div
+          className={`h-full ${thresholdColor(threshold)} transition-all`}
+          style={{ width: `${percent}%` }}
+          data-threshold={threshold}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface UnknownUsageRowProps {
+  label: string;
+  limit: number;
+  testId: string;
+}
+
+function UnknownUsageRow({ label, limit, testId }: UnknownUsageRowProps) {
+  return (
+    <div
+      className="rounded-md border border-dashed border-[rgba(176,199,217,0.145)] p-3"
+      data-testid={testId}
+    >
+      <div className="flex items-center justify-between text-[13px]">
+        <span className="text-[#A1A4A5]">{label}</span>
+        <span className="font-medium text-[#F0F0F0]">
+          Unknown / {formatNumber(limit)}
+        </span>
+      </div>
+      <p className="mt-2 text-[12px] text-[#A1A4A5]">
+        Usage has not been reported for this billing period yet.
+      </p>
+    </div>
+  );
+}
+
+export interface UsageCardData {
+  emails: MaybeKnownUsageMetric;
+  domains: UsageMetric;
+  apiKeys: UsageMetric;
+  periodStart: string | null;
+  periodEnd: string | null;
+  hasUsagePeriod: boolean;
+}
+
+function formatRange(start: string | null, end: string | null) {
+  if (!start || !end) return "Current period";
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+  try {
+    return `${fmt.format(new Date(start))} – ${fmt.format(new Date(end))}`;
+  } catch {
+    return "Current period";
+  }
+}
+
+export function UsageCard({ data }: { data: UsageCardData }) {
+  const emailUsed = data.emails.used;
+  const emailUsageKnown = data.hasUsagePeriod && emailUsed !== null;
+
+  return (
+    <div
+      className="rounded-lg border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.6)] p-6"
+      data-testid="billing-usage-card"
+    >
+      <div className="mb-5 flex items-baseline justify-between">
+        <h2 className="text-[16px] font-semibold text-[#F0F0F0]">Usage</h2>
+        <span className="text-[12px] text-[#A1A4A5]">
+          {formatRange(data.periodStart, data.periodEnd)}
+        </span>
+      </div>
+      <div className="space-y-5">
+        {emailUsageKnown ? (
+          <UsageRow
+            label="Emails sent"
+            metric={{ used: emailUsed, limit: data.emails.limit }}
+            testId="usage-emails"
+          />
+        ) : (
+          <UnknownUsageRow
+            label="Emails sent"
+            limit={data.emails.limit}
+            testId="usage-emails-unknown"
+          />
+        )}
+        <UsageRow
+          label="Domains"
+          metric={data.domains}
+          testId="usage-domains"
+        />
+        <UsageRow
+          label="API keys"
+          metric={data.apiKeys}
+          testId="usage-api-keys"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings-page.tsx
+++ b/src/components/settings-page.tsx
@@ -4,6 +4,7 @@ import { CopyToClipboard } from "@/components/copy-to-clipboard";
 import { DocumentsTab } from "@/components/settings-documents";
 import { TeamTab } from "@/components/settings-team";
 import { type UsageData, UsageTab } from "@/components/settings-usage";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 
 function isUsageData(value: unknown): value is UsageData {
@@ -57,7 +58,13 @@ const DEFAULT_USAGE: UsageData = {
   team: { domainsUsed: 0, domainsLimit: 3, rateLimit: 2 },
 };
 
-export function SettingsPage() {
+interface SettingsPageProps {
+  billingEnabled?: boolean;
+}
+
+export function SettingsPage({
+  billingEnabled = false,
+}: SettingsPageProps = {}) {
   const [activeTab, setActiveTab] = useState<
     "usage" | "smtp" | "team" | "unsubscribe" | "billing" | "documents"
   >("usage");
@@ -79,6 +86,15 @@ export function SettingsPage() {
       .catch(() => {});
   }, [activeTab]);
 
+  const tabs = [
+    { key: "usage", label: "Usage" },
+    { key: "smtp", label: "SMTP" },
+    { key: "team", label: "Team" },
+    { key: "unsubscribe", label: "Unsubscribe Page" },
+    ...(billingEnabled ? [{ key: "billing", label: "Billing" } as const] : []),
+    { key: "documents", label: "Documents" },
+  ] as const;
+
   return (
     <div>
       <h1 className="text-2xl font-semibold text-[#F0F0F0] mb-6">Settings</h1>
@@ -86,16 +102,7 @@ export function SettingsPage() {
       {/* Tabs */}
       <div className="border-b border-[rgba(176,199,217,0.145)] mb-6 overflow-x-auto">
         <div className="flex items-center gap-0 min-w-max">
-          {(
-            [
-              { key: "usage", label: "Usage" },
-              { key: "smtp", label: "SMTP" },
-              { key: "team", label: "Team" },
-              { key: "unsubscribe", label: "Unsubscribe Page" },
-              { key: "billing", label: "Billing" },
-              { key: "documents", label: "Documents" },
-            ] as const
-          ).map((tab) => (
+          {tabs.map((tab) => (
             <button
               key={tab.key}
               type="button"
@@ -164,13 +171,19 @@ SMTP_PASS=re_YOUR_API_KEY`}
       {/* Team Tab */}
       {activeTab === "team" && <TeamTab />}
 
-      {/* Billing Tab (Stub) */}
+      {/* Billing Tab → dedicated page */}
       {activeTab === "billing" && (
-        <div className="flex flex-col items-center justify-center min-h-[300px] border border-dashed border-[rgba(176,199,217,0.145)] rounded-lg">
+        <div className="flex flex-col items-start gap-3 rounded-lg border border-dashed border-[rgba(176,199,217,0.145)] p-8">
           <p className="text-[14px] text-[#A1A4A5]">
-            Billing and subscription management is out of scope for the current
-            phase.
+            Billing has its own dedicated page with current plan, usage, and
+            management actions.
           </p>
+          <Link
+            href="/settings/billing"
+            className="rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] px-3 py-1.5 text-[13px] font-medium text-[#F0F0F0] hover:bg-[rgba(24,25,28,1)]"
+          >
+            Open billing
+          </Link>
         </div>
       )}
 

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -194,6 +194,27 @@ const NAV_ITEMS = [
     ),
   },
   {
+    label: "Billing",
+    href: "/settings/billing",
+    requiresBilling: true,
+    icon: (
+      <svg
+        aria-hidden="true"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <rect width="20" height="14" x="2" y="5" rx="2" />
+        <line x1="2" x2="22" y1="10" y2="10" />
+      </svg>
+    ),
+  },
+  {
     label: "Settings",
     href: "/settings",
     icon: (
@@ -215,7 +236,11 @@ const NAV_ITEMS = [
   },
 ];
 
-export function Sidebar() {
+interface SidebarProps {
+  billingEnabled?: boolean;
+}
+
+export function Sidebar({ billingEnabled = false }: SidebarProps = {}) {
   const pathname = usePathname();
   const router = useRouter();
   const { data: session } = authClient.useSession();
@@ -276,7 +301,9 @@ export function Sidebar() {
 
       {/* Navigation */}
       <nav className="flex-1 py-2 px-2 overflow-y-auto">
-        {NAV_ITEMS.map((item) => {
+        {NAV_ITEMS.filter(
+          (item) => billingEnabled || !item.requiresBilling,
+        ).map((item) => {
           const isActive =
             pathname === item.href || pathname.startsWith(`${item.href}/`);
           return (

--- a/src/lib/billing/summary.ts
+++ b/src/lib/billing/summary.ts
@@ -1,0 +1,160 @@
+import { db } from "@/lib/db";
+import {
+  apiKeys,
+  domains,
+  plans,
+  subscriptions,
+  usagePeriods,
+} from "@/lib/db/schema";
+import { FREE_PLAN_SLUG, type SubscriptionStatus } from "@opensend/core";
+import { count, desc, eq } from "drizzle-orm";
+
+export interface BillingPlanSummary {
+  id: string;
+  slug: string;
+  name: string;
+  monthlyPriceCents: number;
+  monthlyEmailQuota: number;
+  maxDomains: number;
+  maxApiKeys: number;
+  isPublic: boolean;
+}
+
+export interface BillingSubscriptionSummary {
+  id: string;
+  status: SubscriptionStatus;
+  currentPeriodStart: string | null;
+  currentPeriodEnd: string | null;
+  cancelAtPeriodEnd: boolean;
+}
+
+export interface BillingUsageSummary {
+  emails: { used: number | null; limit: number };
+  domains: { used: number; limit: number };
+  apiKeys: { used: number; limit: number };
+  periodStart: string | null;
+  periodEnd: string | null;
+  hasUsagePeriod: boolean;
+}
+
+export interface BillingSummary {
+  plan: BillingPlanSummary;
+  subscription: BillingSubscriptionSummary | null;
+  usage: BillingUsageSummary;
+}
+
+function toIso(value: Date | null | undefined): string | null {
+  return value ? value.toISOString() : null;
+}
+
+function toPlanSummary(row: {
+  id: string;
+  slug: string;
+  name: string;
+  monthlyPriceCents: number;
+  monthlyEmailQuota: number;
+  maxDomains: number;
+  maxApiKeys: number;
+  isPublic: boolean;
+}): BillingPlanSummary {
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: row.name,
+    monthlyPriceCents: row.monthlyPriceCents,
+    monthlyEmailQuota: row.monthlyEmailQuota,
+    maxDomains: row.maxDomains,
+    maxApiKeys: row.maxApiKeys,
+    isPublic: row.isPublic,
+  };
+}
+
+async function loadPlanAndSubscription(userId: string) {
+  const sub = await db.query.subscriptions.findFirst({
+    where: eq(subscriptions.userId, userId),
+  });
+
+  if (sub) {
+    const plan = await db.query.plans.findFirst({
+      where: eq(plans.id, sub.planId),
+    });
+    if (plan) return { plan, subscription: sub };
+  }
+
+  const free = await db.query.plans.findFirst({
+    where: eq(plans.slug, FREE_PLAN_SLUG),
+  });
+  return { plan: free, subscription: null };
+}
+
+async function loadLatestUsagePeriod(userId: string) {
+  const [latest] = await db
+    .select()
+    .from(usagePeriods)
+    .where(eq(usagePeriods.userId, userId))
+    .orderBy(desc(usagePeriods.periodStart))
+    .limit(1);
+  return latest ?? null;
+}
+
+async function countUserDomains(userId: string) {
+  const [row] = await db
+    .select({ value: count() })
+    .from(domains)
+    .where(eq(domains.userId, userId));
+  return Number(row?.value ?? 0);
+}
+
+async function countUserApiKeys(userId: string) {
+  const [row] = await db
+    .select({ value: count() })
+    .from(apiKeys)
+    .where(eq(apiKeys.userId, userId));
+  return Number(row?.value ?? 0);
+}
+
+export async function loadBillingSummary(
+  userId: string,
+): Promise<BillingSummary | null> {
+  const { plan, subscription } = await loadPlanAndSubscription(userId);
+  if (!plan) return null;
+
+  const usagePeriod = await loadLatestUsagePeriod(userId);
+
+  const [domainCount, apiKeyCount] = await Promise.all([
+    countUserDomains(userId),
+    countUserApiKeys(userId),
+  ]);
+
+  const planSummary = toPlanSummary(plan);
+  const subscriptionSummary: BillingSubscriptionSummary | null = subscription
+    ? {
+        id: subscription.id,
+        status: subscription.status as SubscriptionStatus,
+        currentPeriodStart: toIso(subscription.currentPeriodStart),
+        currentPeriodEnd: toIso(subscription.currentPeriodEnd),
+        cancelAtPeriodEnd: subscription.cancelAtPeriodEnd,
+      }
+    : null;
+
+  const usage: BillingUsageSummary = {
+    emails: {
+      used: usagePeriod ? usagePeriod.emailsSent : null,
+      limit: planSummary.monthlyEmailQuota,
+    },
+    domains: { used: domainCount, limit: planSummary.maxDomains },
+    apiKeys: { used: apiKeyCount, limit: planSummary.maxApiKeys },
+    periodStart: toIso(usagePeriod?.periodStart ?? null),
+    periodEnd: toIso(usagePeriod?.periodEnd ?? null),
+    hasUsagePeriod: usagePeriod !== null,
+  };
+
+  return { plan: planSummary, subscription: subscriptionSummary, usage };
+}
+
+export async function listPublicPlans(): Promise<BillingPlanSummary[]> {
+  const rows = await db.select().from(plans).where(eq(plans.isPublic, true));
+  return rows
+    .map(toPlanSummary)
+    .sort((a, b) => a.monthlyPriceCents - b.monthlyPriceCents);
+}

--- a/src/lib/billing/usage.ts
+++ b/src/lib/billing/usage.ts
@@ -1,0 +1,37 @@
+export interface UsageMetric {
+  used: number;
+  limit: number;
+}
+
+export type UsageThreshold = "ok" | "warn" | "critical";
+
+export const USAGE_WARN_RATIO = 0.8;
+export const USAGE_CRITICAL_RATIO = 1;
+
+export function getUsageRatio({ used, limit }: UsageMetric): number {
+  if (!Number.isFinite(used) || !Number.isFinite(limit)) return 0;
+  if (limit <= 0) return used > 0 ? 1 : 0;
+  return Math.max(0, used) / limit;
+}
+
+export function getUsageThreshold(metric: UsageMetric): UsageThreshold {
+  const ratio = getUsageRatio(metric);
+  if (ratio >= USAGE_CRITICAL_RATIO) return "critical";
+  if (ratio >= USAGE_WARN_RATIO) return "warn";
+  return "ok";
+}
+
+export function formatUsagePercent(metric: UsageMetric): string {
+  const ratio = getUsageRatio(metric);
+  const clamped = Math.min(Math.max(ratio, 0), 1);
+  return `${Math.round(clamped * 100)}%`;
+}
+
+export function getProgressBarPercent(metric: UsageMetric): number {
+  const ratio = getUsageRatio(metric);
+  return Math.min(Math.max(ratio * 100, 0), 100);
+}
+
+export function isOverLimit({ used, limit }: UsageMetric): boolean {
+  return limit > 0 && used >= limit;
+}

--- a/tests/billing-sidebar.test.tsx
+++ b/tests/billing-sidebar.test.tsx
@@ -1,0 +1,31 @@
+import { Sidebar } from "@/components/sidebar";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/emails",
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    useSession: () => ({
+      data: { user: { email: "e2e@example.com", name: "E2E" } },
+    }),
+    signOut: vi.fn(),
+  },
+}));
+
+afterEach(cleanup);
+
+describe("<Sidebar /> billing visibility", () => {
+  it("hides the Billing entry when billing is disabled", () => {
+    render(<Sidebar billingEnabled={false} />);
+    expect(screen.queryByText("Billing")).toBeNull();
+  });
+
+  it("shows the Billing entry when billing is enabled", () => {
+    render(<Sidebar billingEnabled={true} />);
+    expect(screen.getByText("Billing")).toBeDefined();
+  });
+});

--- a/tests/billing-usage-card.test.tsx
+++ b/tests/billing-usage-card.test.tsx
@@ -1,0 +1,85 @@
+import { UsageCard } from "@/components/billing/usage-card";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+afterEach(cleanup);
+
+describe("<UsageCard />", () => {
+  it("renders all three quota rows with formatted ratios", () => {
+    render(
+      <UsageCard
+        data={{
+          emails: { used: 250, limit: 1000 },
+          domains: { used: 0, limit: 1 },
+          apiKeys: { used: 1, limit: 3 },
+          periodStart: "2026-05-01T00:00:00.000Z",
+          periodEnd: "2026-05-31T00:00:00.000Z",
+          hasUsagePeriod: true,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Emails sent")).toBeDefined();
+    expect(screen.getByText("Domains")).toBeDefined();
+    expect(screen.getByText("API keys")).toBeDefined();
+    expect(screen.getByText(/250 \/ 1,000/)).toBeDefined();
+    expect(screen.getByTestId("usage-emails-percent").textContent).toBe("25%");
+  });
+
+  it("colours the bar amber when usage crosses the warn threshold", () => {
+    render(
+      <UsageCard
+        data={{
+          emails: { used: 850, limit: 1000 },
+          domains: { used: 0, limit: 1 },
+          apiKeys: { used: 0, limit: 3 },
+          periodStart: null,
+          periodEnd: null,
+          hasUsagePeriod: true,
+        }}
+      />,
+    );
+
+    const emailsRow = screen.getByTestId("usage-emails");
+    const bar = emailsRow.querySelector('[data-threshold="warn"]');
+    expect(bar).not.toBeNull();
+  });
+
+  it("colours the bar red when usage hits the limit", () => {
+    render(
+      <UsageCard
+        data={{
+          emails: { used: 1500, limit: 1000 },
+          domains: { used: 0, limit: 1 },
+          apiKeys: { used: 0, limit: 3 },
+          periodStart: null,
+          periodEnd: null,
+          hasUsagePeriod: true,
+        }}
+      />,
+    );
+
+    const emailsRow = screen.getByTestId("usage-emails");
+    const bar = emailsRow.querySelector('[data-threshold="critical"]');
+    expect(bar).not.toBeNull();
+  });
+
+  it("renders an unknown email usage state when no usage period exists", () => {
+    render(
+      <UsageCard
+        data={{
+          emails: { used: null, limit: 1000 },
+          domains: { used: 0, limit: 1 },
+          apiKeys: { used: 0, limit: 3 },
+          periodStart: null,
+          periodEnd: null,
+          hasUsagePeriod: false,
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("usage-emails-unknown")).toBeDefined();
+    expect(screen.getByText("Unknown / 1,000")).toBeDefined();
+    expect(screen.getByText(/has not been reported/)).toBeDefined();
+  });
+});

--- a/tests/billing-usage.test.ts
+++ b/tests/billing-usage.test.ts
@@ -1,0 +1,87 @@
+import {
+  USAGE_CRITICAL_RATIO,
+  USAGE_WARN_RATIO,
+  formatUsagePercent,
+  getProgressBarPercent,
+  getUsageRatio,
+  getUsageThreshold,
+  isOverLimit,
+} from "@/lib/billing/usage";
+import { describe, expect, it } from "vitest";
+
+describe("getUsageRatio", () => {
+  it("returns 0 for an unused metric", () => {
+    expect(getUsageRatio({ used: 0, limit: 1000 })).toBe(0);
+  });
+
+  it("returns the proportional ratio", () => {
+    expect(getUsageRatio({ used: 250, limit: 1000 })).toBe(0.25);
+    expect(getUsageRatio({ used: 800, limit: 1000 })).toBe(0.8);
+  });
+
+  it("treats limit=0 as already-saturated when usage is non-zero", () => {
+    expect(getUsageRatio({ used: 0, limit: 0 })).toBe(0);
+    expect(getUsageRatio({ used: 1, limit: 0 })).toBe(1);
+  });
+
+  it("never returns a negative ratio for negative usage", () => {
+    expect(getUsageRatio({ used: -10, limit: 100 })).toBe(0);
+  });
+
+  it("handles ratios above 1 (over-quota) without clamping the raw value", () => {
+    expect(getUsageRatio({ used: 1500, limit: 1000 })).toBe(1.5);
+  });
+});
+
+describe("getUsageThreshold", () => {
+  it("returns 'ok' below the warn threshold", () => {
+    expect(getUsageThreshold({ used: 500, limit: 1000 })).toBe("ok");
+    expect(
+      getUsageThreshold({ used: USAGE_WARN_RATIO * 1000 - 1, limit: 1000 }),
+    ).toBe("ok");
+  });
+
+  it("returns 'warn' once usage hits 80%", () => {
+    expect(getUsageThreshold({ used: 800, limit: 1000 })).toBe("warn");
+    expect(getUsageThreshold({ used: 999, limit: 1000 })).toBe("warn");
+  });
+
+  it("returns 'critical' at and above 100%", () => {
+    expect(getUsageThreshold({ used: 1000, limit: 1000 })).toBe("critical");
+    expect(getUsageThreshold({ used: 1500, limit: 1000 })).toBe("critical");
+    expect(USAGE_CRITICAL_RATIO).toBe(1);
+  });
+});
+
+describe("formatUsagePercent", () => {
+  it("rounds to the nearest whole percent", () => {
+    expect(formatUsagePercent({ used: 0, limit: 1000 })).toBe("0%");
+    expect(formatUsagePercent({ used: 500, limit: 1000 })).toBe("50%");
+    expect(formatUsagePercent({ used: 999, limit: 1000 })).toBe("100%");
+  });
+
+  it("clamps over-quota usage to 100% for display", () => {
+    expect(formatUsagePercent({ used: 1500, limit: 1000 })).toBe("100%");
+  });
+});
+
+describe("getProgressBarPercent", () => {
+  it("clamps to [0, 100] for the progress bar width", () => {
+    expect(getProgressBarPercent({ used: 0, limit: 1000 })).toBe(0);
+    expect(getProgressBarPercent({ used: 500, limit: 1000 })).toBe(50);
+    expect(getProgressBarPercent({ used: 1500, limit: 1000 })).toBe(100);
+    expect(getProgressBarPercent({ used: -10, limit: 1000 })).toBe(0);
+  });
+});
+
+describe("isOverLimit", () => {
+  it("flags when usage meets or exceeds limit", () => {
+    expect(isOverLimit({ used: 999, limit: 1000 })).toBe(false);
+    expect(isOverLimit({ used: 1000, limit: 1000 })).toBe(true);
+    expect(isOverLimit({ used: 2000, limit: 1000 })).toBe(true);
+  });
+
+  it("treats limit=0 as never reached", () => {
+    expect(isOverLimit({ used: 100, limit: 0 })).toBe(false);
+  });
+});

--- a/tests/e2e/billing-page.spec.ts
+++ b/tests/e2e/billing-page.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "@playwright/test";
+
+const billingBackend = process.env.BILLING_BACKEND?.toLowerCase() ?? "disabled";
+const billingEnabled =
+  billingBackend === "stripe" && Boolean(process.env.STRIPE_SECRET_KEY);
+
+test.describe("Billing — disabled (self-host default)", () => {
+  test.skip(billingEnabled, "Only runs when billing is disabled");
+
+  test.beforeEach(async ({ context }) => {
+    await context.addCookies([
+      {
+        name: "better-auth.session_token",
+        value: "billing-disabled-e2e-session-token",
+        domain: "localhost",
+        path: "/",
+        httpOnly: true,
+        sameSite: "Lax",
+      },
+    ]);
+  });
+
+  test("/settings/billing returns 404", async ({ page }) => {
+    const response = await page.goto("/settings/billing");
+    expect(response?.status()).toBe(404);
+  });
+
+  test("/pricing returns 404", async ({ page }) => {
+    const response = await page.goto("/pricing");
+    expect(response?.status()).toBe(404);
+  });
+
+  test("/api/billing/checkout returns 404 without billing backend", async ({
+    request,
+  }) => {
+    const response = await request.post("/api/billing/checkout", {
+      data: { plan_id: "any" },
+    });
+    expect(response.status()).toBe(404);
+  });
+
+  test("/api/billing/portal returns 404 without billing backend", async ({
+    request,
+  }) => {
+    const response = await request.post("/api/billing/portal", { data: {} });
+    expect(response.status()).toBe(404);
+  });
+});
+
+test.describe("Billing — enabled (Stripe)", () => {
+  test.skip(
+    !billingEnabled,
+    "Requires BILLING_BACKEND=stripe + STRIPE_SECRET_KEY",
+  );
+
+  test("dashboard → pricing → checkout redirect lands on checkout.stripe.com", async ({
+    page,
+    context,
+  }) => {
+    await context.addCookies([
+      {
+        name: "better-auth.session_token",
+        value: "e2e-session-token",
+        domain: "localhost",
+        path: "/",
+        httpOnly: true,
+        sameSite: "Lax",
+      },
+    ]);
+
+    await page.route("**/api/auth/get-session", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          session: { id: "e2e-session", token: "e2e-session-token" },
+          user: { id: "e2e-user", email: "e2e@example.com", name: "E2E User" },
+        }),
+      });
+    });
+
+    await page.route("**/api/billing/checkout", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          url: "https://checkout.stripe.com/c/pay/cs_test_123",
+        }),
+      });
+    });
+
+    await page.goto("/pricing");
+    await expect(page.getByRole("heading", { name: "Plans" })).toBeVisible();
+
+    const upgradeButton = page
+      .locator('[data-testid$="-upgrade"]:not([disabled])')
+      .first();
+    await expect(upgradeButton).toBeVisible();
+
+    const navigationPromise = page.waitForURL(/checkout\.stripe\.com/);
+    await upgradeButton.click();
+    await navigationPromise;
+
+    expect(page.url()).toMatch(/^https:\/\/checkout\.stripe\.com\//);
+  });
+});

--- a/tests/settings-page.test.tsx
+++ b/tests/settings-page.test.tsx
@@ -56,4 +56,26 @@ describe("SettingsPage", () => {
     expect(screen.getByText("0 / 3,000")).toBeTruthy();
     expect(screen.queryByText("Missing or invalid API key")).toBeNull();
   });
+
+  it("hides the billing settings tab when billing is disabled", () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+
+    render(<SettingsPage billingEnabled={false} />);
+
+    expect(screen.queryByRole("button", { name: "Billing" })).toBeNull();
+  });
+
+  it("shows the billing settings tab when billing is enabled", () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+
+    render(<SettingsPage billingEnabled={true} />);
+
+    expect(screen.getByRole("button", { name: "Billing" })).toBeDefined();
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,8 +10,19 @@ export default defineConfig({
     include: ["tests/**/*.test.{ts,tsx}"],
   },
   resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
+    alias: [
+      {
+        find: "@opensend/core/src/webhook-events",
+        replacement: path.resolve(
+          __dirname,
+          "./packages/core/src/webhook-events.ts",
+        ),
+      },
+      {
+        find: "@opensend/core",
+        replacement: path.resolve(__dirname, "./packages/core/src/index.ts"),
+      },
+      { find: "@", replacement: path.resolve(__dirname, "./src") },
+    ],
   },
 });


### PR DESCRIPTION
## Summary
- Adds the feature-gated dashboard billing page at `/settings/billing` with current plan, subscription status, Manage Billing, and usage cards.
- Adds dashboard pricing at `/pricing` backed by public plan data and `/api/billing/checkout` redirects.
- Adds billing summary/plans API helpers, hides billing sidebar/settings entries when `BILLING_BACKEND=disabled`, and returns 404 for disabled billing API/page surfaces.
- Keeps missing usage-period data explicit with an unknown/empty state instead of inventing email usage.

## Tests
- `bun run test tests/billing-usage.test.ts tests/billing-usage-card.test.tsx tests/billing-sidebar.test.tsx tests/settings-page.test.tsx tests/billing-checkout-portal.test.ts`
- `make check`
- `make test` (passed on rerun; one unrelated `tests/broadcasts-list.test.ts` URL-sync assertion flaked once and passed when rerun directly)
- `bun run test:e2e tests/e2e/billing-page.spec.ts`

## Issue reference
Closes #137
Parent epic: #132

## Relationship to #136
This PR intentionally does not implement quota enforcement or backend usage semantics. It only reads existing billing tables/routes and renders safe fallback/unknown states so #136 can add enforcement and usage counters independently.

## Residual risks
- Live Stripe Checkout and Customer Portal round-trips were not run with real hosted session cookies and Stripe secrets.
- Usage card email counts depend on `usage_periods`; until #136 populates quota semantics consistently, missing rows render as unknown.
