### PR TITLE
Add machine-readable send API error envelope

### DIFF
--- a/agent_docs/learnings/active/2026-05-04-issue-170-send-api-error-envelope.md
+++ b/agent_docs/learnings/active/2026-05-04-issue-170-send-api-error-envelope.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-04
+issue: "#170"
+type: decision
+promoted_to: null
+---
+
+## Keep the first public error envelope at the send API boundary
+
+**What:** Issue #170 adds a shared `src/lib/api-errors.ts` envelope and applies it to `POST /api/emails`, `POST /api/emails/batch`, quota failures, send-route rate-limit responses, and SDK parsing. The envelope carries `name`, `code`, `message`, `statusCode`, and sanitized optional `details`.
+
+**Why:** Error codes are now a public API contract, but the first parity slice should avoid churn across dashboard/internal routes. Keeping the scope at send APIs preserves success response shapes and limits compatibility risk.
+
+**Pattern:** Validation details should expose only `formErrors` and `fieldErrors`; auth errors distinguish missing/malformed/invalid bearer keys without echoing keys, token hashes, or raw validation payloads.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -27,9 +27,16 @@ interface SDKOptions {
   baseUrl: string;
 }
 
+interface ApiError {
+  message: string;
+  statusCode: number;
+  name?: string;
+  code?: string;
+}
+
 interface ApiResponse<T> {
   data: T | null;
-  error: { message: string; statusCode: number } | null;
+  error: ApiError | null;
 }
 
 export type SendEmailPayload = EmailOptions & {
@@ -101,6 +108,43 @@ function normalizeBaseUrl(baseUrl?: string): string {
   return normalized.toString().replace(/\/$/, "");
 }
 
+function getStringProperty(
+  value: Record<string, unknown>,
+  key: string,
+): string | null {
+  const property = value[key];
+  return typeof property === "string" ? property : null;
+}
+
+function parseApiErrorBody(parsedBody: unknown, response: Response): ApiError {
+  const errorBody =
+    parsedBody && typeof parsedBody === "object"
+      ? (parsedBody as Record<string, unknown>)
+      : null;
+
+  if (!errorBody) {
+    return {
+      message: response.statusText || "Request failed",
+      statusCode: response.status,
+    };
+  }
+
+  const message =
+    getStringProperty(errorBody, "message") ??
+    getStringProperty(errorBody, "error") ??
+    response.statusText ??
+    "Request failed";
+  const name = getStringProperty(errorBody, "name");
+  const code = getStringProperty(errorBody, "code");
+
+  return {
+    message,
+    statusCode: response.status,
+    ...(name ? { name } : {}),
+    ...(code ? { code } : {}),
+  };
+}
+
 async function renderReactToHtml(element: unknown): Promise<string | null> {
   try {
     const { renderToStaticMarkup } = await import("react-dom/server");
@@ -139,20 +183,9 @@ class HttpClient {
       const parsedBody = rawBody ? (JSON.parse(rawBody) as unknown) : null;
 
       if (!response.ok) {
-        const errorBody =
-          parsedBody && typeof parsedBody === "object" ? parsedBody : null;
-
         return {
           data: null,
-          error: {
-            message:
-              errorBody &&
-              "error" in errorBody &&
-              typeof errorBody.error === "string"
-                ? errorBody.error
-                : response.statusText || "Request failed",
-            statusCode: response.status,
-          },
+          error: parseApiErrorBody(parsedBody, response),
         };
       }
 
@@ -163,6 +196,8 @@ class HttpClient {
         error: {
           message: error instanceof Error ? error.message : "Unknown error",
           statusCode: 500,
+          name: "internal_server_error",
+          code: "internal_server_error",
         },
       };
     }
@@ -424,6 +459,7 @@ class OpenSend {
 export { OpenSend };
 export type {
   SDKOptions,
+  ApiError,
   ApiResponse,
   EmailOptions,
   EmailResponse,

--- a/src/app/api/emails/batch/route.ts
+++ b/src/app/api/emails/batch/route.ts
@@ -1,4 +1,9 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import {
+  getApiKeyAuthHeaderError,
+  publicApiKeyUnauthorizedResponse,
+  validateApiKey,
+} from "@/lib/api-auth";
+import { publicApiError, zodValidationDetails } from "@/lib/api-errors";
 import { quotaExceededResponse, reserveEmailQuota } from "@/lib/billing/quota";
 import { db } from "@/lib/db";
 import { emails } from "@/lib/db/schema";
@@ -74,16 +79,23 @@ export async function POST(request: Request): Promise<Response> {
     route: "/api/emails/batch",
   });
 
-  const auth = await validateApiKey(request.headers.get("authorization"));
+  const authHeader = request.headers.get("authorization");
+  const authHeaderError = getApiKeyAuthHeaderError(authHeader);
+  const auth = authHeaderError ? null : await validateApiKey(authHeader);
   if (!auth) {
     recordBatchMetric(telemetry, {
       durationMs: performance.now() - startedAt,
       outcome: "unauthorized",
     });
-    const response = unauthorizedResponse();
-    response.headers.set("x-correlation-id", telemetry.correlationId);
-    response.headers.set("traceparent", telemetry.traceparent);
-    return response;
+    return publicApiKeyUnauthorizedResponse(
+      authHeaderError ?? "invalid_api_key",
+      {
+        headers: {
+          "x-correlation-id": telemetry.correlationId,
+          traceparent: telemetry.traceparent,
+        },
+      },
+    );
   }
 
   let body: unknown;
@@ -94,9 +106,11 @@ export async function POST(request: Request): Promise<Response> {
       durationMs: performance.now() - startedAt,
       outcome: "invalid",
     });
-    return jsonWithTelemetry({ error: "Invalid JSON body" }, telemetry, {
-      status: 400,
-    });
+    return jsonWithTelemetry(
+      publicApiError("invalid_json", "Request body must be valid JSON.", 400),
+      telemetry,
+      { status: 400 },
+    );
   }
 
   const result = batchSendEmailSchema.safeParse(body);
@@ -106,7 +120,12 @@ export async function POST(request: Request): Promise<Response> {
       outcome: "invalid",
     });
     return jsonWithTelemetry(
-      { error: "Validation failed", details: result.error.flatten() },
+      publicApiError(
+        "validation_error",
+        "Validation failed.",
+        422,
+        zodValidationDetails(result.error),
+      ),
       telemetry,
       { status: 422 },
     );
@@ -243,8 +262,6 @@ export async function POST(request: Request): Promise<Response> {
     });
     return jsonWithTelemetry({ data: results }, telemetry);
   } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to send batch emails";
     recordTelemetryError(telemetry, "email.batch_accept.failed", err);
     emitCloudWatchMetric(telemetry, {
       metrics: [
@@ -261,6 +278,14 @@ export async function POST(request: Request): Promise<Response> {
         Outcome: "failed",
       },
     });
-    return jsonWithTelemetry({ error: message }, telemetry, { status: 500 });
+    return jsonWithTelemetry(
+      publicApiError(
+        "internal_server_error",
+        "Failed to send batch emails.",
+        500,
+      ),
+      telemetry,
+      { status: 500 },
+    );
   }
 }

