### PR TITLE
Support idempotency keys for batch sends and SDK options

### DIFF
--- a/agent_docs/learnings/active/2026-05-04-issue-176-batch-idempotency-conflict.md
+++ b/agent_docs/learnings/active/2026-05-04-issue-176-batch-idempotency-conflict.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-04
+issue: 176
+type: decision
+promoted_to: null
+---
+
+# Batch idempotency preserves the existing conflict contract
+
+For issue #176, batch send idempotency uses the existing `emails.idempotency_key` unique column by persisting the request key only on the first accepted row in a batch. Retries precheck that key before body persistence, quota reservation, or queue publishing and return the same public `409 idempotency_conflict` shape used by single send, with `details.id` set to the first accepted row id.
+
+This avoids a schema migration and avoids colliding with the per-row unique index. If future product requirements need replaying every accepted batch id, add a request-level idempotency store instead of forcing the same key onto every email row.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -53,6 +53,45 @@ const { data } = await client.emails.send({
 });
 ```
 
+## Idempotency Keys
+
+Pass a per-request `idempotencyKey` option to prevent accidental duplicate
+acceptance when retrying sends. Keys must match the API contract: 1-255
+characters. OpenSend preserves the existing send contract for duplicate keys: the
+API returns `409 idempotency_conflict` with the originally accepted email id in
+`details.id`; batch duplicates are rejected before reserving quota, creating
+additional rows, or publishing more queue jobs.
+
+```typescript
+await client.emails.send(
+  {
+    from: "hello@updates.example.com",
+    to: "user@example.com",
+    subject: "Welcome!",
+    html: "<h1>Welcome aboard</h1>",
+  },
+  { idempotencyKey: "welcome-user-123" },
+);
+
+await client.emails.sendBatch(
+  [
+    {
+      from: "hello@updates.example.com",
+      to: "a@example.com",
+      subject: "Hi A",
+      html: "<p>A</p>",
+    },
+    {
+      from: "hello@updates.example.com",
+      to: "b@example.com",
+      subject: "Hi B",
+      html: "<p>B</p>",
+    },
+  ],
+  { idempotencyKey: "batch-campaign-123" },
+);
+```
+
 ## Listing Emails
 
 ```typescript

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -27,6 +27,10 @@ interface SDKOptions {
   baseUrl: string;
 }
 
