### PR TITLE
Honor custom return-path DNS records

### DIFF
--- a/agent_docs/learnings/active/2026-05-05-issue-185-return-path-dns.md
+++ b/agent_docs/learnings/active/2026-05-05-issue-185-return-path-dns.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-05
+issue: "#185"
+type: pattern
+promoted_to: null
+---
+
+## Domain return-path DNS records
+
+**What:** Custom domain create now treats `custom_return_path` as a single DNS label and uses the effective label (`send` by default) for SES MAIL FROM MX/SPF record names.
+
+**Pattern:** Keep DKIM records on the identity domain, but build MX/SPF records as `<effective-return-path>.<domain>` in both persisted records and Cloudflare auto-configure/check paths. API responses should expose both persisted `custom_return_path` and effective `return_path` so clients can show default behavior without rewriting stored rows.

--- a/packages/core/src/dto/index.ts
+++ b/packages/core/src/dto/index.ts
@@ -137,6 +137,8 @@ export interface DomainResponse {
   status: string;
   region: string;
   records: DomainRecord[];
+  custom_return_path?: string | null;
+  return_path?: string;
   open_tracking?: boolean;
   click_tracking?: boolean;
   tracking_subdomain?: string | null;

--- a/packages/core/src/services/domain.ts
+++ b/packages/core/src/services/domain.ts
@@ -8,6 +8,21 @@ type DomainInsert = typeof domains.$inferInsert;
 type DomainRecord = NonNullable<DomainRow["records"]>[number];
 type DomainCapability = NonNullable<DomainRow["capabilities"]>[number];
 
+export const DEFAULT_RETURN_PATH = "send";
+
+export function getEffectiveReturnPathLabel(
+  customReturnPath: string | null | undefined,
+): string {
+  return customReturnPath?.trim() || DEFAULT_RETURN_PATH;
+}
+
+export function buildReturnPathRecordName(
+  domainName: string,
+  customReturnPath: string | null | undefined,
+): string {
+  return `${getEffectiveReturnPathLabel(customReturnPath)}.${domainName}`;
+}
+
 export type CreateDomainIdentityResult = {
   dkimTokens: string[];
   status?: string;
@@ -38,6 +53,7 @@ export type DomainDetail = Pick<
   | "tls"
   | "capabilities"
   | "createdAt"
+  | "customReturnPath"
 >;
 
 export type DomainServiceListItem = Pick<
@@ -87,6 +103,7 @@ function buildDomainRecords(
   domainName: string,
   region: string,
   dkimTokens: string[],
+  customReturnPath: string | null | undefined,
 ): DomainRecord[] {
   const dkimRecords: DomainRecord[] = dkimTokens.map((token) => ({
     type: "CNAME",
@@ -96,9 +113,14 @@ function buildDomainRecords(
     ttl: "Auto",
   }));
 
+  const returnPathRecordName = buildReturnPathRecordName(
+    domainName,
+    customReturnPath,
+  );
+
   const spfRecord: DomainRecord = {
     type: "TXT",
-    name: domainName,
+    name: returnPathRecordName,
     value: "v=spf1 include:amazonses.com ~all",
     status: "pending",
     ttl: "Auto",
@@ -106,7 +128,7 @@ function buildDomainRecords(
 
   const mxRecord: DomainRecord = {
     type: "MX",
-    name: domainName,
+    name: returnPathRecordName,
     value: `feedback-smtp.${region}.amazonses.com`,
     status: "pending",
     ttl: "Auto",
@@ -129,6 +151,7 @@ function toDomainDetail(row: DomainRow): DomainDetail {
     tls: row.tls,
     capabilities: row.capabilities,
     createdAt: row.createdAt,
+    customReturnPath: row.customReturnPath,
   };
 }
 
@@ -179,6 +202,7 @@ export function createDomainService({
         domainName,
         region,
         identity.dkimTokens,
+        input.customReturnPath,
       );
 
       const [row] = await repository.create({

--- a/src/app/api/domains/[id]/auto-configure/route.ts
+++ b/src/app/api/domains/[id]/auto-configure/route.ts
@@ -53,6 +53,7 @@ export async function POST(
     const { records: cfRecords, warnings } = await autoConfigureDomain(
       domain.name,
       dkimTokens,
+      domain.customReturnPath,
     );
 
     const allRecords = cfRecords.map((record) => ({

--- a/src/app/api/domains/[id]/route.ts
+++ b/src/app/api/domains/[id]/route.ts
@@ -14,6 +14,7 @@ import {
   domainRouteParamsSchema,
   updateDomainSchema,
 } from "@/lib/validation/domains";
+import { getEffectiveReturnPathLabel } from "@opensend/core";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
@@ -54,6 +55,8 @@ export async function GET(
       status: domain.status,
       region: domain.region,
       records: domain.records || [],
+      custom_return_path: domain.customReturnPath,
+      return_path: getEffectiveReturnPathLabel(domain.customReturnPath),
       open_tracking: domain.trackOpens,
       click_tracking: domain.trackClicks,
       tracking_subdomain: domain.trackingSubdomain,

--- a/src/app/api/domains/[id]/verify/route.ts
+++ b/src/app/api/domains/[id]/verify/route.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/domain-cache";
 import { queueEvent } from "@/lib/events";
 import { verifyDomainParamsSchema } from "@/lib/validation/domains";
+import { getEffectiveReturnPathLabel } from "@opensend/core";
 import { eq } from "drizzle-orm";
 
 export async function POST(
@@ -106,6 +107,8 @@ export async function POST(
       name: updated.name,
       status: updated.status,
       records: updated.records || [],
+      custom_return_path: updated.customReturnPath,
+      return_path: getEffectiveReturnPathLabel(updated.customReturnPath),
       created_at: updated.createdAt,
     });
   } catch (err) {

--- a/src/app/api/domains/route.ts
+++ b/src/app/api/domains/route.ts
@@ -3,7 +3,10 @@ import { checkDomainQuota, quotaExceededResponse } from "@/lib/billing/quota";
 import { invalidateDomainCaches } from "@/lib/domain-cache";
 import { createDomainIdentity } from "@/lib/ses";
 import { createDomainSchema } from "@/lib/validation/domains";
-import { createDomainService } from "@opensend/core";
+import {
+  createDomainService,
+  getEffectiveReturnPathLabel,
+} from "@opensend/core";
 
 function domainService() {
   return createDomainService({
@@ -63,6 +66,8 @@ export async function POST(request: Request): Promise<Response> {
         status: row.status,
         region: row.region,
         records: row.records || [],
+        custom_return_path: row.customReturnPath,
+        return_path: getEffectiveReturnPathLabel(row.customReturnPath),
         open_tracking: row.trackOpens,
         click_tracking: row.trackClicks,
         tracking_subdomain: row.trackingSubdomain,

--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -41,6 +41,13 @@ function headers(token: string) {
   };
 }
 
+function buildReturnPathRecordName(
+  domainName: string,
+  customReturnPath: string | null | undefined,
+): string {
+  return `${customReturnPath?.trim() || "send"}.${domainName}`;
+}
+
 async function handleResponse<T>(response: Response): Promise<T> {
   const data = (await response.json()) as CloudflareResponse<T>;
   if (!response.ok || !data.success) {
@@ -147,18 +154,23 @@ export interface AutoConfigureResult {
 export async function autoConfigureDomain(
   domain: string,
   dkimTokens: string[],
+  customReturnPath?: string | null,
 ): Promise<AutoConfigureResult> {
   if (!domain) throw new Error("domain is required");
   if (!dkimTokens || dkimTokens.length === 0)
     throw new Error("DKIM tokens are required");
 
+  const returnPathRecordName = buildReturnPathRecordName(
+    domain,
+    customReturnPath,
+  );
   const warnings: string[] = [];
   const results: DNSRecordResult[] = [];
 
   // Check existing MX and TXT records before creating anything
   const [existingMX, existingTXT] = await Promise.all([
-    listDNSRecords({ name: domain, type: "MX" }),
-    listDNSRecords({ name: domain, type: "TXT" }),
+    listDNSRecords({ name: returnPathRecordName, type: "MX" }),
+    listDNSRecords({ name: returnPathRecordName, type: "TXT" }),
   ]);
 
   // DKIM CNAME records — skip gracefully if already exist
@@ -197,7 +209,7 @@ export async function autoConfigureDomain(
   } else {
     const spfRecord = await createDNSRecord({
       type: "TXT",
-      name: domain,
+      name: returnPathRecordName,
       content: "v=spf1 include:amazonses.com ~all",
       ttl: 300,
     });
@@ -213,7 +225,7 @@ export async function autoConfigureDomain(
   } else {
     const mxRecord = await createDNSRecord({
       type: "MX",
-      name: domain,
+      name: returnPathRecordName,
       content: "feedback-smtp.us-east-1.amazonses.com",
       ttl: 300,
       priority: 10,

--- a/src/lib/validation/domains.ts
+++ b/src/lib/validation/domains.ts
@@ -22,10 +22,22 @@ export const domainCapabilitySchema = z.object({
   enabled: z.boolean(),
 });
 
+export const returnPathLabelSchema = z
+  .string()
+  .trim()
+  .min(1, "Return path is required")
+  .max(63, "Return path must be 63 characters or less")
+  .regex(/^[A-Za-z]/, "Return path must start with a letter")
+  .regex(/[A-Za-z0-9]$/, "Return path must end with a letter or number")
+  .regex(
+    /^[A-Za-z0-9-]+$/,
+    "Return path can only contain letters, numbers, and hyphens",
+  );
+
 export const createDomainSchema = z.object({
   name: z.string().trim().min(1, "Domain name is required").max(255),
   region: domainRegionSchema.optional().default("us-east-1"),
-  custom_return_path: z.string().trim().min(1).max(255).optional(),
+  custom_return_path: returnPathLabelSchema.optional(),
   open_tracking: z.boolean().optional(),
   click_tracking: z.boolean().optional(),
   tracking_subdomain: z.string().trim().min(1).max(255).optional(),

--- a/tests/api-domains.test.ts
+++ b/tests/api-domains.test.ts
@@ -108,6 +108,22 @@ describe("Domain API validation", () => {
     expect(mockDb.insert).not.toHaveBeenCalled();
   });
 
+  it("returns 422 for invalid custom return path labels", async () => {
+    const { POST } = await import("@/app/api/domains/route");
+    const req = makeRequest("http://localhost:3015/api/domains", "POST", {
+      name: "example.com",
+      custom_return_path: "outbound.example",
+    });
+
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(json.error).toBe("Validation failed");
+    expect(json.details.fieldErrors.custom_return_path).toBeDefined();
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
   it("returns 422 for invalid domain update payload", async () => {
     const { PATCH } = await import("@/app/api/domains/[id]/route");
     const req = makeRequest(
@@ -213,6 +229,7 @@ describe("Domain API validation", () => {
     mockDb.query.domains.findFirst.mockResolvedValue({
       id: VALID_DOMAIN_ID,
       name: "example.com",
+      customReturnPath: "outbound",
     });
     mockCreateDomainIdentity.mockResolvedValue({
       dkimTokens: ["dkim-1", "dkim-2", "dkim-3"],
@@ -249,10 +266,10 @@ describe("Domain API validation", () => {
     expect(res.status).toBe(200);
     expect(json.ok).toBe(true);
     expect(json.cloudflare_records).toBe(1);
-    expect(mockAutoConfigureDomain).toHaveBeenCalledWith("example.com", [
-      "dkim-1",
-      "dkim-2",
-      "dkim-3",
-    ]);
+    expect(mockAutoConfigureDomain).toHaveBeenCalledWith(
+      "example.com",
+      ["dkim-1", "dkim-2", "dkim-3"],
+      "outbound",
+    );
   });
 });

--- a/tests/cache-invalidation-routes.test.ts
+++ b/tests/cache-invalidation-routes.test.ts
@@ -33,6 +33,8 @@ vi.mock("@opensend/core", () => ({
   createDomainService: () => ({
     createDomain: mockCreateDomain,
   }),
+  getEffectiveReturnPathLabel: (customReturnPath: string | null | undefined) =>
+    customReturnPath?.trim() || "send",
 }));
 
 vi.mock("@/lib/api-auth", () => ({
@@ -134,6 +136,7 @@ describe("cache invalidation routes", () => {
       tls: "opportunistic",
       capabilities: [{ name: "sending", enabled: true }],
       createdAt: new Date("2026-04-28T00:00:00.000Z"),
+      customReturnPath: null,
     });
 
     const route = await import("@/app/api/domains/route");
@@ -149,6 +152,10 @@ describe("cache invalidation routes", () => {
     );
 
     expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      custom_return_path: null,
+      return_path: "send",
+    });
     expect(mockCreateDomain).toHaveBeenCalledWith({
       name: "Example.COM",
       region: "us-east-1",

--- a/tests/cloudflare.test.ts
+++ b/tests/cloudflare.test.ts
@@ -341,7 +341,9 @@ describe("Cloudflare DNS Client", () => {
               id: `dns-record-${i}`,
               type: i < 3 ? "CNAME" : i === 3 ? "TXT" : "MX",
               name:
-                i < 3 ? `token${i + 1}._domainkey.example.com` : "example.com",
+                i < 3
+                  ? `token${i + 1}._domainkey.example.com`
+                  : "send.example.com",
               content:
                 i < 3
                   ? `token${i + 1}.dkim.amazonses.com`
@@ -365,6 +367,10 @@ describe("Cloudflare DNS Client", () => {
       expect(warnings).toHaveLength(0);
       // 2 GETs (list) + 3 DKIM + 1 SPF + 1 MX
       expect(mockFetch).toHaveBeenCalledTimes(7);
+      expect(mockFetch.mock.calls[0][0]).toContain("name=send.example.com");
+      expect(mockFetch.mock.calls[0][0]).toContain("type=MX");
+      expect(mockFetch.mock.calls[1][0]).toContain("name=send.example.com");
+      expect(mockFetch.mock.calls[1][0]).toContain("type=TXT");
 
       // Verify each DKIM CNAME record was created correctly
       for (let i = 0; i < 3; i++) {
@@ -379,7 +385,7 @@ describe("Cloudflare DNS Client", () => {
       const spfBody = JSON.parse(spfCall[1].body);
       expect(spfBody).toEqual({
         type: "TXT",
-        name: "example.com",
+        name: "send.example.com",
         content: "v=spf1 include:amazonses.com ~all",
         ttl: 300,
       });
@@ -388,11 +394,60 @@ describe("Cloudflare DNS Client", () => {
       const mxBody = JSON.parse(mxCall[1].body);
       expect(mxBody).toEqual({
         type: "MX",
-        name: "example.com",
+        name: "send.example.com",
         content: "feedback-smtp.us-east-1.amazonses.com",
         ttl: 300,
         priority: 10,
       });
+    });
+
+    it("uses a custom return path label for SPF and MX records", async () => {
+      // listDNSRecords for MX → empty
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, result: [] }),
+      });
+      // listDNSRecords for TXT → empty
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, result: [] }),
+      });
+      // One DKIM record, one SPF record, one MX record
+      for (let i = 0; i < 3; i++) {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            success: true,
+            result: {
+              id: `custom-dns-record-${i}`,
+              type: i === 0 ? "CNAME" : i === 1 ? "TXT" : "MX",
+              name:
+                i === 0
+                  ? "token1._domainkey.example.com"
+                  : "outbound.example.com",
+              content:
+                i === 0
+                  ? "token1.dkim.amazonses.com"
+                  : i === 1
+                    ? "v=spf1 include:amazonses.com ~all"
+                    : "feedback-smtp.us-east-1.amazonses.com",
+              ttl: 300,
+              ...(i === 2 ? { priority: 10 } : {}),
+            },
+          }),
+        });
+      }
+
+      await autoConfigureDomain("example.com", ["token1"], "outbound");
+
+      expect(mockFetch.mock.calls[0][0]).toContain("name=outbound.example.com");
+      expect(mockFetch.mock.calls[1][0]).toContain("name=outbound.example.com");
+
+      const spfBody = JSON.parse(mockFetch.mock.calls[3][1].body);
+      expect(spfBody.name).toBe("outbound.example.com");
+
+      const mxBody = JSON.parse(mockFetch.mock.calls[4][1].body);
+      expect(mxBody.name).toBe("outbound.example.com");
     });
 
     it("skips MX and merges SPF when existing records are present", async () => {
@@ -405,7 +460,7 @@ describe("Cloudflare DNS Client", () => {
             {
               id: "existing-mx",
               type: "MX",
-              name: "example.com",
+              name: "send.example.com",
               content: "mx01.mail.icloud.com",
               ttl: 3600,
               priority: 10,
@@ -422,7 +477,7 @@ describe("Cloudflare DNS Client", () => {
             {
               id: "existing-spf",
               type: "TXT",
-              name: "example.com",
+              name: "send.example.com",
               content: "v=spf1 include:icloud.com ~all",
               ttl: 3600,
             },
@@ -453,7 +508,7 @@ describe("Cloudflare DNS Client", () => {
           result: {
             id: "existing-spf",
             type: "TXT",
-            name: "example.com",
+            name: "send.example.com",
             content: "v=spf1 include:icloud.com include:amazonses.com ~all",
             ttl: 3600,
           },

--- a/tests/domain-service.test.ts
+++ b/tests/domain-service.test.ts
@@ -82,7 +82,7 @@ describe("domain service", () => {
     const result = await service.createDomain({
       name: "Example.COM",
       region: "eu-west-1",
-      customReturnPath: "bounce.example.com",
+      customReturnPath: "outbound",
       openTracking: true,
       clickTracking: true,
       trackingSubdomain: "track.example.com",
@@ -97,7 +97,7 @@ describe("domain service", () => {
       region: "eu-west-1",
       status: "not_started",
       dkimTokens: ["dkim-a", "dkim-b"],
-      customReturnPath: "bounce.example.com",
+      customReturnPath: "outbound",
       trackOpens: true,
       trackClicks: true,
       trackingSubdomain: "track.example.com",
@@ -122,14 +122,14 @@ describe("domain service", () => {
       },
       {
         type: "TXT",
-        name: "example.com",
+        name: "outbound.example.com",
         value: "v=spf1 include:amazonses.com ~all",
         status: "pending",
         ttl: "Auto",
       },
       {
         type: "MX",
-        name: "example.com",
+        name: "outbound.example.com",
         value: "feedback-smtp.eu-west-1.amazonses.com",
         status: "pending",
         ttl: "Auto",
@@ -140,6 +140,7 @@ describe("domain service", () => {
       id: "created-domain",
       name: "example.com",
       region: "eu-west-1",
+      customReturnPath: "outbound",
       trackOpens: true,
       trackClicks: true,
     });
@@ -177,6 +178,23 @@ describe("domain service", () => {
       ],
       userId: null,
     });
+    expect(inserted[0]?.records).toEqual([
+      {
+        type: "TXT",
+        name: "send.example.com",
+        value: "v=spf1 include:amazonses.com ~all",
+        status: "pending",
+        ttl: "Auto",
+      },
+      {
+        type: "MX",
+        name: "send.example.com",
+        value: "feedback-smtp.us-east-1.amazonses.com",
+        status: "pending",
+        ttl: "Auto",
+        priority: 10,
+      },
+    ]);
   });
 
   it("lists with normalized pagination and maps public list fields", async () => {

--- a/tests/domain-validation.test.ts
+++ b/tests/domain-validation.test.ts
@@ -1,0 +1,44 @@
+import { createDomainSchema } from "@/lib/validation/domains";
+import { describe, expect, it } from "vitest";
+
+const basePayload = {
+  name: "example.com",
+};
+
+describe("domain validation", () => {
+  it("accepts an omitted custom return path so callers get the default send label", () => {
+    const result = createDomainSchema.safeParse(basePayload);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.custom_return_path).toBeUndefined();
+    }
+  });
+
+  it("accepts a valid custom return path label", () => {
+    const result = createDomainSchema.safeParse({
+      ...basePayload,
+      custom_return_path: "outbound-1",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.custom_return_path).toBe("outbound-1");
+    }
+  });
+
+  it.each([
+    ["too long", "a".repeat(64)],
+    ["does not start with a letter", "1outbound"],
+    ["does not end with a letter or number", "outbound-"],
+    ["contains a dot", "outbound.example"],
+    ["contains an underscore", "out_bound"],
+  ])("rejects a custom return path label that %s", (_reason, label) => {
+    const result = createDomainSchema.safeParse({
+      ...basePayload,
+      custom_return_path: label,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Use `send` as the default return-path label for domain MX/SPF records.
- Use `custom_return_path` labels like `outbound` for persisted DNS records and Cloudflare auto-configure MX/SPF checks/creates.
- Tighten `custom_return_path` validation to DNS-label rules and expose both persisted `custom_return_path` and effective `return_path` in domain responses.

Closes #185

## Validation
- `make check`
- `bunx vitest run tests/domain-service.test.ts tests/domain-validation.test.ts tests/cloudflare.test.ts tests/api-domains.test.ts tests/cache-invalidation-routes.test.ts`
- `make test`

## Not tested
- Playwright E2E: no dashboard UI/copy flow changed.