### PR TITLE
Implement wait_for_event automation resume semantics

### DIFF
--- a/agent_docs/learnings/active/2026-05-03-120-wait-for-event.md
+++ b/agent_docs/learnings/active/2026-05-03-120-wait-for-event.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-03
+issue: "#120/#167"
+type: decision
+promoted_to: null
+---
+
+## Wait-for-event uses JSON run state and fails deterministically on timeout
+
+**What:** `wait_for_event` stores its waiting metadata and matched event output in `automation_runs.step_states`; no new wait table was added for this backend slice. The first tick marks the step `waiting` and sets `next_step_at` only when `timeout_seconds` is configured. A matching `/api/events/send` for the same tenant/contact completes the waiting step and queues the next step; a due timeout fails the step/run with a deterministic timeout error.
+
+**Why:** Issue #167 prioritizes preserving the one-step-per-tick runner contract and avoiding schema expansion unless JSON state is insufficient. The current bounded lookup scans waiting runs for the contact/user and keeps event routes non-sleeping while still proving resume semantics.
+
+**Fix:** Add an indexed wait table only if production matching volume or race/idempotency requirements exceed the bounded JSON-state lookup.

--- a/packages/core/src/db/repositories/automationRunRepo.ts
+++ b/packages/core/src/db/repositories/automationRunRepo.ts
@@ -81,6 +81,25 @@ export const automationRunRepo = {
     return { data, hasMore };
   },
 
