### PR TITLE
Automations dashboard MVP and runs viewer

### DIFF
--- a/agent_docs/learnings/active/2026-05-02-issue-119-automation-dashboard-api-layer.md
+++ b/agent_docs/learnings/active/2026-05-02-issue-119-automation-dashboard-api-layer.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-02
+issue: "#119"
+type: decision
+promoted_to: null
+---
+
+## Keep Automations dashboard UI on the existing API foundation
+
+**What:** The dashboard MVP should reuse the staging automation CRUD/runs APIs from #116/#117/#118 and add UI-specific list enrichment (step count and last run summary) instead of replacing those routes with a parallel dashboard-only implementation.
+
+**Why:** The API and runner already own validation, user scoping, and run state shape. Duplicating route logic risks drifting from the runner contract and breaking API tests.
+
+**Fix:** Add dashboard components and form helpers around the existing `trigger -> optional delay -> send_email -> end` payload, and keep any UI list needs as small additive API fields.

--- a/packages/core/src/db/repositories/automationRepo.ts
+++ b/packages/core/src/db/repositories/automationRepo.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, lt } from "drizzle-orm";
+import { and, asc, desc, eq, ilike, lt } from "drizzle-orm";
 import {
   type AutomationConnectionDTO,
   type AutomationStepInput,
@@ -234,12 +234,14 @@ export const automationRepo = {
       limit?: number;
       after?: string;
       status?: string;
+      search?: string;
       userId?: string | null;
     } = {},
   ) {
-    const { limit = 20, after, status, userId } = options;
+    const { limit = 20, after, status, search, userId } = options;
     const conditions = [];
     if (status) conditions.push(eq(automations.status, status));
+    if (search) conditions.push(ilike(automations.name, `%${search}%`));
     if (userId) conditions.push(eq(automations.userId, userId));
     if (after) conditions.push(lt(automations.id, after));
 

--- a/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/src/app/(dashboard)/automations/[id]/page.tsx
@@ -1,0 +1,12 @@
+import { AutomationDetail } from "@/components/automation-detail";
+
+export const dynamic = "force-dynamic";
+
+export default async function AutomationDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return <AutomationDetail automationId={id} />;
+}

--- a/src/app/(dashboard)/automations/[id]/runs/[runId]/page.tsx
+++ b/src/app/(dashboard)/automations/[id]/runs/[runId]/page.tsx
@@ -1,0 +1,12 @@
+import { AutomationRunDetail } from "@/components/automation-run-detail";
+
+export const dynamic = "force-dynamic";
+
+export default async function AutomationRunPage({
+  params,
+}: {
+  params: Promise<{ id: string; runId: string }>;
+}) {
+  const { id, runId } = await params;
+  return <AutomationRunDetail automationId={id} runId={runId} />;
+}

--- a/src/app/(dashboard)/automations/new/page.tsx
+++ b/src/app/(dashboard)/automations/new/page.tsx
@@ -1,0 +1,7 @@
+import { AutomationBuilder } from "@/components/automation-builder";
+
+export const dynamic = "force-dynamic";
+
+export default function NewAutomationPage() {
+  return <AutomationBuilder mode="create" />;
+}

--- a/src/app/(dashboard)/automations/page.tsx
+++ b/src/app/(dashboard)/automations/page.tsx
@@ -1,0 +1,14 @@
+import { AutomationsList } from "@/components/automations-list";
+
+export const dynamic = "force-dynamic";
+
+export default function AutomationsPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold text-[#F0F0F0] mb-6">
+        Automations
+      </h1>
+      <AutomationsList />
+    </div>
+  );
+}

