### PR TITLE
Extract domains API core service

### DIFF
--- a/agent_docs/learnings/active/2026-05-03-issue-71-domains-thin-adapter.md
+++ b/agent_docs/learnings/active/2026-05-03-issue-71-domains-thin-adapter.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-03
+issue: "#71"
+type: pattern
+promoted_to: null
+---
+
+## Domains thin-adapter follow-up
+
+**What:** `POST/GET /api/domains` now delegate create/list business logic to `packages/core/src/services/domain.ts` through `createDomainService(...)`; the Next.js route remains responsible for API-key auth, request JSON/Zod parsing, billing quota gate, and HTTP response/status mapping.
+
+**Why:** Issue #71 is migrating reusable business logic toward `packages/core` before a Hono control-plane adapter. Domains needed a bounded extraction that preserved existing SES identity behavior and quota enforcement without coupling core to app-layer billing internals.
+
+**Pattern:** Keep billing quota checks at the adapter boundary, inject app SES/cache dependencies into the core service, and test the service independently for lowercasing, default capabilities, SES DNS record construction, pagination normalization, and cache invalidation hooks.

--- a/packages/core/src/services/domain.ts
+++ b/packages/core/src/services/domain.ts
@@ -1,38 +1,246 @@
 import { domainRepo } from "../db/repositories/domainRepo";
-import { dnsService } from "./dns";
+import type { domains } from "../db/schema";
 import { emailProvider } from "./emailProvider";
 
