### PR TITLE
Add backend condition step branching

### DIFF
--- a/agent_docs/learnings/active/2026-05-03-120-condition-predicate-dsl.md
+++ b/agent_docs/learnings/active/2026-05-03-120-condition-predicate-dsl.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-03
+issue: "#120"
+type: decision
+promoted_to: null
+---
+
+## Condition step predicate DSL stays intentionally small
+
+**What:** The first condition-step backend slice accepts one predicate per step: `left` path, comparison `operator`, and optional literal `right` value. Paths are limited to `event.*`, `contact.*`, and `steps.<key>.output.*`; branch labels are stored on connections as optional `type` values.
+
+**Why:** Issue #120 explicitly calls for simple comparisons instead of a broad expression language. Single-predicate steps keep validation, deterministic runner failures, and future UI mapping small while still allowing composition through multiple condition steps.
+
+**Fix:** Extend the DSL only with focused tests and runner semantics; avoid adding expression-tree parsing or arbitrary code-like conditions without a new product decision.

--- a/packages/core/src/db/repositories/automationRepo.ts
+++ b/packages/core/src/db/repositories/automationRepo.ts
@@ -17,6 +17,11 @@ import {
 const ALLOWED_STATUSES = new Set(["draft", "enabled", "disabled"]);
 
 const STEP_KEY_PATTERN = /^[A-Za-z0-9_:-]{1,64}$/;
+const CONNECTION_TYPES = new Set([
+  "default",
+  "condition_met",
+  "condition_not_met",
+]);
 
 export interface ValidatedAutomation {
   triggerEventName: string;
@@ -117,6 +122,10 @@ export function validateAutomationInput(
   >;
 
   const connections = input.connections ?? [];
+  const stepTypesByKey = new Map(
+    normalized.map((step) => [step.key, step.type]),
+  );
+  const seenConnectionBranches = new Set<string>();
   for (const edge of connections) {
     if (!edge || typeof edge.from !== "string" || typeof edge.to !== "string") {
       throw new AutomationValidationError(
@@ -124,12 +133,37 @@ export function validateAutomationInput(
         "connection_edge_invalid",
       );
     }
+    if (
+      edge.type !== undefined &&
+      (typeof edge.type !== "string" || !CONNECTION_TYPES.has(edge.type))
+    ) {
+      throw new AutomationValidationError(
+        `connection ${edge.from} -> ${edge.to} has invalid branch label`,
+        "connection_type_invalid",
+      );
+    }
+    const branchType = edge.type ?? "default";
     if (!seenKeys.has(edge.from) || !seenKeys.has(edge.to)) {
       throw new AutomationValidationError(
         `connection ${edge.from} -> ${edge.to} references unknown step key`,
         "connection_unknown_step",
       );
     }
+    const fromStepType = stepTypesByKey.get(edge.from);
+    if (branchType !== "default" && fromStepType !== "condition") {
+      throw new AutomationValidationError(
+        `connection ${edge.from} -> ${edge.to} uses condition branch label from a non-condition step`,
+        "connection_branch_from_non_condition",
+      );
+    }
+    const branchKey = `${edge.from}:${branchType}`;
+    if (seenConnectionBranches.has(branchKey)) {
+      throw new AutomationValidationError(
+        `connection from ${edge.from} has duplicate ${branchType} branch`,
+        "connection_branch_duplicate",
+      );
+    }
+    seenConnectionBranches.add(branchKey);
     if (edge.from === edge.to) {
       throw new AutomationValidationError(
         `connection ${edge.from} -> ${edge.to} cannot be a self-loop`,

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -376,7 +376,11 @@ export const webhookDeliveries = pgTable(
 
 // ── Automations ─────────────────────────────────────────────────────
 
-export type AutomationConnection = { from: string; to: string };
+export type AutomationConnection = {
+  from: string;
+  to: string;
+  type?: "default" | "condition_met" | "condition_not_met";
+};
 
 export type AutomationStepStateEntry = {
   status:

--- a/packages/core/src/dto/automations.ts
+++ b/packages/core/src/dto/automations.ts
@@ -20,9 +20,15 @@ export type AutomationRunStatus =
   | "cancelled"
   | "skipped";
 
+export type AutomationConnectionType =
+  | "default"
+  | "condition_met"
+  | "condition_not_met";
+
 export interface AutomationConnectionDTO {
   from: string;
   to: string;
+  type?: AutomationConnectionType;
 }
 
 export interface TriggerStepConfig {
@@ -50,11 +56,34 @@ export interface SendEmailStepConfig {
 
 export type EndStepConfig = Record<string, never>;
 
+export type ConditionOperator =
+  | "equals"
+  | "not_equals"
+  | "greater_than"
+  | "greater_than_or_equal"
+  | "less_than"
+  | "less_than_or_equal"
+  | "contains"
+  | "exists";
+
+export type ConditionComparableValue = string | number | boolean | null;
+
+export interface ConditionPredicateConfig {
+  left: string;
+  operator: ConditionOperator;
+  right?: ConditionComparableValue;
+}
+
+export interface ConditionStepConfig {
+  predicate: ConditionPredicateConfig;
+}
+
 export type AutomationStepConfig =
   | TriggerStepConfig
   | DelayStepConfig
   | SendEmailStepConfig
-  | EndStepConfig;
+  | EndStepConfig
+  | ConditionStepConfig;
 
 export interface AutomationStepInput {
   key: string;
@@ -132,6 +161,18 @@ export interface AutomationRunDTO {
 }
 
 const RESERVED_EVENT_PREFIX = "resend:";
+const CONDITION_PATH_PATTERN =
+  /^(event|contact)\.[A-Za-z0-9_.-]+$|^steps\.[A-Za-z0-9_:-]+\.output(\.[A-Za-z0-9_.-]+)?$/;
+const CONDITION_OPERATORS: ReadonlySet<ConditionOperator> = new Set([
+  "equals",
+  "not_equals",
+  "greater_than",
+  "greater_than_or_equal",
+  "less_than",
+  "less_than_or_equal",
+  "contains",
+  "exists",
+]);
 const MAX_DELAY_DAYS = 30;
 export const MAX_DELAY_SECONDS = MAX_DELAY_DAYS * 24 * 60 * 60;
 
@@ -279,6 +320,68 @@ export function normalizeSendEmailConfig(
   return config;
 }
 
+function isComparableValue(value: unknown): value is ConditionComparableValue {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+}
+
+export function normalizeConditionConfig(
+  raw: Record<string, unknown>,
+): ConditionStepConfig {
+  const predicate =
+    typeof raw.predicate === "object" && raw.predicate !== null
+      ? (raw.predicate as Record<string, unknown>)
+      : null;
+  if (!predicate) {
+    throw new AutomationValidationError(
+      "condition step requires config.predicate",
+      "condition_predicate_required",
+    );
+  }
+
+  const left = typeof predicate.left === "string" ? predicate.left.trim() : "";
+  if (!CONDITION_PATH_PATTERN.test(left)) {
+    throw new AutomationValidationError(
+      "condition predicate left must reference event.*, contact.*, or steps.<key>.output.*",
+      "condition_left_invalid",
+    );
+  }
+
+  const operator = predicate.operator;
+  if (
+    typeof operator !== "string" ||
+    !CONDITION_OPERATORS.has(operator as ConditionOperator)
+  ) {
+    throw new AutomationValidationError(
+      "condition predicate operator is unsupported",
+      "condition_operator_invalid",
+    );
+  }
+
+  if (operator === "exists") {
+    return { predicate: { left, operator: "exists" } };
+  }
+
+  if (!("right" in predicate) || !isComparableValue(predicate.right)) {
+    throw new AutomationValidationError(
+      "condition predicate right must be a string, number, boolean, or null",
+      "condition_right_invalid",
+    );
+  }
+
+  return {
+    predicate: {
+      left,
+      operator: operator as ConditionOperator,
+      right: predicate.right,
+    },
+  };
+}
+
 export function normalizeStepConfig(
   type: AutomationStepType,
   config: Record<string, unknown>,
@@ -296,10 +399,15 @@ export function normalizeStepConfig(
         string,
         unknown
       >;
+    case "condition":
+      return normalizeConditionConfig(config) as unknown as Record<
+        string,
+        unknown
+      >;
     case "end":
       return {};
     default:
-      // Reserved step types pass through unchanged; runner is not built yet.
+      // Reserved step types pass through unchanged until their runners are built.
       return config;
   }
 }

--- a/src/app/api/automations/[id]/route.ts
+++ b/src/app/api/automations/[id]/route.ts
@@ -30,7 +30,7 @@ async function loadSteps(automationId: string) {
 function toStepInputs(
   steps: Array<{
     key: string;
-    type: "trigger" | "delay" | "send_email" | "end";
+    type: AutomationStepInput["type"];
     config?: Record<string, unknown>;
     position?: number;
   }>,
@@ -144,8 +144,27 @@ export async function PATCH(
       if (validated.triggerEventName !== undefined) {
         updates.triggerEventName = validated.triggerEventName;
       }
-      if (validated.connections !== undefined)
-        updates.connections = validated.connections;
+      if (validated.connections !== undefined) {
+        const existingSteps = await loadSteps(existing.id);
+        const normalized = automationRepo.validate({
+          name: validated.name ?? existing.name,
+          status:
+            validated.status ??
+            (existing.status as "draft" | "enabled" | "disabled"),
+          triggerEventName:
+            updates.triggerEventName ?? existing.triggerEventName ?? undefined,
+          steps: existingSteps.map((step) => ({
+            key: step.key,
+            type: step.type as AutomationStepInput["type"],
+            config: step.config ?? {},
+            position: step.position,
+          })),
+          connections: validated.connections,
+          userId: auth.userId,
+        });
+        updates.triggerEventName = normalized.triggerEventName;
+        updates.connections = normalized.connections;
+      }
       if (Object.keys(updates).length > 0) {
         await automationRepo.update(existing.id, updates);
       }

--- a/src/app/api/automations/route.ts
+++ b/src/app/api/automations/route.ts
@@ -14,7 +14,7 @@ import { count, desc, inArray } from "drizzle-orm";
 function toStepInputs(
   steps: Array<{
     key: string;
-    type: "trigger" | "delay" | "send_email" | "end";
+    type: AutomationStepInput["type"];
     config?: Record<string, unknown>;
     position?: number;
   }>,

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -405,7 +405,11 @@ export const contactsToSegments = pgTable(
 
 // ── Automations ─────────────────────────────────────────────────────
 
-export type AutomationConnection = { from: string; to: string };
+export type AutomationConnection = {
+  from: string;
+  to: string;
+  type?: "default" | "condition_met" | "condition_not_met";
+};
 
 export type AutomationStepStateEntry = {
   status:

--- a/src/lib/validation/automations.ts
+++ b/src/lib/validation/automations.ts
@@ -7,24 +7,87 @@ export const automationStepTypeSchema = z.enum([
   "delay",
   "send_email",
   "end",
+  "condition",
 ]);
+
+const conditionComparableValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+]);
+
+const conditionPredicateSchema = z
+  .object({
+    left: z
+      .string()
+      .trim()
+      .regex(
+        /^(event|contact)\.[A-Za-z0-9_.-]+$|^steps\.[A-Za-z0-9_:-]+\.output(\.[A-Za-z0-9_.-]+)?$/,
+        "left must reference event.*, contact.*, or steps.<key>.output.*",
+      ),
+    operator: z.enum([
+      "equals",
+      "not_equals",
+      "greater_than",
+      "greater_than_or_equal",
+      "less_than",
+      "less_than_or_equal",
+      "contains",
+      "exists",
+    ]),
+    right: conditionComparableValueSchema.optional(),
+  })
+  .superRefine((predicate, ctx) => {
+    if (predicate.operator !== "exists" && !("right" in predicate)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["right"],
+        message: "right is required unless the condition operator is exists",
+      });
+    }
+  });
+
+// First condition slice intentionally supports one predicate only. Compose
+// branching with multiple condition steps instead of accepting expression trees.
+const conditionStepConfigSchema = z.object({
+  predicate: conditionPredicateSchema,
+});
 
 const automationStepConfigSchema = z.record(z.string(), z.unknown());
 
-export const automationStepSchema = z.object({
-  key: z
-    .string()
-    .min(1)
-    .max(64)
-    .regex(/^[A-Za-z0-9_:-]+$/, "step key may only contain A-Z, 0-9, _, :, -"),
-  type: automationStepTypeSchema,
-  config: automationStepConfigSchema.optional(),
-  position: z.number().int().nonnegative().optional(),
-});
+export const automationStepSchema = z
+  .object({
+    key: z
+      .string()
+      .min(1)
+      .max(64)
+      .regex(
+        /^[A-Za-z0-9_:-]+$/,
+        "step key may only contain A-Z, 0-9, _, :, -",
+      ),
+    type: automationStepTypeSchema,
+    config: automationStepConfigSchema.optional(),
+    position: z.number().int().nonnegative().optional(),
+  })
+  .superRefine((step, ctx) => {
+    if (step.type === "condition") {
+      const parsed = conditionStepConfigSchema.safeParse(step.config);
+      if (!parsed.success) {
+        for (const issue of parsed.error.issues) {
+          ctx.addIssue({
+            ...issue,
+            path: ["config", ...issue.path],
+          });
+        }
+      }
+    }
+  });
 
 export const automationConnectionSchema = z.object({
   from: z.string().min(1).max(64),
   to: z.string().min(1).max(64),
+  type: z.enum(["default", "condition_met", "condition_not_met"]).optional(),
 });
 
 export const createAutomationSchema = z.object({

--- a/src/lib/workers/automation-runner.ts
+++ b/src/lib/workers/automation-runner.ts
@@ -10,8 +10,11 @@ import {
   templates,
 } from "@/lib/db/schema";
 import {
+  type ConditionOperator,
+  type ConditionStepConfig,
   automationRunRepo,
   emailService,
+  normalizeConditionConfig,
   parseDurationToCappedSeconds,
 } from "@opensend/core";
 import { asc, eq } from "drizzle-orm";
@@ -136,9 +139,17 @@ function nextStepKey(
   automation: Automation,
   steps: AutomationStep[],
   currentKey: string,
+  branch: AutomationConnection["type"] = "default",
 ): string | null {
   const connections = (automation.connections ?? []) as AutomationConnection[];
-  const connected = connections.find((edge) => edge.from === currentKey)?.to;
+  const connected =
+    connections.find((edge) => edge.from === currentKey && edge.type === branch)
+      ?.to ??
+    connections.find(
+      (edge) =>
+        edge.from === currentKey &&
+        (edge.type === "default" || edge.type === undefined),
+    )?.to;
   if (connected && steps.some((step) => step.key === connected)) {
     return connected;
   }
@@ -158,8 +169,9 @@ async function advanceRun(
   states: StepStates,
   now: Date,
   output?: Record<string, unknown>,
+  branch: AutomationConnection["type"] = "default",
 ) {
-  const nextKey = nextStepKey(automation, steps, step.key);
+  const nextKey = nextStepKey(automation, steps, step.key, branch);
   const completedStates = setStepState(states, step.key, {
     status: "completed",
     completedAt: iso(now),
@@ -324,6 +336,152 @@ function getSendEmailConfig(step: AutomationStep): {
     subject: readString(config.subject),
     replyTo: readString(config.reply_to),
   };
+}
+
+function buildStepOutputContext(states: StepStates): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(states).map(([key, state]) => [
+      key,
+      { output: state.output ?? {} },
+    ]),
+  );
+}
+
+function buildConditionContext(
+  delivery: CustomEventDelivery | null,
+  contact: Contact | null,
+  states: StepStates,
+): Record<string, unknown> {
+  const eventPayload = delivery?.payload ?? {};
+  const contactContext = contact
+    ? {
+        id: contact.id,
+        email: contact.email,
+        first_name: contact.firstName ?? "",
+        firstName: contact.firstName ?? "",
+        last_name: contact.lastName ?? "",
+        lastName: contact.lastName ?? "",
+        unsubscribed: contact.unsubscribed,
+        custom_properties: contact.customProperties ?? {},
+        customProperties: contact.customProperties ?? {},
+      }
+    : null;
+
+  return {
+    event: eventPayload,
+    contact: contactContext,
+    steps: buildStepOutputContext(states),
+  };
+}
+
+function resolveConditionPath(
+  context: Record<string, unknown>,
+  path: string,
+): unknown {
+  const stepMatch = /^steps\.([A-Za-z0-9_:-]+)\.output(?:\.(.+))?$/.exec(path);
+  if (stepMatch) {
+    const stepContext = getPath(context.steps, [stepMatch[1], "output"]);
+    return stepMatch[2]
+      ? getPath(stepContext, stepMatch[2].split("."))
+      : stepContext;
+  }
+
+  const [root, ...parts] = path.split(".");
+  return getPath(context[root], parts);
+}
+
+function toComparable(value: unknown): string | number | boolean | null {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  throw new Error(
+    "condition predicate left resolved to a non-comparable value",
+  );
+}
+
+function compareNumbers(
+  left: string | number | boolean | null,
+  right: string | number | boolean | null | undefined,
+  operator: ConditionOperator,
+): boolean {
+  const leftNumber = typeof left === "number" ? left : Number(left);
+  const rightNumber = typeof right === "number" ? right : Number(right);
+  if (!Number.isFinite(leftNumber) || !Number.isFinite(rightNumber)) {
+    throw new Error(`condition ${operator} requires numeric operands`);
+  }
+  if (operator === "greater_than") return leftNumber > rightNumber;
+  if (operator === "greater_than_or_equal") return leftNumber >= rightNumber;
+  if (operator === "less_than") return leftNumber < rightNumber;
+  return leftNumber <= rightNumber;
+}
+
+function evaluateConditionPredicate(
+  config: ConditionStepConfig,
+  context: Record<string, unknown>,
+): boolean {
+  const leftRaw = resolveConditionPath(context, config.predicate.left);
+  if (leftRaw === undefined) {
+    throw new Error(`condition variable not found: ${config.predicate.left}`);
+  }
+
+  const left = toComparable(leftRaw);
+  const right = config.predicate.right;
+  switch (config.predicate.operator) {
+    case "exists":
+      return left !== null;
+    case "equals":
+      return left === right;
+    case "not_equals":
+      return left !== right;
+    case "greater_than":
+    case "greater_than_or_equal":
+    case "less_than":
+    case "less_than_or_equal":
+      return compareNumbers(left, right, config.predicate.operator);
+    case "contains":
+      if (typeof left !== "string" || typeof right !== "string") {
+        throw new Error("condition contains requires string operands");
+      }
+      return left.includes(right);
+  }
+}
+
+async function processConditionStep(
+  deps: AutomationRunnerDeps,
+  run: AutomationRun,
+  automation: Automation,
+  steps: AutomationStep[],
+  step: AutomationStep,
+  states: StepStates,
+  now: Date,
+) {
+  const config = normalizeConditionConfig(step.config ?? {});
+  const delivery = run.triggerEventId
+    ? await deps.getDelivery(run.triggerEventId)
+    : null;
+  const contact = run.contactId ? await deps.getContact(run.contactId) : null;
+  const matched = evaluateConditionPredicate(
+    config,
+    buildConditionContext(delivery, contact, states),
+  );
+  const branch = matched ? "condition_met" : "condition_not_met";
+
+  return await advanceRun(
+    deps,
+    run,
+    automation,
+    steps,
+    step,
+    states,
+    now,
+    { matched, branch },
+    branch,
+  );
 }
 
 async function processSendEmailStep(
@@ -540,6 +698,18 @@ export async function processAutomationRunStep(
         nextStepAt: scheduledFor,
         failureReason: null,
       });
+    }
+
+    if (step.type === "condition") {
+      return await processConditionStep(
+        deps,
+        run,
+        automation,
+        steps,
+        step,
+        states,
+        now,
+      );
     }
 
     if (step.type === "send_email") {

--- a/tests/api-automations-events.test.ts
+++ b/tests/api-automations-events.test.ts
@@ -198,6 +198,126 @@ describe("automation API routes", () => {
     );
   });
 
+  it("creates an automation with a condition branch payload", async () => {
+    mockAutomationCreate.mockResolvedValue({
+      automation: {
+        ...automation,
+        connections: [
+          { from: "trigger", to: "condition" },
+          { from: "condition", to: "met", type: "condition_met" },
+          {
+            from: "condition",
+            to: "not_met",
+            type: "condition_not_met",
+          },
+        ],
+      },
+      steps: [
+        triggerStep,
+        {
+          ...triggerStep,
+          id: "step_condition",
+          key: "condition",
+          type: "condition",
+          config: {
+            predicate: {
+              left: "event.plan",
+              operator: "equals",
+              right: "pro",
+            },
+          },
+          position: 1,
+        },
+      ],
+    });
+    const { POST } = await import("@/app/api/automations/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/automations", {
+        name: "Branching",
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.signed_up" },
+          },
+          {
+            key: "condition",
+            type: "condition",
+            config: {
+              predicate: {
+                left: "event.plan",
+                operator: "equals",
+                right: "pro",
+              },
+            },
+          },
+          { key: "met", type: "end", config: {} },
+          { key: "not_met", type: "end", config: {} },
+        ],
+        connections: [
+          { from: "trigger", to: "condition" },
+          { from: "condition", to: "met", type: "condition_met" },
+          {
+            from: "condition",
+            to: "not_met",
+            type: "condition_not_met",
+          },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockAutomationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connections: expect.arrayContaining([
+          { from: "condition", to: "met", type: "condition_met" },
+        ]),
+      }),
+    );
+  });
+
+  it("returns 422 when repository graph validation rejects condition branches", async () => {
+    mockAutomationCreate.mockRejectedValue(
+      new TestAutomationValidationError(
+        "connection condition -> missing references unknown step key",
+        "connection_unknown_step",
+      ),
+    );
+    const { POST } = await import("@/app/api/automations/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/automations", {
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.signed_up" },
+          },
+          {
+            key: "condition",
+            type: "condition",
+            config: {
+              predicate: {
+                left: "event.plan",
+                operator: "equals",
+                right: "pro",
+              },
+            },
+          },
+        ],
+        connections: [
+          { from: "condition", to: "missing", type: "condition_met" },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "connection_unknown_step",
+    });
+  });
+
   it("rejects invalid automation create payloads with 422", async () => {
     const { POST } = await import("@/app/api/automations/route");
 

--- a/tests/automation-runner.test.ts
+++ b/tests/automation-runner.test.ts
@@ -242,6 +242,224 @@ describe("automation runner", () => {
     });
   });
 
+  it("evaluates condition steps and advances to the met branch in one tick", async () => {
+    const { processAutomationRunStep } = await import(
+      "@/lib/workers/automation-runner"
+    );
+    const conditionAutomation: Automation = {
+      ...automation,
+      connections: [
+        { from: "trigger", to: "condition" },
+        { from: "condition", to: "pro_end", type: "condition_met" },
+        { from: "condition", to: "free_end", type: "condition_not_met" },
+      ],
+    };
+    const conditionSteps: AutomationStep[] = [
+      steps[0],
+      {
+        ...steps[1],
+        key: "condition",
+        type: "condition",
+        config: {
+          predicate: {
+            left: "event.plan",
+            operator: "equals",
+            right: "pro",
+          },
+        },
+        position: 1,
+      },
+      { ...steps[3], key: "pro_end", position: 2 },
+      { ...steps[3], key: "free_end", position: 3 },
+    ];
+    const setup = deps({
+      getAutomation: vi.fn().mockResolvedValue(conditionAutomation),
+      listSteps: vi.fn().mockResolvedValue(conditionSteps),
+    });
+
+    await processAutomationRunStep(
+      run({ currentStepKey: "condition" }),
+      setup.deps,
+    );
+
+    expect(setup.updates[0]).toMatchObject({
+      status: "queued",
+      currentStepKey: "pro_end",
+    });
+    expect(setup.updates[0]?.stepStates?.condition).toMatchObject({
+      status: "completed",
+      output: { matched: true, branch: "condition_met" },
+    });
+  });
+
+  it("evaluates condition steps and advances to the not-met branch", async () => {
+    const { processAutomationRunStep } = await import(
+      "@/lib/workers/automation-runner"
+    );
+    const conditionAutomation: Automation = {
+      ...automation,
+      connections: [
+        { from: "condition", to: "pro_end", type: "condition_met" },
+        { from: "condition", to: "free_end", type: "condition_not_met" },
+      ],
+    };
+    const conditionSteps: AutomationStep[] = [
+      {
+        ...steps[1],
+        key: "condition",
+        type: "condition",
+        config: {
+          predicate: {
+            left: "event.plan",
+            operator: "equals",
+            right: "enterprise",
+          },
+        },
+        position: 0,
+      },
+      { ...steps[3], key: "pro_end", position: 1 },
+      { ...steps[3], key: "free_end", position: 2 },
+    ];
+    const setup = deps({
+      getAutomation: vi.fn().mockResolvedValue(conditionAutomation),
+      listSteps: vi.fn().mockResolvedValue(conditionSteps),
+    });
+
+    await processAutomationRunStep(
+      run({ currentStepKey: "condition" }),
+      setup.deps,
+    );
+
+    expect(setup.updates[0]).toMatchObject({
+      status: "queued",
+      currentStepKey: "free_end",
+    });
+    expect(setup.updates[0]?.stepStates?.condition.output).toEqual({
+      matched: false,
+      branch: "condition_not_met",
+    });
+  });
+
+  it("can compare prior step output values in condition predicates", async () => {
+    const { processAutomationRunStep } = await import(
+      "@/lib/workers/automation-runner"
+    );
+    const conditionAutomation: Automation = {
+      ...automation,
+      connections: [
+        { from: "condition", to: "matched", type: "condition_met" },
+        { from: "condition", to: "not_matched", type: "condition_not_met" },
+      ],
+    };
+    const conditionSteps: AutomationStep[] = [
+      {
+        ...steps[1],
+        key: "condition",
+        type: "condition",
+        config: {
+          predicate: {
+            left: "steps.send.output.email_id",
+            operator: "equals",
+            right: "email_1",
+          },
+        },
+        position: 0,
+      },
+      { ...steps[3], key: "matched", position: 1 },
+      { ...steps[3], key: "not_matched", position: 2 },
+    ];
+    const setup = deps({
+      getAutomation: vi.fn().mockResolvedValue(conditionAutomation),
+      listSteps: vi.fn().mockResolvedValue(conditionSteps),
+    });
+
+    await processAutomationRunStep(
+      run({
+        currentStepKey: "condition",
+        stepStates: {
+          send: {
+            status: "completed",
+            output: { email_id: "email_1" },
+          },
+        },
+      }),
+      setup.deps,
+    );
+
+    expect(setup.updates[0]).toMatchObject({
+      status: "queued",
+      currentStepKey: "matched",
+    });
+  });
+
+  it("fails condition steps with missing variables at the step level", async () => {
+    const { processAutomationRunStep } = await import(
+      "@/lib/workers/automation-runner"
+    );
+    const conditionSteps: AutomationStep[] = [
+      {
+        ...steps[1],
+        key: "condition",
+        type: "condition",
+        config: {
+          predicate: {
+            left: "event.missing",
+            operator: "equals",
+            right: "pro",
+          },
+        },
+        position: 0,
+      },
+    ];
+    const setup = deps({
+      listSteps: vi.fn().mockResolvedValue(conditionSteps),
+    });
+
+    await processAutomationRunStep(
+      run({ currentStepKey: "condition" }),
+      setup.deps,
+    );
+
+    expect(setup.updates[0]).toMatchObject({
+      status: "failed",
+      currentStepKey: "condition",
+      failureReason: "condition variable not found: event.missing",
+    });
+    expect(setup.updates[0]?.stepStates?.condition).toMatchObject({
+      status: "failed",
+      error: "condition variable not found: event.missing",
+    });
+  });
+
+  it("fails condition steps with invalid persisted predicate configs", async () => {
+    const { processAutomationRunStep } = await import(
+      "@/lib/workers/automation-runner"
+    );
+    const conditionSteps: AutomationStep[] = [
+      {
+        ...steps[1],
+        key: "condition",
+        type: "condition",
+        config: { predicate: { left: "event.plan", operator: "between" } },
+        position: 0,
+      },
+    ];
+    const setup = deps({
+      listSteps: vi.fn().mockResolvedValue(conditionSteps),
+    });
+
+    await processAutomationRunStep(
+      run({ currentStepKey: "condition" }),
+      setup.deps,
+    );
+
+    expect(setup.updates[0]).toMatchObject({
+      status: "failed",
+      currentStepKey: "condition",
+      failureReason: "condition predicate operator is unsupported",
+    });
+  });
+
   it("fails missing or unpublished templates with a step-level error", async () => {
     const { processAutomationRunStep } = await import(
       "@/lib/workers/automation-runner"

--- a/tests/core-automation-repo.test.ts
+++ b/tests/core-automation-repo.test.ts
@@ -166,6 +166,130 @@ describe("automationRepo.create", () => {
     ).rejects.toMatchObject({ code: "connection_unknown_step" });
   });
 
+  it("accepts condition steps with explicit met and not-met branches", async () => {
+    const { automationRepo } = await import(
+      "../packages/core/src/db/repositories/automationRepo"
+    );
+
+    await expect(
+      automationRepo.create({
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.signed_up" },
+            position: 0,
+          },
+          {
+            key: "condition",
+            type: "condition",
+            config: {
+              predicate: {
+                left: "event.plan",
+                operator: "equals",
+                right: "pro",
+              },
+            },
+            position: 1,
+          },
+          { key: "met", type: "end", config: {}, position: 2 },
+          { key: "not_met", type: "end", config: {}, position: 3 },
+        ],
+        connections: [
+          { from: "trigger", to: "condition" },
+          { from: "condition", to: "met", type: "condition_met" },
+          { from: "condition", to: "not_met", type: "condition_not_met" },
+        ],
+      }),
+    ).resolves.toMatchObject({ automation: { id: "auto_1" } });
+  });
+
+  it("rejects unsupported condition predicate configs", async () => {
+    const { automationRepo } = await import(
+      "../packages/core/src/db/repositories/automationRepo"
+    );
+
+    await expect(
+      automationRepo.create({
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.signed_up" },
+            position: 0,
+          },
+          {
+            key: "condition",
+            type: "condition",
+            config: {
+              predicate: { left: "event.plan", operator: "between" },
+            },
+            position: 1,
+          },
+          { key: "end", type: "end", config: {}, position: 2 },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "condition_operator_invalid" });
+  });
+
+  it("rejects condition branch labels from non-condition steps", async () => {
+    const { automationRepo } = await import(
+      "../packages/core/src/db/repositories/automationRepo"
+    );
+
+    await expect(
+      automationRepo.create({
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.signed_up" },
+            position: 0,
+          },
+          { key: "end", type: "end", config: {}, position: 1 },
+        ],
+        connections: [{ from: "trigger", to: "end", type: "condition_met" }],
+      }),
+    ).rejects.toMatchObject({ code: "connection_branch_from_non_condition" });
+  });
+
+  it("rejects duplicate branch labels from the same step", async () => {
+    const { automationRepo } = await import(
+      "../packages/core/src/db/repositories/automationRepo"
+    );
+
+    await expect(
+      automationRepo.create({
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.signed_up" },
+            position: 0,
+          },
+          {
+            key: "condition",
+            type: "condition",
+            config: {
+              predicate: {
+                left: "event.plan",
+                operator: "equals",
+                right: "pro",
+              },
+            },
+            position: 1,
+          },
+          { key: "met", type: "end", config: {}, position: 2 },
+          { key: "also_met", type: "end", config: {}, position: 3 },
+        ],
+        connections: [
+          { from: "condition", to: "met", type: "condition_met" },
+          { from: "condition", to: "also_met", type: "condition_met" },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "connection_branch_duplicate" });
+  });
+
   it("rejects trigger event names that use the reserved resend: prefix", async () => {
     const { automationRepo } = await import(
       "../packages/core/src/db/repositories/automationRepo"


### PR DESCRIPTION
## Summary\n- Add validated backend condition-step config with a deliberately small one-predicate DSL.\n- Add optional connection branch labels: default, condition_met, condition_not_met, with repository graph validation.\n- Teach the automation runner to evaluate condition predicates on the due tick, persist { matched, branch }, and advance to the selected branch while preserving one-step-per-run-tick behavior.\n- Cover repository validation, API payload behavior, and runner met/not-met/error semantics.\n\n## Tests\n- make check\n- make test\n- bun run test tests/core-automation-repo.test.ts tests/automation-runner.test.ts tests/api-automations-events.test.ts tests/automations-schema.test.ts\n\n## Notes\n- No dashboard canvas/UI changes included.\n- No database migration required; connection labels are additive JSON shape metadata.