+export interface RequestOptions {
+  idempotencyKey?: string;
+}
+
 interface ApiError {
   message: string;
   statusCode: number;
@@ -166,12 +170,16 @@ class HttpClient {
     method: string,
     path: string,
     body?: unknown,
+    requestOptions: RequestOptions = {},
   ): Promise<ApiResponse<T>> {
     try {
       const headers: Record<string, string> = {
         Authorization: `Bearer ${this.apiKey}`,
         "Content-Type": "application/json",
       };
+      if (requestOptions.idempotencyKey !== undefined) {
+        headers["Idempotency-Key"] = requestOptions.idempotencyKey;
+      }
 
       const options: RequestInit = { method, headers };
       if (body !== undefined) {
@@ -207,7 +215,10 @@ class HttpClient {
 class Emails {
   constructor(private readonly http: HttpClient) {}
 
-  async send(payload: SendEmailPayload): Promise<ApiResponse<EmailResponse>> {
+  async send(
+    payload: SendEmailPayload,
+    options: RequestOptions = {},
+  ): Promise<ApiResponse<EmailResponse>> {
     const { react, ...rest } = payload;
 
     if (react != null) {
@@ -217,16 +228,23 @@ class Emails {
       }
     }
 
-    return this.http.request<EmailResponse>("POST", "/api/emails", rest);
+    return this.http.request<EmailResponse>(
+      "POST",
+      "/api/emails",
+      rest,
+      options,
+    );
   }
 
   async sendBatch(
     payload: SendEmailPayload[],
+    options: RequestOptions = {},
   ): Promise<ApiResponse<BatchEmailResponse>> {
     return this.http.request<BatchEmailResponse>(
       "POST",
       "/api/emails/batch",
       payload,
+      options,
     );
   }
 

--- a/src/app/api/emails/batch/route.ts
+++ b/src/app/api/emails/batch/route.ts
@@ -147,6 +147,49 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
+  const idempotencyKey = request.headers.get("idempotency-key");
+  if (
+    idempotencyKey &&
+    (idempotencyKey.length < 1 || idempotencyKey.length > 255)
+  ) {
+    recordBatchMetric(telemetry, {
+      durationMs: performance.now() - startedAt,
+      outcome: "invalid",
+    });
+    return jsonWithTelemetry(
+      publicApiError(
+        "invalid_idempotency_key",
+        "Idempotency-Key must be between 1 and 255 characters.",
+        400,
+      ),
+      telemetry,
+      { status: 400 },
+    );
+  }
+
+  if (idempotencyKey) {
+    const existing = await db.query.emails.findFirst({
+      where: eq(emails.idempotencyKey, idempotencyKey),
+    });
+    if (existing) {
+      recordBatchMetric(telemetry, {
+        durationMs: performance.now() - startedAt,
+        outcome: "accepted",
+        count: 0,
+      });
+      return jsonWithTelemetry(
+        publicApiError(
+          "idempotency_conflict",
+          "A request with this idempotency key has already been accepted.",
+          409,
+          { id: existing.id },
+        ),
+        telemetry,
+        { status: 409 },
+      );
+    }
+  }
+
   let body: unknown;
   try {
     body = await request.json();
@@ -199,7 +242,7 @@ export async function POST(request: Request): Promise<Response> {
       }
       const persisted: Array<{ id: string; shouldQueueNow: boolean }> = [];
 
-      for (const item of validatedItems) {
+      for (const [index, item] of validatedItems.entries()) {
         const to = normalizeToArray(item.to) as string[];
         const cc = normalizeToArray(item.cc);
         const bcc = normalizeToArray(item.bcc);
@@ -235,6 +278,7 @@ export async function POST(request: Request): Promise<Response> {
             status: shouldQueueNow ? "queued" : "scheduled",
             scheduledAt: scheduledAt,
             topicId: item.topic_id || null,
+            idempotencyKey: index === 0 ? idempotencyKey : null,
             userId: auth.userId,
           })
           .returning({ id: emails.id });

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -21,10 +21,12 @@ const API_GROUPS: EndpointGroup[] = [
       {
         method: "POST",
         path: "/api/emails",
-        description: "Send an email",
+        description:
+          "Send an email. Reusing the same Idempotency-Key returns the existing 409 idempotency_conflict response instead of accepting a duplicate.",
         curl: `curl -X POST https://api.opensend.com/api/emails \\
   -H "Authorization: Bearer re_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
+  -H "Idempotency-Key: welcome-user-123" \\
   -d '{
     "from": "you@example.com",
     "to": "user@example.com",
@@ -49,10 +51,12 @@ const API_GROUPS: EndpointGroup[] = [
       {
         method: "POST",
         path: "/api/emails/batch",
-        description: "Send a batch of emails",
+        description:
+          "Send a batch of emails with one Idempotency-Key for the whole batch. Duplicate keys return 409 idempotency_conflict before quota reservation, row persistence, or queue publish.",
         curl: `curl -X POST https://api.opensend.com/api/emails/batch \\
   -H "Authorization: Bearer re_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
+  -H "Idempotency-Key: batch-campaign-123" \\
   -d '[
     { "from": "you@example.com", "to": "a@example.com", "subject": "Hi A", "html": "<p>A</p>" },
     { "from": "you@example.com", "to": "b@example.com", "subject": "Hi B", "html": "<p>B</p>" }

--- a/src/components/api-code-drawer.tsx
+++ b/src/components/api-code-drawer.tsx
@@ -52,10 +52,11 @@ const { data, error } = await resend.emails.send({
   to: ['user@gmail.com'],
   subject: 'Hello World',
   html: '<p>Congrats on sending your <strong>first email</strong>!</p>',
-});`,
+}, { idempotencyKey: 'welcome-user-123' });`,
       curl: `curl -X POST https://api.example.com/emails \\
   -H "Authorization: Bearer re_123456789" \\
   -H "Content-Type: application/json" \\
+  -H "Idempotency-Key: welcome-user-123" \\
   -d '{
     "from": "you@example.com",
     "to": ["user@gmail.com"],
@@ -84,10 +85,11 @@ const { data, error } = await resend.batch.send([
     subject: 'Hello User 2',
     html: '<p>Hello User 2</p>',
   },
-]);`,
+], { idempotencyKey: 'batch-campaign-123' });`,
       curl: `curl -X POST https://api.example.com/emails/batch \\
   -H "Authorization: Bearer re_123456789" \\
   -H "Content-Type: application/json" \\
+  -H "Idempotency-Key: batch-campaign-123" \\
   -d '[
     {
       "from": "you@example.com",

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -9,6 +9,7 @@ const mockGetApiKeyAuthHeaderError = vi.hoisted(() => vi.fn());
 const mockEmitCloudWatchMetric = vi.hoisted(() => vi.fn());
 const mockLogTelemetry = vi.hoisted(() => vi.fn());
 const mockRecordTelemetryError = vi.hoisted(() => vi.fn());
+const mockReserveEmailQuota = vi.hoisted(() => vi.fn());
 const mockDb = vi.hoisted(() => ({
   insert: vi.fn(),
   select: vi.fn(),
@@ -82,6 +83,16 @@ vi.mock("@opensend/core", () => {
 vi.mock("@/lib/db", () => ({
   db: mockDb,
 }));
+
+vi.mock("@/lib/billing/quota", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/billing/quota")>(
+    "@/lib/billing/quota",
+  );
+  return {
+    ...actual,
+    reserveEmailQuota: mockReserveEmailQuota,
+  };
+});
 
 vi.mock("@/lib/api-auth", async () => {
   const actual =
@@ -225,7 +236,14 @@ describe("POST /api/emails", () => {
     mockEmitCloudWatchMetric.mockReset();
     mockLogTelemetry.mockReset();
     mockRecordTelemetryError.mockReset();
+    mockReserveEmailQuota.mockReset();
+    mockReserveEmailQuota.mockResolvedValue({ ok: true, bypassed: true });
     mockGetApiKeyAuthHeaderError.mockReturnValue(null);
+    Object.assign(mockDb.query, {
+      emails: { findFirst: vi.fn().mockResolvedValue(null) },
+      contacts: { findFirst: vi.fn().mockResolvedValue(null) },
+    });
+    mockDb.insert = vi.fn();
     mockDb.transaction.mockImplementation(
       async (callback: (tx: typeof mockDb) => unknown) => callback(mockDb),
     );
@@ -534,7 +552,14 @@ describe("POST /api/emails/batch", () => {
     mockEmitCloudWatchMetric.mockReset();
     mockLogTelemetry.mockReset();
     mockRecordTelemetryError.mockReset();
+    mockReserveEmailQuota.mockReset();
+    mockReserveEmailQuota.mockResolvedValue({ ok: true, bypassed: true });
     mockGetApiKeyAuthHeaderError.mockReturnValue(null);
+    Object.assign(mockDb.query, {
+      emails: { findFirst: vi.fn().mockResolvedValue(null) },
+      contacts: { findFirst: vi.fn().mockResolvedValue(null) },
+    });
+    mockDb.insert = vi.fn();
     mockDb.transaction.mockImplementation(
       async (callback: (tx: typeof mockDb) => unknown) => callback(mockDb),
     );
@@ -587,6 +612,101 @@ describe("POST /api/emails/batch", () => {
       code: "invalid_json",
       statusCode: 400,
     });
+  });
+
+  it("returns 400 for an invalid batch Idempotency-Key before reserving quota", async () => {
+    const { POST } = await import("@/app/api/emails/batch/route");
+    const req = makeRequest(
+      "POST",
+      [
+        {
+          from: "sender@domain.com",
+          to: ["user@test.com"],
+          subject: "Test",
+          html: "<p>Test</p>",
+        },
+      ],
+      {
+        Authorization: "Bearer re_test123",
+        "Idempotency-Key": "x".repeat(256),
+      },
+    );
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "invalid_idempotency_key",
+      code: "invalid_idempotency_key",
+      statusCode: 400,
+    });
+    expect(mockReserveEmailQuota).not.toHaveBeenCalled();
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits duplicate batch Idempotency-Key retries before quota, rows, or queue", async () => {
+    const findFirst = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "email-1" });
+    Object.assign(mockDb.query, {
+      emails: { findFirst },
+      contacts: { findFirst: vi.fn().mockResolvedValue(null) },
+    });
+
+    let callCount = 0;
+    const valuesMock = vi.fn().mockImplementation(() => ({
+      returning: vi.fn().mockResolvedValue([{ id: `email-${++callCount}` }]),
+    }));
+    mockDb.insert = vi.fn().mockReturnValue({ values: valuesMock });
+
+    const { POST } = await import("@/app/api/emails/batch/route");
+    const emailsArr = [
+      {
+        from: "sender@domain.com",
+        to: ["user1@test.com"],
+        subject: "Test 1",
+        html: "<p>1</p>",
+      },
+      {
+        from: "sender@domain.com",
+        to: ["user2@test.com"],
+        subject: "Test 2",
+        html: "<p>2</p>",
+      },
+    ];
+
+    const first = await POST(
+      makeRequest("POST", emailsArr, {
+        Authorization: "Bearer re_test123",
+        "Idempotency-Key": "batch-key-1",
+      }),
+    );
+    const retry = await POST(
+      makeRequest("POST", emailsArr, {
+        Authorization: "Bearer re_test123",
+        "Idempotency-Key": "batch-key-1",
+      }),
+    );
+
+    expect(first.status).toBe(200);
+    expect(await first.json()).toEqual({
+      data: [{ id: "email-1" }, { id: "email-2" }],
+    });
+    expect(retry.status).toBe(409);
+    await expect(retry.json()).resolves.toMatchObject({
+      name: "idempotency_conflict",
+      code: "idempotency_conflict",
+      statusCode: 409,
+      details: { id: "email-1" },
+    });
+
+    expect(mockReserveEmailQuota).toHaveBeenCalledTimes(1);
+    expect(mockDb.insert).toHaveBeenCalledTimes(2);
+    expect(mockPublishBackgroundJob).toHaveBeenCalledTimes(2);
+    expect(
+      valuesMock.mock.calls.map(([value]) => value.idempotencyKey),
+    ).toEqual(["batch-key-1", null]);
   });
 
   it("injects managed unsubscribe headers for batch items with known contact placeholders", async () => {

--- a/tests/sdk-client.test.tsx
+++ b/tests/sdk-client.test.tsx
@@ -48,6 +48,51 @@ describe("OpenSend SDK", () => {
     });
   });
 
+  it("forwards Idempotency-Key for single and batch send request options", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ id: "email_789" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new OpenSend("re_test", {
+      baseUrl: "https://api.example.com",
+    });
+    const payload = {
+      from: "hello@example.com",
+      to: "user@example.com",
+      subject: "Hello",
+      html: "<p>Hello</p>",
+    };
+
+    await client.emails.send(payload, { idempotencyKey: "send-key-1" });
+    await client.emails.sendBatch([payload], { idempotencyKey: "batch-key-1" });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example.com/api/emails",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Idempotency-Key": "send-key-1",
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.example.com/api/emails/batch",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Idempotency-Key": "batch-key-1",
+        }),
+      }),
+    );
+  });
+
   it("renders react payloads to html before sending", async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(JSON.stringify({ id: "email_456" }), {


### PR DESCRIPTION
## Summary
- Adds `Idempotency-Key` handling to `POST /api/emails/batch` with the same public validation/error shape as single send.
- Stores the batch request key on the first accepted email row so duplicate retries return `409 idempotency_conflict` before quota reservation, duplicate row persistence, or queue publish.
- Adds typed SDK request options for `emails.send(payload, { idempotencyKey })` and `emails.sendBatch(payloads, { idempotencyKey })`.
- Documents single and batch idempotency usage in SDK and API examples.

## Validation
- `make check` ✅
- `bun run test tests/sdk-client.test.tsx` ✅
- `bun run test tests/api-emails.test.ts --testTimeout=15000` ✅
- `bun run test tests/automation-runner.test.ts --testTimeout=30000` ✅ baseline timeout isolation
- `bun run test -- --testTimeout=15000` ⚠️ 705/706 passed; one existing full-suite-load timeout remained in `tests/automation-runner.test.ts > advances trigger then schedules delay next_step_at without sleeping`. The same file passed standalone with a 30s timeout in 3.76s.
- `make test` ⚠️ failed under default 5s Vitest timeout with baseline full-suite timing noise across unrelated tests; focused changed tests passed.
- Push guardrails ran `scripts/check-changed-files.mjs`, full typecheck, and Biome changed-file lint ✅

## Notes
- This intentionally preserves the existing duplicate-key public contract (`409 idempotency_conflict` with `details.id`) instead of adding a new request-level replay table. If we later want safe replay of every batch id, add a request-level idempotency store rather than writing the same key to every email row.

Closes #176