--- a/src/app/api/emails/route.ts
+++ b/src/app/api/emails/route.ts
@@ -1,4 +1,10 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import {
+  getApiKeyAuthHeaderError,
+  publicApiKeyUnauthorizedResponse,
+  unauthorizedResponse,
+  validateApiKey,
+} from "@/lib/api-auth";
+import { publicApiError, zodValidationDetails } from "@/lib/api-errors";
 import {
   quotaExceededResponse,
   releaseEmailQuota,
@@ -18,7 +24,7 @@ import {
   recordTelemetryError,
 } from "@opensend/core";
 import { and, desc, eq, gt, lt } from "drizzle-orm";
-import { type ZodError, flattenError } from "zod";
+import type { ZodError } from "zod";
 
 // ── Helpers ───────────────────────────────────────────────────────
 
@@ -78,16 +84,23 @@ export async function POST(request: Request): Promise<Response> {
     route: "/api/emails",
   });
 
-  const auth = await validateApiKey(request.headers.get("authorization"));
+  const authHeader = request.headers.get("authorization");
+  const authHeaderError = getApiKeyAuthHeaderError(authHeader);
+  const auth = authHeaderError ? null : await validateApiKey(authHeader);
   if (!auth) {
     recordAcceptMetric(telemetry, {
       durationMs: performance.now() - startedAt,
       outcome: "unauthorized",
     });
-    const response = unauthorizedResponse();
-    response.headers.set("x-correlation-id", telemetry.correlationId);
-    response.headers.set("traceparent", telemetry.traceparent);
-    return response;
+    return publicApiKeyUnauthorizedResponse(
+      authHeaderError ?? "invalid_api_key",
+      {
+        headers: {
+          "x-correlation-id": telemetry.correlationId,
+          traceparent: telemetry.traceparent,
+        },
+      },
+    );
   }
 
   const idempotencyKey = request.headers.get("idempotency-key");