+type DomainRow = typeof domains.$inferSelect;
+type DomainInsert = typeof domains.$inferInsert;
+
+type DomainRecord = NonNullable<DomainRow["records"]>[number];
+type DomainCapability = NonNullable<DomainRow["capabilities"]>[number];
+
+export type CreateDomainIdentityResult = {
+  dkimTokens: string[];
+  status?: string;
+};
+
+export type CreateDomainInput = {
+  name: string;
+  region?: string;
+  customReturnPath?: string;
+  openTracking?: boolean;
+  clickTracking?: boolean;
+  trackingSubdomain?: string;
+  tls?: string;
+  capabilities?: DomainCapability[];
+  userId?: string | null;
+};
+
+export type DomainDetail = Pick<
+  DomainRow,
+  | "id"
+  | "name"
+  | "status"
+  | "region"
+  | "records"
+  | "trackOpens"
+  | "trackClicks"
+  | "trackingSubdomain"
+  | "tls"
+  | "capabilities"
+  | "createdAt"
+>;
+
+export type DomainServiceListItem = Pick<
+  DomainRow,
+  "id" | "name" | "status" | "region" | "capabilities" | "createdAt"
+>;
+
+export type DomainListResult = {
+  data: DomainServiceListItem[];
+  hasMore: boolean;
+};
+
+export type DomainRepository = {
+  list(options: { limit?: number; after?: string }): Promise<{
+    data: DomainRow[];
+    hasMore: boolean;
+  }>;
+  create(data: DomainInsert): Promise<DomainRow[]>;
+  findById(id: string): Promise<DomainRow | undefined>;
+  update(id: string, data: Partial<DomainInsert>): Promise<DomainRow[]>;
+  delete(id: string): Promise<Array<{ id: string }>>;
+};
+
+export type DomainServiceDependencies = {
+  repository?: DomainRepository;
+  createDomainIdentity?: (
+    domain: string,
+  ) => Promise<CreateDomainIdentityResult>;
+  getDomainIdentity?: (domain: string) => Promise<{ verified?: boolean }>;
+  deleteDomainIdentity?: (domain: string) => Promise<void>;
+  invalidateDomainCaches?: (domain: {
+    id: string;
+    name: string;
+  }) => Promise<void>;
+};
+
+const defaultCapabilities: DomainCapability[] = [
+  { name: "sending", enabled: true },
+  { name: "receiving", enabled: false },
+];
+
+function normalizeLimit(limit: number | undefined): number {
+  return Math.min(Math.max(limit || 20, 1), 100);
+}
+
+function buildDomainRecords(
+  domainName: string,
+  region: string,
+  dkimTokens: string[],
+): DomainRecord[] {
+  const dkimRecords: DomainRecord[] = dkimTokens.map((token) => ({
+    type: "CNAME",
+    name: `${token}._domainkey.${domainName}`,
+    value: `${token}.dkim.amazonses.com`,
+    status: "pending",
+    ttl: "Auto",
+  }));
+
+  const spfRecord: DomainRecord = {
+    type: "TXT",
+    name: domainName,
+    value: "v=spf1 include:amazonses.com ~all",
+    status: "pending",
+    ttl: "Auto",
+  };
+
+  const mxRecord: DomainRecord = {
+    type: "MX",
+    name: domainName,
+    value: `feedback-smtp.${region}.amazonses.com`,
+    status: "pending",
+    ttl: "Auto",
+    priority: 10,
+  };
+
+  return [...dkimRecords, spfRecord, mxRecord];
+}
+
+function toDomainDetail(row: DomainRow): DomainDetail {
+  return {
+    id: row.id,
+    name: row.name,
+    status: row.status,
+    region: row.region,
+    records: row.records,
+    trackOpens: row.trackOpens,
+    trackClicks: row.trackClicks,
+    trackingSubdomain: row.trackingSubdomain,
+    tls: row.tls,
+    capabilities: row.capabilities,
+    createdAt: row.createdAt,
+  };
+}
+
+function toDomainServiceListItem(row: DomainRow): DomainServiceListItem {
+  return {
+    id: row.id,
+    name: row.name,
+    status: row.status,
+    region: row.region,
+    capabilities: row.capabilities,
+    createdAt: row.createdAt,
+  };
+}
+
+export function createDomainService({
+  repository = domainRepo,
+  createDomainIdentity = (domain: string) =>
+    emailProvider.createDomainIdentity(domain).then((result) => ({
+      dkimTokens: result.dkimTokens ?? [],
+    })),
+  getDomainIdentity = (domain: string) =>
+    emailProvider.getDomainIdentity(domain),
+  deleteDomainIdentity = (domain: string) =>
+    emailProvider.deleteDomainIdentity(domain),
+  invalidateDomainCaches = async () => {},
+}: DomainServiceDependencies = {}) {
+  return {
+    async listDomains(options: {
+      limit?: number;
+      after?: string;
+    }): Promise<DomainListResult> {
+      const result = await repository.list({
+        limit: normalizeLimit(options.limit),
+        after: options.after || undefined,
+      });
+
+      return {
+        data: result.data.map(toDomainServiceListItem),
+        hasMore: result.hasMore,
+      };
+    },
+
+    async createDomain(input: CreateDomainInput): Promise<DomainDetail> {
+      const domainName = input.name.toLowerCase();
+      const region = input.region ?? "us-east-1";
+      const identity = await createDomainIdentity(domainName);
+      const records = buildDomainRecords(
+        domainName,
+        region,
+        identity.dkimTokens,
+      );
+
+      const [row] = await repository.create({
+        name: domainName,
+        region,
+        status: "not_started",
+        dkimTokens: identity.dkimTokens,
+        records,
+        customReturnPath: input.customReturnPath ?? null,
+        trackOpens: input.openTracking ?? false,
+        trackClicks: input.clickTracking ?? false,
+        trackingSubdomain: input.trackingSubdomain ?? null,
+        tls: input.tls ?? "opportunistic",
+        capabilities: input.capabilities ?? defaultCapabilities,
+        userId: input.userId ?? null,
+      });
+
+      await invalidateDomainCaches({ id: row.id, name: row.name });
+
+      return toDomainDetail(row);
+    },
+
+    async verify(id: string) {
+      const domain = await repository.findById(id);
+      if (!domain) throw new Error("Domain not found");
+
+      const identity = await getDomainIdentity(domain.name);
+      const status: "pending" | "verified" | "failed" = identity.verified
+        ? "verified"
+        : "pending";
+
+      return await repository.update(id, { status });
+    },
+
+    async delete(id: string) {
+      const domain = await repository.findById(id);
+      if (domain) {
+        await deleteDomainIdentity(domain.name);
+      }
+      return await repository.delete(id);
+    },
+  };
+}
+
 export class DomainService {
+  private readonly service: ReturnType<typeof createDomainService>;
+
+  constructor(dependencies: DomainServiceDependencies = {}) {
+    this.service = createDomainService(dependencies);
+  }
+
   async create(params: { name: string; region?: string }) {
-    const dkim = await emailProvider.createDomainIdentity(params.name);
-    return await domainRepo.create({
-      name: params.name,
-      region: params.region || "us-east-1",
-      status: "pending",
-      dkimTokens: dkim.dkimTokens,
-    });
+    return await this.service.createDomain(params);
   }
 
   async verify(id: string) {
-    const domain = await domainRepo.findById(id);
-    if (!domain) throw new Error("Domain not found");
-
-    const identity = await emailProvider.getDomainIdentity(domain.name);
-
-    const status: "pending" | "verified" | "failed" = identity.verified
-      ? "verified"
-      : "pending";
-
-    return await domainRepo.update(id, { status });
+    return await this.service.verify(id);
   }
 
   async delete(id: string) {
-    const domain = await domainRepo.findById(id);
-    if (domain) {
-      await emailProvider.deleteDomainIdentity(domain.name);
-    }
-    return await domainRepo.delete(id);
+    return await this.service.delete(id);
   }
 }
 
