### PR TITLE
Extract webhook API core service

### DIFF
--- a/agent_docs/learnings/active/2026-05-04-issue-179-webhook-service-extraction.md
+++ b/agent_docs/learnings/active/2026-05-04-issue-179-webhook-service-extraction.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-04
+issue: 179
+type: pattern
+promoted_to: null
+---
+
+# Webhook service extraction
+
+Extract webhook route business logic into `packages/core/src/services/webhook.ts` using the domains service factory pattern: injectable repository plus injectable signing-secret generator, core-level status/field mapping, and thin Next adapters for auth, parse/validation, service invocation, and HTTP response mapping.
+
+Route tests that mock `@opensend/core` should avoid `importOriginal` for the whole package; importing the real core module inside every route-smoke test adds enough overhead to trip the 5s Vitest timeout in the large route smoke file.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export * from "./webhook-signing";
 export * from "./webhook-events";
 export * from "./services/dns";
 export * from "./services/domain";
+export * from "./services/webhook";
 export * from "./services/apiKeys";
 export * from "./services/email";
 export * from "./services/emailProvider";

--- a/packages/core/src/services/webhook.ts
+++ b/packages/core/src/services/webhook.ts
@@ -1,0 +1,188 @@
+import { randomBytes } from "node:crypto";
+import { webhookRepo } from "../db/repositories/webhookRepo";
+import type { webhooks } from "../db/schema";
+
+type WebhookRow = typeof webhooks.$inferSelect;
+type WebhookInsert = typeof webhooks.$inferInsert;
+
+type PublicWebhookStatus = "enabled" | "disabled";
+type StoredWebhookStatus = "active" | "disabled";
+
+export type WebhookServiceListItem = {
+  id: string;
+  endpoint: string;
+  events: string[];
+  status: PublicWebhookStatus;
+  createdAt: WebhookRow["createdAt"];
+};
+
+export type WebhookServiceDetail = WebhookServiceListItem;
+
+export type WebhookServiceCreateResult = WebhookServiceDetail & {
+  signingSecret: string | null;
+};
+
+export type WebhookListResult = {
+  data: WebhookServiceListItem[];
+  hasMore: boolean;
+};
+
+export type CreateWebhookInput = {
+  endpoint: string;
+  events: string[];
+};
+
+export type UpdateWebhookInput = {
+  endpoint?: string;
+  events?: string[];
+  status?: PublicWebhookStatus;
+  active?: boolean;
+};
+
+export type WebhookRepository = {
+  list(options: { limit?: number; after?: string }): Promise<{
+    data: WebhookRow[];
+    hasMore: boolean;
+  }>;
+  create(data: WebhookInsert): Promise<WebhookRow[]>;
+  findById(id: string): Promise<WebhookRow | undefined>;
+  update(id: string, data: Partial<WebhookInsert>): Promise<WebhookRow[]>;
+  delete(id: string): Promise<Array<{ id: string }>>;
+};
+
+export type WebhookServiceDependencies = {
+  repository?: WebhookRepository;
+  generateSigningSecret?: () => string;
+};
+
+function normalizeLimit(limit: number | undefined): number {
+  return Math.min(Math.max(limit || 20, 1), 100);
+}
+
+function generateSecureSigningSecret(): string {
+  return `whsec_${randomBytes(24).toString("base64url")}`;
+}
+
+function toPublicStatus(status: string): PublicWebhookStatus {
+  return status === "active" ? "enabled" : "disabled";
+}
+
+function toStoredStatus(
+  input: PublicWebhookStatus | boolean,
+): StoredWebhookStatus {
+  if (typeof input === "boolean") return input ? "active" : "disabled";
+  return input === "enabled" ? "active" : "disabled";
+}
+
+function toWebhookListItem(row: WebhookRow): WebhookServiceListItem {
+  return {
+    id: row.id,
+    endpoint: row.url,
+    events: row.eventTypes,
+    status: toPublicStatus(row.status),
+    createdAt: row.createdAt,
+  };
+}
+
+function toWebhookCreateResult(row: WebhookRow): WebhookServiceCreateResult {
+  return {
+    ...toWebhookListItem(row),
+    signingSecret: row.signingSecret,
+  };
+}
+
+function buildUpdateData(input: UpdateWebhookInput): Partial<WebhookInsert> {
+  const data: Partial<WebhookInsert> = {};
+
+  if (input.endpoint !== undefined) data.url = input.endpoint;
+  if (input.events !== undefined) data.eventTypes = input.events;
+  if (input.status !== undefined) data.status = toStoredStatus(input.status);
+  if (input.status === undefined && input.active !== undefined) {
+    data.status = toStoredStatus(input.active);
+  }
+
+  return data;
+}
+
+export function createWebhookService({
+  repository = webhookRepo,
+  generateSigningSecret = generateSecureSigningSecret,
+}: WebhookServiceDependencies = {}) {
+  return {
+    async listWebhooks(options: {
+      limit?: number;
+      after?: string;
+    }): Promise<WebhookListResult> {
+      const result = await repository.list({
+        limit: normalizeLimit(options.limit),
+        after: options.after || undefined,
+      });
+
+      return {
+        data: result.data.map(toWebhookListItem),
+        hasMore: result.hasMore,
+      };
+    },
+
+    async createWebhook(
+      input: CreateWebhookInput,
+    ): Promise<WebhookServiceCreateResult> {
+      const signingSecret = generateSigningSecret();
+      const [row] = await repository.create({
+        url: input.endpoint,
+        eventTypes: input.events,
+        signingSecret,
+      });
+
+      return toWebhookCreateResult(row);
+    },
+
+    async getWebhook(id: string): Promise<WebhookServiceDetail | undefined> {
+      const row = await repository.findById(id);
+      return row ? toWebhookListItem(row) : undefined;
+    },
+
+    async updateWebhook(
+      id: string,
+      input: UpdateWebhookInput,
+    ): Promise<WebhookServiceDetail | undefined> {
+      const [row] = await repository.update(id, buildUpdateData(input));
+      return row ? toWebhookListItem(row) : undefined;
+    },
+
+    async deleteWebhook(id: string): Promise<{ id: string } | undefined> {
+      const [deleted] = await repository.delete(id);
+      return deleted;
+    },
+  };
+}
+
+export class WebhookService {
+  private readonly service: ReturnType<typeof createWebhookService>;
+
+  constructor(dependencies: WebhookServiceDependencies = {}) {
+    this.service = createWebhookService(dependencies);
+  }
+
+  async list(options: { limit?: number; after?: string }) {
+    return await this.service.listWebhooks(options);
+  }
+
+  async create(input: CreateWebhookInput) {
+    return await this.service.createWebhook(input);
+  }
+
+  async get(id: string) {
+    return await this.service.getWebhook(id);
+  }
+
+  async update(id: string, input: UpdateWebhookInput) {
+    return await this.service.updateWebhook(id, input);
+  }
+
+  async delete(id: string) {
+    return await this.service.deleteWebhook(id);
+  }
+}
+
+export const webhookService = createWebhookService();

