### PR TITLE
Fix staging unit test regressions

### DIFF
--- a/tests/api-domains.test.ts
+++ b/tests/api-domains.test.ts
@@ -25,6 +25,7 @@ vi.mock("@/lib/db", () => ({
 
 vi.mock("@/lib/api-auth", () => ({
   authorizeDashboardOrApiKey: mockValidateApiKey,
+  validateApiKey: mockValidateApiKey,
   unauthorizedResponse: () =>
     Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
 }));

--- a/tests/broadcasts-list.test.ts
+++ b/tests/broadcasts-list.test.ts
@@ -95,6 +95,7 @@ function mockFetchSuccess(
 describe("BroadcastsList", () => {
   beforeEach(async () => {
     vi.resetModules();
+    vi.clearAllMocks();
     const mod = await import("@/components/broadcasts-list");
     BroadcastsList = mod.BroadcastsList;
   });


### PR DESCRIPTION
## Summary
- Fixes staging CI run https://github.com/namuh-eng/opensend/actions/runs/25311390678 unit regression in `tests/api-domains.test.ts` by updating the stale `@/lib/api-auth` mock for the route's `validateApiKey` import.
- Stabilizes `tests/broadcasts-list.test.ts` by clearing router/mock call history per test before asserting URL sync calls.

## Tests
- `bun run test tests/api-domains.test.ts tests/broadcasts-list.test.ts`
- `make check`
- `make test`

## Notes
- Onboarding acceptance remains a known baseline failure at `drizzle-kit push`; this PR intentionally does not touch that lane.
- PR #183 was not modified.