### PR TITLE
automations: add contact_update backend action

### DIFF
--- a/agent_docs/learnings/active/2026-05-04-issue-178-contact-update-shape.md
+++ b/agent_docs/learnings/active/2026-05-04-issue-178-contact-update-shape.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-04
+issue: "#178"
+type: decision
+promoted_to: null
+---
+
+## contact_update uses explicit fields plus separate properties
+
+**What:** The backend `contact_update` step accepts `config.fields` for first-class contact fields (`email`, `first_name`, `last_name`, explicit `unsubscribed`) and `config.properties` for custom property updates. Reserved/compliance-sensitive keys are rejected from `properties` so generic property merging cannot accidentally mutate unsubscribe status, topics, segments, or identity fields.
+
+**Why:** Issue #178 requires safe contact mutation semantics and minimal output. Keeping first-class fields separate from custom properties preserves unspecified fields and makes compliance-sensitive updates explicit.
+
+**Fix:** Future contact mutation slices should keep destructive/compliance-sensitive fields out of generic property maps and should output changed field names only, not full contact or payload dumps.

--- a/packages/core/src/dto/automations.ts
+++ b/packages/core/src/dto/automations.ts
@@ -83,13 +83,26 @@ export interface WaitForEventStepConfig {
   timeout_seconds?: number;
 }
 
+export type ContactUpdateValue = string | number | boolean | null;
+
+export interface ContactUpdateStepConfig {
+  fields?: {
+    email?: ContactUpdateValue;
+    first_name?: ContactUpdateValue;
+    last_name?: ContactUpdateValue;
+    unsubscribed?: ContactUpdateValue;
+  };
+  properties?: Record<string, ContactUpdateValue>;
+}
+
 export type AutomationStepConfig =
   | TriggerStepConfig
   | DelayStepConfig
   | SendEmailStepConfig
   | EndStepConfig
   | ConditionStepConfig
