### PR TITLE
docs(parity): file #176 for Idempotency keys

### DIFF
--- a/agent_docs/resend-parity.md
+++ b/agent_docs/resend-parity.md
@@ -30,7 +30,7 @@ Rows are ordered roughly by priority within each area. The inspector's tie-break
 | Batch send (`POST /emails/batch`) | up to 100/req | TBD | ? | ? | ? | ? | P1 | | |
 | Scheduled send (`scheduled_at`) | natural-language + ISO | TBD | ? | ? | ? | ? | P1 | | |
 | Cancel scheduled send | `PATCH /emails/:id` | TBD | ? | ? | ? | ? | P2 | | |
-| Idempotency keys | `Idempotency-Key` header | TBD | ? | ? | ? | ? | P0 | | |
+| Idempotency keys | `Idempotency-Key` header on single and batch send; 24-hour expiry and 256-char max ([docs](https://resend.com/docs/dashboard/emails/idempotency-keys)) | partial: single send validates, checks, and stores `idempotency-key` (`src/app/api/emails/route.ts:155`, `src/app/api/emails/route.ts:210`, `src/app/api/emails/route.ts:361`); batch send ignores the header and does not persist a request key (`src/app/api/emails/batch/route.ts:119`, `src/app/api/emails/batch/route.ts:221`); SDK has no request-options/header path (`packages/sdk/src/index.ts:165`, `packages/sdk/src/index.ts:210`, `packages/sdk/src/index.ts:223`) | partial | behind | behind | n/a | P0 | #176 | 2026-05-04 |
 | Reply-To list | array | TBD | ? | ? | ? | ? | P2 | | |
 | Attachments | base64 + URL fetch | TBD | ? | ? | ? | ? | P1 | | |
 | Tags / metadata | `tags[]` for analytics filter | TBD | ? | ? | ? | ? | P1 | | |


### PR DESCRIPTION
## What
- Filed parity spec issue #176 for the unfiled P0 Idempotency keys gap.
- Updated `agent_docs/resend-parity.md` with Resend behavior, OpenSend evidence, gap columns, issue number, and UTC review date.

## Evidence
- Resend docs: `Idempotency-Key` applies to single and batch send, max 256 chars, expires after 24 hours.
- OpenSend single send reads/checks/stores `idempotency-key`.
- OpenSend batch route does not read or persist a request idempotency key.
- SDK request path lacks a typed request-options/header argument.

## Tested
- `git diff --check agent_docs/resend-parity.md`
- `gh issue view #176` confirmed open issue with `spec-ready` and `parity` labels.

## Not tested
- Runtime app tests; docs-only matrix update.