--- a/src/app/api/webhooks/[id]/route.ts
+++ b/src/app/api/webhooks/[id]/route.ts
@@ -1,8 +1,15 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
-import { db } from "@/lib/db";
-import { webhooks } from "@/lib/db/schema";
 import { updateWebhookSchema } from "@/lib/validation/webhooks";
-import { eq } from "drizzle-orm";
+import { createWebhookService } from "@opensend/core";
+
+function webhookService() {
+  return createWebhookService();
+}
+
+function mapWebhookError(error: unknown, fallback: string): Response {
+  const message = error instanceof Error ? error.message : fallback;
+  return Response.json({ error: message }, { status: 500 });
+}
 
 export async function GET(
   request: Request,
@@ -14,11 +21,7 @@ export async function GET(
   const { id } = await params;
 
   try {
-    const [webhook] = await db
-      .select()
-      .from(webhooks)
-      .where(eq(webhooks.id, id))
-      .limit(1);
+    const webhook = await webhookService().getWebhook(id);
 
     if (!webhook) {
       return Response.json({ error: "Webhook not found" }, { status: 404 });
@@ -27,15 +30,13 @@ export async function GET(
     return Response.json({
       object: "webhook",
       id: webhook.id,
-      endpoint: webhook.url,
-      events: webhook.eventTypes,
-      status: webhook.status === "active" ? "enabled" : "disabled",
+      endpoint: webhook.endpoint,
+      events: webhook.events,
+      status: webhook.status,
       created_at: webhook.createdAt,
     });
-  } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to retrieve webhook";
-    return Response.json({ error: message }, { status: 500 });
+  } catch (error) {
+    return mapWebhookError(error, "Failed to retrieve webhook");
   }
 }
 
@@ -65,28 +66,12 @@ export async function PATCH(
 
   try {
     const validated = result.data;
-    const updateData: Record<string, unknown> = {};
-    if (validated.endpoint !== undefined) updateData.url = validated.endpoint;
-    if (validated.url !== undefined) updateData.url = validated.url;
-
-    if (validated.events !== undefined)
-      updateData.eventTypes = validated.events;
-    if (validated.event_types !== undefined)
-      updateData.eventTypes = validated.event_types;
-
-    // Support "active" (boolean) and "status" ("enabled"/"disabled").
-    if (validated.status !== undefined) {
-      updateData.status =
-        validated.status === "enabled" ? "active" : "disabled";
-    } else if (validated.active !== undefined) {
-      updateData.status = validated.active ? "active" : "disabled";
-    }
-
-    const [updated] = await db
-      .update(webhooks)
-      .set(updateData)
-      .where(eq(webhooks.id, id))
-      .returning();
+    const updated = await webhookService().updateWebhook(id, {
+      endpoint: validated.endpoint ?? validated.url,
+      events: validated.events ?? validated.event_types,
+      status: validated.status,
+      active: validated.active,
+    });
 
     if (!updated) {
       return Response.json({ error: "Webhook not found" }, { status: 404 });
@@ -95,11 +80,13 @@ export async function PATCH(
     return Response.json({
       object: "webhook",
       id: updated.id,
+      endpoint: updated.endpoint,
+      events: updated.events,
+      status: updated.status,
+      created_at: updated.createdAt,
     });
-  } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to update webhook";
-    return Response.json({ error: message }, { status: 500 });
+  } catch (error) {
+    return mapWebhookError(error, "Failed to update webhook");
   }
 }
 
@@ -113,10 +100,7 @@ export async function DELETE(
   const { id } = await params;
 
   try {
-    const [deleted] = await db
-      .delete(webhooks)
-      .where(eq(webhooks.id, id))
-      .returning({ id: webhooks.id });
+    const deleted = await webhookService().deleteWebhook(id);
 
     if (!deleted) {
       return Response.json({ error: "Webhook not found" }, { status: 404 });
@@ -127,9 +111,7 @@ export async function DELETE(
       id: deleted.id,
       deleted: true,
     });
-  } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to delete webhook";
-    return Response.json({ error: message }, { status: 500 });
+  } catch (error) {
+    return mapWebhookError(error, "Failed to delete webhook");
   }
 }

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -1,56 +1,40 @@
-import { randomBytes } from "node:crypto";
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
-import { db } from "@/lib/db";
-import { webhooks } from "@/lib/db/schema";
 import { createWebhookSchema } from "@/lib/validation/webhooks";
-import { desc, lt } from "drizzle-orm";
+import { createWebhookService } from "@opensend/core";
+
+function webhookService() {
+  return createWebhookService();
+}
+
+function mapWebhookError(error: unknown, fallback: string): Response {
+  const message = error instanceof Error ? error.message : fallback;
+  return Response.json({ error: message }, { status: 500 });
+}
 
 export async function GET(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
 
   const url = new URL(request.url);
-  const limit = Math.min(
-    Math.max(Number(url.searchParams.get("limit")) || 20, 1),
-    100,
-  );
+  const limit = Number(url.searchParams.get("limit")) || 20;
   const after = url.searchParams.get("after") || "";
 
   try {
-    const query = db
-      .select({
-        id: webhooks.id,
-        url: webhooks.url,
-        eventTypes: webhooks.eventTypes,
-        status: webhooks.status,
-        createdAt: webhooks.createdAt,
-      })
-      .from(webhooks);
-
-    if (after) {
-      query.where(lt(webhooks.id, after));
-    }
-
-    const results = await query.orderBy(desc(webhooks.id)).limit(limit + 1);
-
-    const hasMore = results.length > limit;
-    const dataRows = hasMore ? results.slice(0, limit) : results;
+    const result = await webhookService().listWebhooks({ limit, after });
 
     return Response.json({
       object: "list",
-      data: dataRows.map((w) => ({
-        id: w.id,
-        endpoint: w.url,
-        events: w.eventTypes,
-        status: w.status === "active" ? "enabled" : "disabled",
-        created_at: w.createdAt,
+      data: result.data.map((webhook) => ({
+        id: webhook.id,
+        endpoint: webhook.endpoint,
+        events: webhook.events,
+        status: webhook.status,
+        created_at: webhook.createdAt,
       })),
-      has_more: hasMore,
+      has_more: result.hasMore,
     });
-  } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to list webhooks";
-    return Response.json({ error: message }, { status: 500 });
+  } catch (error) {
+    return mapWebhookError(error, "Failed to list webhooks");
   }
 }
 
@@ -74,9 +58,8 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   const validated = result.data;
-  const endpoint = validated.endpoint ?? (validated as { url?: string }).url;
-  const events =
-    validated.events ?? (validated as { event_types?: string[] }).event_types;
+  const endpoint = validated.endpoint ?? validated.url;
+  const events = validated.events ?? validated.event_types;
 
   if (!endpoint || !events) {
     return Response.json(
@@ -86,32 +69,21 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   try {
-    const signingSecret = `whsec_${randomBytes(24).toString("base64url")}`;
-
-    const [webhook] = await db
-      .insert(webhooks)
-      .values({
-        url: endpoint,
-        eventTypes: events,
-        signingSecret,
-      })
-      .returning();
+    const webhook = await webhookService().createWebhook({ endpoint, events });
 
     return Response.json(
       {
         object: "webhook",
         id: webhook.id,
-        endpoint: webhook.url,
-        events: webhook.eventTypes,
-        status: webhook.status === "active" ? "enabled" : "disabled",
+        endpoint: webhook.endpoint,
+        events: webhook.events,
+        status: webhook.status,
         signing_secret: webhook.signingSecret,
         created_at: webhook.createdAt,
       },
       { status: 201 },
     );
-  } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to create webhook";
-    return Response.json({ error: message }, { status: 500 });
+  } catch (error) {
+    return mapWebhookError(error, "Failed to create webhook");
   }
 }

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -10,6 +10,7 @@ const mockDelete = vi.hoisted(() => vi.fn());
 const mockValidateApiKey = vi.hoisted(() => vi.fn());
 const mockCountFn = vi.hoisted(() => vi.fn());
 const mockValidateDashboardKey = vi.hoisted(() => vi.fn());
+const mockCreateWebhookService = vi.hoisted(() => vi.fn());
 const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
 
@@ -206,6 +207,16 @@ describe("route smoke coverage", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    vi.doMock("@opensend/core", () => ({
+      createWebhookService: mockCreateWebhookService,
+    }));
+    mockCreateWebhookService.mockReturnValue({
+      listWebhooks: vi.fn().mockResolvedValue({ data: [], hasMore: false }),
+      createWebhook: vi.fn(),
+      getWebhook: vi.fn(),
+      updateWebhook: vi.fn(),
+      deleteWebhook: vi.fn(),
+    });
     vi.doMock("@/lib/api-auth", async () => {
       const actual =
         await vi.importActual<typeof import("@/lib/api-auth")>(
@@ -754,39 +765,84 @@ describe("route smoke coverage", () => {
     expect(detailDelete.status).toBe(200);
   });
 
-  it("covers webhook routes for happy path and 404s", async () => {
+  it("covers webhook routes for compatibility, pagination, status mapping, and 404s", async () => {
+    const listWebhooks = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: "wh-1",
+          endpoint: "https://example.com/webhook",
+          events: ["email.sent"],
+          status: "enabled",
+          createdAt: "2026-04-23T00:00:00.000Z",
+        },
+      ],
+      hasMore: true,
+    });
+    const createWebhook = vi.fn().mockResolvedValue({
+      id: "wh-2",
+      endpoint: "https://example.com/created",
+      events: ["email.delivered"],
+      status: "enabled",
+      signingSecret: "whsec_test_secret",
+      createdAt: "2026-04-23T00:00:00.000Z",
+    });
+    const getWebhook = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: "wh-1",
+        endpoint: "https://example.com/webhook",
+        events: ["email.sent"],
+        status: "enabled",
+        createdAt: "2026-04-23T00:00:00.000Z",
+      })
+      .mockResolvedValueOnce(undefined);
+    const updateWebhook = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: "wh-1",
+        endpoint: "https://example.com/webhook",
+        events: ["email.sent"],
+        status: "disabled",
+        createdAt: "2026-04-23T00:00:00.000Z",
+      })
+      .mockResolvedValueOnce(undefined);
+    const deleteWebhook = vi
+      .fn()
+      .mockResolvedValueOnce({ id: "wh-1" })
+      .mockResolvedValueOnce(undefined);
+
+    mockCreateWebhookService.mockReturnValue({
+      listWebhooks,
+      createWebhook,
+      getWebhook,
+      updateWebhook,
+      deleteWebhook,
+    });
+
     const listRoute = await import("@/app/api/webhooks/route");
     const detailRoute = await import("@/app/api/webhooks/[id]/route");
 
-    mockSelect.mockImplementationOnce(() =>
-      makeChain([
-        {
-          id: "wh-1",
-          url: "https://example.com/webhook",
-          eventTypes: ["email.sent"],
-          status: "active",
-          createdAt: "2026-04-23T00:00:00.000Z",
-        },
-      ]),
-    );
     const listRes = await listRoute.GET(
-      makeNextRequest("http://localhost/api/webhooks?limit=10", {
+      makeNextRequest("http://localhost/api/webhooks?limit=500&after=wh-3", {
         headers: { authorization: "Bearer token" },
       }),
     );
     expect(listRes.status).toBe(200);
-
-    mockInsert.mockImplementationOnce(() =>
-      makeChain([
+    await expect(listRes.json()).resolves.toEqual({
+      object: "list",
+      data: [
         {
-          id: "wh-2",
-          url: "https://example.com/created",
-          eventTypes: ["email.delivered"],
-          status: "active",
-          createdAt: "2026-04-23T00:00:00.000Z",
+          id: "wh-1",
+          endpoint: "https://example.com/webhook",
+          events: ["email.sent"],
+          status: "enabled",
+          created_at: "2026-04-23T00:00:00.000Z",
         },
-      ]),
-    );
+      ],
+      has_more: true,
+    });
+    expect(listWebhooks).toHaveBeenCalledWith({ limit: 500, after: "wh-3" });
+
     const createRes = await listRoute.POST(
       makeNextRequest("http://localhost/api/webhooks", {
         method: "POST",
@@ -801,21 +857,20 @@ describe("route smoke coverage", () => {
       }),
     );
     expect(createRes.status).toBe(201);
-    const createJson = await createRes.json();
-    expect(createJson.object).toBe("webhook");
+    await expect(createRes.json()).resolves.toEqual({
+      object: "webhook",
+      id: "wh-2",
+      endpoint: "https://example.com/created",
+      events: ["email.delivered"],
+      status: "enabled",
+      signing_secret: "whsec_test_secret",
+      created_at: "2026-04-23T00:00:00.000Z",
+    });
+    expect(createWebhook).toHaveBeenCalledWith({
+      endpoint: "https://example.com/created",
+      events: ["email.delivered"],
+    });
 
-    // Detail GET
-    mockSelect.mockImplementationOnce(() =>
-      makeChain([
-        {
-          id: "wh-1",
-          url: "https://example.com/webhook",
-          eventTypes: ["email.sent"],
-          status: "active",
-          createdAt: "2026-04-23T00:00:00.000Z",
-        },
-      ]),
-    );
     const detailGetRes = await detailRoute.GET(
       makeNextRequest("http://localhost/api/webhooks/wh-1", {
         headers: { authorization: "Bearer token" },
@@ -824,7 +879,6 @@ describe("route smoke coverage", () => {
     );
     expect(detailGetRes.status).toBe(200);
 
-    mockSelect.mockImplementationOnce(() => makeChain([]));
     const notFoundRes = await detailRoute.GET(
       makeNextRequest("http://localhost/api/webhooks/missing", {
         headers: { authorization: "Bearer token" },
@@ -833,7 +887,6 @@ describe("route smoke coverage", () => {
     );
     expect(notFoundRes.status).toBe(404);
 
-    mockUpdate.mockImplementationOnce(() => makeChain([{ id: "wh-1" }]));
     const patchRes = await detailRoute.PATCH(
       makeNextRequest("http://localhost/api/webhooks/wh-1", {
         method: "PATCH",
@@ -846,10 +899,33 @@ describe("route smoke coverage", () => {
       { params: Promise.resolve({ id: "wh-1" }) },
     );
     expect(patchRes.status).toBe(200);
-    const patchJson = await patchRes.json();
-    expect(patchJson.object).toBe("webhook");
+    await expect(patchRes.json()).resolves.toMatchObject({
+      object: "webhook",
+      id: "wh-1",
+      endpoint: "https://example.com/webhook",
+      events: ["email.sent"],
+      status: "disabled",
+    });
+    expect(updateWebhook).toHaveBeenCalledWith("wh-1", {
+      endpoint: undefined,
+      events: undefined,
+      status: undefined,
+      active: false,
+    });
 
-    mockDelete.mockImplementationOnce(() => makeChain([{ id: "wh-1" }]));
+    const patchNotFoundRes = await detailRoute.PATCH(
+      makeNextRequest("http://localhost/api/webhooks/missing", {
+        method: "PATCH",
+        headers: {
+          authorization: "Bearer token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ status: "enabled" }),
+      }),
+      { params: Promise.resolve({ id: "missing" }) },
+    );
+    expect(patchNotFoundRes.status).toBe(404);
+
     const deleteRes = await detailRoute.DELETE(
       makeNextRequest("http://localhost/api/webhooks/wh-1", {
         method: "DELETE",
@@ -858,9 +934,21 @@ describe("route smoke coverage", () => {
       { params: Promise.resolve({ id: "wh-1" }) },
     );
     expect(deleteRes.status).toBe(200);
-    const deleteJson = await deleteRes.json();
-    expect(deleteJson.deleted).toBe(true);
-  });
+    await expect(deleteRes.json()).resolves.toEqual({
+      object: "webhook",
+      id: "wh-1",
+      deleted: true,
+    });
+
+    const deleteNotFoundRes = await detailRoute.DELETE(
+      makeNextRequest("http://localhost/api/webhooks/missing", {
+        method: "DELETE",
+        headers: { authorization: "Bearer token" },
+      }),
+      { params: Promise.resolve({ id: "missing" }) },
+    );
+    expect(deleteNotFoundRes.status).toBe(404);
+  }, 10000);
 
   it("rejects unsupported webhook event types in create and update routes", async () => {
     const listRoute = await import("@/app/api/webhooks/route");
@@ -899,7 +987,7 @@ describe("route smoke coverage", () => {
 
     expect(patchRes.status).toBe(422);
     expect(mockUpdate).not.toHaveBeenCalled();
-  });
+  }, 10000);
 
   it("covers broadcasts and templates detail routes with happy path and 404s", async () => {
     const broadcastsRoute = await import("@/app/api/broadcasts/[id]/route");

--- a/tests/webhook-service.test.ts
+++ b/tests/webhook-service.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type WebhookRepository,
+  createWebhookService,
+} from "../packages/core/src/services/webhook";
+
+type WebhookRow = NonNullable<
+  Awaited<ReturnType<WebhookRepository["findById"]>>
+>;
+type WebhookInsert = Parameters<WebhookRepository["create"]>[0];
+
+function webhookRow(overrides: Partial<WebhookRow> = {}): WebhookRow {
+  return {
+    id: "webhook-1",
+    url: "https://example.com/webhook",
+    eventTypes: ["email.sent"],
+    status: "active",
+    signingSecret: "whsec_existing",
+    createdAt: new Date("2026-05-04T00:00:00.000Z"),
+    document: null,
+    userId: null,
+    ...overrides,
+  };
+}
+
+function createRepository(overrides: Partial<WebhookRepository> = {}) {
+  const repository: WebhookRepository = {
+    async list() {
+      return { data: [], hasMore: false };
+    },
+    async create(data: WebhookInsert) {
+      return [webhookRow({ ...data, id: "created-webhook" })];
+    },
+    async findById() {
+      return webhookRow();
+    },
+    async update(id, data) {
+      return [webhookRow({ id, ...data })];
+    },
+    async delete(id: string) {
+      return [{ id }];
+    },
+    ...overrides,
+  };
+
+  return repository;
+}
+
+describe("webhook service", () => {
+  it("lists with normalized pagination and maps public list fields", async () => {
+    let listOptions: { limit?: number; after?: string } | null = null;
+    const service = createWebhookService({
+      repository: createRepository({
+        async list(options) {
+          listOptions = options;
+          return {
+            data: [
+              webhookRow({
+                id: "webhook-2",
+                status: "disabled",
+                createdAt: new Date("2026-05-04T01:00:00.000Z"),
+              }),
+            ],
+            hasMore: true,
+          };
+        },
+      }),
+    });
+
+    const result = await service.listWebhooks({
+      limit: 500,
+      after: "webhook-3",
+    });
+
+    expect(listOptions).toEqual({ limit: 100, after: "webhook-3" });
+    expect(result).toEqual({
+      data: [
+        {
+          id: "webhook-2",
+          endpoint: "https://example.com/webhook",
+          events: ["email.sent"],
+          status: "disabled",
+          createdAt: new Date("2026-05-04T01:00:00.000Z"),
+        },
+      ],
+      hasMore: true,
+    });
+  });
+
+  it("creates with an injectable signing secret generator", async () => {
+    const inserted: WebhookInsert[] = [];
+    const generateSigningSecret = vi.fn(() => "whsec_test_secret");
+    const service = createWebhookService({
+      generateSigningSecret,
+      repository: createRepository({
+        async create(data) {
+          inserted.push(data);
+          return [webhookRow({ ...data, id: "created-webhook" })];
+        },
+      }),
+    });
+
+    const result = await service.createWebhook({
+      endpoint: "https://example.com/created",
+      events: ["email.delivered"],
+    });
+
+    expect(generateSigningSecret).toHaveBeenCalledOnce();
+    expect(inserted[0]).toMatchObject({
+      url: "https://example.com/created",
+      eventTypes: ["email.delivered"],
+      signingSecret: "whsec_test_secret",
+    });
+    expect(result).toMatchObject({
+      id: "created-webhook",
+      endpoint: "https://example.com/created",
+      events: ["email.delivered"],
+      status: "enabled",
+      signingSecret: "whsec_test_secret",
+    });
+  });
+
+  it("maps update status and active flags to stored status", async () => {
+    const updates: Array<Partial<WebhookInsert>> = [];
+    const service = createWebhookService({
+      repository: createRepository({
+        async update(id, data) {
+          updates.push(data);
+          return [webhookRow({ id, ...data })];
+        },
+      }),
+    });
+
+    const disabled = await service.updateWebhook("webhook-1", {
+      endpoint: "https://example.com/new",
+      events: ["email.bounced"],
+      status: "disabled",
+    });
+    const enabled = await service.updateWebhook("webhook-1", { active: true });
+
+    expect(updates).toEqual([
+      {
+        url: "https://example.com/new",
+        eventTypes: ["email.bounced"],
+        status: "disabled",
+      },
+      { status: "active" },
+    ]);
+    expect(disabled).toMatchObject({
+      endpoint: "https://example.com/new",
+      events: ["email.bounced"],
+      status: "disabled",
+    });
+    expect(enabled).toMatchObject({ status: "enabled" });
+  });
+
+  it("returns undefined for not found get, update, and delete operations", async () => {
+    const service = createWebhookService({
+      repository: createRepository({
+        async findById() {
+          return undefined;
+        },
+        async update() {
+          return [];
+        },
+        async delete() {
+          return [];
+        },
+      }),
+    });
+
+    await expect(service.getWebhook("missing")).resolves.toBeUndefined();
+    await expect(
+      service.updateWebhook("missing", { status: "enabled" }),
+    ).resolves.toBeUndefined();
+    await expect(service.deleteWebhook("missing")).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Extract webhook CRUD/pagination/status/signing-secret behavior into `packages/core/src/services/webhook.ts` following the domains service factory pattern.
- Keep `src/app/api/webhooks/*` as thin adapters for auth, JSON parsing, validation, service invocation, and HTTP response mapping.
- Preserve public webhook response fields, including `endpoint`, `events`, `status`, create-only `signing_secret`, delete shape, and not-found mapping.

Closes #179

## Changes
- **core**: add injectable webhook service with repository and signing-secret generator dependencies.
- **routes**: replace inline Drizzle CRUD and crypto secret generation with service calls.
- **tests**: add service behavior coverage and route compatibility assertions for pagination, create mapping, status mapping, not-found, and delete.
- **learnings**: document the webhook service extraction pattern and route mock performance note.

## How to Test
- [x] `bun run test tests/webhook-service.test.ts tests/api-auth-date-range-routes.test.ts`
- [x] `make check`
- [ ] `make test` currently has unrelated baseline timeouts/failures outside this webhook slice; see PR notes.

## Notes
- No webhook dispatcher/retry redesign, event filtering, dashboard replay, or Hono control-plane cutover in this PR.
- `make test` was re-run after the changes; webhook-related tests passed, but the full suite still failed on existing timeout/flaky areas: `api-auth-cache`, `api-domains`, `api-emails`, `automation-runner`, `billing-quota`, and `quota-routes`.