-  | WaitForEventStepConfig;
+  | WaitForEventStepConfig
+  | ContactUpdateStepConfig;
 
 export interface AutomationStepInput {
   key: string;
@@ -169,6 +182,18 @@ export interface AutomationRunDTO {
 const RESERVED_EVENT_PREFIX = "resend:";
 const CONDITION_PATH_PATTERN =
   /^(event|contact)\.[A-Za-z0-9_.-]+$|^steps\.[A-Za-z0-9_:-]+\.output(\.[A-Za-z0-9_.-]+)?$/;
+const CONTACT_UPDATE_RESERVED_PROPERTY_KEYS = new Set([
+  "email",
+  "first_name",
+  "firstName",
+  "last_name",
+  "lastName",
+  "unsubscribed",
+  "segments",
+  "topics",
+  "topic_subscriptions",
+  "topicSubscriptions",
+]);
 const CONDITION_OPERATORS: ReadonlySet<ConditionOperator> = new Set([
   "equals",
   "not_equals",
@@ -415,6 +440,154 @@ export function normalizeWaitForEventConfig(
   return config;
 }
 
+function isContactUpdateValue(value: unknown): value is ContactUpdateValue {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+}
+
+function normalizeContactUpdateValue(
+  value: unknown,
+  code: string,
+  field: string,
+): ContactUpdateValue {
+  if (!isContactUpdateValue(value)) {
+    throw new AutomationValidationError(
+      `contact_update ${field} must be a string, number, boolean, or null`,
+      code,
+    );
+  }
+  return value;
+}
+
+function assertNoUnknownKeys(
+  source: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  code: string,
+  label: string,
+): void {
+  const unknown = Object.keys(source).find((key) => !allowed.has(key));
+  if (unknown) {
+    throw new AutomationValidationError(
+      `${label} contains unsupported key "${unknown}"`,
+      code,
+    );
+  }
+}
+
+export function normalizeContactUpdateConfig(
+  raw: Record<string, unknown>,
+): ContactUpdateStepConfig {
+  assertNoUnknownKeys(
+    raw,
+    new Set(["fields", "properties"]),
+    "contact_update_config_invalid",
+    "contact_update config",
+  );
+
+  const config: ContactUpdateStepConfig = {};
+  if (raw.fields !== undefined) {
+    if (
+      typeof raw.fields !== "object" ||
+      raw.fields === null ||
+      Array.isArray(raw.fields)
+    ) {
+      throw new AutomationValidationError(
+        "contact_update fields must be an object",
+        "contact_update_fields_invalid",
+      );
+    }
+
+    const fieldsRaw = raw.fields as Record<string, unknown>;
+    assertNoUnknownKeys(
+      fieldsRaw,
+      new Set(["email", "first_name", "last_name", "unsubscribed"]),
+      "contact_update_field_invalid",
+      "contact_update fields",
+    );
+
+    const fields: NonNullable<ContactUpdateStepConfig["fields"]> = {};
+    if ("email" in fieldsRaw) {
+      fields.email = normalizeContactUpdateValue(
+        fieldsRaw.email,
+        "contact_update_email_invalid",
+        "email",
+      );
+    }
+    if ("first_name" in fieldsRaw) {
+      fields.first_name = normalizeContactUpdateValue(
+        fieldsRaw.first_name,
+        "contact_update_first_name_invalid",
+        "first_name",
+      );
+    }
+    if ("last_name" in fieldsRaw) {
+      fields.last_name = normalizeContactUpdateValue(
+        fieldsRaw.last_name,
+        "contact_update_last_name_invalid",
+        "last_name",
+      );
+    }
+    if ("unsubscribed" in fieldsRaw) {
+      fields.unsubscribed = normalizeContactUpdateValue(
+        fieldsRaw.unsubscribed,
+        "contact_update_unsubscribed_invalid",
+        "unsubscribed",
+      );
+    }
+    if (Object.keys(fields).length > 0) config.fields = fields;
+  }
+
+  if (raw.properties !== undefined) {
+    if (
+      typeof raw.properties !== "object" ||
+      raw.properties === null ||
+      Array.isArray(raw.properties)
+    ) {
+      throw new AutomationValidationError(
+        "contact_update properties must be an object",
+        "contact_update_properties_invalid",
+      );
+    }
+
+    const propertiesRaw = raw.properties as Record<string, unknown>;
+    const properties: Record<string, ContactUpdateValue> = {};
+    for (const [key, value] of Object.entries(propertiesRaw)) {
+      const trimmedKey = key.trim();
+      if (!trimmedKey) {
+        throw new AutomationValidationError(
+          "contact_update property keys must be non-empty",
+          "contact_update_property_key_invalid",
+        );
+      }
+      if (CONTACT_UPDATE_RESERVED_PROPERTY_KEYS.has(trimmedKey)) {
+        throw new AutomationValidationError(
+          `contact_update properties cannot modify reserved contact field "${trimmedKey}"`,
+          "contact_update_property_reserved",
+        );
+      }
+      properties[trimmedKey] = normalizeContactUpdateValue(
+        value,
+        "contact_update_property_value_invalid",
+        `property ${trimmedKey}`,
+      );
+    }
+    if (Object.keys(properties).length > 0) config.properties = properties;
+  }
+
+  if (!config.fields && !config.properties) {
+    throw new AutomationValidationError(
+      "contact_update requires at least one field or property",
+      "contact_update_empty",
+    );
+  }
+
+  return config;
+}
+
 export function normalizeStepConfig(
   type: AutomationStepType,
   config: Record<string, unknown>,
@@ -439,6 +612,11 @@ export function normalizeStepConfig(
       >;
     case "wait_for_event":
       return normalizeWaitForEventConfig(config) as unknown as Record<
+        string,
+        unknown
+      >;
+    case "contact_update":
+      return normalizeContactUpdateConfig(config) as unknown as Record<
         string,
         unknown
       >;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -46,7 +46,14 @@ export type CreateDomainPayload = DomainOptions;
 
 export interface AutomationStepPayload {
   key: string;
-  type: "trigger" | "delay" | "send_email" | "end";
+  type:
+    | "trigger"
+    | "delay"
+    | "send_email"
+    | "end"
+    | "condition"
+    | "wait_for_event"
+    | "contact_update";
   config?: Record<string, unknown>;
   position?: number;
 }

--- a/src/lib/validation/automations.ts
+++ b/src/lib/validation/automations.ts
@@ -9,6 +9,7 @@ export const automationStepTypeSchema = z.enum([
   "end",
   "condition",
   "wait_for_event",
+  "contact_update",
 ]);
 
 const conditionComparableValueSchema = z.union([
@@ -55,6 +56,67 @@ const conditionStepConfigSchema = z.object({
   predicate: conditionPredicateSchema,
 });
 
+const contactUpdateValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+]);
+
+const contactUpdateFieldsSchema = z
+  .object({
+    email: contactUpdateValueSchema.optional(),
+    first_name: contactUpdateValueSchema.optional(),
+    last_name: contactUpdateValueSchema.optional(),
+    unsubscribed: contactUpdateValueSchema.optional(),
+  })
+  .strict();
+
+const contactUpdateReservedPropertyKeys = new Set([
+  "email",
+  "first_name",
+  "firstName",
+  "last_name",
+  "lastName",
+  "unsubscribed",
+  "segments",
+  "topics",
+  "topic_subscriptions",
+  "topicSubscriptions",
+]);
+
+const contactUpdatePropertiesSchema = z
+  .record(z.string().trim().min(1), contactUpdateValueSchema)
+  .superRefine((properties, ctx) => {
+    for (const key of Object.keys(properties)) {
+      if (contactUpdateReservedPropertyKeys.has(key.trim())) {
+        ctx.addIssue({
+          code: "custom",
+          path: [key],
+          message: `properties cannot modify reserved contact field ${key}`,
+        });
+      }
+    }
+  });
+
+const contactUpdateStepConfigSchema = z
+  .object({
+    fields: contactUpdateFieldsSchema.optional(),
+    properties: contactUpdatePropertiesSchema.optional(),
+  })
+  .strict()
+  .superRefine((config, ctx) => {
+    if (
+      (!config.fields || Object.keys(config.fields).length === 0) &&
+      (!config.properties || Object.keys(config.properties).length === 0)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "contact_update requires at least one field or property",
+      });
+    }
+  });
+
 const waitForEventStepConfigSchema = z.object({
   event_name: z
     .string()
@@ -100,6 +162,18 @@ export const automationStepSchema = z
 
     if (step.type === "wait_for_event") {
       const parsed = waitForEventStepConfigSchema.safeParse(step.config);
+      if (!parsed.success) {
+        for (const issue of parsed.error.issues) {
+          ctx.addIssue({
+            ...issue,
+            path: ["config", ...issue.path],
+          });
+        }
+      }
+    }
+
+    if (step.type === "contact_update") {
+      const parsed = contactUpdateStepConfigSchema.safeParse(step.config);
       if (!parsed.success) {
         for (const issue of parsed.error.issues) {
           ctx.addIssue({

--- a/src/lib/workers/automation-runner.ts
+++ b/src/lib/workers/automation-runner.ts
@@ -12,10 +12,12 @@ import {
 import {
   type ConditionOperator,
   type ConditionStepConfig,
+  type ContactUpdateStepConfig,
   type WaitForEventStepConfig,
   automationRunRepo,
   emailService,
   normalizeConditionConfig,
+  normalizeContactUpdateConfig,
   normalizeWaitForEventConfig,
   parseDurationToCappedSeconds,
 } from "@opensend/core";
@@ -50,6 +52,10 @@ export interface AutomationRunnerDeps {
   getContact: (id: string) => Promise<Contact | null>;
   getTemplate: (id: string) => Promise<Template | null>;
   sendEmail: (input: RunnerSendEmailInput) => Promise<{ id: string }>;
+  updateContact: (
+    id: string,
+    data: Partial<typeof contacts.$inferInsert>,
+  ) => Promise<Contact | null>;
   listWaitingRunsByContact: (input: {
     contactId: string;
     userId?: string | null;
@@ -105,6 +111,14 @@ const defaultDeps: AutomationRunnerDeps = {
   },
   async sendEmail(input) {
     return await emailService.send(input);
+  },
+  async updateContact(id, data) {
+    const [updated] = await db
+      .update(contacts)
+      .set(data)
+      .where(eq(contacts.id, id))
+      .returning();
+    return updated ?? null;
   },
   async listWaitingRunsByContact(input) {
     return await automationRunRepo.listWaitingByContact(input);
@@ -564,6 +578,216 @@ async function processWaitForEventStep(
   });
 }
 
+function isUniqueViolation(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  if ("code" in error && (error as { code?: unknown }).code === "23505") {
+    return true;
+  }
+  return "cause" in error && isUniqueViolation(error.cause);
+}
+
+function resolveContactUpdateScalar(
+  value: unknown,
+  context: Record<string, unknown>,
+): unknown {
+  return resolveReference(value, context);
+}
+
+function toOptionalString(value: unknown, field: string): string | null {
+  if (value === null) return null;
+  if (typeof value !== "string") {
+    throw new Error(`contact_update ${field} must resolve to a string or null`);
+  }
+  return value.trim() || null;
+}
+
+function toRequiredEmail(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new Error(
+      "contact_update email must resolve to a valid email string",
+    );
+  }
+  const email = value.trim().toLowerCase();
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) || email.length > 512) {
+    throw new Error(
+      "contact_update email must resolve to a valid email string",
+    );
+  }
+  return email;
+}
+
+function toBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`contact_update ${field} must resolve to a boolean`);
+  }
+  return value;
+}
+
+function toPropertyString(value: unknown, key: string): string {
+  if (value === null) return "";
+  if (
+    typeof value !== "string" &&
+    typeof value !== "number" &&
+    typeof value !== "boolean"
+  ) {
+    throw new Error(
+      `contact_update property ${key} must resolve to a string, number, boolean, or null`,
+    );
+  }
+  return String(value);
+}
+
+function buildContactUpdate(
+  config: ContactUpdateStepConfig,
+  contact: Contact,
+  context: Record<string, unknown>,
+): {
+  data: Partial<typeof contacts.$inferInsert>;
+  changedFields: string[];
+} {
+  const data: Partial<typeof contacts.$inferInsert> = {};
+  const changedFields = new Set<string>();
+  const fields = config.fields ?? {};
+
+  if ("email" in fields) {
+    const email = toRequiredEmail(
+      resolveContactUpdateScalar(fields.email, context),
+    );
+    if (email !== contact.email) {
+      data.email = email;
+      changedFields.add("email");
+    }
+  }
+
+  if ("first_name" in fields) {
+    const firstName = toOptionalString(
+      resolveContactUpdateScalar(fields.first_name, context),
+      "first_name",
+    );
+    if ((contact.firstName ?? null) !== firstName) {
+      data.firstName = firstName;
+      changedFields.add("first_name");
+    }
+  }
+
+  if ("last_name" in fields) {
+    const lastName = toOptionalString(
+      resolveContactUpdateScalar(fields.last_name, context),
+      "last_name",
+    );
+    if ((contact.lastName ?? null) !== lastName) {
+      data.lastName = lastName;
+      changedFields.add("last_name");
+    }
+  }
+
+  if ("unsubscribed" in fields) {
+    const unsubscribed = toBoolean(
+      resolveContactUpdateScalar(fields.unsubscribed, context),
+      "unsubscribed",
+    );
+    if (contact.unsubscribed !== unsubscribed) {
+      data.unsubscribed = unsubscribed;
+      changedFields.add("unsubscribed");
+    }
+  }
+
+  if (config.properties) {
+    const currentProperties = contact.customProperties ?? {};
+    const nextProperties: Record<string, string> = { ...currentProperties };
+    let propertiesChanged = false;
+    for (const [key, rawValue] of Object.entries(config.properties)) {
+      const value = toPropertyString(
+        resolveContactUpdateScalar(rawValue, context),
+        key,
+      );
+      if (nextProperties[key] !== value) {
+        nextProperties[key] = value;
+        propertiesChanged = true;
+        changedFields.add(`properties.${key}`);
+      }
+    }
+    if (propertiesChanged) {
+      data.customProperties = nextProperties;
+    }
+  }
+
+  return { data, changedFields: [...changedFields] };
+}
+
+async function processContactUpdateStep(
+  deps: AutomationRunnerDeps,
+  run: AutomationRun,
+  automation: Automation,
+  steps: AutomationStep[],
+  step: AutomationStep,
+  states: StepStates,
+  now: Date,
+) {
+  if (!run.contactId) {
+    return await failRun(
+      deps,
+      run,
+      step.key,
+      states,
+      now,
+      "contact_update requires a contact",
+    );
+  }
+
+  const contact = await deps.getContact(run.contactId);
+  if (!contact) {
+    return await failRun(
+      deps,
+      run,
+      step.key,
+      states,
+      now,
+      "contact_update contact not found",
+    );
+  }
+
+  const config = normalizeContactUpdateConfig(step.config ?? {});
+  const delivery = run.triggerEventId
+    ? await deps.getDelivery(run.triggerEventId)
+    : null;
+  const context = buildVariableContext(delivery, contact, states);
+  const { data, changedFields } = buildContactUpdate(config, contact, context);
+
+  if (changedFields.length > 0) {
+    try {
+      const updated = await deps.updateContact(contact.id, data);
+      if (!updated) {
+        return await failRun(
+          deps,
+          run,
+          step.key,
+          states,
+          now,
+          "contact_update contact not found",
+        );
+      }
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        return await failRun(
+          deps,
+          run,
+          step.key,
+          states,
+          now,
+          "contact_update email already exists",
+        );
+      }
+      throw error;
+    }
+  }
+
+  return await advanceRun(deps, run, automation, steps, step, states, now, {
+    contact_id: contact.id,
+    changed_fields: changedFields,
+  });
+}
+
 async function processSendEmailStep(
   deps: AutomationRunnerDeps,
   run: AutomationRun,
@@ -794,6 +1018,18 @@ export async function processAutomationRunStep(
 
     if (step.type === "wait_for_event") {
       return await processWaitForEventStep(deps, run, step, states, now);
+    }
+
+    if (step.type === "contact_update") {
+      return await processContactUpdateStep(
+        deps,
+        run,
+        automation,
+        steps,
+        step,
+        states,
+        now,
+      );
     }
 
     if (step.type === "send_email") {

--- a/tests/api-automations-events.test.ts
+++ b/tests/api-automations-events.test.ts
@@ -361,6 +361,96 @@ describe("automation API routes", () => {
     );
   });
 
+  it("creates an automation with a valid contact_update step", async () => {
+    mockAutomationCreate.mockResolvedValue({
+      automation,
+      steps: [
+        triggerStep,
+        {
+          ...triggerStep,
+          id: "step_update",
+          key: "update",
+          type: "contact_update",
+          config: {
+            fields: { first_name: "event.first_name", unsubscribed: true },
+            properties: { plan: "event.plan" },
+          },
+          position: 1,
+        },
+      ],
+    });
+    const { POST } = await import("@/app/api/automations/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/automations", {
+        name: "Update contact",
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.signed_up" },
+          },
+          {
+            key: "update",
+            type: "contact_update",
+            config: {
+              fields: { first_name: "event.first_name", unsubscribed: true },
+              properties: { plan: "event.plan" },
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockAutomationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        steps: expect.arrayContaining([
+          expect.objectContaining({
+            type: "contact_update",
+            config: {
+              fields: { first_name: "event.first_name", unsubscribed: true },
+              properties: { plan: "event.plan" },
+            },
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it("rejects invalid contact_update config with field-level errors", async () => {
+    const { POST } = await import("@/app/api/automations/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/automations", {
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.signed_up" },
+          },
+          {
+            key: "update",
+            type: "contact_update",
+            config: {
+              fields: { segments: ["vip"] },
+              properties: { unsubscribed: "event.unsubscribed" },
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(422);
+    const json = await response.json();
+    expect(json.details.fieldErrors.steps).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("segments"),
+        expect.stringContaining("reserved contact field"),
+      ]),
+    );
+  });
+
   it("returns 422 when repository graph validation rejects condition branches", async () => {
     mockAutomationCreate.mockRejectedValue(
       new TestAutomationValidationError(

--- a/tests/automation-runner.test.ts
+++ b/tests/automation-runner.test.ts
@@ -6,7 +6,11 @@ import type {
   customEventDeliveries,
   templates,
 } from "@/lib/db/schema";
-import type { AutomationRunnerDeps } from "@/lib/workers/automation-runner";
+import {
+  type AutomationRunnerDeps,
+  processAutomationRunStep,
+  resumeWaitingRunsForEvent,
+} from "@/lib/workers/automation-runner";
 import { describe, expect, it, vi } from "vitest";
 
 type AutomationRun = typeof automationRuns.$inferSelect;
@@ -153,6 +157,7 @@ function deps(overrides: Partial<AutomationRunnerDeps> = {}) {
     getContact: vi.fn().mockResolvedValue(contact),
     getTemplate: vi.fn().mockResolvedValue(template),
     sendEmail,
+    updateContact: vi.fn().mockResolvedValue(contact),
     listWaitingRunsByContact: vi.fn().mockResolvedValue([]),
     updateRun: vi.fn(async (_id, data) => {
       updates.push(data as Partial<AutomationRun>);
@@ -165,9 +170,6 @@ function deps(overrides: Partial<AutomationRunnerDeps> = {}) {
 
 describe("automation runner", () => {
   it("advances trigger then schedules delay next_step_at without sleeping", async () => {
-    const { processAutomationRunStep } = await import(
-      "@/lib/workers/automation-runner"
-    );
     const setup = deps();
 
     await processAutomationRunStep(run(), setup.deps);
@@ -196,9 +198,6 @@ describe("automation runner", () => {
   });
 
   it("resumes a due delayed run and calls the email publishing boundary", async () => {
-    const { processAutomationRunStep } = await import(
-      "@/lib/workers/automation-runner"
-    );
     const setup = deps();
 
     await processAutomationRunStep(
@@ -244,9 +243,6 @@ describe("automation runner", () => {
   });
 
   it("evaluates condition steps and advances to the met branch in one tick", async () => {
-    const { processAutomationRunStep } = await import(
-      "@/lib/workers/automation-runner"
-    );
     const conditionAutomation: Automation = {
       ...automation,
       connections: [
@@ -294,9 +290,6 @@ describe("automation runner", () => {
   });
 
   it("enters wait_for_event waiting state without downstream work in the same tick", async () => {
-    const { processAutomationRunStep } = await import(
-      "@/lib/workers/automation-runner"
-    );
     const waitAutomation: Automation = {
       ...automation,
       connections: [
@@ -339,9 +332,6 @@ describe("automation runner", () => {
   });
 
   it("fails a due wait_for_event timeout deterministically", async () => {
-    const { processAutomationRunStep } = await import(
-      "@/lib/workers/automation-runner"
-    );
     const waitSteps: AutomationStep[] = [
       {
         ...steps[1],
@@ -379,9 +369,6 @@ describe("automation runner", () => {
   });
 
   it("resumes a matching wait_for_event run and stores payload output", async () => {
-    const { resumeWaitingRunsForEvent } = await import(
-      "@/lib/workers/automation-runner"
-    );
     const waitAutomation: Automation = {
       ...automation,
       connections: [{ from: "wait", to: "send" }],
@@ -448,9 +435,6 @@ describe("automation runner", () => {
   });
 
   it("does not resume wait_for_event runs for non-matching events", async () => {
-    const { resumeWaitingRunsForEvent } = await import(
-      "@/lib/workers/automation-runner"
-    );
     const waitSteps: AutomationStep[] = [
       {
         ...steps[1],
@@ -483,9 +467,6 @@ describe("automation runner", () => {
   });
 
   it("resolves waited event output for downstream send_email variables", async () => {
-    const { processAutomationRunStep } = await import(
-      "@/lib/workers/automation-runner"
-    );
     const waitSendStep: AutomationStep = {
       ...steps[2],
       config: {
@@ -526,9 +507,6 @@ describe("automation runner", () => {
   });
 
   it("evaluates condition steps and advances to the not-met branch", async () => {
-    const { processAutomationRunStep } = await import(
-      "@/lib/workers/automation-runner"
-    );
     const conditionAutomation: Automation = {
       ...automation,
       connections: [
@@ -574,9 +552,6 @@ describe("automation runner", () => {
   });
 
   it("can compare prior step output values in condition predicates", async () => {
-    const { processAutomationRunStep } = await import(
-      "@/lib/workers/automation-runner"
-    );
     const conditionAutomation: Automation = {
       ...automation,
       connections: [
@@ -626,9 +601,6 @@ describe("automation runner", () => {
   });
 
   it("fails condition steps with missing variables at the step level", async () => {
-    const { processAutomationRunStep } = await import(
-      "@/lib/workers/automation-runner"
-    );
     const conditionSteps: AutomationStep[] = [
       {
         ...steps[1],
@@ -665,9 +637,6 @@ describe("automation runner", () => {
   });
 
   it("fails condition steps with invalid persisted predicate configs", async () => {
-    const { processAutomationRunStep } = await import(
-      "@/lib/workers/automation-runner"
-    );
     const conditionSteps: AutomationStep[] = [
       {
         ...steps[1],
@@ -693,10 +662,154 @@ describe("automation runner", () => {
     });
   });
 
-  it("fails missing or unpublished templates with a step-level error", async () => {
-    const { processAutomationRunStep } = await import(
-      "@/lib/workers/automation-runner"
+  it("updates the current contact with resolved fields and minimal output", async () => {
+    const updateAutomation: Automation = {
+      ...automation,
+      connections: [{ from: "update", to: "end" }],
+    };
+    const updateStep: AutomationStep = {
+      ...steps[1],
+      key: "update",
+      type: "contact_update",
+      config: {
+        fields: {
+          email: "event.new_email",
+          first_name: "wait_events.wait.payload.first_name",
+          unsubscribed: true,
+        },
+        properties: {
+          plan: "event.plan",
+          invoice: "wait_events.wait.payload.invoice_id",
+        },
+      },
+      position: 0,
+    };
+    const setup = deps({
+      getAutomation: vi.fn().mockResolvedValue(updateAutomation),
+      listSteps: vi.fn().mockResolvedValue([updateStep, steps[3]]),
+      getDelivery: vi.fn().mockResolvedValue({
+        ...delivery,
+        payload: { plan: "pro", new_email: "NEW@example.com" },
+      }),
+    });
+
+    await processAutomationRunStep(
+      run({
+        currentStepKey: "update",
+        stepStates: {
+          wait: {
+            status: "completed",
+            output: {
+              waited_event: {
+                payload: { first_name: "Grace", invoice_id: "inv_1" },
+              },
+            },
+          },
+        },
+      }),
+      setup.deps,
     );
+
+    expect(setup.deps.updateContact).toHaveBeenCalledWith(contact.id, {
+      email: "new@example.com",
+      firstName: "Grace",
+      unsubscribed: true,
+      customProperties: { plan: "pro", invoice: "inv_1" },
+    });
+    expect(setup.updates[0]).toMatchObject({
+      status: "queued",
+      currentStepKey: "end",
+    });
+    expect(setup.updates[0]?.stepStates?.update.output).toEqual({
+      contact_id: contact.id,
+      changed_fields: [
+        "email",
+        "first_name",
+        "unsubscribed",
+        "properties.plan",
+        "properties.invoice",
+      ],
+    });
+  });
+
+  it("fails contact_update without a current contact", async () => {
+    const updateStep: AutomationStep = {
+      ...steps[1],
+      key: "update",
+      type: "contact_update",
+      config: { fields: { first_name: "event.first_name" } },
+      position: 0,
+    };
+    const setup = deps({ listSteps: vi.fn().mockResolvedValue([updateStep]) });
+
+    await processAutomationRunStep(
+      run({ currentStepKey: "update", contactId: null }),
+      setup.deps,
+    );
+
+    expect(setup.deps.updateContact).not.toHaveBeenCalled();
+    expect(setup.updates[0]).toMatchObject({
+      status: "failed",
+      currentStepKey: "update",
+      failureReason: "contact_update requires a contact",
+    });
+  });
+
+  it("fails contact_update when email resolves invalid", async () => {
+    const updateStep: AutomationStep = {
+      ...steps[1],
+      key: "update",
+      type: "contact_update",
+      config: { fields: { email: "event.bad_email" } },
+      position: 0,
+    };
+    const setup = deps({
+      listSteps: vi.fn().mockResolvedValue([updateStep]),
+      getDelivery: vi.fn().mockResolvedValue({
+        ...delivery,
+        payload: { bad_email: "not-an-email" },
+      }),
+    });
+
+    await processAutomationRunStep(
+      run({ currentStepKey: "update" }),
+      setup.deps,
+    );
+
+    expect(setup.deps.updateContact).not.toHaveBeenCalled();
+    expect(setup.updates[0]).toMatchObject({
+      status: "failed",
+      failureReason:
+        "contact_update email must resolve to a valid email string",
+    });
+  });
+
+  it("fails contact_update email unique conflicts deterministically", async () => {
+    const updateStep: AutomationStep = {
+      ...steps[1],
+      key: "update",
+      type: "contact_update",
+      config: { fields: { email: "taken@example.com" } },
+      position: 0,
+    };
+    const setup = deps({
+      listSteps: vi.fn().mockResolvedValue([updateStep]),
+      updateContact: vi.fn().mockRejectedValue({ code: "23505" }),
+    });
+
+    await processAutomationRunStep(
+      run({ currentStepKey: "update" }),
+      setup.deps,
+    );
+
+    expect(setup.updates[0]).toMatchObject({
+      status: "failed",
+      currentStepKey: "update",
+      failureReason: "contact_update email already exists",
+    });
+  });
+
+  it("fails missing or unpublished templates with a step-level error", async () => {
     const setup = deps({
       getTemplate: vi.fn().mockResolvedValue({ ...template, status: "draft" }),
     });
@@ -716,9 +829,6 @@ describe("automation runner", () => {
   });
 
   it("skips send_email for unsubscribed contacts", async () => {
-    const { processAutomationRunStep } = await import(
-      "@/lib/workers/automation-runner"
-    );
     const setup = deps({
       getContact: vi.fn().mockResolvedValue({ ...contact, unsubscribed: true }),
     });

--- a/tests/core-automation-repo.test.ts
+++ b/tests/core-automation-repo.test.ts
@@ -288,6 +288,86 @@ describe("automationRepo.create", () => {
     ).rejects.toMatchObject({ code: "wait_for_event_timeout_invalid" });
   });
 
+  it("accepts contact_update steps with explicit safe field and property mappings", async () => {
+    const { automationRepo } = await import(
+      "../packages/core/src/db/repositories/automationRepo"
+    );
+
+    await expect(
+      automationRepo.create({
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.updated" },
+          },
+          {
+            key: "update",
+            type: "contact_update",
+            config: {
+              fields: {
+                email: "event.email",
+                first_name: "contact.first_name",
+                last_name: "steps.enrich.output.last_name",
+                unsubscribed: false,
+              },
+              properties: { plan: "wait_events.wait.payload.plan" },
+            },
+          },
+        ],
+        connections: [{ from: "trigger", to: "update" }],
+      }),
+    ).resolves.toMatchObject({ automation: { id: "auto_1" } });
+  });
+
+  it("rejects contact_update configs with dangerous generic property fields", async () => {
+    const { automationRepo } = await import(
+      "../packages/core/src/db/repositories/automationRepo"
+    );
+
+    await expect(
+      automationRepo.create({
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.updated" },
+          },
+          {
+            key: "update",
+            type: "contact_update",
+            config: {
+              properties: { unsubscribed: "event.unsubscribed" },
+            },
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "contact_update_property_reserved" });
+  });
+
+  it("rejects contact_update configs with unsupported top-level or field keys", async () => {
+    const { automationRepo } = await import(
+      "../packages/core/src/db/repositories/automationRepo"
+    );
+
+    await expect(
+      automationRepo.create({
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.updated" },
+          },
+          {
+            key: "update",
+            type: "contact_update",
+            config: { fields: { segments: ["vip"] } },
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "contact_update_field_invalid" });
+  });
+
   it("rejects condition branch labels from non-condition steps", async () => {
     const { automationRepo } = await import(
       "../packages/core/src/db/repositories/automationRepo"


### PR DESCRIPTION
## Summary
- Add validated backend `contact_update` automation action config with explicit `fields` plus separate custom `properties` updates.
- Execute `contact_update` in the runner using existing automation variable sources (`event.*`, `contact.*`, `steps.*.output.*`, `wait_events.*`) and one-step-per-tick advancement.
- Fail missing contacts, invalid resolved email values, and email uniqueness conflicts with step-level errors/run failure reasons.
- Keep step output minimal: `contact_id` plus changed field names only.

## Safety notes
- `unsubscribed` is only writable through explicit `fields.unsubscribed`.
- Generic `properties` rejects reserved/contact-compliance keys (`email`, name fields, `unsubscribed`, topics, segments) to avoid accidental mutation.
- Unspecified first-class fields and unspecified custom properties are preserved.

## Validation
- `make check` ✅
- `bun run test -- --testTimeout=10000 tests/core-automation-repo.test.ts tests/api-automations-events.test.ts tests/automation-runner.test.ts` ✅ (50 tests)
- `make test` ⚠️ attempted; default 5s Vitest timeout hit unrelated existing cold-start timeouts in `tests/api-domains.test.ts`, `tests/api-emails.test.ts`, `tests/billing-quota.test.ts`, and `tests/quota-routes.test.ts`.
- `bun run test -- --testTimeout=10000` ⚠️ attempted; still hit unrelated >10s cold-start timeouts in `tests/api-domains.test.ts`, `tests/billing-quota.test.ts`, and `tests/quota-routes.test.ts`.

Closes #178.