+  async listWaitingByContact(input: {
+    contactId: string;
+    userId?: string | null;
+    limit?: number;
+  }) {
+    const conditions = [
+      eq(automationRuns.status, "waiting"),
+      eq(automationRuns.contactId, input.contactId),
+    ];
+    if (input.userId) conditions.push(eq(automationRuns.userId, input.userId));
+
+    return await db
+      .select()
+      .from(automationRuns)
+      .where(and(...conditions))
+      .orderBy(asc(automationRuns.updatedAt))
+      .limit(input.limit ?? 50);
+  },
+
   async listDue(
     options: { limit?: number; statuses?: string[]; before?: Date } = {},
   ) {

--- a/packages/core/src/dto/automations.ts
+++ b/packages/core/src/dto/automations.ts
@@ -78,12 +78,18 @@ export interface ConditionStepConfig {
   predicate: ConditionPredicateConfig;
 }
 
+export interface WaitForEventStepConfig {
+  event_name: string;
+  timeout_seconds?: number;
+}
+
 export type AutomationStepConfig =
   | TriggerStepConfig
   | DelayStepConfig
   | SendEmailStepConfig
   | EndStepConfig
-  | ConditionStepConfig;
+  | ConditionStepConfig
+  | WaitForEventStepConfig;
 
 export interface AutomationStepInput {
   key: string;
@@ -175,6 +181,7 @@ const CONDITION_OPERATORS: ReadonlySet<ConditionOperator> = new Set([
 ]);
 const MAX_DELAY_DAYS = 30;
 export const MAX_DELAY_SECONDS = MAX_DELAY_DAYS * 24 * 60 * 60;
+export const MAX_WAIT_FOR_EVENT_TIMEOUT_SECONDS = MAX_DELAY_SECONDS;
 
 export class AutomationValidationError extends Error {
   readonly code: string;
@@ -382,6 +389,32 @@ export function normalizeConditionConfig(
   };
 }
 
+export function normalizeWaitForEventConfig(
+  raw: Record<string, unknown>,
+): WaitForEventStepConfig {
+  const eventName =
+    typeof raw.event_name === "string" ? raw.event_name.trim() : "";
+  assertEventNameAllowed(eventName);
+
+  const config: WaitForEventStepConfig = { event_name: eventName };
+  if (raw.timeout_seconds !== undefined) {
+    if (
+      typeof raw.timeout_seconds !== "number" ||
+      !Number.isInteger(raw.timeout_seconds) ||
+      raw.timeout_seconds < 1 ||
+      raw.timeout_seconds > MAX_WAIT_FOR_EVENT_TIMEOUT_SECONDS
+    ) {
+      throw new AutomationValidationError(
+        `wait_for_event timeout_seconds must be an integer between 1 and ${MAX_WAIT_FOR_EVENT_TIMEOUT_SECONDS}`,
+        "wait_for_event_timeout_invalid",
+      );
+    }
+    config.timeout_seconds = raw.timeout_seconds;
+  }
+
+  return config;
+}
+
 export function normalizeStepConfig(
   type: AutomationStepType,
   config: Record<string, unknown>,
@@ -401,6 +434,11 @@ export function normalizeStepConfig(
       >;
     case "condition":
       return normalizeConditionConfig(config) as unknown as Record<
+        string,
+        unknown
+      >;
+    case "wait_for_event":
+      return normalizeWaitForEventConfig(config) as unknown as Record<
         string,
         unknown
       >;

--- a/src/app/api/events/send/route.ts
+++ b/src/app/api/events/send/route.ts
@@ -6,6 +6,7 @@ import {
 import { db } from "@/lib/db";
 import { contacts } from "@/lib/db/schema";
 import { sendEventSchema } from "@/lib/validation/events";
+import { resumeWaitingRunsForEvent } from "@/lib/workers/automation-runner";
 import {
   AutomationValidationError,
   automationRepo,
@@ -70,6 +71,7 @@ export async function POST(request: Request): Promise<Response> {
       email: event.email?.toLowerCase().trim() ?? null,
       userId: auth.userId,
     });
+    const resumedRuns = await resumeWaitingRunsForEvent(delivery);
 
     const matching = await automationRepo.findEnabledByTriggerEventName(
       event.event,
@@ -92,6 +94,7 @@ export async function POST(request: Request): Promise<Response> {
       {
         object: "event_delivery",
         delivery: formatCustomEventDelivery(delivery),
+        resumed_runs: resumedRuns.map(formatRunListItem),
         automation_runs: runs.map(formatRunListItem),
       },
       { status: 202 },

--- a/src/lib/validation/automations.ts
+++ b/src/lib/validation/automations.ts
@@ -8,6 +8,7 @@ export const automationStepTypeSchema = z.enum([
   "send_email",
   "end",
   "condition",
+  "wait_for_event",
 ]);
 
 const conditionComparableValueSchema = z.union([
@@ -54,6 +55,20 @@ const conditionStepConfigSchema = z.object({
   predicate: conditionPredicateSchema,
 });
 
+const waitForEventStepConfigSchema = z.object({
+  event_name: z
+    .string()
+    .trim()
+    .min(1, "event_name is required")
+    .max(255, "event_name must be at most 255 characters"),
+  timeout_seconds: z
+    .number()
+    .int("timeout_seconds must be an integer")
+    .min(1, "timeout_seconds must be at least 1")
+    .max(30 * 24 * 60 * 60, "timeout_seconds must be at most 30 days")
+    .optional(),
+});
+
 const automationStepConfigSchema = z.record(z.string(), z.unknown());
 
 export const automationStepSchema = z
@@ -73,6 +88,18 @@ export const automationStepSchema = z
   .superRefine((step, ctx) => {
     if (step.type === "condition") {
       const parsed = conditionStepConfigSchema.safeParse(step.config);
+      if (!parsed.success) {
+        for (const issue of parsed.error.issues) {
+          ctx.addIssue({
+            ...issue,
+            path: ["config", ...issue.path],
+          });
+        }
+      }
+    }
+
+    if (step.type === "wait_for_event") {
+      const parsed = waitForEventStepConfigSchema.safeParse(step.config);
       if (!parsed.success) {
         for (const issue of parsed.error.issues) {
           ctx.addIssue({

--- a/src/lib/workers/automation-runner.ts
+++ b/src/lib/workers/automation-runner.ts
@@ -12,9 +12,11 @@ import {
 import {
   type ConditionOperator,
   type ConditionStepConfig,
+  type WaitForEventStepConfig,
   automationRunRepo,
   emailService,
   normalizeConditionConfig,
+  normalizeWaitForEventConfig,
   parseDurationToCappedSeconds,
 } from "@opensend/core";
 import { asc, eq } from "drizzle-orm";
@@ -48,6 +50,11 @@ export interface AutomationRunnerDeps {
   getContact: (id: string) => Promise<Contact | null>;
   getTemplate: (id: string) => Promise<Template | null>;
   sendEmail: (input: RunnerSendEmailInput) => Promise<{ id: string }>;
+  listWaitingRunsByContact: (input: {
+    contactId: string;
+    userId?: string | null;
+    limit?: number;
+  }) => Promise<AutomationRun[]>;
   updateRun: (
     id: string,
     data: Partial<typeof automationRuns.$inferInsert>,
@@ -98,6 +105,9 @@ const defaultDeps: AutomationRunnerDeps = {
   },
   async sendEmail(input) {
     return await emailService.send(input);
+  },
+  async listWaitingRunsByContact(input) {
+    return await automationRunRepo.listWaitingByContact(input);
   },
   async updateRun(id, data) {
     const [updated] = await automationRunRepo.update(id, data);
@@ -244,6 +254,7 @@ function getPath(source: unknown, path: string[]): unknown {
 function buildVariableContext(
   delivery: CustomEventDelivery | null,
   contact: Contact,
+  states: StepStates = {},
 ): Record<string, unknown> {
   const eventPayload = delivery?.payload ?? {};
   const customProperties = contact.customProperties ?? {};
@@ -271,6 +282,8 @@ function buildVariableContext(
     lastName: contact.lastName ?? "",
     event: eventPayload,
     contact: contactContext,
+    steps: buildStepOutputContext(states),
+    wait_events: buildWaitEventContext(states),
   };
 }
 
@@ -280,7 +293,8 @@ function resolveReference(
 ): unknown {
   if (typeof value !== "string") return value;
   const trimmed = value.trim();
-  const directPath = /^(event|contact)\.([A-Za-z0-9_.-]+)$/.exec(trimmed);
+  const directPath =
+    /^(event|contact|wait_events|steps)\.([A-Za-z0-9_.:-]+)$/.exec(trimmed);
   if (directPath) {
     return getPath(context[directPath[1]], directPath[2].split("."));
   }
@@ -344,6 +358,14 @@ function buildStepOutputContext(states: StepStates): Record<string, unknown> {
       key,
       { output: state.output ?? {} },
     ]),
+  );
+}
+
+function buildWaitEventContext(states: StepStates): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(states)
+      .filter(([, state]) => state.output?.waited_event !== undefined)
+      .map(([key, state]) => [key, state.output?.waited_event ?? {}]),
   );
 }
 
@@ -484,6 +506,64 @@ async function processConditionStep(
   );
 }
 
+function scheduledTimeoutFor(
+  now: Date,
+  config: WaitForEventStepConfig,
+): Date | null {
+  return typeof config.timeout_seconds === "number"
+    ? new Date(now.getTime() + config.timeout_seconds * 1000)
+    : null;
+}
+
+async function processWaitForEventStep(
+  deps: AutomationRunnerDeps,
+  run: AutomationRun,
+  step: AutomationStep,
+  states: StepStates,
+  now: Date,
+) {
+  const config = normalizeWaitForEventConfig(step.config ?? {});
+  const existing = run.stepStates?.[step.key];
+  if (existing?.status === "waiting") {
+    return await failRun(
+      deps,
+      run,
+      step.key,
+      states,
+      now,
+      `wait_for_event timed out waiting for ${config.event_name}`,
+    );
+  }
+
+  if (!run.contactId) {
+    return await failRun(
+      deps,
+      run,
+      step.key,
+      states,
+      now,
+      "wait_for_event requires a contact",
+    );
+  }
+
+  const scheduledFor = scheduledTimeoutFor(now, config);
+  const waitingStates = setStepState(states, step.key, {
+    status: "waiting",
+    ...(scheduledFor ? { scheduledFor: iso(scheduledFor) } : {}),
+    output: {
+      waiting_for_event: config.event_name,
+      ...(scheduledFor ? { timeout_at: iso(scheduledFor) } : {}),
+    },
+  });
+  return await deps.updateRun(run.id, {
+    status: "waiting",
+    currentStepKey: step.key,
+    stepStates: waitingStates,
+    nextStepAt: scheduledFor,
+    failureReason: null,
+  });
+}
+
 async function processSendEmailStep(
   deps: AutomationRunnerDeps,
   run: AutomationRun,
@@ -563,7 +643,7 @@ async function processSendEmailStep(
   const delivery = run.triggerEventId
     ? await deps.getDelivery(run.triggerEventId)
     : null;
-  const context = buildVariableContext(delivery, contact);
+  const context = buildVariableContext(delivery, contact, states);
   const explicitVariables = Object.fromEntries(
     Object.entries(config.variables).map(([key, value]) => [
       key,
@@ -712,6 +792,10 @@ export async function processAutomationRunStep(
       );
     }
 
+    if (step.type === "wait_for_event") {
+      return await processWaitForEventStep(deps, run, step, states, now);
+    }
+
     if (step.type === "send_email") {
       return await processSendEmailStep(
         deps,
@@ -752,6 +836,76 @@ export async function processAutomationRunStep(
       error instanceof Error ? error.message : "automation step failed";
     return await failRun(deps, run, step.key, states, now, reason);
   }
+}
+
+function waitedEventOutput(
+  delivery: CustomEventDelivery,
+  matchedAt: Date,
+): Record<string, unknown> {
+  return {
+    delivery_id: delivery.id,
+    event_name: delivery.eventName,
+    payload: delivery.payload ?? {},
+    contact_id: delivery.contactId,
+    email: delivery.email,
+    received_at: iso(delivery.receivedAt),
+    matched_at: iso(matchedAt),
+  };
+}
+
+export async function resumeWaitingRunsForEvent(
+  delivery: CustomEventDelivery,
+  deps: AutomationRunnerDeps = defaultDeps,
+): Promise<AutomationRun[]> {
+  if (!delivery.contactId) return [];
+
+  const now = deps.now();
+  const waitingRuns = await deps.listWaitingRunsByContact({
+    contactId: delivery.contactId,
+    userId: delivery.userId,
+    limit: 50,
+  });
+  const resumed: AutomationRun[] = [];
+
+  for (const run of waitingRuns) {
+    if (run.contactId !== delivery.contactId || !run.currentStepKey) continue;
+
+    const automation = await deps.getAutomation(run.automationId);
+    if (!automation) continue;
+
+    const steps = await deps.listSteps(run.automationId);
+    const step = findStep(steps, run.currentStepKey);
+    if (!step || step.type !== "wait_for_event") continue;
+
+    const existing = run.stepStates?.[step.key];
+    if (existing?.status !== "waiting" || existing.output?.waited_event) {
+      continue;
+    }
+
+    const config = normalizeWaitForEventConfig(step.config ?? {});
+    if (config.event_name !== delivery.eventName) continue;
+
+    const states = setStepState(cloneStepStates(run), step.key, {
+      status: "running",
+      startedAt: existing.startedAt ?? iso(now),
+    });
+    const updated = await advanceRun(
+      deps,
+      run,
+      automation,
+      steps,
+      step,
+      states,
+      now,
+      {
+        ...(existing.output ?? {}),
+        waited_event: waitedEventOutput(delivery, now),
+      },
+    );
+    if (updated) resumed.push(updated);
+  }
+
+  return resumed;
 }
 
 export async function processScheduledAutomations(

--- a/tests/api-automations-events.test.ts
+++ b/tests/api-automations-events.test.ts
@@ -10,6 +10,7 @@ const mockCustomEventCreate = vi.hoisted(() => vi.fn());
 const mockCustomEventList = vi.hoisted(() => vi.fn());
 const mockDeliveryRecord = vi.hoisted(() => vi.fn());
 const mockRunCreateFromTrigger = vi.hoisted(() => vi.fn());
+const mockResumeWaitingRunsForEvent = vi.hoisted(() => vi.fn());
 const mockDbSelect = vi.hoisted(() => vi.fn());
 const mockDbInsert = vi.hoisted(() => vi.fn());
 const mockDbUpdate = vi.hoisted(() => vi.fn());
@@ -53,6 +54,10 @@ vi.mock("@/lib/api-auth", () => ({
   validateApiKey: mockValidateApiKey,
   unauthorizedResponse: () =>
     Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/workers/automation-runner", () => ({
+  resumeWaitingRunsForEvent: mockResumeWaitingRunsForEvent,
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -155,6 +160,7 @@ describe("automation API routes", () => {
     vi.resetModules();
     vi.clearAllMocks();
     mockValidateApiKey.mockResolvedValue(auth);
+    mockResumeWaitingRunsForEvent.mockResolvedValue([]);
     mockDbSelect.mockReturnValue(queryRows([triggerStep]));
   });
 
@@ -277,6 +283,84 @@ describe("automation API routes", () => {
     );
   });
 
+  it("creates an automation with a valid wait_for_event step", async () => {
+    mockAutomationCreate.mockResolvedValue({
+      automation,
+      steps: [
+        triggerStep,
+        {
+          ...triggerStep,
+          id: "step_wait",
+          key: "wait",
+          type: "wait_for_event",
+          config: { event_name: "invoice.paid", timeout_seconds: 600 },
+          position: 1,
+        },
+      ],
+    });
+    const { POST } = await import("@/app/api/automations/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/automations", {
+        name: "Wait",
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.signed_up" },
+          },
+          {
+            key: "wait",
+            type: "wait_for_event",
+            config: { event_name: "invoice.paid", timeout_seconds: 600 },
+          },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockAutomationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        steps: expect.arrayContaining([
+          expect.objectContaining({
+            type: "wait_for_event",
+            config: { event_name: "invoice.paid", timeout_seconds: 600 },
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it("rejects invalid wait_for_event config with field-level errors", async () => {
+    const { POST } = await import("@/app/api/automations/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/automations", {
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.signed_up" },
+          },
+          {
+            key: "wait",
+            type: "wait_for_event",
+            config: { event_name: "", timeout_seconds: 0 },
+          },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(422);
+    const json = await response.json();
+    expect(json.details.fieldErrors.steps).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("event_name"),
+        expect.stringContaining("timeout_seconds"),
+      ]),
+    );
+  });
+
   it("returns 422 when repository graph validation rejects condition branches", async () => {
     mockAutomationCreate.mockRejectedValue(
       new TestAutomationValidationError(
@@ -361,6 +445,7 @@ describe("events API routes", () => {
     vi.resetModules();
     vi.clearAllMocks();
     mockValidateApiKey.mockResolvedValue(auth);
+    mockResumeWaitingRunsForEvent.mockResolvedValue([]);
   });
 
   it("creates and lists custom events", async () => {
@@ -415,7 +500,7 @@ describe("events API routes", () => {
     const both = await POST(
       jsonRequest("http://localhost/api/events/send", {
         event: "user.signed_up",
-        contact_id: "11111111-1111-1111-1111-111111111111",
+        contact_id: "11111111-1111-4111-8111-111111111111",
         email: "u@example.com",
       }),
     );
@@ -485,6 +570,64 @@ describe("events API routes", () => {
       "user.signed_up",
       "user_1",
     );
+    expect(mockResumeWaitingRunsForEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "delivery_1" }),
+    );
     expect(mockRunCreateFromTrigger).toHaveBeenCalledTimes(2);
+  });
+
+  it("includes wait_for_event resumed runs when sending a matching event", async () => {
+    mockContactFindFirst.mockResolvedValue({ id: "contact_1" });
+    mockDeliveryRecord.mockResolvedValue({
+      id: "delivery_1",
+      eventName: "invoice.paid",
+      contactId: "contact_1",
+      email: "user@example.com",
+      payload: { invoice_id: "inv_1" },
+      receivedAt: now,
+    });
+    mockResumeWaitingRunsForEvent.mockResolvedValue([
+      {
+        id: "run_wait",
+        automationId: "auto_1",
+        status: "queued",
+        triggerEventId: "trigger_delivery",
+        contactId: "contact_1",
+        stepStates: {
+          wait: {
+            status: "completed",
+            output: {
+              waited_event: {
+                delivery_id: "delivery_1",
+                payload: { invoice_id: "inv_1" },
+              },
+            },
+          },
+        },
+        startedAt: now,
+        completedAt: null,
+        currentStepKey: "send",
+        failureReason: null,
+        nextStepAt: now,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+    mockFindEnabledByTriggerEventName.mockResolvedValue([]);
+    const { POST } = await import("@/app/api/events/send/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/events/send", {
+        event: "invoice.paid",
+        contact_id: "11111111-1111-4111-8111-111111111111",
+        payload: { invoice_id: "inv_1" },
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      resumed_runs: [{ id: "run_wait", current_step_key: "send" }],
+      automation_runs: [],
+    });
   });
 });

--- a/tests/automation-runner.test.ts
+++ b/tests/automation-runner.test.ts
@@ -153,6 +153,7 @@ function deps(overrides: Partial<AutomationRunnerDeps> = {}) {
     getContact: vi.fn().mockResolvedValue(contact),
     getTemplate: vi.fn().mockResolvedValue(template),
     sendEmail,
+    listWaitingRunsByContact: vi.fn().mockResolvedValue([]),
     updateRun: vi.fn(async (_id, data) => {
       updates.push(data as Partial<AutomationRun>);
       return { ...run(), ...data } as AutomationRun;
@@ -290,6 +291,238 @@ describe("automation runner", () => {
       status: "completed",
       output: { matched: true, branch: "condition_met" },
     });
+  });
+
+  it("enters wait_for_event waiting state without downstream work in the same tick", async () => {
+    const { processAutomationRunStep } = await import(
+      "@/lib/workers/automation-runner"
+    );
+    const waitAutomation: Automation = {
+      ...automation,
+      connections: [
+        { from: "trigger", to: "wait" },
+        { from: "wait", to: "send" },
+      ],
+    };
+    const waitSteps: AutomationStep[] = [
+      steps[0],
+      {
+        ...steps[1],
+        key: "wait",
+        type: "wait_for_event",
+        config: { event_name: "invoice.paid", timeout_seconds: 900 },
+        position: 1,
+      },
+      steps[2],
+    ];
+    const setup = deps({
+      getAutomation: vi.fn().mockResolvedValue(waitAutomation),
+      listSteps: vi.fn().mockResolvedValue(waitSteps),
+    });
+
+    await processAutomationRunStep(run({ currentStepKey: "wait" }), setup.deps);
+
+    expect(setup.sendEmail).not.toHaveBeenCalled();
+    expect(setup.updates[0]).toMatchObject({
+      status: "waiting",
+      currentStepKey: "wait",
+      nextStepAt: new Date("2026-05-02T00:15:00.000Z"),
+    });
+    expect(setup.updates[0]?.stepStates?.wait).toMatchObject({
+      status: "waiting",
+      scheduledFor: "2026-05-02T00:15:00.000Z",
+      output: {
+        waiting_for_event: "invoice.paid",
+        timeout_at: "2026-05-02T00:15:00.000Z",
+      },
+    });
+  });
+
+  it("fails a due wait_for_event timeout deterministically", async () => {
+    const { processAutomationRunStep } = await import(
+      "@/lib/workers/automation-runner"
+    );
+    const waitSteps: AutomationStep[] = [
+      {
+        ...steps[1],
+        key: "wait",
+        type: "wait_for_event",
+        config: { event_name: "invoice.paid", timeout_seconds: 60 },
+        position: 0,
+      },
+    ];
+    const setup = deps({
+      listSteps: vi.fn().mockResolvedValue(waitSteps),
+    });
+
+    await processAutomationRunStep(
+      run({
+        currentStepKey: "wait",
+        status: "waiting",
+        nextStepAt: now,
+        stepStates: {
+          wait: {
+            status: "waiting",
+            scheduledFor: now.toISOString(),
+            output: { waiting_for_event: "invoice.paid" },
+          },
+        },
+      }),
+      setup.deps,
+    );
+
+    expect(setup.updates[0]).toMatchObject({
+      status: "failed",
+      currentStepKey: "wait",
+      failureReason: "wait_for_event timed out waiting for invoice.paid",
+    });
+  });
+
+  it("resumes a matching wait_for_event run and stores payload output", async () => {
+    const { resumeWaitingRunsForEvent } = await import(
+      "@/lib/workers/automation-runner"
+    );
+    const waitAutomation: Automation = {
+      ...automation,
+      connections: [{ from: "wait", to: "send" }],
+    };
+    const waitSteps: AutomationStep[] = [
+      {
+        ...steps[1],
+        key: "wait",
+        type: "wait_for_event",
+        config: { event_name: "invoice.paid", timeout_seconds: 3600 },
+        position: 0,
+      },
+      steps[2],
+    ];
+    const waitingRun = run({
+      currentStepKey: "wait",
+      status: "waiting",
+      stepStates: {
+        wait: {
+          status: "waiting",
+          scheduledFor: "2026-05-02T01:00:00.000Z",
+          output: { waiting_for_event: "invoice.paid" },
+        },
+      },
+    });
+    const invoiceDelivery: Delivery = {
+      ...delivery,
+      id: "41111111-1111-1111-1111-111111111112",
+      eventName: "invoice.paid",
+      payload: { invoice_id: "inv_1", plan: "pro" },
+    };
+    const setup = deps({
+      getAutomation: vi.fn().mockResolvedValue(waitAutomation),
+      listSteps: vi.fn().mockResolvedValue(waitSteps),
+      listWaitingRunsByContact: vi.fn().mockResolvedValue([waitingRun]),
+    });
+
+    const resumed = await resumeWaitingRunsForEvent(
+      invoiceDelivery,
+      setup.deps,
+    );
+
+    expect(resumed).toHaveLength(1);
+    expect(setup.updates[0]).toMatchObject({
+      status: "queued",
+      currentStepKey: "send",
+      nextStepAt: now,
+    });
+    expect(setup.updates[0]?.stepStates?.wait).toMatchObject({
+      status: "completed",
+      output: {
+        waiting_for_event: "invoice.paid",
+        waited_event: {
+          delivery_id: invoiceDelivery.id,
+          event_name: "invoice.paid",
+          payload: { invoice_id: "inv_1", plan: "pro" },
+          contact_id: contact.id,
+          email: "user@example.com",
+          received_at: now.toISOString(),
+          matched_at: now.toISOString(),
+        },
+      },
+    });
+  });
+
+  it("does not resume wait_for_event runs for non-matching events", async () => {
+    const { resumeWaitingRunsForEvent } = await import(
+      "@/lib/workers/automation-runner"
+    );
+    const waitSteps: AutomationStep[] = [
+      {
+        ...steps[1],
+        key: "wait",
+        type: "wait_for_event",
+        config: { event_name: "invoice.paid" },
+        position: 0,
+      },
+    ];
+    const setup = deps({
+      listSteps: vi.fn().mockResolvedValue(waitSteps),
+      listWaitingRunsByContact: vi.fn().mockResolvedValue([
+        run({
+          currentStepKey: "wait",
+          status: "waiting",
+          stepStates: {
+            wait: {
+              status: "waiting",
+              output: { waiting_for_event: "invoice.paid" },
+            },
+          },
+        }),
+      ]),
+    });
+
+    const resumed = await resumeWaitingRunsForEvent(delivery, setup.deps);
+
+    expect(resumed).toEqual([]);
+    expect(setup.updates).toHaveLength(0);
+  });
+
+  it("resolves waited event output for downstream send_email variables", async () => {
+    const { processAutomationRunStep } = await import(
+      "@/lib/workers/automation-runner"
+    );
+    const waitSendStep: AutomationStep = {
+      ...steps[2],
+      config: {
+        template: {
+          id: "31111111-1111-1111-1111-111111111111",
+          variables: { plan: "wait_events.wait.payload.plan" },
+        },
+        subject: "Invoice {{wait_events.wait.payload.invoice_id}} paid",
+      },
+    };
+    const setup = deps({
+      listSteps: vi.fn().mockResolvedValue([waitSendStep]),
+    });
+
+    await processAutomationRunStep(
+      run({
+        currentStepKey: "send",
+        stepStates: {
+          wait: {
+            status: "completed",
+            output: {
+              waited_event: {
+                payload: { invoice_id: "inv_1", plan: "enterprise" },
+              },
+            },
+          },
+        },
+      }),
+      setup.deps,
+    );
+
+    expect(setup.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: "Invoice inv_1 paid",
+        html: "<p>Ada picked enterprise</p>",
+      }),
+    );
   });
 
   it("evaluates condition steps and advances to the not-met branch", async () => {

--- a/tests/core-automation-repo.test.ts
+++ b/tests/core-automation-repo.test.ts
@@ -232,6 +232,62 @@ describe("automationRepo.create", () => {
     ).rejects.toMatchObject({ code: "condition_operator_invalid" });
   });
 
+  it("accepts wait_for_event steps with bounded timeout config", async () => {
+    const { automationRepo } = await import(
+      "../packages/core/src/db/repositories/automationRepo"
+    );
+
+    await expect(
+      automationRepo.create({
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.signed_up" },
+            position: 0,
+          },
+          {
+            key: "wait",
+            type: "wait_for_event",
+            config: { event_name: "invoice.paid", timeout_seconds: 3600 },
+            position: 1,
+          },
+          { key: "end", type: "end", config: {}, position: 2 },
+        ],
+        connections: [
+          { from: "trigger", to: "wait" },
+          { from: "wait", to: "end" },
+        ],
+      }),
+    ).resolves.toMatchObject({ automation: { id: "auto_1" } });
+  });
+
+  it("rejects invalid wait_for_event timeout config", async () => {
+    const { automationRepo } = await import(
+      "../packages/core/src/db/repositories/automationRepo"
+    );
+
+    await expect(
+      automationRepo.create({
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.signed_up" },
+            position: 0,
+          },
+          {
+            key: "wait",
+            type: "wait_for_event",
+            config: { event_name: "invoice.paid", timeout_seconds: 0 },
+            position: 1,
+          },
+          { key: "end", type: "end", config: {}, position: 2 },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "wait_for_event_timeout_invalid" });
+  });
+
   it("rejects condition branch labels from non-condition steps", async () => {
     const { automationRepo } = await import(
       "../packages/core/src/db/repositories/automationRepo"


### PR DESCRIPTION
## Summary
- Adds validated `wait_for_event` automation step config (`event_name`, optional bounded `timeout_seconds`).
- Runner now enters a waiting state without downstream work, fails deterministically on due timeout, and resolves waited event output for downstream variables.
- `/api/events/send` resumes matching waiting runs for the same tenant/contact and returns `resumed_runs` alongside trigger fan-out runs.
- Uses existing `automation_runs.step_states` JSON state; no new table/migration.

## Tests
- `bun run typecheck && bun run lint && bun run test tests/automation-runner.test.ts tests/api-automations-events.test.ts tests/core-automation-repo.test.ts`
- `make check && make test` — 85 files / 692 tests passed

Closes #167
Parent: #120