--- a/src/app/api/automations/route.ts
+++ b/src/app/api/automations/route.ts
@@ -1,5 +1,7 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { formatAutomation, formatAutomationListItem } from "@/lib/automations";
+import { db } from "@/lib/db";
+import { automationRuns, automationSteps } from "@/lib/db/schema";
 import { listAutomationsQuerySchema } from "@/lib/validation/automations";
 import { createAutomationSchema } from "@/lib/validation/automations";
 import {
@@ -7,6 +9,7 @@ import {
   AutomationValidationError,
   automationRepo,
 } from "@opensend/core";
+import { count, desc, inArray } from "drizzle-orm";
 
 function toStepInputs(
   steps: Array<{
@@ -78,6 +81,7 @@ export async function GET(request: Request): Promise<Response> {
   const url = new URL(request.url);
   const parsed = listAutomationsQuerySchema.safeParse({
     status: url.searchParams.get("status") ?? undefined,
+    search: url.searchParams.get("search") ?? undefined,
     limit: url.searchParams.get("limit") ?? undefined,
     after: url.searchParams.get("after") ?? undefined,
   });
@@ -93,12 +97,57 @@ export async function GET(request: Request): Promise<Response> {
       limit: parsed.data.limit ?? 25,
       after: parsed.data.after,
       status: parsed.data.status,
+      search: parsed.data.search,
       userId: auth.userId,
     });
+    const automationIds = data.map((automation) => automation.id);
+    const stepCountsByAutomationId = new Map<string, number>();
+    const lastRunByAutomationId = new Map<
+      string,
+      { status: string; created_at: Date }
+    >();
+
+    if (automationIds.length > 0) {
+      const stepCounts = await db
+        .select({
+          automationId: automationSteps.automationId,
+          total: count(),
+        })
+        .from(automationSteps)
+        .where(inArray(automationSteps.automationId, automationIds))
+        .groupBy(automationSteps.automationId);
+
+      for (const row of stepCounts) {
+        stepCountsByAutomationId.set(row.automationId, Number(row.total));
+      }
+
+      const runs = await db
+        .select({
+          automationId: automationRuns.automationId,
+          status: automationRuns.status,
+          createdAt: automationRuns.createdAt,
+        })
+        .from(automationRuns)
+        .where(inArray(automationRuns.automationId, automationIds))
+        .orderBy(desc(automationRuns.createdAt));
+
+      for (const run of runs) {
+        if (!lastRunByAutomationId.has(run.automationId)) {
+          lastRunByAutomationId.set(run.automationId, {
+            status: run.status,
+            created_at: run.createdAt,
+          });
+        }
+      }
+    }
 
     return Response.json({
       object: "list",
-      data: data.map(formatAutomationListItem),
+      data: data.map((automation) => ({
+        ...formatAutomationListItem(automation),
+        step_count: stepCountsByAutomationId.get(automation.id) ?? 0,
+        last_run: lastRunByAutomationId.get(automation.id) ?? null,
+      })),
       has_more: hasMore,
     });
   } catch (err) {

--- a/src/components/automation-builder-form.tsx
+++ b/src/components/automation-builder-form.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import {
+  type AutomationFormState,
+  type AutomationFormValidationError,
+  validateFormState,
+} from "@/lib/automations/form";
+import { useEffect, useState } from "react";
+
+interface TemplateOption {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  state: AutomationFormState;
+  onChange: (next: AutomationFormState) => void;
+  showStatus?: boolean;
+  formErrors?: AutomationFormValidationError[];
+}
+
+function getApiKey(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return localStorage?.getItem?.("api_key") ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function findError(
+  errors: AutomationFormValidationError[],
+  field: keyof AutomationFormState,
+): string | undefined {
+  return errors.find((e) => e.field === field)?.message;
+}
+
+export function AutomationBuilderForm({
+  state,
+  onChange,
+  showStatus = true,
+  formErrors,
+}: Props) {
+  const [templates, setTemplates] = useState<TemplateOption[]>([]);
+  const [templatesLoading, setTemplatesLoading] = useState(true);
+  const [templatesError, setTemplatesError] = useState<string | null>(null);
+  const errors = formErrors ?? validateFormState(state);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadTemplates() {
+      setTemplatesLoading(true);
+      setTemplatesError(null);
+      try {
+        const apiKey = getApiKey();
+        const headers: Record<string, string> = {};
+        if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+        const res = await fetch("/api/templates?status=published", { headers });
+        if (!res.ok) {
+          if (!cancelled) {
+            setTemplates([]);
+            setTemplatesError(
+              res.status === 401
+                ? "Set an API key to load published templates."
+                : "Could not load templates.",
+            );
+          }
+          return;
+        }
+        const data = await res.json();
+        if (cancelled) return;
+        setTemplates(
+          (data?.data ?? []).map((t: { id: string; name: string }) => ({
+            id: t.id,
+            name: t.name,
+          })),
+        );
+      } catch {
+        if (!cancelled) {
+          setTemplates([]);
+          setTemplatesError("Could not load templates.");
+        }
+      } finally {
+        if (!cancelled) setTemplatesLoading(false);
+      }
+    }
+    loadTemplates();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const update = (patch: Partial<AutomationFormState>) =>
+    onChange({ ...state, ...patch });
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-[rgba(176,199,217,0.145)] p-5 space-y-4">
+        <h2 className="text-[14px] font-semibold text-[#F0F0F0]">Settings</h2>
+        <label className="block">
+          <span className="text-[13px] text-[#A1A4A5]">Name</span>
+          <input
+            type="text"
+            value={state.name}
+            onChange={(e) => update({ name: e.target.value })}
+            className="mt-1 w-full h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+            aria-invalid={Boolean(findError(errors, "name"))}
+          />
+          {findError(errors, "name") ? (
+            <span className="mt-1 block text-[12px] text-red-400">
+              {findError(errors, "name")}
+            </span>
+          ) : null}
+        </label>
+        {showStatus ? (
+          <label className="block">
+            <span className="text-[13px] text-[#A1A4A5]">Status</span>
+            <select
+              value={state.status}
+              onChange={(e) =>
+                update({
+                  status: e.target.value as AutomationFormState["status"],
+                })
+              }
+              className="mt-1 w-full h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+            >
+              <option value="draft">Draft</option>
+              <option value="enabled">Enabled</option>
+              <option value="disabled">Disabled</option>
+            </select>
+          </label>
+        ) : null}
+      </div>
+
+      <ol className="space-y-3" aria-label="Automation steps">
+        <li
+          className="rounded-lg border border-[rgba(176,199,217,0.145)] p-5"
+          data-step="trigger"
+        >
+          <div className="flex items-center gap-3 mb-3">
+            <span className="rounded-full border border-[rgba(176,199,217,0.3)] text-[11px] font-semibold text-[#A1A4A5] px-2 py-0.5">
+              1
+            </span>
+            <h3 className="text-[14px] font-semibold text-[#F0F0F0]">
+              Trigger
+            </h3>
+            <span className="text-[12px] text-[#A1A4A5]">
+              Run when this custom event arrives
+            </span>
+          </div>
+          <label className="block">
+            <span className="text-[13px] text-[#A1A4A5]">Event name</span>
+            <input
+              type="text"
+              value={state.triggerEventName}
+              onChange={(e) => update({ triggerEventName: e.target.value })}
+              placeholder="user.signed_up"
+              className="mt-1 w-full h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+              aria-invalid={Boolean(findError(errors, "triggerEventName"))}
+            />
+            {findError(errors, "triggerEventName") ? (
+              <span className="mt-1 block text-[12px] text-red-400">
+                {findError(errors, "triggerEventName")}
+              </span>
+            ) : null}
+          </label>
+        </li>
+
+        <li
+          className="rounded-lg border border-[rgba(176,199,217,0.145)] p-5"
+          data-step="delay"
+        >
+          <div className="flex items-center gap-3 mb-3">
+            <span className="rounded-full border border-[rgba(176,199,217,0.3)] text-[11px] font-semibold text-[#A1A4A5] px-2 py-0.5">
+              2
+            </span>
+            <h3 className="text-[14px] font-semibold text-[#F0F0F0]">Delay</h3>
+            <label className="ml-auto inline-flex items-center gap-2 text-[12px] text-[#A1A4A5] cursor-pointer">
+              <input
+                type="checkbox"
+                checked={state.delayEnabled}
+                onChange={(e) => update({ delayEnabled: e.target.checked })}
+                className="accent-white"
+              />
+              Add a delay
+            </label>
+          </div>
+          {state.delayEnabled ? (
+            <label className="block">
+              <span className="text-[13px] text-[#A1A4A5]">Duration</span>
+              <input
+                type="text"
+                value={state.delayDuration}
+                onChange={(e) => update({ delayDuration: e.target.value })}
+                placeholder="1 hour"
+                className="mt-1 w-full h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+                aria-invalid={Boolean(findError(errors, "delayDuration"))}
+              />
+              <span className="mt-1 block text-[12px] text-[#666]">
+                Examples: 30 minutes, 1 hour, 3 days. Max 30 days.
+              </span>
+              {findError(errors, "delayDuration") ? (
+                <span className="mt-1 block text-[12px] text-red-400">
+                  {findError(errors, "delayDuration")}
+                </span>
+              ) : null}
+            </label>
+          ) : (
+            <p className="text-[13px] text-[#666]">
+              Skip the delay to send immediately when the event arrives.
+            </p>
+          )}
+        </li>
+
+        <li
+          className="rounded-lg border border-[rgba(176,199,217,0.145)] p-5"
+          data-step="send_email"
+        >
+          <div className="flex items-center gap-3 mb-3">
+            <span className="rounded-full border border-[rgba(176,199,217,0.3)] text-[11px] font-semibold text-[#A1A4A5] px-2 py-0.5">
+              {state.delayEnabled ? 3 : 2}
+            </span>
+            <h3 className="text-[14px] font-semibold text-[#F0F0F0]">
+              Send email
+            </h3>
+            <span className="text-[12px] text-[#A1A4A5]">
+              Use a published template
+            </span>
+          </div>
+          <label className="block">
+            <span className="text-[13px] text-[#A1A4A5]">
+              Published template
+            </span>
+            <select
+              value={state.templateId}
+              onChange={(e) => update({ templateId: e.target.value })}
+              className="mt-1 w-full h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+              aria-invalid={Boolean(findError(errors, "templateId"))}
+            >
+              <option value="">
+                {templatesLoading
+                  ? "Loading published templates..."
+                  : "Select a published template"}
+              </option>
+              {templates.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+            {templatesError ? (
+              <span className="mt-1 block text-[12px] text-red-400">
+                {templatesError}
+              </span>
+            ) : null}
+            {findError(errors, "templateId") ? (
+              <span className="mt-1 block text-[12px] text-red-400">
+                {findError(errors, "templateId")}
+              </span>
+            ) : null}
+          </label>
+          <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-3">
+            <label className="block">
+              <span className="text-[13px] text-[#A1A4A5]">From override</span>
+              <input
+                type="text"
+                value={state.fromOverride}
+                onChange={(e) => update({ fromOverride: e.target.value })}
+                placeholder="optional"
+                className="mt-1 w-full h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+              />
+            </label>
+            <label className="block">
+              <span className="text-[13px] text-[#A1A4A5]">
+                Subject override
+              </span>
+              <input
+                type="text"
+                value={state.subjectOverride}
+                onChange={(e) => update({ subjectOverride: e.target.value })}
+                placeholder="optional"
+                className="mt-1 w-full h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+              />
+            </label>
+            <label className="block md:col-span-2">
+              <span className="text-[13px] text-[#A1A4A5]">
+                Reply-to override
+              </span>
+              <input
+                type="text"
+                value={state.replyToOverride}
+                onChange={(e) => update({ replyToOverride: e.target.value })}
+                placeholder="optional"
+                className="mt-1 w-full h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+              />
+            </label>
+          </div>
+        </li>
+
+        <li
+          className="rounded-lg border border-dashed border-[rgba(176,199,217,0.145)] p-5"
+          data-step="end"
+        >
+          <div className="flex items-center gap-3">
+            <span className="rounded-full border border-[rgba(176,199,217,0.3)] text-[11px] font-semibold text-[#A1A4A5] px-2 py-0.5">
+              {state.delayEnabled ? 4 : 3}
+            </span>
+            <h3 className="text-[14px] font-semibold text-[#F0F0F0]">End</h3>
+            <span className="text-[12px] text-[#A1A4A5]">
+              Run finishes here
+            </span>
+          </div>
+        </li>
+      </ol>
+    </div>
+  );
+}

--- a/src/components/automation-builder.tsx
+++ b/src/components/automation-builder.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { AutomationBuilderForm } from "@/components/automation-builder-form";
+import {
+  type AutomationFormState,
+  DEFAULT_FORM_STATE,
+  buildConnections,
+  buildSteps,
+  validateFormState,
+} from "@/lib/automations/form";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+interface Props {
+  mode: "create";
+}
+
+function getApiKey(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return localStorage?.getItem?.("api_key") ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function AutomationBuilder({ mode }: Props) {
+  const router = useRouter();
+  const [state, setState] = useState<AutomationFormState>(DEFAULT_FORM_STATE);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const errors = validateFormState(state);
+  const canSave = errors.length === 0 && !submitting;
+
+  const handleSubmit = async () => {
+    if (!canSave) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const apiKey = getApiKey();
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+      const res = await fetch("/api/automations", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          name: state.name,
+          status: state.status,
+          triggerEventName: state.triggerEventName,
+          steps: buildSteps(state),
+          connections: buildConnections(state),
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body?.error ?? "Could not create automation.");
+        return;
+      }
+      const data = await res.json();
+      router.push(`/automations/${data.id}`);
+    } catch {
+      setError("Could not create automation.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <Link
+            href="/automations"
+            className="text-[12px] text-[#A1A4A5] hover:text-[#F0F0F0]"
+          >
+            &larr; All automations
+          </Link>
+          <h1 className="mt-2 text-2xl font-semibold text-[#F0F0F0]">
+            New automation
+          </h1>
+          <p className="mt-1 text-[13px] text-[#A1A4A5]">
+            MVP path: trigger → optional delay → send_email → end.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!canSave}
+          className="h-9 px-4 text-[13px] font-medium bg-white text-black rounded-md hover:bg-gray-200 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {submitting ? "Saving..." : "Create automation"}
+        </button>
+      </div>
+
+      {error ? (
+        <p
+          role="alert"
+          className="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-[13px] text-red-300"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      <AutomationBuilderForm
+        state={state}
+        onChange={setState}
+        showStatus={mode === "create"}
+        formErrors={errors}
+      />
+    </div>
+  );
+}

--- a/src/components/automation-detail.tsx
+++ b/src/components/automation-detail.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { AutomationBuilderForm } from "@/components/automation-builder-form";
+import { AutomationRunsList } from "@/components/automation-runs-list";
+import { formatRelativeTime } from "@/components/emails-sending-data-table";
+import {
+  type ApiAutomation,
+  type AutomationFormState,
+  DEFAULT_FORM_STATE,
+  buildConnections,
+  buildSteps,
+  fromAutomation,
+  validateFormState,
+} from "@/lib/automations/form";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+interface Props {
+  automationId: string;
+}
+
+type Tab = "steps" | "runs";
+
+function getApiKey(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return localStorage?.getItem?.("api_key") ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function capitalize(s: string): string {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+}
+
+export function AutomationDetail({ automationId }: Props) {
+  const router = useRouter();
+  const [automation, setAutomation] = useState<ApiAutomation | null>(null);
+  const [state, setState] = useState<AutomationFormState>(DEFAULT_FORM_STATE);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
+  const [tab, setTab] = useState<Tab>("steps");
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setNotFound(false);
+    try {
+      const apiKey = getApiKey();
+      const headers: Record<string, string> = {};
+      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+      const res = await fetch(`/api/automations/${automationId}`, { headers });
+      if (res.status === 404) {
+        setNotFound(true);
+        return;
+      }
+      if (!res.ok) {
+        setError(
+          res.status === 401
+            ? "Set an API key to view this automation."
+            : "Failed to load automation.",
+        );
+        return;
+      }
+      const data: ApiAutomation = await res.json();
+      setAutomation(data);
+      setState(fromAutomation(data));
+    } catch {
+      setError("Failed to load automation.");
+    } finally {
+      setLoading(false);
+    }
+  }, [automationId]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const errors = validateFormState(state);
+  const canSave = errors.length === 0 && !saving;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const apiKey = getApiKey();
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+      const res = await fetch(`/api/automations/${automationId}`, {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify({
+          name: state.name,
+          status: state.status,
+          triggerEventName: state.triggerEventName,
+          steps: buildSteps(state),
+          connections: buildConnections(state),
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body?.error ?? "Could not save automation.");
+        return;
+      }
+      const data: ApiAutomation = await res.json();
+      setAutomation(data);
+      setState(fromAutomation(data));
+    } catch {
+      setError("Could not save automation.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setError(null);
+    try {
+      const apiKey = getApiKey();
+      const headers: Record<string, string> = {};
+      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+      const res = await fetch(`/api/automations/${automationId}`, {
+        method: "DELETE",
+        headers,
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body?.error ?? "Could not delete automation.");
+        return;
+      }
+      router.push("/automations");
+    } catch {
+      setError("Could not delete automation.");
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-[14px] text-[#A1A4A5]">
+        Loading automation...
+      </div>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <div className="max-w-3xl mx-auto py-16 text-center">
+        <h2 className="text-[18px] font-semibold text-[#F0F0F0] mb-2">
+          Automation not found
+        </h2>
+        <p className="text-[14px] text-[#A1A4A5] mb-6">
+          It may have been deleted, or the link may be stale.
+        </p>
+        <Link
+          href="/automations"
+          className="text-[13px] text-[#A1A4A5] hover:text-[#F0F0F0] underline"
+        >
+          Back to automations
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <Link
+            href="/automations"
+            className="text-[12px] text-[#A1A4A5] hover:text-[#F0F0F0]"
+          >
+            &larr; All automations
+          </Link>
+          <h1 className="mt-2 text-2xl font-semibold text-[#F0F0F0]">
+            {state.name || "Untitled automation"}
+          </h1>
+          <p className="mt-1 text-[13px] text-[#A1A4A5]">
+            Status: {capitalize(state.status)}
+            {automation
+              ? ` · Updated ${formatRelativeTime((automation as ApiAutomation & { updated_at?: string }).updated_at ?? new Date().toISOString())}`
+              : ""}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="h-9 px-3 text-[13px] font-medium border border-[rgba(176,199,217,0.145)] text-[#A1A4A5] rounded-md hover:text-red-300 hover:border-red-500/40"
+          >
+            Delete
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!canSave}
+            className="h-9 px-4 text-[13px] font-medium bg-white text-black rounded-md hover:bg-gray-200 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Save changes"}
+          </button>
+        </div>
+      </div>
+
+      {error ? (
+        <p
+          role="alert"
+          className="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-[13px] text-red-300"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      <div
+        role="tablist"
+        aria-label="Automation sections"
+        className="mb-6 flex gap-1 border-b border-[rgba(176,199,217,0.145)]"
+      >
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === "steps"}
+          onClick={() => setTab("steps")}
+          className={`-mb-px px-3 py-2 text-[13px] font-medium border-b-2 transition-colors ${tab === "steps" ? "border-white text-[#F0F0F0]" : "border-transparent text-[#A1A4A5] hover:text-[#F0F0F0]"}`}
+        >
+          Steps
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === "runs"}
+          onClick={() => setTab("runs")}
+          className={`-mb-px px-3 py-2 text-[13px] font-medium border-b-2 transition-colors ${tab === "runs" ? "border-white text-[#F0F0F0]" : "border-transparent text-[#A1A4A5] hover:text-[#F0F0F0]"}`}
+        >
+          Runs
+        </button>
+      </div>
+
+      {tab === "steps" ? (
+        <AutomationBuilderForm
+          state={state}
+          onChange={setState}
+          formErrors={errors}
+        />
+      ) : (
+        <AutomationRunsList automationId={automationId} />
+      )}
+    </div>
+  );
+}

--- a/src/components/automation-run-detail.tsx
+++ b/src/components/automation-run-detail.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { formatDuration } from "@/components/automation-runs-list";
+import { formatRelativeTime } from "@/components/emails-sending-data-table";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+interface RunStepState {
+  status: string;
+  startedAt?: string;
+  completedAt?: string;
+  scheduledFor?: string;
+  error?: string;
+  output?: Record<string, unknown>;
+}
+
+interface AutomationRunDetailPayload {
+  id: string;
+  automation_id: string;
+  trigger_event_id: string | null;
+  contact_id: string | null;
+  status: string;
+  current_step_key: string | null;
+  failed_step_key: string | null;
+  failure_reason: string | null;
+  step_states: Record<string, RunStepState>;
+  started_at: string | null;
+  completed_at: string | null;
+  next_step_at: string | null;
+  duration_ms: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface Props {
+  automationId: string;
+  runId: string;
+}
+
+function getApiKey(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return localStorage?.getItem?.("api_key") ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function capitalize(value: string): string {
+  return value ? value.charAt(0).toUpperCase() + value.slice(1) : value;
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "—";
+  return `${formatRelativeTime(value)} · ${new Date(value).toLocaleString()}`;
+}
+
+function JsonBlock({ value }: { value: Record<string, unknown> | undefined }) {
+  if (!value || Object.keys(value).length === 0) return <span>—</span>;
+  return (
+    <pre className="mt-2 max-h-48 overflow-auto rounded-md border border-[rgba(176,199,217,0.145)] bg-black/30 p-3 text-[12px] text-[#A1A4A5]">
+      {JSON.stringify(value, null, 2)}
+    </pre>
+  );
+}
+
+export function AutomationRunDetail({ automationId, runId }: Props) {
+  const [run, setRun] = useState<AutomationRunDetailPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadRun() {
+      setLoading(true);
+      setError(null);
+      setNotFound(false);
+      try {
+        const apiKey = getApiKey();
+        const headers: Record<string, string> = {};
+        if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+        const res = await fetch(
+          `/api/automations/${automationId}/runs/${runId}`,
+          {
+            headers,
+          },
+        );
+        if (cancelled) return;
+        if (res.status === 404) {
+          setNotFound(true);
+          return;
+        }
+        if (!res.ok) {
+          setError(
+            res.status === 401
+              ? "Set an API key to view this run."
+              : "Failed to load run.",
+          );
+          return;
+        }
+        setRun((await res.json()) as AutomationRunDetailPayload);
+      } catch {
+        if (!cancelled) setError("Failed to load run.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    loadRun();
+    return () => {
+      cancelled = true;
+    };
+  }, [automationId, runId]);
+
+  if (loading) {
+    return (
+      <div className="py-16 text-center text-[14px] text-[#A1A4A5]">
+        Loading run...
+      </div>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <div className="mx-auto max-w-3xl py-16 text-center">
+        <h1 className="mb-2 text-[18px] font-semibold text-[#F0F0F0]">
+          Run not found
+        </h1>
+        <Link
+          href={`/automations/${automationId}`}
+          className="text-[13px] text-[#A1A4A5] underline hover:text-[#F0F0F0]"
+        >
+          Back to automation
+        </Link>
+      </div>
+    );
+  }
+
+  if (error || !run) {
+    return (
+      <div className="mx-auto max-w-3xl py-16">
+        <p
+          role="alert"
+          className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-[13px] text-red-300"
+        >
+          {error ?? "Failed to load run."}
+        </p>
+      </div>
+    );
+  }
+
+  const stepEntries = Object.entries(run.step_states);
+
+  return (
+    <div className="mx-auto max-w-4xl">
+      <div className="mb-6">
+        <Link
+          href={`/automations/${automationId}`}
+          className="text-[12px] text-[#A1A4A5] hover:text-[#F0F0F0]"
+        >
+          &larr; Back to automation
+        </Link>
+        <h1 className="mt-2 text-2xl font-semibold text-[#F0F0F0]">
+          Run {run.id}
+        </h1>
+        <p className="mt-1 text-[13px] text-[#A1A4A5]">
+          {capitalize(run.status)} · {formatDuration(run.duration_ms)}
+        </p>
+      </div>
+
+      <section className="mb-6 grid grid-cols-1 gap-3 md:grid-cols-2">
+        {[
+          ["Started", formatDate(run.started_at)],
+          ["Finished", formatDate(run.completed_at)],
+          ["Waiting until", formatDate(run.next_step_at)],
+          ["Current step", run.current_step_key ?? "—"],
+          ["Failed step", run.failed_step_key ?? "—"],
+          ["Failure reason", run.failure_reason ?? "—"],
+          ["Trigger event", run.trigger_event_id ?? "—"],
+          ["Contact", run.contact_id ?? "—"],
+        ].map(([label, value]) => (
+          <div
+            key={label}
+            className="rounded-lg border border-[rgba(176,199,217,0.145)] p-4"
+          >
+            <div className="text-[12px] text-[#A1A4A5]">{label}</div>
+            <div className="mt-1 break-words text-[14px] text-[#F0F0F0]">
+              {value}
+            </div>
+          </div>
+        ))}
+      </section>
+
+      <section className="rounded-lg border border-[rgba(176,199,217,0.145)]">
+        <div className="border-b border-[rgba(176,199,217,0.145)] px-4 py-3">
+          <h2 className="text-[14px] font-semibold text-[#F0F0F0]">
+            Step states
+          </h2>
+        </div>
+        {stepEntries.length === 0 ? (
+          <p className="px-4 py-8 text-center text-[13px] text-[#A1A4A5]">
+            No step-level state has been recorded yet.
+          </p>
+        ) : (
+          <div className="divide-y divide-[rgba(176,199,217,0.145)]">
+            {stepEntries.map(([key, state]) => (
+              <div key={key} className="p-4">
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <h3 className="text-[14px] font-semibold text-[#F0F0F0]">
+                    {key}
+                  </h3>
+                  <span className="rounded-full border border-[rgba(176,199,217,0.145)] px-2 py-0.5 text-[12px] text-[#A1A4A5]">
+                    {capitalize(state.status)}
+                  </span>
+                </div>
+                <dl className="grid grid-cols-1 gap-2 text-[13px] md:grid-cols-3">
+                  <div>
+                    <dt className="text-[#666]">Started</dt>
+                    <dd className="text-[#A1A4A5]">
+                      {formatDate(state.startedAt)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-[#666]">Completed</dt>
+                    <dd className="text-[#A1A4A5]">
+                      {formatDate(state.completedAt)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-[#666]">Scheduled</dt>
+                    <dd className="text-[#A1A4A5]">
+                      {formatDate(state.scheduledFor)}
+                    </dd>
+                  </div>
+                </dl>
+                {state.error ? (
+                  <p className="mt-3 text-[13px] text-red-300">{state.error}</p>
+                ) : null}
+                <JsonBlock value={state.output} />
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/automation-runs-list.tsx
+++ b/src/components/automation-runs-list.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { formatRelativeTime } from "@/components/emails-sending-data-table";
+import Link from "next/link";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface AutomationRunListItem {
+  id: string;
+  automation_id: string;
+  status: string;
+  current_step_key: string | null;
+  failed_step_key: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  next_step_at: string | null;
+  duration_ms: number | null;
+  failure_reason: string | null;
+  created_at: string;
+}
+
+const RUN_STATUSES = [
+  "queued",
+  "running",
+  "waiting",
+  "completed",
+  "failed",
+  "cancelled",
+  "skipped",
+] as const;
+
+function getApiKey(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return localStorage?.getItem?.("api_key") ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function capitalize(s: string): string {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+}
+
+export function formatDuration(ms: number | null): string {
+  if (ms === null || ms === undefined) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  const sec = Math.round(ms / 1000);
+  if (sec < 60) return `${sec}s`;
+  const min = Math.floor(sec / 60);
+  const remSec = sec % 60;
+  if (min < 60) return remSec ? `${min}m ${remSec}s` : `${min}m`;
+  const hr = Math.floor(min / 60);
+  const remMin = min % 60;
+  return remMin ? `${hr}h ${remMin}m` : `${hr}h`;
+}
+
+interface Props {
+  automationId: string;
+}
+
+export function AutomationRunsList({ automationId }: Props) {
+  const [runs, setRuns] = useState<AutomationRunListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState("");
+  const [statusOpen, setStatusOpen] = useState(false);
+  const statusRef = useRef<HTMLDivElement>(null);
+
+  const fetchRuns = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (statusFilter) params.set("status", statusFilter);
+      const apiKey = getApiKey();
+      const headers: Record<string, string> = {};
+      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+      const res = await fetch(
+        `/api/automations/${automationId}/runs?${params.toString()}`,
+        { headers },
+      );
+      if (!res.ok) {
+        setRuns([]);
+        setError(
+          res.status === 401
+            ? "Set an API key to view runs."
+            : "Failed to load runs.",
+        );
+        return;
+      }
+      const data = await res.json();
+      setRuns(data.data ?? []);
+    } catch {
+      setRuns([]);
+      setError("Failed to load runs.");
+    } finally {
+      setLoading(false);
+    }
+  }, [automationId, statusFilter]);
+
+  useEffect(() => {
+    fetchRuns();
+  }, [fetchRuns]);
+
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (statusRef.current && !statusRef.current.contains(e.target as Node)) {
+        setStatusOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, []);
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-4">
+        <div className="relative" ref={statusRef}>
+          <button
+            type="button"
+            onClick={() => setStatusOpen((v) => !v)}
+            className="h-9 px-3 text-[13px] border border-[rgba(176,199,217,0.145)] rounded-md text-[#A1A4A5] hover:text-[#F0F0F0] hover:border-[rgba(176,199,217,0.3)] transition-colors flex items-center gap-1.5 min-w-[140px]"
+          >
+            <span>
+              {statusFilter ? capitalize(statusFilter) : "All Statuses"}
+            </span>
+            <svg
+              aria-hidden="true"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              className="ml-auto"
+            >
+              <path d="M6 9l6 6 6-6" />
+            </svg>
+          </button>
+          {statusOpen ? (
+            <div
+              role="menu"
+              className="absolute top-full left-0 mt-1 w-[200px] bg-[#0a0a0a] border border-[rgba(176,199,217,0.145)] rounded-md shadow-lg z-50 py-1"
+            >
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  setStatusFilter("");
+                  setStatusOpen(false);
+                }}
+                className={`w-full px-3 py-1.5 text-left text-[13px] hover:bg-[rgba(176,199,217,0.08)] transition-colors ${!statusFilter ? "text-[#F0F0F0]" : "text-[#A1A4A5]"}`}
+              >
+                All Statuses
+              </button>
+              {RUN_STATUSES.map((s) => (
+                <button
+                  type="button"
+                  key={s}
+                  role="menuitem"
+                  onClick={() => {
+                    setStatusFilter(s);
+                    setStatusOpen(false);
+                  }}
+                  className={`w-full px-3 py-1.5 text-left text-[13px] hover:bg-[rgba(176,199,217,0.08)] transition-colors ${statusFilter === s ? "text-[#F0F0F0]" : "text-[#A1A4A5]"}`}
+                >
+                  {capitalize(s)}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={fetchRuns}
+          className="h-9 px-3 text-[13px] border border-[rgba(176,199,217,0.145)] rounded-md text-[#A1A4A5] hover:text-[#F0F0F0] hover:border-[rgba(176,199,217,0.3)] transition-colors"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {error ? (
+        <p
+          role="alert"
+          className="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-[13px] text-red-300"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12 text-[14px] text-[#A1A4A5]">
+          Loading runs...
+        </div>
+      ) : runs.length === 0 ? (
+        <div className="rounded-md border border-dashed border-[rgba(176,199,217,0.145)] py-12 px-6 text-center">
+          <h3 className="text-[14px] font-semibold text-[#F0F0F0] mb-1">
+            No runs yet
+          </h3>
+          <p className="text-[13px] text-[#A1A4A5]">
+            Send a matching event with `POST /api/events/send` to trigger this
+            automation.
+          </p>
+        </div>
+      ) : (
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-[rgba(176,199,217,0.145)]">
+              <th className="px-3 py-2 text-left text-[12px] font-medium text-[#A1A4A5]">
+                Status
+              </th>
+              <th className="px-3 py-2 text-left text-[12px] font-medium text-[#A1A4A5]">
+                Started
+              </th>
+              <th className="px-3 py-2 text-left text-[12px] font-medium text-[#A1A4A5]">
+                Duration
+              </th>
+              <th className="px-3 py-2 text-left text-[12px] font-medium text-[#A1A4A5]">
+                Current step
+              </th>
+              <th className="px-3 py-2 text-left text-[12px] font-medium text-[#A1A4A5]">
+                Failed step
+              </th>
+              <th className="px-3 py-2 text-left text-[12px] font-medium text-[#A1A4A5]">
+                Failure reason
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {runs.map((run) => (
+              <tr
+                key={run.id}
+                className="border-b border-[rgba(176,199,217,0.145)] hover:bg-[rgba(24,25,28,0.5)] transition-colors"
+              >
+                <td className="px-3 py-2 text-[14px] text-[#F0F0F0]">
+                  <Link
+                    href={`/automations/${automationId}/runs/${run.id}`}
+                    className="hover:underline"
+                  >
+                    {capitalize(run.status)}
+                  </Link>
+                </td>
+                <td
+                  className="px-3 py-2 text-[14px] text-[#A1A4A5]"
+                  title={
+                    run.started_at
+                      ? new Date(run.started_at).toLocaleString()
+                      : ""
+                  }
+                >
+                  {run.started_at
+                    ? formatRelativeTime(run.started_at)
+                    : run.next_step_at
+                      ? `Scheduled ${formatRelativeTime(run.next_step_at)}`
+                      : formatRelativeTime(run.created_at)}
+                </td>
+                <td className="px-3 py-2 text-[14px] text-[#A1A4A5]">
+                  {formatDuration(run.duration_ms)}
+                </td>
+                <td className="px-3 py-2 text-[14px] text-[#A1A4A5]">
+                  {run.current_step_key ?? "—"}
+                </td>
+                <td className="px-3 py-2 text-[14px] text-red-300">
+                  {run.failed_step_key ?? "—"}
+                </td>
+                <td className="px-3 py-2 text-[14px] text-red-300 max-w-[280px] truncate">
+                  {run.failure_reason ?? "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/src/components/automations-list.tsx
+++ b/src/components/automations-list.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+import { formatRelativeTime } from "@/components/emails-sending-data-table";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface AutomationListItem {
+  id: string;
+  name: string;
+  status: string;
+  trigger_event_name: string | null;
+  step_count: number;
+  last_run?: { status: string; created_at: string } | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const AUTOMATION_STATUSES = ["draft", "enabled", "disabled"] as const;
+
+function capitalize(s: string): string {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+}
+
+function getApiKey(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return localStorage?.getItem?.("api_key") ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function AutomationsList() {
+  const router = useRouter();
+  const [automations, setAutomations] = useState<AutomationListItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState("");
+  const [search, setSearch] = useState("");
+  const [statusOpen, setStatusOpen] = useState(false);
+  const [actionMenuId, setActionMenuId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const statusRef = useRef<HTMLDivElement>(null);
+  const actionMenuRef = useRef<HTMLDivElement>(null);
+  const searchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchAutomations = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (search) params.set("search", search);
+      if (statusFilter) params.set("status", statusFilter);
+      const apiKey = getApiKey();
+      const headers: Record<string, string> = {};
+      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+      const res = await fetch(`/api/automations?${params.toString()}`, {
+        headers,
+      });
+      if (!res.ok) {
+        setAutomations([]);
+        setTotal(0);
+        if (res.status === 401) {
+          setError("Unauthorized — set an API key to view automations.");
+        } else {
+          setError("Failed to load automations.");
+        }
+        return;
+      }
+      const data = await res.json();
+      setAutomations(data.data ?? []);
+      setTotal(data.total ?? data.data?.length ?? 0);
+    } catch {
+      setAutomations([]);
+      setTotal(0);
+      setError("Failed to load automations.");
+    } finally {
+      setLoading(false);
+    }
+  }, [search, statusFilter]);
+
+  useEffect(() => {
+    fetchAutomations();
+  }, [fetchAutomations]);
+
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (statusRef.current && !statusRef.current.contains(e.target as Node)) {
+        setStatusOpen(false);
+      }
+      if (
+        actionMenuRef.current &&
+        !actionMenuRef.current.contains(e.target as Node)
+      ) {
+        setActionMenuId(null);
+      }
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, []);
+
+  const handleSearchChange = (value: string) => {
+    if (searchTimeout.current) clearTimeout(searchTimeout.current);
+    searchTimeout.current = setTimeout(() => setSearch(value), 300);
+  };
+
+  const handleDelete = async (item: AutomationListItem) => {
+    setActionMenuId(null);
+    try {
+      const apiKey = getApiKey();
+      const headers: Record<string, string> = {};
+      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+      await fetch(`/api/automations/${item.id}`, {
+        method: "DELETE",
+        headers,
+      });
+      fetchAutomations();
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleToggleEnabled = async (item: AutomationListItem) => {
+    setActionMenuId(null);
+    const nextStatus = item.status === "enabled" ? "disabled" : "enabled";
+    try {
+      const apiKey = getApiKey();
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+      const res = await fetch(`/api/automations/${item.id}`, {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify({ status: nextStatus }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(
+          body?.error ?? `Could not switch automation to ${nextStatus}.`,
+        );
+        return;
+      }
+      fetchAutomations();
+    } catch {
+      setError(`Could not switch automation to ${nextStatus}.`);
+    }
+  };
+
+  return (
+    <div>
+      {/* Filter bar */}
+      <div className="flex items-center gap-3 mb-4">
+        <input
+          type="text"
+          placeholder="Search..."
+          className="flex-1 h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] placeholder-[#666] outline-none focus:border-[rgba(176,199,217,0.3)]"
+          onChange={(e) => handleSearchChange(e.target.value)}
+        />
+
+        <div className="relative" ref={statusRef}>
+          <button
+            type="button"
+            onClick={() => setStatusOpen((v) => !v)}
+            className="h-9 px-3 text-[13px] border border-[rgba(176,199,217,0.145)] rounded-md text-[#A1A4A5] hover:text-[#F0F0F0] hover:border-[rgba(176,199,217,0.3)] transition-colors flex items-center gap-1.5 min-w-[140px]"
+          >
+            <span>
+              {statusFilter ? capitalize(statusFilter) : "All Statuses"}
+            </span>
+            <svg
+              aria-hidden="true"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              className="ml-auto"
+            >
+              <path d="M6 9l6 6 6-6" />
+            </svg>
+          </button>
+          {statusOpen ? (
+            <div
+              role="menu"
+              className="absolute top-full left-0 mt-1 w-[180px] bg-[#0a0a0a] border border-[rgba(176,199,217,0.145)] rounded-md shadow-lg z-50 py-1"
+            >
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  setStatusFilter("");
+                  setStatusOpen(false);
+                }}
+                className={`w-full px-3 py-1.5 text-left text-[13px] hover:bg-[rgba(176,199,217,0.08)] transition-colors ${!statusFilter ? "text-[#F0F0F0]" : "text-[#A1A4A5]"}`}
+              >
+                All Statuses
+              </button>
+              {AUTOMATION_STATUSES.map((s) => (
+                <button
+                  type="button"
+                  key={s}
+                  role="menuitem"
+                  onClick={() => {
+                    setStatusFilter(s);
+                    setStatusOpen(false);
+                  }}
+                  className={`w-full px-3 py-1.5 text-left text-[13px] hover:bg-[rgba(176,199,217,0.08)] transition-colors ${statusFilter === s ? "text-[#F0F0F0]" : "text-[#A1A4A5]"}`}
+                >
+                  {capitalize(s)}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        <Link
+          href="/automations/new"
+          className="h-9 px-4 text-[13px] font-medium bg-white text-black rounded-md hover:bg-gray-200 transition-colors flex items-center gap-1.5"
+        >
+          <svg
+            aria-hidden="true"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+          Create automation
+        </Link>
+      </div>
+
+      {error ? (
+        <p
+          role="alert"
+          className="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-[13px] text-red-300"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-16 text-[14px] text-[#A1A4A5]">
+          Loading automations...
+        </div>
+      ) : automations.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 px-6">
+          <h3 className="text-[16px] font-semibold text-[#F0F0F0] mb-2">
+            No automations
+          </h3>
+          <p className="text-[14px] text-[#A1A4A5] text-center max-w-[420px] mb-6">
+            Trigger an email when a custom event happens. Start with a linear
+            flow: trigger → delay → send_email.
+          </p>
+          <button
+            type="button"
+            onClick={() => router.push("/automations/new")}
+            className="h-9 px-4 text-[13px] font-medium bg-white text-black rounded-md hover:bg-gray-200 transition-colors"
+          >
+            Create automation
+          </button>
+        </div>
+      ) : (
+        <>
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-[rgba(176,199,217,0.145)]">
+                <th className="px-3 py-2 text-left text-[12px] font-medium text-[#A1A4A5] tracking-normal">
+                  Name
+                </th>
+                <th className="px-3 py-2 text-left text-[12px] font-medium text-[#A1A4A5] tracking-normal">
+                  Status
+                </th>
+                <th className="px-3 py-2 text-left text-[12px] font-medium text-[#A1A4A5] tracking-normal">
+                  Trigger event
+                </th>
+                <th className="px-3 py-2 text-left text-[12px] font-medium text-[#A1A4A5] tracking-normal">
+                  Steps
+                </th>
+                <th className="px-3 py-2 text-left text-[12px] font-medium text-[#A1A4A5] tracking-normal">
+                  Last run
+                </th>
+                <th className="px-3 py-2 text-left text-[12px] font-medium text-[#A1A4A5] tracking-normal">
+                  Updated
+                </th>
+                <th className="w-10 px-3 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {automations.map((a) => (
+                <tr
+                  key={a.id}
+                  className="border-b border-[rgba(176,199,217,0.145)] hover:bg-[rgba(24,25,28,0.5)] transition-colors group"
+                >
+                  <td className="px-3 py-2 text-[14px] text-[#F0F0F0]">
+                    <Link
+                      href={`/automations/${a.id}`}
+                      className="hover:underline"
+                    >
+                      {a.name}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-2 text-[14px] text-[#A1A4A5]">
+                    {capitalize(a.status)}
+                  </td>
+                  <td className="px-3 py-2 text-[14px] text-[#A1A4A5]">
+                    {a.trigger_event_name ?? (
+                      <span className="text-[#666]">—</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-[14px] text-[#A1A4A5]">
+                    {a.step_count}
+                  </td>
+                  <td className="px-3 py-2 text-[14px] text-[#A1A4A5]">
+                    {a.last_run ? (
+                      <span
+                        title={new Date(a.last_run.created_at).toLocaleString()}
+                      >
+                        {capitalize(a.last_run.status)} ·{" "}
+                        {formatRelativeTime(a.last_run.created_at)}
+                      </span>
+                    ) : (
+                      <span className="text-[#666]">No runs</span>
+                    )}
+                  </td>
+                  <td
+                    className="px-3 py-2 text-[14px] text-[#A1A4A5]"
+                    title={new Date(a.updated_at).toLocaleString()}
+                  >
+                    {formatRelativeTime(a.updated_at)}
+                  </td>
+                  <td className="w-10 px-3 py-2 relative">
+                    <div ref={actionMenuId === a.id ? actionMenuRef : null}>
+                      <button
+                        type="button"
+                        aria-label="More actions"
+                        onClick={() =>
+                          setActionMenuId(actionMenuId === a.id ? null : a.id)
+                        }
+                        className="p-1 rounded hover:bg-[rgba(176,199,217,0.145)] text-[#A1A4A5] hover:text-[#F0F0F0] transition-colors opacity-0 group-hover:opacity-100"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          width="16"
+                          height="16"
+                          viewBox="0 0 24 24"
+                          fill="currentColor"
+                        >
+                          <circle cx="12" cy="5" r="1.5" />
+                          <circle cx="12" cy="12" r="1.5" />
+                          <circle cx="12" cy="19" r="1.5" />
+                        </svg>
+                      </button>
+                      {actionMenuId === a.id ? (
+                        <div className="absolute right-0 top-full mt-1 w-[200px] bg-[#0a0a0a] border border-[rgba(176,199,217,0.145)] rounded-md shadow-lg z-50 py-1">
+                          <button
+                            type="button"
+                            onClick={() => {
+                              router.push(`/automations/${a.id}`);
+                              setActionMenuId(null);
+                            }}
+                            className="w-full px-3 py-1.5 text-left text-[13px] text-[#A1A4A5] hover:bg-[rgba(176,199,217,0.08)] hover:text-[#F0F0F0] transition-colors"
+                          >
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleToggleEnabled(a)}
+                            className="w-full px-3 py-1.5 text-left text-[13px] text-[#A1A4A5] hover:bg-[rgba(176,199,217,0.08)] hover:text-[#F0F0F0] transition-colors"
+                          >
+                            {a.status === "enabled" ? "Disable" : "Enable"}
+                          </button>
+                          <div className="my-1 border-t border-[rgba(176,199,217,0.145)]" />
+                          <button
+                            type="button"
+                            onClick={() => handleDelete(a)}
+                            className="w-full px-3 py-1.5 text-left text-[13px] text-red-400 hover:bg-[rgba(176,199,217,0.08)] hover:text-red-300 transition-colors"
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      ) : null}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className="mt-3 text-[13px] text-[#A1A4A5]">
+            {total} {total === 1 ? "automation" : "automations"}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -47,6 +47,32 @@ const NAV_ITEMS = [
     ),
   },
   {
+    label: "Automations",
+    href: "/automations",
+    icon: (
+      <svg
+        aria-hidden="true"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <circle cx="6" cy="6" r="2.5" />
+        <circle cx="18" cy="6" r="2.5" />
+        <circle cx="18" cy="18" r="2.5" />
+        <circle cx="6" cy="18" r="2.5" />
+        <path d="M8.5 6h7" />
+        <path d="M18 8.5v7" />
+        <path d="M15.5 18h-7" />
+        <path d="M6 15.5v-7" />
+      </svg>
+    ),
+  },
+  {
     label: "Templates",
     href: "/templates",
     icon: (

--- a/src/lib/automations.ts
+++ b/src/lib/automations.ts
@@ -83,7 +83,9 @@ export function formatRunListItem(run: AutomationRunRow) {
     current_step_key: run.currentStepKey,
     failed_step_key: findFailedStepKey(run.stepStates),
     failure_reason: run.failureReason,
+    next_step_at: run.nextStepAt,
     created_at: run.createdAt,
+    updated_at: run.updatedAt,
   };
 }
 

--- a/src/lib/automations/form.ts
+++ b/src/lib/automations/form.ts
@@ -1,0 +1,232 @@
+export type AutomationStatus = "draft" | "enabled" | "disabled";
+
+export interface AutomationFormStep {
+  key: string;
+  type: "trigger" | "delay" | "send_email" | "end";
+  config: Record<string, unknown>;
+  position: number;
+}
+
+export interface AutomationFormState {
+  name: string;
+  status: AutomationStatus;
+  triggerEventName: string;
+  delayEnabled: boolean;
+  delayDuration: string;
+  templateId: string;
+  fromOverride: string;
+  subjectOverride: string;
+  replyToOverride: string;
+}
+
+export const DEFAULT_FORM_STATE: AutomationFormState = {
+  name: "Untitled automation",
+  status: "draft",
+  triggerEventName: "",
+  delayEnabled: false,
+  delayDuration: "1 hour",
+  templateId: "",
+  fromOverride: "",
+  subjectOverride: "",
+  replyToOverride: "",
+};
+
+export function buildSteps(state: AutomationFormState): AutomationFormStep[] {
+  const steps: AutomationFormStep[] = [];
+  let position = 0;
+
+  steps.push({
+    key: "trigger",
+    type: "trigger",
+    config: { event_name: state.triggerEventName },
+    position: position++,
+  });
+
+  if (state.delayEnabled) {
+    steps.push({
+      key: "delay",
+      type: "delay",
+      config: { duration: state.delayDuration },
+      position: position++,
+    });
+  }
+
+  const sendConfig: Record<string, unknown> = {
+    template: { id: state.templateId },
+  };
+  if (state.fromOverride.trim()) sendConfig.from = state.fromOverride.trim();
+  if (state.subjectOverride.trim())
+    sendConfig.subject = state.subjectOverride.trim();
+  if (state.replyToOverride.trim())
+    sendConfig.reply_to = state.replyToOverride.trim();
+
+  steps.push({
+    key: "send_email",
+    type: "send_email",
+    config: sendConfig,
+    position: position++,
+  });
+
+  steps.push({
+    key: "end",
+    type: "end",
+    config: {},
+    position: position++,
+  });
+
+  return steps;
+}
+
+export function buildConnections(state: AutomationFormState): Array<{
+  from: string;
+  to: string;
+}> {
+  const order: string[] = ["trigger"];
+  if (state.delayEnabled) order.push("delay");
+  order.push("send_email", "end");
+  const connections: Array<{ from: string; to: string }> = [];
+  for (let i = 0; i < order.length - 1; i += 1) {
+    connections.push({ from: order[i], to: order[i + 1] });
+  }
+  return connections;
+}
+
+export interface AutomationFormValidationError {
+  field: keyof AutomationFormState;
+  message: string;
+}
+
+const RESERVED_PREFIX = "resend:";
+const DURATION_PATTERN =
+  /^\s*(\d+(?:\.\d+)?)\s*(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days|w|week|weeks)\s*$/i;
+const UNIT_TO_SECONDS: Record<string, number> = {
+  s: 1,
+  sec: 1,
+  secs: 1,
+  second: 1,
+  seconds: 1,
+  m: 60,
+  min: 60,
+  mins: 60,
+  minute: 60,
+  minutes: 60,
+  h: 3600,
+  hr: 3600,
+  hrs: 3600,
+  hour: 3600,
+  hours: 3600,
+  d: 86400,
+  day: 86400,
+  days: 86400,
+  w: 604800,
+  week: 604800,
+  weeks: 604800,
+};
+const MAX_DELAY_SECONDS = 30 * 24 * 60 * 60;
+
+export function validateFormState(
+  state: AutomationFormState,
+): AutomationFormValidationError[] {
+  const errors: AutomationFormValidationError[] = [];
+
+  if (!state.name.trim()) {
+    errors.push({ field: "name", message: "Name is required." });
+  }
+
+  const trigger = state.triggerEventName.trim();
+  if (!trigger) {
+    errors.push({
+      field: "triggerEventName",
+      message: "Trigger event name is required.",
+    });
+  } else if (trigger.toLowerCase().startsWith(RESERVED_PREFIX)) {
+    errors.push({
+      field: "triggerEventName",
+      message: `Event names beginning with "${RESERVED_PREFIX}" are reserved.`,
+    });
+  }
+
+  if (state.delayEnabled) {
+    const match = DURATION_PATTERN.exec(state.delayDuration);
+    if (!match) {
+      errors.push({
+        field: "delayDuration",
+        message:
+          'Delay must be a natural-language duration like "1 hour" or "3 days".',
+      });
+    } else {
+      const amount = Number.parseFloat(match[1]);
+      const unit = match[2].toLowerCase();
+      const factor = UNIT_TO_SECONDS[unit];
+      if (!Number.isFinite(amount) || amount <= 0 || !factor) {
+        errors.push({
+          field: "delayDuration",
+          message: "Delay must be a positive duration.",
+        });
+      } else {
+        const seconds = Math.round(amount * factor);
+        if (seconds > MAX_DELAY_SECONDS) {
+          errors.push({
+            field: "delayDuration",
+            message: "Delay must be 30 days or less.",
+          });
+        }
+      }
+    }
+  }
+
+  if (!state.templateId) {
+    errors.push({
+      field: "templateId",
+      message: "Pick a published template to send.",
+    });
+  }
+
+  return errors;
+}
+
+export interface ApiAutomationStep {
+  key: string;
+  type: string;
+  config: Record<string, unknown>;
+  position: number;
+}
+
+export interface ApiAutomation {
+  id: string;
+  name: string;
+  status: AutomationStatus | string;
+  trigger_event_name: string | null;
+  steps?: ApiAutomationStep[];
+}
+
+export function fromAutomation(automation: ApiAutomation): AutomationFormState {
+  const state: AutomationFormState = {
+    ...DEFAULT_FORM_STATE,
+    name: automation.name,
+    status: (automation.status as AutomationStatus) ?? "draft",
+    triggerEventName: automation.trigger_event_name ?? "",
+  };
+  const steps = automation.steps ?? [];
+  const trigger = steps.find((s) => s.type === "trigger");
+  if (trigger?.config && typeof trigger.config === "object") {
+    const eventName = (trigger.config as Record<string, unknown>).event_name;
+    if (typeof eventName === "string") state.triggerEventName = eventName;
+  }
+  const delay = steps.find((s) => s.type === "delay");
+  if (delay) {
+    state.delayEnabled = true;
+    const dur = (delay.config as Record<string, unknown>)?.duration;
+    if (typeof dur === "string") state.delayDuration = dur;
+  }
+  const send = steps.find((s) => s.type === "send_email");
+  if (send) {
+    const cfg = send.config as Record<string, unknown>;
+    const tmpl = cfg.template as { id?: unknown } | undefined;
+    if (tmpl && typeof tmpl.id === "string") state.templateId = tmpl.id;
+    if (typeof cfg.from === "string") state.fromOverride = cfg.from;
+    if (typeof cfg.subject === "string") state.subjectOverride = cfg.subject;
+    if (typeof cfg.reply_to === "string") state.replyToOverride = cfg.reply_to;
+  }
+  return state;
+}

--- a/src/lib/validation/automations.ts
+++ b/src/lib/validation/automations.ts
@@ -51,6 +51,7 @@ export const updateAutomationSchema = z
 
 export const listAutomationsQuerySchema = z.object({
   status: automationStatusSchema.optional(),
+  search: z.string().trim().min(1).max(255).optional(),
   limit: z.coerce.number().int().min(1).max(100).optional(),
   after: z.string().min(1).optional(),
 });

--- a/tests/api-automations-events.test.ts
+++ b/tests/api-automations-events.test.ts
@@ -34,6 +34,7 @@ function queryRows<T>(rows: T[]) {
     from: vi.fn().mockReturnThis(),
     where: vi.fn().mockReturnThis(),
     orderBy: vi.fn().mockReturnThis(),
+    groupBy: vi.fn().mockReturnThis(),
     limit: vi.fn().mockResolvedValue(rows),
     // biome-ignore lint/suspicious/noThenProperty: mocks Drizzle thenable builders
     then: (resolve: (value: T[]) => unknown) => Promise.resolve(resolve(rows)),

--- a/tests/automation-form.test.ts
+++ b/tests/automation-form.test.ts
@@ -1,0 +1,117 @@
+import {
+  type AutomationFormState,
+  DEFAULT_FORM_STATE,
+  buildConnections,
+  buildSteps,
+  fromAutomation,
+  validateFormState,
+} from "@/lib/automations/form";
+import { describe, expect, it } from "vitest";
+
+const validState: AutomationFormState = {
+  ...DEFAULT_FORM_STATE,
+  name: "Welcome sequence",
+  status: "enabled",
+  triggerEventName: "user.signed_up",
+  delayEnabled: true,
+  delayDuration: "3 days",
+  templateId: "tmpl_published",
+  fromOverride: "hello@example.com",
+  subjectOverride: "Welcome!",
+  replyToOverride: "support@example.com",
+};
+
+describe("automation MVP form helpers", () => {
+  it("builds the linear trigger -> delay -> send_email -> end path", () => {
+    expect(validateFormState(validState)).toEqual([]);
+
+    expect(buildSteps(validState)).toEqual([
+      {
+        key: "trigger",
+        type: "trigger",
+        config: { event_name: "user.signed_up" },
+        position: 0,
+      },
+      {
+        key: "delay",
+        type: "delay",
+        config: { duration: "3 days" },
+        position: 1,
+      },
+      {
+        key: "send_email",
+        type: "send_email",
+        config: {
+          template: { id: "tmpl_published" },
+          from: "hello@example.com",
+          subject: "Welcome!",
+          reply_to: "support@example.com",
+        },
+        position: 2,
+      },
+      { key: "end", type: "end", config: {}, position: 3 },
+    ]);
+    expect(buildConnections(validState)).toEqual([
+      { from: "trigger", to: "delay" },
+      { from: "delay", to: "send_email" },
+      { from: "send_email", to: "end" },
+    ]);
+  });
+
+  it("omits delay and optional overrides when disabled or blank", () => {
+    const state = {
+      ...validState,
+      delayEnabled: false,
+      fromOverride: "",
+      subjectOverride: "",
+      replyToOverride: "",
+    };
+
+    expect(buildSteps(state).map((step) => step.type)).toEqual([
+      "trigger",
+      "send_email",
+      "end",
+    ]);
+    expect(buildConnections(state)).toEqual([
+      { from: "trigger", to: "send_email" },
+      { from: "send_email", to: "end" },
+    ]);
+  });
+
+  it("validates required fields, reserved events, and the 30-day delay cap", () => {
+    const errors = validateFormState({
+      ...validState,
+      name: "",
+      triggerEventName: "resend:delivered",
+      delayDuration: "31 days",
+      templateId: "",
+    });
+
+    expect(errors.map((error) => error.field)).toEqual([
+      "name",
+      "triggerEventName",
+      "delayDuration",
+      "templateId",
+    ]);
+  });
+
+  it("hydrates edit state from an existing automation detail payload", () => {
+    expect(
+      fromAutomation({
+        id: "auto_1",
+        name: "Existing",
+        status: "disabled",
+        trigger_event_name: "fallback.event",
+        steps: buildSteps(validState),
+      }),
+    ).toMatchObject({
+      name: "Existing",
+      status: "disabled",
+      triggerEventName: "user.signed_up",
+      delayEnabled: true,
+      delayDuration: "3 days",
+      templateId: "tmpl_published",
+      subjectOverride: "Welcome!",
+    });
+  });
+});

--- a/tests/e2e/automations-dashboard.spec.ts
+++ b/tests/e2e/automations-dashboard.spec.ts
@@ -1,0 +1,158 @@
+import { type BrowserContext, type Page, expect, test } from "@playwright/test";
+
+const automation = {
+  object: "automation",
+  id: "auto_1",
+  name: "Welcome automation",
+  status: "enabled",
+  trigger_event_name: "user.signed_up",
+  step_count: 4,
+  last_run: { status: "failed", created_at: "2026-05-02T10:00:00.000Z" },
+  connections: [
+    { from: "trigger", to: "delay" },
+    { from: "delay", to: "send_email" },
+    { from: "send_email", to: "end" },
+  ],
+  steps: [
+    {
+      id: "step_1",
+      key: "trigger",
+      type: "trigger",
+      config: { event_name: "user.signed_up" },
+      position: 0,
+    },
+    {
+      id: "step_2",
+      key: "delay",
+      type: "delay",
+      config: { duration: "1 hour" },
+      position: 1,
+    },
+    {
+      id: "step_3",
+      key: "send_email",
+      type: "send_email",
+      config: { template: { id: "tmpl_1" }, subject: "Hi" },
+      position: 2,
+    },
+    { id: "step_4", key: "end", type: "end", config: {}, position: 3 },
+  ],
+  created_at: "2026-05-02T09:00:00.000Z",
+  updated_at: "2026-05-02T09:30:00.000Z",
+};
+
+async function signIn(context: BrowserContext) {
+  await context.addCookies([
+    {
+      name: "better-auth.session_token",
+      value: "e2e-session-token",
+      domain: "localhost",
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+    },
+  ]);
+}
+
+async function mockAutomationApis(page: Page) {
+  await page.route("**/api/auth/get-session", async (route) => {
+    await route.fulfill({
+      json: {
+        session: { id: "e2e-session", token: "e2e-session-token" },
+        user: { id: "e2e-user", email: "e2e@example.com", name: "E2E User" },
+      },
+    });
+  });
+  await page.route("**/api/templates?status=published", async (route) => {
+    await route.fulfill({
+      json: {
+        object: "list",
+        data: [
+          { id: "tmpl_1", name: "Published welcome", status: "published" },
+        ],
+      },
+    });
+  });
+  await page.route(/.*\/api\/automations(?:\?.*)?$/, async (route) => {
+    if (route.request().method() === "POST") {
+      await route.fulfill({
+        json: { ...automation, id: "auto_created", name: "Created automation" },
+      });
+      return;
+    }
+    await route.fulfill({
+      json: { object: "list", data: [automation], has_more: false },
+    });
+  });
+  await page.route("**/api/automations/auto_1", async (route) => {
+    await route.fulfill({ json: automation });
+  });
+  await page.route("**/api/automations/auto_1/runs?**", async (route) => {
+    await route.fulfill({
+      json: {
+        object: "list",
+        data: [
+          {
+            id: "run_1",
+            automation_id: "auto_1",
+            status: "failed",
+            current_step_key: null,
+            failed_step_key: "send_email",
+            failure_reason: "Template render failed",
+            started_at: "2026-05-02T10:00:00.000Z",
+            completed_at: "2026-05-02T10:00:05.000Z",
+            next_step_at: null,
+            duration_ms: 5000,
+            created_at: "2026-05-02T10:00:00.000Z",
+          },
+        ],
+        has_more: false,
+      },
+    });
+  });
+}
+
+test("automations dashboard lists automations and shows run failure fields", async ({
+  context,
+  page,
+}) => {
+  await signIn(context);
+  await mockAutomationApis(page);
+
+  await page.goto("/automations");
+  await expect(
+    page.getByRole("heading", { name: "Automations" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "Welcome automation" }),
+  ).toBeVisible();
+  await expect(page.getByText("user.signed_up")).toBeVisible();
+  await expect(page.getByText("Failed ·")).toBeVisible();
+
+  await page.getByRole("link", { name: "Welcome automation" }).click();
+  await page.getByRole("tab", { name: "Runs" }).click();
+  await expect(page.getByRole("link", { name: "Failed" })).toBeVisible();
+  await expect(page.getByText("send_email")).toBeVisible();
+  await expect(page.getByText("Template render failed")).toBeVisible();
+});
+
+test("automation create form submits the MVP linear flow", async ({
+  context,
+  page,
+}) => {
+  await signIn(context);
+  await mockAutomationApis(page);
+
+  await page.goto("/automations/new");
+  await page
+    .getByRole("textbox", { name: "Name", exact: true })
+    .fill("Created automation");
+  await page.getByLabel("Event name").fill("user.created");
+  await page.getByLabel("Add a delay").check();
+  await page.getByLabel("Duration").fill("1 hour");
+  await page.getByLabel("Published template").selectOption("tmpl_1");
+  await page.getByLabel("Subject override").fill("Welcome");
+  await page.getByRole("button", { name: "Create automation" }).click();
+
+  await expect(page).toHaveURL(/\/automations\/auto_created/);
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 const NAV_ITEMS = [
   { label: "Emails", path: "/emails" },
   { label: "Broadcasts", path: "/broadcasts" },
+  { label: "Automations", path: "/automations" },
   { label: "Templates", path: "/templates" },
   { label: "Audience", path: "/audience" },
   { label: "Metrics", path: "/metrics" },
@@ -13,7 +14,7 @@ const NAV_ITEMS = [
   { label: "Settings", path: "/settings" },
 ];
 
-test("sidebar renders with all 10 nav items", async ({ page }) => {
+test("sidebar renders with all nav items", async ({ page }) => {
   await page.goto("/");
   const sidebar = page.locator("nav");
   for (const item of NAV_ITEMS) {


### PR DESCRIPTION
## Summary
- Adds Automations dashboard navigation plus `/automations`, create, detail/edit, runs list, and run detail pages for the MVP linear path.
- Adds a form helper that builds `trigger -> optional delay -> send_email -> end` payloads with 30-day delay validation and published-template selection.
- Extends the existing automation list API with search, step counts, last-run summary, and run-list waiting timestamps for dashboard tables.
- Adds focused Vitest and mocked Playwright coverage for list/run fields and create flow.

Closes #119.
Refs #57.

## Tests
- `make check`
- `make test`
- `bun run test -- tests/automation-form.test.ts tests/api-automations-events.test.ts`
- `bunx playwright test -c .pw-automations-119.config.ts automations-dashboard.spec.ts` using a temporary local config on port 3016

## Residual risks
- Full Playwright suite was not run; default port 3015 was occupied by another worktree during targeted E2E, so the new smoke was run on port 3016 with a temporary config.
- Dashboard template loading still depends on the existing templates API auth behavior/local API key pattern.
- Advanced automation steps and visual canvas remain intentionally hidden/out of scope for #120+.