-export const domainService = new DomainService();
+export const domainService = createDomainService();

--- a/src/app/api/domains/route.ts
+++ b/src/app/api/domains/route.ts
@@ -1,19 +1,23 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { checkDomainQuota, quotaExceededResponse } from "@/lib/billing/quota";
-import { db } from "@/lib/db";
-import { domains } from "@/lib/db/schema";
 import { invalidateDomainCaches } from "@/lib/domain-cache";
 import { createDomainIdentity } from "@/lib/ses";
 import { createDomainSchema } from "@/lib/validation/domains";
-import { and, desc, lt } from "drizzle-orm";
-import { NextResponse } from "next/server";
+import { createDomainService } from "@opensend/core";
 
-const defaultCapabilities = [
-  { name: "sending", enabled: true },
-  { name: "receiving", enabled: false },
-];
+function domainService() {
+  return createDomainService({
+    createDomainIdentity,
+    invalidateDomainCaches,
+  });
+}
 
-export async function POST(request: Request) {
+function mapDomainError(error: unknown, fallback: string): Response {
+  console.error(`${fallback}:`, error);
+  return Response.json({ error: fallback }, { status: 500 });
+}
+
+export async function POST(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
 
@@ -21,76 +25,37 @@ export async function POST(request: Request) {
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
   const result = createDomainSchema.safeParse(body);
   if (!result.success) {
-    return NextResponse.json(
+    return Response.json(
       { error: "Validation failed", details: result.error.flatten() },
       { status: 422 },
     );
   }
 
   try {
-    const validated = result.data;
-    const domainName = validated.name.toLowerCase();
-
     const quota = await checkDomainQuota(auth.userId);
     if (!quota.ok) {
       return quotaExceededResponse(quota.info);
     }
 
-    const identity = await createDomainIdentity(domainName);
+    const validated = result.data;
+    const row = await domainService().createDomain({
+      name: validated.name,
+      region: validated.region,
+      customReturnPath: validated.custom_return_path,
+      openTracking: validated.open_tracking,
+      clickTracking: validated.click_tracking,
+      trackingSubdomain: validated.tracking_subdomain,
+      tls: validated.tls,
+      capabilities: validated.capabilities,
+      userId: auth.userId,
+    });
 
-    const dkimRecords = identity.dkimTokens.map((token) => ({
-      type: "CNAME",
-      name: `${token}._domainkey.${domainName}`,
-      value: `${token}.dkim.amazonses.com`,
-      status: "pending" as const,
-      ttl: "Auto",
-    }));
-
-    const spfRecord = {
-      type: "TXT",
-      name: domainName,
-      value: "v=spf1 include:amazonses.com ~all",
-      status: "pending" as const,
-      ttl: "Auto",
-    };
-
-    const mxRecord = {
-      type: "MX",
-      name: domainName,
-      value: `feedback-smtp.${validated.region}.amazonses.com`,
-      status: "pending" as const,
-      ttl: "Auto",
-      priority: 10,
-    };
-
-    const allRecords = [...dkimRecords, spfRecord, mxRecord];
-
-    const [row] = await db
-      .insert(domains)
-      .values({
-        name: domainName,
-        region: validated.region,
-        status: "not_started",
-        dkimTokens: identity.dkimTokens,
-        records: allRecords,
-        customReturnPath: validated.custom_return_path || null,
-        trackOpens: validated.open_tracking ?? false,
-        trackClicks: validated.click_tracking ?? false,
-        trackingSubdomain: validated.tracking_subdomain || null,
-        tls: validated.tls,
-        capabilities: validated.capabilities || defaultCapabilities,
-        userId: auth.userId,
-      })
-      .returning();
-
-    await invalidateDomainCaches({ id: row.id, name: row.name });
-
-    return NextResponse.json(
+    return Response.json(
       {
         object: "domain",
         id: row.id,
@@ -108,44 +73,24 @@ export async function POST(request: Request) {
       { status: 201 },
     );
   } catch (error) {
-    console.error("Failed to create domain:", error);
-    return NextResponse.json(
-      { error: "Failed to create domain" },
-      { status: 500 },
-    );
+    return mapDomainError(error, "Failed to create domain");
   }
 }
 
-export async function GET(request: Request) {
+export async function GET(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
 
   const url = new URL(request.url);
-  const limit = Math.min(
-    Math.max(Number(url.searchParams.get("limit")) || 20, 1),
-    100,
-  );
+  const limit = Number(url.searchParams.get("limit")) || 20;
   const after = url.searchParams.get("after") || "";
 
   try {
-    const conditions = [];
-    if (after) {
-      conditions.push(lt(domains.id, after));
-    }
+    const result = await domainService().listDomains({ limit, after });
 
-    const results = await db
-      .select()
-      .from(domains)
-      .where(conditions.length > 0 ? and(...conditions) : undefined)
-      .orderBy(desc(domains.id))
-      .limit(limit + 1);
-
-    const hasMore = results.length > limit;
-    const rows = hasMore ? results.slice(0, limit) : results;
-
-    return NextResponse.json({
+    return Response.json({
       object: "list",
-      data: rows.map((r) => ({
+      data: result.data.map((r) => ({
         id: r.id,
         name: r.name,
         status: r.status,
@@ -153,13 +98,9 @@ export async function GET(request: Request) {
         capabilities: r.capabilities,
         created_at: r.createdAt,
       })),
-      has_more: hasMore,
+      has_more: result.hasMore,
     });
   } catch (error) {
-    console.error("Failed to fetch domains:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch domains" },
-      { status: 500 },
-    );
+    return mapDomainError(error, "Failed to fetch domains");
   }
 }

--- a/tests/cache-invalidation-routes.test.ts
+++ b/tests/cache-invalidation-routes.test.ts
@@ -4,6 +4,7 @@ const mockValidateApiKey = vi.hoisted(() => vi.fn());
 const mockInvalidateApiKeyAuthCache = vi.hoisted(() => vi.fn());
 const mockCreateApiKey = vi.hoisted(() => vi.fn());
 const mockDeleteApiKey = vi.hoisted(() => vi.fn());
+const mockCreateDomain = vi.hoisted(() => vi.fn());
 const mockGetCachedDomainById = vi.hoisted(() => vi.fn());
 const mockGetCachedDomainIdentity = vi.hoisted(() => vi.fn());
 const mockInvalidateDomainCaches = vi.hoisted(() => vi.fn());
@@ -28,6 +29,9 @@ vi.mock("@opensend/core", () => ({
   createApiKeyService: () => ({
     createApiKey: mockCreateApiKey,
     deleteApiKey: mockDeleteApiKey,
+  }),
+  createDomainService: () => ({
+    createDomain: mockCreateDomain,
   }),
 }));
 
@@ -81,6 +85,7 @@ describe("cache invalidation routes", () => {
       domain: null,
       userId: "user-1",
     });
+    mockCreateDomain.mockReset();
   });
 
   it("delegates api-key create through the thin adapter", async () => {
@@ -115,29 +120,19 @@ describe("cache invalidation routes", () => {
     });
   });
 
-  it("invalidates domain caches after create", async () => {
-    mockCreateDomainIdentity.mockResolvedValue({
-      dkimTokens: ["a", "b", "c"],
-      status: "PENDING",
-    });
-    mockDb.insert.mockReturnValue({
-      values: vi.fn().mockReturnValue({
-        returning: vi.fn().mockResolvedValue([
-          {
-            id: VALID_DOMAIN_ID,
-            name: "example.com",
-            status: "not_started",
-            region: "us-east-1",
-            records: [],
-            trackOpens: false,
-            trackClicks: false,
-            trackingSubdomain: null,
-            tls: "opportunistic",
-            capabilities: [{ name: "sending", enabled: true }],
-            createdAt: new Date("2026-04-28T00:00:00.000Z"),
-          },
-        ]),
-      }),
+  it("delegates domain create through the thin adapter", async () => {
+    mockCreateDomain.mockResolvedValue({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+      status: "not_started",
+      region: "us-east-1",
+      records: [],
+      trackOpens: false,
+      trackClicks: false,
+      trackingSubdomain: null,
+      tls: "opportunistic",
+      capabilities: [{ name: "sending", enabled: true }],
+      createdAt: new Date("2026-04-28T00:00:00.000Z"),
     });
 
     const route = await import("@/app/api/domains/route");
@@ -148,14 +143,21 @@ describe("cache invalidation routes", () => {
           authorization: "Bearer key",
           "content-type": "application/json",
         },
-        body: JSON.stringify({ name: "example.com" }),
+        body: JSON.stringify({ name: "Example.COM" }),
       }),
     );
 
     expect(response.status).toBe(201);
-    expect(mockInvalidateDomainCaches).toHaveBeenCalledWith({
-      id: VALID_DOMAIN_ID,
-      name: "example.com",
+    expect(mockCreateDomain).toHaveBeenCalledWith({
+      name: "Example.COM",
+      region: "us-east-1",
+      customReturnPath: undefined,
+      openTracking: undefined,
+      clickTracking: undefined,
+      trackingSubdomain: undefined,
+      tls: "opportunistic",
+      capabilities: undefined,
+      userId: "user-1",
     });
   });
 

--- a/tests/domain-service.test.ts
+++ b/tests/domain-service.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type DomainRepository,
+  createDomainService,
+} from "../packages/core/src/services/domain";
+
+type DomainRow = NonNullable<Awaited<ReturnType<DomainRepository["findById"]>>>;
+type DomainInsert = Parameters<DomainRepository["create"]>[0];
+
+function domainRow(overrides: Partial<DomainRow> = {}): DomainRow {
+  return {
+    id: "domain-1",
+    name: "example.com",
+    status: "not_started",
+    region: "us-east-1",
+    dkimTokens: ["token-1", "token-2", "token-3"],
+    records: [],
+    trackClicks: false,
+    trackOpens: false,
+    tls: "opportunistic",
+    createdAt: new Date("2026-05-03T00:00:00.000Z"),
+    document: null,
+    userId: "user-1",
+    customReturnPath: null,
+    trackingSubdomain: null,
+    capabilities: [{ name: "sending", enabled: true }],
+    ...overrides,
+  };
+}
+
+function createRepository(overrides: Partial<DomainRepository> = {}) {
+  const repository: DomainRepository = {
+    async list() {
+      return { data: [], hasMore: false };
+    },
+    async create(data: DomainInsert) {
+      return [domainRow({ ...data, id: "created-domain" })];
+    },
+    async findById() {
+      return domainRow();
+    },
+    async update(id, data) {
+      return [domainRow({ id, ...data })];
+    },
+    async delete(id: string) {
+      return [{ id }];
+    },
+    ...overrides,
+  };
+
+  return repository;
+}
+
+describe("domain service", () => {
+  it("creates a domain identity, persists SES DNS records, and invalidates caches", async () => {
+    const inserted: DomainInsert[] = [];
+    const createDomainIdentity = vi.fn(async () => ({
+      dkimTokens: ["dkim-a", "dkim-b"],
+      status: "PENDING",
+    }));
+    const invalidateDomainCaches =
+      vi.fn<(_: { id: string; name: string }) => Promise<void>>();
+    const repository = createRepository({
+      async create(data) {
+        inserted.push(data);
+        return [
+          domainRow({
+            ...data,
+            id: "created-domain",
+            createdAt: new Date("2026-05-03T00:00:00.000Z"),
+          }),
+        ];
+      },
+    });
+
+    const service = createDomainService({
+      repository,
+      createDomainIdentity,
+      invalidateDomainCaches,
+    });
+
+    const result = await service.createDomain({
+      name: "Example.COM",
+      region: "eu-west-1",
+      customReturnPath: "bounce.example.com",
+      openTracking: true,
+      clickTracking: true,
+      trackingSubdomain: "track.example.com",
+      tls: "enforced",
+      capabilities: [{ name: "sending", enabled: false }],
+      userId: "user-1",
+    });
+
+    expect(createDomainIdentity).toHaveBeenCalledWith("example.com");
+    expect(inserted[0]).toMatchObject({
+      name: "example.com",
+      region: "eu-west-1",
+      status: "not_started",
+      dkimTokens: ["dkim-a", "dkim-b"],
+      customReturnPath: "bounce.example.com",
+      trackOpens: true,
+      trackClicks: true,
+      trackingSubdomain: "track.example.com",
+      tls: "enforced",
+      capabilities: [{ name: "sending", enabled: false }],
+      userId: "user-1",
+    });
+    expect(inserted[0]?.records).toEqual([
+      {
+        type: "CNAME",
+        name: "dkim-a._domainkey.example.com",
+        value: "dkim-a.dkim.amazonses.com",
+        status: "pending",
+        ttl: "Auto",
+      },
+      {
+        type: "CNAME",
+        name: "dkim-b._domainkey.example.com",
+        value: "dkim-b.dkim.amazonses.com",
+        status: "pending",
+        ttl: "Auto",
+      },
+      {
+        type: "TXT",
+        name: "example.com",
+        value: "v=spf1 include:amazonses.com ~all",
+        status: "pending",
+        ttl: "Auto",
+      },
+      {
+        type: "MX",
+        name: "example.com",
+        value: "feedback-smtp.eu-west-1.amazonses.com",
+        status: "pending",
+        ttl: "Auto",
+        priority: 10,
+      },
+    ]);
+    expect(result).toMatchObject({
+      id: "created-domain",
+      name: "example.com",
+      region: "eu-west-1",
+      trackOpens: true,
+      trackClicks: true,
+    });
+    expect(invalidateDomainCaches).toHaveBeenCalledWith({
+      id: "created-domain",
+      name: "example.com",
+    });
+  });
+
+  it("uses external API defaults when optional create fields are omitted", async () => {
+    const inserted: DomainInsert[] = [];
+    const service = createDomainService({
+      repository: createRepository({
+        async create(data) {
+          inserted.push(data);
+          return [domainRow({ ...data })];
+        },
+      }),
+      createDomainIdentity: async () => ({ dkimTokens: [] }),
+    });
+
+    await service.createDomain({ name: "example.com" });
+
+    expect(inserted[0]).toMatchObject({
+      region: "us-east-1",
+      status: "not_started",
+      customReturnPath: null,
+      trackOpens: false,
+      trackClicks: false,
+      trackingSubdomain: null,
+      tls: "opportunistic",
+      capabilities: [
+        { name: "sending", enabled: true },
+        { name: "receiving", enabled: false },
+      ],
+      userId: null,
+    });
+  });
+
+  it("lists with normalized pagination and maps public list fields", async () => {
+    let listOptions: { limit?: number; after?: string } | null = null;
+    const service = createDomainService({
+      repository: createRepository({
+        async list(options) {
+          listOptions = options;
+          return {
+            data: [domainRow({ id: "domain-2", name: "two.example" })],
+            hasMore: true,
+          };
+        },
+      }),
+    });
+
+    const result = await service.listDomains({ limit: 500, after: "domain-3" });
+
+    expect(listOptions).toEqual({ limit: 100, after: "domain-3" });
+    expect(result).toEqual({
+      data: [
+        {
+          id: "domain-2",
+          name: "two.example",
+          status: "not_started",
+          region: "us-east-1",
+          capabilities: [{ name: "sending", enabled: true }],
+          createdAt: new Date("2026-05-03T00:00:00.000Z"),
+        },
+      ],
+      hasMore: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extracted domain create/list business logic from `src/app/api/domains/route.ts` into injectable `createDomainService` in `packages/core/src/services/domain.ts`.
- Kept the Next.js route as auth -> JSON/Zod parse -> billing quota gate -> service call -> HTTP response mapping.
- Preserved existing external JSON shapes/status codes, SES identity inputs/outputs, domain cache invalidation, and default domain record/capability behavior.
- Added a #71 learning note for the domains thin-adapter pattern.

## Validation
- `bun run test tests/domain-service.test.ts tests/api-domains.test.ts tests/quota-routes.test.ts tests/cache-invalidation-routes.test.ts` — passed (20 tests)
- `make check` — passed (typecheck + Biome)
- `make test` — passed (85 files, 682 tests)
- Push guardrails — passed (full-project typecheck + changed-file Biome)

## Remaining risk
- Playwright E2E was not run because this bounded slice only changes API route/service logic; focused service/API/quota/cache tests and the full unit suite cover the changed contract.
- `#71` remains open as the architecture tracker for further thin-adapter slices and future control-plane migration work.