@@ -100,7 +113,11 @@ export async function POST(request: Request): Promise<Response> {
       outcome: "invalid",
     });
     return jsonWithTelemetry(
-      { error: "Invalid idempotency key length" },
+      publicApiError(
+        "invalid_idempotency_key",
+        "Idempotency-Key must be between 1 and 255 characters.",
+        400,
+      ),
       telemetry,
       { status: 400 },
     );
@@ -114,9 +131,11 @@ export async function POST(request: Request): Promise<Response> {
       durationMs: performance.now() - startedAt,
       outcome: "invalid",
     });
-    return jsonWithTelemetry({ error: "Invalid JSON body" }, telemetry, {
-      status: 400,
-    });
+    return jsonWithTelemetry(
+      publicApiError("invalid_json", "Request body must be valid JSON.", 400),
+      telemetry,
+      { status: 400 },
+    );
   }
 
   const result = sendEmailSchema.safeParse(body);
@@ -126,7 +145,12 @@ export async function POST(request: Request): Promise<Response> {
       outcome: "invalid",
     });
     return jsonWithTelemetry(
-      { error: "Validation failed", details: flattenError(result.error) },
+      publicApiError(
+        "validation_error",
+        "Validation failed.",
+        422,
+        zodValidationDetails(result.error),
+      ),
       telemetry,
       { status: 422 },
     );
@@ -144,7 +168,16 @@ export async function POST(request: Request): Promise<Response> {
         durationMs: performance.now() - startedAt,
         outcome: "queued",
       });
-      return jsonWithTelemetry({ id: existing.id }, telemetry, { status: 409 });
+      return jsonWithTelemetry(
+        publicApiError(
+          "idempotency_conflict",
+          "A request with this idempotency key has already been accepted.",
+          409,
+          { id: existing.id },
+        ),
+        telemetry,
+        { status: 409 },
+      );
     }
   }
 
@@ -171,9 +204,11 @@ export async function POST(request: Request): Promise<Response> {
           durationMs: performance.now() - startedAt,
           outcome: "invalid",
         });
-        return jsonWithTelemetry({ error: "Template not found" }, telemetry, {
-          status: 404,
-        });
+        return jsonWithTelemetry(
+          publicApiError("not_found", "Template not found.", 404),
+          telemetry,
+          { status: 404 },
+        );
       }
 
       // Validate required variables
@@ -194,10 +229,17 @@ export async function POST(request: Request): Promise<Response> {
             outcome: "invalid",
           });
           return jsonWithTelemetry(
-            {
-              error: "Validation failed",
-              message: `Missing required template variable: ${requiredVar}`,
-            },
+            publicApiError(
+              "validation_error",
+              `Missing required template variable: ${requiredVar}`,
+              422,
+              {
+                formErrors: [],
+                fieldErrors: {
+                  template: [`Missing required variable: ${requiredVar}`],
+                },
+              },
+            ),
             telemetry,
             { status: 422 },
           );
@@ -324,7 +366,6 @@ export async function POST(request: Request): Promise<Response> {
     quotaReserved = false;
     return jsonWithTelemetry({ id: createdEmail.id }, telemetry);
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Failed to send email";
     recordTelemetryError(telemetry, "email.accept.failed", err);
     recordAcceptMetric(telemetry, {
       durationMs: performance.now() - startedAt,
@@ -333,7 +374,11 @@ export async function POST(request: Request): Promise<Response> {
     if (quotaReserved) {
       await releaseEmailQuota(auth.userId, 1);
     }
-    return jsonWithTelemetry({ error: message }, telemetry, { status: 500 });
+    return jsonWithTelemetry(
+      publicApiError("internal_server_error", "Failed to send email.", 500),
+      telemetry,
+      { status: 500 },
+    );
   }
 }
 
@@ -442,5 +487,5 @@ export async function DELETE(request: Request): Promise<Response> {
 
 // Error fallback for Zod (kept explicit for strict typing in route handlers)
 export function formatZodError(error: ZodError): Record<string, unknown> {
-  return flattenError(error);
+  return zodValidationDetails(error);
 }

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/db";
 import { apiKeys } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { headers } from "next/headers";
+import { publicApiErrorResponse } from "./api-errors";
 import { auth } from "./auth";
 
 export interface AuthResult {
@@ -13,7 +14,31 @@ export interface AuthResult {
   userId: string | null;
 }
 
+export type ApiKeyAuthHeaderError = "missing_api_key" | "malformed_api_key";
+export type ApiKeyAuthErrorCode = ApiKeyAuthHeaderError | "invalid_api_key";
+
+const API_KEY_AUTH_MESSAGES: Record<ApiKeyAuthErrorCode, string> = {
+  missing_api_key:
+    "Missing API key. Provide an Authorization: Bearer <api_key> header.",
+  malformed_api_key:
+    "Malformed API key. Use the Authorization: Bearer <api_key> header format.",
+  invalid_api_key: "Invalid API key.",
+};
+
 const API_KEY_AUTH_CACHE_TTL_SECONDS = 300;
+
+export function getApiKeyAuthHeaderError(
+  authHeader: string | null | undefined,
+): ApiKeyAuthHeaderError | null {
+  if (!authHeader) return "missing_api_key";
+
+  const parts = authHeader.split(" ");
+  if (parts.length !== 2 || parts[0] !== "Bearer" || !parts[1]) {
+    return "malformed_api_key";
+  }
+
+  return null;
+}
 
 function getApiKeyAuthCacheKeyFromHash(tokenHash: string): string {
   return `auth:apikey:${tokenHash}`;
@@ -52,12 +77,9 @@ export async function invalidateApiKeyAuthCache(
 export async function validateApiKey(
   authHeader: string | null | undefined,
 ): Promise<AuthResult | null> {
-  if (!authHeader) return null;
+  if (getApiKeyAuthHeaderError(authHeader)) return null;
 
-  const parts = authHeader.split(" ");
-  if (parts.length !== 2 || parts[0] !== "Bearer") return null;
-
-  const rawKey = parts[1];
+  const rawKey = authHeader?.split(" ")[1];
   if (!rawKey) return null;
 
   const hashedKey = createHash("sha256").update(rawKey).digest("hex");
@@ -139,6 +161,13 @@ export function validateDashboardKey(
 /**
  * Helper to create a 401 JSON response.
  */
+export function publicApiKeyUnauthorizedResponse(
+  code: ApiKeyAuthErrorCode = "invalid_api_key",
+  init?: ResponseInit,
+): Response {
+  return publicApiErrorResponse(code, API_KEY_AUTH_MESSAGES[code], 401, init);
+}
+
 export function unauthorizedResponse(): Response {
   return Response.json(
     { error: "Missing or invalid API key" },

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -1,0 +1,66 @@
+import { type ZodError, flattenError } from "zod";
+
+export type PublicApiErrorCode =
+  | "invalid_json"
+  | "validation_error"
+  | "missing_api_key"
+  | "malformed_api_key"
+  | "invalid_api_key"
+  | "invalid_idempotency_key"
+  | "idempotency_conflict"
+  | "not_found"
+  | "quota_exceeded"
+  | "rate_limit_exceeded"
+  | "rate_limit_unavailable"
+  | "internal_server_error";
+
+export type PublicApiErrorDetails =
+  | { formErrors: string[]; fieldErrors: Record<string, string[]> }
+  | Record<string, string | number | boolean | null>;
+
+export interface PublicApiErrorEnvelope {
+  name: PublicApiErrorCode;
+  code: PublicApiErrorCode;
+  message: string;
+  statusCode: number;
+  details?: PublicApiErrorDetails;
+}
+
+export function publicApiError(
+  code: PublicApiErrorCode,
+  message: string,
+  statusCode: number,
+  details?: PublicApiErrorDetails,
+): PublicApiErrorEnvelope {
+  return details === undefined
+    ? { name: code, code, message, statusCode }
+    : { name: code, code, message, statusCode, details };
+}
+
+export function publicApiErrorResponse(
+  code: PublicApiErrorCode,
+  message: string,
+  statusCode: number,
+  init?: ResponseInit & { details?: PublicApiErrorDetails },
+): Response {
+  const headers = new Headers(init?.headers);
+  return Response.json(
+    publicApiError(code, message, statusCode, init?.details),
+    {
+      ...init,
+      status: statusCode,
+      headers,
+    },
+  );
+}
+
+export function zodValidationDetails(error: ZodError): {
+  formErrors: string[];
+  fieldErrors: Record<string, string[]>;
+} {
+  const flattened = flattenError(error);
+  return {
+    formErrors: flattened.formErrors,
+    fieldErrors: flattened.fieldErrors,
+  };
+}

--- a/src/lib/billing/quota.ts
+++ b/src/lib/billing/quota.ts
@@ -1,3 +1,4 @@
+import { publicApiErrorResponse } from "@/lib/api-errors";
 import { db } from "@/lib/db";
 import {
   apiKeys,
@@ -344,16 +345,14 @@ export function quotaExceededResponse(
   info: QuotaExceededInfo,
   init?: ResponseInit,
 ): Response {
-  const headers = new Headers(init?.headers);
-  return Response.json(
-    {
-      error: "quota_exceeded",
+  return publicApiErrorResponse("quota_exceeded", "Quota exceeded.", 402, {
+    ...init,
+    details: {
       resource: info.resource,
       limit: info.limit,
       used: info.used,
       plan: info.plan,
       upgrade_url: info.upgrade_url,
     },
-    { ...init, status: 402, headers },
-  );
+  });
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -73,6 +73,13 @@ async function checkRate(
 }
 
 // Rate limit tiers by route pattern
+function isSendApiPost(pathname: string, method: string): boolean {
+  return (
+    method === "POST" &&
+    (pathname === "/api/emails" || pathname === "/api/emails/batch")
+  );
+}
+
 function getLimits(
   pathname: string,
   method: string,
@@ -145,23 +152,34 @@ export async function middleware(request: NextRequest) {
   const result = await checkRate(rateLimitKey, max, windowMs, rateLimit);
 
   if (!result.allowed) {
+    const message =
+      result.status === 429
+        ? "Rate limit exceeded. Try again later."
+        : result.error;
+    const headers = new Headers({ "X-RateLimit-Backend": backend });
+    if (result.status === 429) {
+      headers.set("Retry-After", String(result.retryAfter));
+    }
+
+    if (isSendApiPost(pathname, request.method)) {
+      const code =
+        result.status === 429
+          ? "rate_limit_exceeded"
+          : "rate_limit_unavailable";
+      return NextResponse.json(
+        {
+          name: code,
+          code,
+          message,
+          statusCode: result.status,
+        },
+        { status: result.status, headers },
+      );
+    }
+
     return NextResponse.json(
-      {
-        error:
-          result.status === 429
-            ? "Rate limit exceeded. Try again later."
-            : result.error,
-      },
-      {
-        status: result.status,
-        headers:
-          result.status === 429
-            ? {
-                "Retry-After": String(result.retryAfter),
-                "X-RateLimit-Backend": backend,
-              }
-            : { "X-RateLimit-Backend": backend },
-      },
+      { error: message },
+      { status: result.status, headers },
     );
   }
 

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mockSendEmail = vi.hoisted(() => vi.fn());
 const mockPublishBackgroundJob = vi.hoisted(() => vi.fn());
 const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockGetApiKeyAuthHeaderError = vi.hoisted(() => vi.fn());
 const mockEmitCloudWatchMetric = vi.hoisted(() => vi.fn());
 const mockLogTelemetry = vi.hoisted(() => vi.fn());
 const mockRecordTelemetryError = vi.hoisted(() => vi.fn());
@@ -82,11 +83,16 @@ vi.mock("@/lib/db", () => ({
   db: mockDb,
 }));
 
-vi.mock("@/lib/api-auth", () => ({
-  validateApiKey: mockValidateApiKey,
-  unauthorizedResponse: () =>
-    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
-}));
+vi.mock("@/lib/api-auth", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/api-auth")>("@/lib/api-auth");
+  return {
+    validateApiKey: mockValidateApiKey,
+    getApiKeyAuthHeaderError: mockGetApiKeyAuthHeaderError,
+    publicApiKeyUnauthorizedResponse: actual.publicApiKeyUnauthorizedResponse,
+    unauthorizedResponse: actual.unauthorizedResponse,
+  };
+});
 
 // Mock drizzle-orm operators
 vi.mock("drizzle-orm", async () => {
@@ -131,7 +137,20 @@ function makeRequest(
 // ── Auth Middleware Tests ──────────────────────────────────────────
 
 describe("API Key Authentication", () => {
-  it("returns 401 when no auth header", async () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetApiKeyAuthHeaderError.mockImplementation(
+      (authHeader: string | null | undefined) => {
+        if (!authHeader) return "missing_api_key";
+        const parts = authHeader.split(" ");
+        return parts.length === 2 && parts[0] === "Bearer" && parts[1]
+          ? null
+          : "malformed_api_key";
+      },
+    );
+  });
+
+  it("returns 401 with a machine-readable code when no auth header", async () => {
     mockValidateApiKey.mockResolvedValue(null);
     const { POST } = await import("@/app/api/emails/route");
     const req = makeRequest("POST", {
@@ -142,16 +161,56 @@ describe("API Key Authentication", () => {
     });
     const res = await POST(req);
     expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "missing_api_key",
+      code: "missing_api_key",
+      statusCode: 401,
+      message: expect.any(String),
+    });
   });
 
-  it("returns 401 for invalid key", async () => {
+  it("returns 401 with a malformed key code for bad Authorization shape", async () => {
     mockValidateApiKey.mockResolvedValue(null);
-    const { GET } = await import("@/app/api/emails/route");
-    const req = new Request("http://localhost:3015/api/emails", {
-      headers: { Authorization: "Bearer bad_key" },
-    });
-    const res = await GET(req);
+    const { POST } = await import("@/app/api/emails/route");
+    const req = makeRequest(
+      "POST",
+      {
+        from: "a@b.com",
+        to: ["c@d.com"],
+        subject: "X",
+        html: "<p>Y</p>",
+      },
+      { Authorization: "Basic nope" },
+    );
+    const res = await POST(req);
     expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "malformed_api_key",
+      code: "malformed_api_key",
+      statusCode: 401,
+    });
+  });
+
+  it("returns 401 with an invalid key code for send requests", async () => {
+    mockValidateApiKey.mockResolvedValue(null);
+    const { POST } = await import("@/app/api/emails/route");
+    const req = makeRequest(
+      "POST",
+      {
+        from: "a@b.com",
+        to: ["c@d.com"],
+        subject: "X",
+        html: "<p>Y</p>",
+      },
+      { Authorization: "Bearer bad_key" },
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "invalid_api_key",
+      code: "invalid_api_key",
+      statusCode: 401,
+    });
   });
 });
 
@@ -165,6 +224,7 @@ describe("POST /api/emails", () => {
     mockEmitCloudWatchMetric.mockReset();
     mockLogTelemetry.mockReset();
     mockRecordTelemetryError.mockReset();
+    mockGetApiKeyAuthHeaderError.mockReturnValue(null);
     mockDb.transaction.mockImplementation(
       async (callback: (tx: typeof mockDb) => unknown) => callback(mockDb),
     );
@@ -190,7 +250,10 @@ describe("POST /api/emails", () => {
     expect(res.status).toBe(422);
     const json = await res.json();
     expect(json).toEqual({
-      error: "Validation failed",
+      name: "validation_error",
+      code: "validation_error",
+      message: "Validation failed.",
+      statusCode: 422,
       details: {
         formErrors: [],
         fieldErrors: {
@@ -198,6 +261,28 @@ describe("POST /api/emails", () => {
           subject: [expect.any(String)],
         },
       },
+    });
+  });
+
+  it("returns 400 with invalid_json for malformed JSON", async () => {
+    const { POST } = await import("@/app/api/emails/route");
+    const req = new Request("http://localhost:3015/api/emails", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer re_test123",
+        "Content-Type": "application/json",
+      },
+      body: "{",
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "invalid_json",
+      code: "invalid_json",
+      message: "Request body must be valid JSON.",
+      statusCode: 400,
     });
   });
 
@@ -402,6 +487,7 @@ describe("POST /api/emails/batch", () => {
     mockEmitCloudWatchMetric.mockReset();
     mockLogTelemetry.mockReset();
     mockRecordTelemetryError.mockReset();
+    mockGetApiKeyAuthHeaderError.mockReturnValue(null);
     mockDb.transaction.mockImplementation(
       async (callback: (tx: typeof mockDb) => unknown) => callback(mockDb),
     );
@@ -426,8 +512,34 @@ describe("POST /api/emails/batch", () => {
     const res = await POST(req);
     expect(res.status).toBe(422);
     const json = await res.json();
-    expect(json.error).toBe("Validation failed");
+    expect(json).toMatchObject({
+      name: "validation_error",
+      code: "validation_error",
+      message: "Validation failed.",
+      statusCode: 422,
+    });
     expect(json.details.formErrors[0]).toContain("100");
+  });
+
+  it("returns 400 with invalid_json for malformed batch JSON", async () => {
+    const { POST } = await import("@/app/api/emails/batch/route");
+    const req = new Request("http://localhost:3015/api/emails/batch", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer re_test123",
+        "Content-Type": "application/json",
+      },
+      body: "[",
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "invalid_json",
+      code: "invalid_json",
+      statusCode: 400,
+    });
   });
 
   it("sends batch and returns array of ids", async () => {

--- a/tests/middleware-rate-limit.test.ts
+++ b/tests/middleware-rate-limit.test.ts
@@ -78,7 +78,10 @@ describe("middleware rate limiting", () => {
     expect(response.headers.get("retry-after")).toBe("17");
     expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
     await expect(response.json()).resolves.toEqual({
-      error: "Rate limit exceeded. Try again later.",
+      name: "rate_limit_exceeded",
+      code: "rate_limit_exceeded",
+      message: "Rate limit exceeded. Try again later.",
+      statusCode: 429,
     });
   });
 
@@ -94,7 +97,10 @@ describe("middleware rate limiting", () => {
     expect(response.status).toBe(503);
     expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
     await expect(response.json()).resolves.toEqual({
-      error: "Rate limiting is temporarily unavailable.",
+      name: "rate_limit_unavailable",
+      code: "rate_limit_unavailable",
+      message: "Rate limiting is temporarily unavailable.",
+      statusCode: 503,
     });
   });
 });

--- a/tests/quota-routes.test.ts
+++ b/tests/quota-routes.test.ts
@@ -15,6 +15,7 @@ const mockDb = vi.hoisted(() => ({
 vi.mock("@/lib/db", () => ({ db: mockDb }));
 vi.mock("@/lib/api-auth", () => ({
   validateApiKey: mockValidateApiKey,
+  getApiKeyAuthHeaderError: () => null,
   unauthorizedResponse: () =>
     Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
 }));
@@ -29,7 +30,17 @@ vi.mock("@/lib/billing/quota", () => ({
     used: number;
     plan: string;
     upgrade_url: string;
-  }) => Response.json({ error: "quota_exceeded", ...info }, { status: 402 }),
+  }) =>
+    Response.json(
+      {
+        name: "quota_exceeded",
+        code: "quota_exceeded",
+        message: "Quota exceeded.",
+        statusCode: 402,
+        details: info,
+      },
+      { status: 402 },
+    ),
 }));
 vi.mock("@/lib/ses", () => ({
   createDomainIdentity: mockCreateDomainIdentity,
@@ -106,11 +117,16 @@ describe("quota route gates", () => {
 
     expect(res.status).toBe(402);
     await expect(res.json()).resolves.toMatchObject({
-      error: "quota_exceeded",
-      limit: 3,
-      used: 3,
-      plan: "free",
-      upgrade_url: "/dashboard/billing",
+      name: "quota_exceeded",
+      code: "quota_exceeded",
+      message: "Quota exceeded.",
+      statusCode: 402,
+      details: {
+        limit: 3,
+        used: 3,
+        plan: "free",
+        upgrade_url: "/dashboard/billing",
+      },
     });
     expect(mockReserveEmailQuota).toHaveBeenCalledWith(
       "user-1",

--- a/tests/sdk-client.test.tsx
+++ b/tests/sdk-client.test.tsx
@@ -99,6 +99,69 @@ describe("OpenSend SDK", () => {
     );
   });
 
+  it("exposes machine-readable API error fields without dropping message or status", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          name: "validation_error",
+          code: "validation_error",
+          message: "Validation failed.",
+          statusCode: 422,
+          details: { fieldErrors: { to: ["Required"] }, formErrors: [] },
+        }),
+        { status: 422, statusText: "Unprocessable Entity" },
+      ),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new OpenSend("re_test", {
+      baseUrl: "https://api.example.com",
+    });
+
+    const response = await client.emails.send({
+      from: "hello@example.com",
+      to: "user@example.com",
+      subject: "Hello",
+      html: "<p>Hello</p>",
+    });
+
+    expect(response).toEqual({
+      data: null,
+      error: {
+        name: "validation_error",
+        code: "validation_error",
+        message: "Validation failed.",
+        statusCode: 422,
+      },
+    });
+  });
+
+  it("keeps legacy string error parsing for older routes", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ error: "Missing or invalid API key" }), {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new OpenSend("re_test", {
+      baseUrl: "https://api.example.com",
+    });
+
+    const response = await client.emails.list();
+
+    expect(response).toEqual({
+      data: null,
+      error: {
+        message: "Missing or invalid API key",
+        statusCode: 401,
+      },
+    });
+  });
+
   it("treats empty successful responses as null data", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()


### PR DESCRIPTION
## Summary
- Adds a shared public API error envelope with `name`, `code`, `message`, `statusCode`, and sanitized optional `details`.
- Applies the envelope to send API failures for `POST /api/emails`, `POST /api/emails/batch`, quota failures, and send-route rate-limit failures while preserving success response shapes and telemetry headers.
- Updates SDK error parsing to preserve existing `message`/`statusCode` and expose machine-readable `name`/`code` fields.

Closes #170

## Validation
- `make check` ✅
- `bun run test tests/api-emails.test.ts tests/quota-routes.test.ts tests/sdk-client.test.tsx tests/middleware-rate-limit.test.ts tests/api-auth-date-range-routes.test.ts` ✅ (50 tests)
- `bun run test tests/api-auth-date-range-routes.test.ts tests/api-domains.test.ts tests/broadcasts-list.test.ts` ✅ (36 tests; reran files that failed during an earlier full parallel run)
- `bun run test tests/automation-runner.test.ts` ✅ (14 tests; focused rerun after full parallel timeout)
- `make check && make test` ⚠️ `make check` passed, full `make test` reached 84/85 files passing and then timed out only on `tests/automation-runner.test.ts > advances trigger then schedules delay next_step_at without sleeping`; the same file passes focused in 2.53s.

## Risk
- New error codes are public API contract; this PR intentionally limits the route surface to send APIs and send-route middleware failures.
- Quota response details are now nested under `details` for public envelope consistency.
