### PR TITLE
Add DMARC DNS guidance to domain setup

### DIFF
--- a/agent_docs/learnings/active/2026-05-05-issue-188-dmarc-dns.md
+++ b/agent_docs/learnings/active/2026-05-05-issue-188-dmarc-dns.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-05
+issue: "#188"
+type: pattern
+promoted_to: null
+---
+
+## DMARC DNS guidance parity
+
+**What:** Domain record generation now emits a starter `_dmarc.<domain>` TXT record with `v=DMARC1; p=none;` alongside DKIM and return-path SPF/MX. Cloudflare auto-configure creates that record only when missing and warns instead of overwriting an existing DMARC policy.
+
+**Pattern:** Treat DMARC as identity-domain guidance, not return-path DNS. Preserve existing domain records during auto-configure and only replace records Cloudflare actually created or updated so skipped customer-owned DMARC policies do not disappear from the dashboard guidance payload.

--- a/packages/core/src/services/domain.ts
+++ b/packages/core/src/services/domain.ts
@@ -9,6 +9,11 @@ type DomainRecord = NonNullable<DomainRow["records"]>[number];
 type DomainCapability = NonNullable<DomainRow["capabilities"]>[number];
 
 export const DEFAULT_RETURN_PATH = "send";
+export const DMARC_RECORD_VALUE = "v=DMARC1; p=none;";
+
+export function buildDmarcRecordName(domainName: string): string {
+  return `_dmarc.${domainName}`;
+}
 
 export function getEffectiveReturnPathLabel(
   customReturnPath: string | null | undefined,
@@ -135,7 +140,15 @@ function buildDomainRecords(
     priority: 10,
   };
 
-  return [...dkimRecords, spfRecord, mxRecord];
+  const dmarcRecord: DomainRecord = {
+    type: "TXT",
+    name: buildDmarcRecordName(domainName),
+    value: DMARC_RECORD_VALUE,
+    status: "pending",
+    ttl: "Auto",
+  };
+
+  return [...dkimRecords, spfRecord, mxRecord, dmarcRecord];
 }
 
 function toDomainDetail(row: DomainRow): DomainDetail {

--- a/src/app/api/domains/[id]/auto-configure/route.ts
+++ b/src/app/api/domains/[id]/auto-configure/route.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/domain-cache";
 import { createDomainIdentity } from "@/lib/ses";
 import { autoConfigureDomainParamsSchema } from "@/lib/validation/domains";
+import { DMARC_RECORD_VALUE, buildDmarcRecordName } from "@opensend/core";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
@@ -56,7 +57,7 @@ export async function POST(
       domain.customReturnPath,
     );
 
-    const allRecords = cfRecords.map((record) => ({
+    const configuredRecords = cfRecords.map((record) => ({
       type: record.type,
       name: record.name,
       value: record.content,
@@ -64,6 +65,38 @@ export async function POST(
       ttl: "Auto",
       ...(record.priority !== undefined ? { priority: record.priority } : {}),
     }));
+
+    const existingRecords = (domain.records ?? []) as Array<{
+      type: string;
+      name: string;
+      value: string;
+      status: string;
+      ttl: string;
+      priority?: number;
+    }>;
+    const configuredKeys = new Set(
+      configuredRecords.map((record) => `${record.type}:${record.name}`),
+    );
+    const allRecords = [
+      ...existingRecords.filter(
+        (record) => !configuredKeys.has(`${record.type}:${record.name}`),
+      ),
+      ...configuredRecords,
+    ];
+
+    const dmarcRecordName = buildDmarcRecordName(domain.name);
+    const hasDmarcRecord = allRecords.some(
+      (record) => record.type === "TXT" && record.name === dmarcRecordName,
+    );
+    if (!hasDmarcRecord) {
+      allRecords.push({
+        type: "TXT",
+        name: dmarcRecordName,
+        value: DMARC_RECORD_VALUE,
+        status: "pending",
+        ttl: "Auto",
+      });
+    }
 
     await db
       .update(domains)

--- a/src/components/domain-detail.tsx
+++ b/src/components/domain-detail.tsx
@@ -637,6 +637,10 @@ function RecordsTab({ domain }: { domain: DomainDetailData }) {
       (r.type === "TXT" && r.value.includes("v=spf1")),
   );
 
+  const dmarcRecords = records.filter(
+    (r) => r.type === "TXT" && r.name.startsWith("_dmarc."),
+  );
+
   return (
     <div className="bg-[rgba(24,25,28,0.88)] border border-[rgba(176,199,217,0.145)] rounded-lg p-6">
       {/* Header */}
@@ -716,7 +720,21 @@ function RecordsTab({ domain }: { domain: DomainDetailData }) {
         />
       </div>
 
-      {/* Section 3: Enable Receiving */}
+      {/* Section 3: DMARC guidance */}
+      <div className="mb-8 border-t border-[rgba(176,199,217,0.145)] pt-6">
+        <h3 className="text-[14px] font-semibold text-[#F0F0F0] mb-1">
+          DMARC Policy
+        </h3>
+        <p className="text-[13px] text-[#A1A4A5] mb-4">
+          Publish this starter TXT record so receivers can evaluate SPF and DKIM
+          alignment before you enforce a stricter policy.
+        </p>
+        <DNSRecordTable
+          records={dmarcRecords.length > 0 ? dmarcRecords : null}
+        />
+      </div>
+
+      {/* Section 4: Enable Receiving */}
       <div className="border-t border-[rgba(176,199,217,0.145)] pt-6">
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-[14px] font-semibold text-[#F0F0F0]">

--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -1,3 +1,5 @@
+import { DMARC_RECORD_VALUE, buildDmarcRecordName } from "@opensend/core";
+
 // ── Types ──────────────────────────────────────────────────────────
 
 export interface DNSRecord {
@@ -167,10 +169,13 @@ export async function autoConfigureDomain(
   const warnings: string[] = [];
   const results: DNSRecordResult[] = [];
 
-  // Check existing MX and TXT records before creating anything
-  const [existingMX, existingTXT] = await Promise.all([
+  const dmarcRecordName = buildDmarcRecordName(domain);
+
+  // Check existing MX, SPF TXT, and DMARC TXT records before creating anything
+  const [existingMX, existingTXT, existingDmarcTXT] = await Promise.all([
     listDNSRecords({ name: returnPathRecordName, type: "MX" }),
     listDNSRecords({ name: returnPathRecordName, type: "TXT" }),
+    listDNSRecords({ name: dmarcRecordName, type: "TXT" }),
   ]);
 
   // DKIM CNAME records — skip gracefully if already exist
@@ -214,6 +219,22 @@ export async function autoConfigureDomain(
       ttl: 300,
     });
     results.push(spfRecord);
+  }
+
+  // DMARC TXT record — create starter guidance only when missing. Never
+  // overwrite an existing customer DMARC policy.
+  if (existingDmarcTXT.length > 0) {
+    warnings.push(
+      "DMARC record already exists — skipped to avoid overwriting your policy",
+    );
+  } else {
+    const dmarcRecord = await createDNSRecord({
+      type: "TXT",
+      name: dmarcRecordName,
+      content: DMARC_RECORD_VALUE,
+      ttl: 300,
+    });
+    results.push(dmarcRecord);
   }
 
   // MX record — skip entirely if any MX records already exist to avoid

--- a/tests/api-domains.test.ts
+++ b/tests/api-domains.test.ts
@@ -170,7 +170,15 @@ describe("Domain API validation", () => {
       id: VALID_DOMAIN_ID,
       name: "example.com",
       status: "pending",
-      records: [{ status: "pending" }],
+      records: [
+        {
+          type: "TXT",
+          name: "_dmarc.example.com",
+          value: "v=DMARC1; p=none;",
+          status: "pending",
+          ttl: "Auto",
+        },
+      ],
     };
     const updated = {
       ...domain,
@@ -201,6 +209,13 @@ describe("Domain API validation", () => {
 
     expect(res.status).toBe(200);
     expect(json.status).toBe("verified");
+    expect(json.records).toContainEqual({
+      type: "TXT",
+      name: "_dmarc.example.com",
+      value: "v=DMARC1; p=none;",
+      status: "pending",
+      ttl: "Auto",
+    });
     expect(mockDb.query.domains.findFirst).toHaveBeenCalledTimes(1);
     expect(mockQueueEvent).toHaveBeenCalledTimes(1);
   });
@@ -230,6 +245,15 @@ describe("Domain API validation", () => {
       id: VALID_DOMAIN_ID,
       name: "example.com",
       customReturnPath: "outbound",
+      records: [
+        {
+          type: "TXT",
+          name: "_dmarc.example.com",
+          value: "v=DMARC1; p=none;",
+          status: "pending",
+          ttl: "Auto",
+        },
+      ],
     });
     mockCreateDomainIdentity.mockResolvedValue({
       dkimTokens: ["dkim-1", "dkim-2", "dkim-3"],
@@ -238,8 +262,13 @@ describe("Domain API validation", () => {
       records: [
         {
           type: "TXT",
-          name: "example.com",
+          name: "outbound.example.com",
           content: "v=spf1 include:amazonses.com ~all",
+        },
+        {
+          type: "TXT",
+          name: "_dmarc.example.com",
+          content: "v=DMARC1; p=none;",
         },
       ],
       warnings: [],
@@ -265,7 +294,14 @@ describe("Domain API validation", () => {
 
     expect(res.status).toBe(200);
     expect(json.ok).toBe(true);
-    expect(json.cloudflare_records).toBe(1);
+    expect(json.cloudflare_records).toBe(2);
+    expect(json.records).toContainEqual({
+      type: "TXT",
+      name: "_dmarc.example.com",
+      value: "v=DMARC1; p=none;",
+      status: "pending",
+      ttl: "Auto",
+    });
     expect(mockAutoConfigureDomain).toHaveBeenCalledWith(
       "example.com",
       ["dkim-1", "dkim-2", "dkim-3"],

--- a/tests/cache-invalidation-routes.test.ts
+++ b/tests/cache-invalidation-routes.test.ts
@@ -33,6 +33,8 @@ vi.mock("@opensend/core", () => ({
   createDomainService: () => ({
     createDomain: mockCreateDomain,
   }),
+  DMARC_RECORD_VALUE: "v=DMARC1; p=none;",
+  buildDmarcRecordName: (domainName: string) => `_dmarc.${domainName}`,
   getEffectiveReturnPathLabel: (customReturnPath: string | null | undefined) =>
     customReturnPath?.trim() || "send",
 }));

--- a/tests/cloudflare.test.ts
+++ b/tests/cloudflare.test.ts
@@ -320,7 +320,7 @@ describe("Cloudflare DNS Client", () => {
   });
 
   describe("autoConfigureDomain", () => {
-    it("creates DKIM, SPF, and MX records for a domain with no existing records", async () => {
+    it("creates DKIM, SPF, DMARC, and MX records for a domain with no existing records", async () => {
       // listDNSRecords for MX → empty
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -331,27 +331,36 @@ describe("Cloudflare DNS Client", () => {
         ok: true,
         json: async () => ({ success: true, result: [] }),
       });
-      // Three DKIM records, one SPF record, one MX record
-      for (let i = 0; i < 5; i++) {
+      // listDNSRecords for DMARC TXT → empty
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, result: [] }),
+      });
+      // Three DKIM records, one SPF record, one DMARC record, one MX record
+      for (let i = 0; i < 6; i++) {
         mockFetch.mockResolvedValueOnce({
           ok: true,
           json: async () => ({
             success: true,
             result: {
               id: `dns-record-${i}`,
-              type: i < 3 ? "CNAME" : i === 3 ? "TXT" : "MX",
+              type: i < 3 ? "CNAME" : i === 5 ? "MX" : "TXT",
               name:
                 i < 3
                   ? `token${i + 1}._domainkey.example.com`
-                  : "send.example.com",
+                  : i === 4
+                    ? "_dmarc.example.com"
+                    : "send.example.com",
               content:
                 i < 3
                   ? `token${i + 1}.dkim.amazonses.com`
                   : i === 3
                     ? "v=spf1 include:amazonses.com ~all"
-                    : "feedback-smtp.us-east-1.amazonses.com",
+                    : i === 4
+                      ? "v=DMARC1; p=none;"
+                      : "feedback-smtp.us-east-1.amazonses.com",
               ttl: 300,
-              ...(i === 4 ? { priority: 10 } : {}),
+              ...(i === 5 ? { priority: 10 } : {}),
             },
           }),
         });
@@ -363,25 +372,27 @@ describe("Cloudflare DNS Client", () => {
         dkimTokens,
       );
 
-      expect(records).toHaveLength(5);
+      expect(records).toHaveLength(6);
       expect(warnings).toHaveLength(0);
-      // 2 GETs (list) + 3 DKIM + 1 SPF + 1 MX
-      expect(mockFetch).toHaveBeenCalledTimes(7);
+      // 3 GETs (list) + 3 DKIM + 1 SPF + 1 DMARC + 1 MX
+      expect(mockFetch).toHaveBeenCalledTimes(9);
       expect(mockFetch.mock.calls[0][0]).toContain("name=send.example.com");
       expect(mockFetch.mock.calls[0][0]).toContain("type=MX");
       expect(mockFetch.mock.calls[1][0]).toContain("name=send.example.com");
       expect(mockFetch.mock.calls[1][0]).toContain("type=TXT");
+      expect(mockFetch.mock.calls[2][0]).toContain("name=_dmarc.example.com");
+      expect(mockFetch.mock.calls[2][0]).toContain("type=TXT");
 
       // Verify each DKIM CNAME record was created correctly
       for (let i = 0; i < 3; i++) {
-        const call = mockFetch.mock.calls[i + 2];
+        const call = mockFetch.mock.calls[i + 3];
         const body = JSON.parse(call[1].body);
         expect(body.type).toBe("CNAME");
         expect(body.name).toBe(`token${i + 1}._domainkey.example.com`);
         expect(body.content).toBe(`token${i + 1}.dkim.amazonses.com`);
       }
 
-      const spfCall = mockFetch.mock.calls[5];
+      const spfCall = mockFetch.mock.calls[6];
       const spfBody = JSON.parse(spfCall[1].body);
       expect(spfBody).toEqual({
         type: "TXT",
@@ -390,7 +401,16 @@ describe("Cloudflare DNS Client", () => {
         ttl: 300,
       });
 
-      const mxCall = mockFetch.mock.calls[6];
+      const dmarcCall = mockFetch.mock.calls[7];
+      const dmarcBody = JSON.parse(dmarcCall[1].body);
+      expect(dmarcBody).toEqual({
+        type: "TXT",
+        name: "_dmarc.example.com",
+        content: "v=DMARC1; p=none;",
+        ttl: 300,
+      });
+
+      const mxCall = mockFetch.mock.calls[8];
       const mxBody = JSON.parse(mxCall[1].body);
       expect(mxBody).toEqual({
         type: "MX",
@@ -412,27 +432,36 @@ describe("Cloudflare DNS Client", () => {
         ok: true,
         json: async () => ({ success: true, result: [] }),
       });
-      // One DKIM record, one SPF record, one MX record
-      for (let i = 0; i < 3; i++) {
+      // listDNSRecords for DMARC TXT → empty
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, result: [] }),
+      });
+      // One DKIM record, one SPF record, one DMARC record, one MX record
+      for (let i = 0; i < 4; i++) {
         mockFetch.mockResolvedValueOnce({
           ok: true,
           json: async () => ({
             success: true,
             result: {
               id: `custom-dns-record-${i}`,
-              type: i === 0 ? "CNAME" : i === 1 ? "TXT" : "MX",
+              type: i === 0 ? "CNAME" : i === 3 ? "MX" : "TXT",
               name:
                 i === 0
                   ? "token1._domainkey.example.com"
-                  : "outbound.example.com",
+                  : i === 2
+                    ? "_dmarc.example.com"
+                    : "outbound.example.com",
               content:
                 i === 0
                   ? "token1.dkim.amazonses.com"
                   : i === 1
                     ? "v=spf1 include:amazonses.com ~all"
-                    : "feedback-smtp.us-east-1.amazonses.com",
+                    : i === 2
+                      ? "v=DMARC1; p=none;"
+                      : "feedback-smtp.us-east-1.amazonses.com",
               ttl: 300,
-              ...(i === 2 ? { priority: 10 } : {}),
+              ...(i === 3 ? { priority: 10 } : {}),
             },
           }),
         });
@@ -443,10 +472,10 @@ describe("Cloudflare DNS Client", () => {
       expect(mockFetch.mock.calls[0][0]).toContain("name=outbound.example.com");
       expect(mockFetch.mock.calls[1][0]).toContain("name=outbound.example.com");
 
-      const spfBody = JSON.parse(mockFetch.mock.calls[3][1].body);
+      const spfBody = JSON.parse(mockFetch.mock.calls[4][1].body);
       expect(spfBody.name).toBe("outbound.example.com");
 
-      const mxBody = JSON.parse(mockFetch.mock.calls[4][1].body);
+      const mxBody = JSON.parse(mockFetch.mock.calls[6][1].body);
       expect(mxBody.name).toBe("outbound.example.com");
     });
 
@@ -484,6 +513,11 @@ describe("Cloudflare DNS Client", () => {
           ],
         }),
       });
+      // listDNSRecords for DMARC TXT → empty
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, result: [] }),
+      });
       // 3 DKIM creates
       for (let i = 0; i < 3; i++) {
         mockFetch.mockResolvedValueOnce({
@@ -514,6 +548,20 @@ describe("Cloudflare DNS Client", () => {
           },
         }),
       });
+      // DMARC create
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          result: {
+            id: "dmarc",
+            type: "TXT",
+            name: "_dmarc.example.com",
+            content: "v=DMARC1; p=none;",
+            ttl: 300,
+          },
+        }),
+      });
 
       const { records, warnings } = await autoConfigureDomain("example.com", [
         "token1",
@@ -521,11 +569,89 @@ describe("Cloudflare DNS Client", () => {
         "token3",
       ]);
 
-      // 3 DKIM + 1 SPF update (no MX)
-      expect(records).toHaveLength(4);
+      // 3 DKIM + 1 SPF update + 1 DMARC create (no MX)
+      expect(records).toHaveLength(5);
       expect(warnings).toHaveLength(2);
       expect(warnings[0]).toMatch(/Merged amazonses.com into existing SPF/);
       expect(warnings[1]).toMatch(/Existing MX records found/);
+    });
+
+    it("skips an existing DMARC record without overwriting the policy", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, result: [] }),
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, result: [] }),
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          result: [
+            {
+              id: "existing-dmarc",
+              type: "TXT",
+              name: "_dmarc.example.com",
+              content: "v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+              ttl: 3600,
+            },
+          ],
+        }),
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          result: {
+            id: "dkim-1",
+            type: "CNAME",
+            name: "token1._domainkey.example.com",
+            content: "token1.dkim.amazonses.com",
+            ttl: 300,
+          },
+        }),
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          result: {
+            id: "spf-1",
+            type: "TXT",
+            name: "send.example.com",
+            content: "v=spf1 include:amazonses.com ~all",
+            ttl: 300,
+          },
+        }),
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          result: {
+            id: "mx-1",
+            type: "MX",
+            name: "send.example.com",
+            content: "feedback-smtp.us-east-1.amazonses.com",
+            ttl: 300,
+            priority: 10,
+          },
+        }),
+      });
+
+      const { warnings } = await autoConfigureDomain("example.com", ["token1"]);
+
+      expect(warnings).toContain(
+        "DMARC record already exists — skipped to avoid overwriting your policy",
+      );
+      const postBodies = mockFetch.mock.calls
+        .filter(([, init]) => init?.method === "POST")
+        .map(([, init]) => JSON.parse(init.body));
+      expect(postBodies).not.toContainEqual(
+        expect.objectContaining({ name: "_dmarc.example.com" }),
+      );
     });
 
     it("throws when domain is empty", async () => {

--- a/tests/domain-dns-records.test.tsx
+++ b/tests/domain-dns-records.test.tsx
@@ -45,6 +45,13 @@ const domainWithRecords: DomainDetailData = {
       status: "verified",
       ttl: "Auto",
     },
+    {
+      type: "TXT",
+      name: "_dmarc.updates.foreverbrowsing.com",
+      value: "v=DMARC1; p=none;",
+      status: "verified",
+      ttl: "Auto",
+    },
   ],
   events: [
     {
@@ -92,6 +99,14 @@ describe("Domain DNS Records Tab (feature-025)", () => {
     const sendingToggle = screen.getByTestId("sending-toggle");
     expect(sendingToggle).toBeTruthy();
     expect(sendingToggle.getAttribute("data-state")).toBe("checked");
+  });
+
+  it("renders DMARC as a separate policy section", () => {
+    render(<DomainDetail domain={domainWithRecords} />);
+    expect(screen.getByText("DMARC Policy")).toBeTruthy();
+    expect(screen.getByText(/evaluate SPF and DKIM alignment/)).toBeTruthy();
+    expect(screen.getByText("_dmarc.updates.foreverbrowsing.com")).toBeTruthy();
+    expect(screen.getByText("v=DMARC1; p=none;")).toBeTruthy();
   });
 
   it("renders Enable Receiving section with toggle", () => {

--- a/tests/domain-service.test.ts
+++ b/tests/domain-service.test.ts
@@ -135,6 +135,13 @@ describe("domain service", () => {
         ttl: "Auto",
         priority: 10,
       },
+      {
+        type: "TXT",
+        name: "_dmarc.example.com",
+        value: "v=DMARC1; p=none;",
+        status: "pending",
+        ttl: "Auto",
+      },
     ]);
     expect(result).toMatchObject({
       id: "created-domain",
@@ -193,6 +200,13 @@ describe("domain service", () => {
         status: "pending",
         ttl: "Auto",
         priority: 10,
+      },
+      {
+        type: "TXT",
+        name: "_dmarc.example.com",
+        value: "v=DMARC1; p=none;",
+        status: "pending",
+        ttl: "Auto",
       },
     ]);
   });

--- a/tests/e2e/domain-dns-records.spec.ts
+++ b/tests/e2e/domain-dns-records.spec.ts
@@ -40,6 +40,12 @@ test.describe("Domain DNS Records Tab (feature-025)", () => {
     await expect(page.getByText("Enable Sending")).toBeVisible();
     await expect(page.getByTestId("sending-toggle")).toBeVisible();
 
+    // Verify DMARC guidance section
+    await expect(page.getByText("DMARC Policy")).toBeVisible();
+    await expect(
+      page.getByText(/evaluate SPF and DKIM alignment/),
+    ).toBeVisible();
+
     // Verify Enable Receiving section
     await expect(page.getByText("Enable Receiving")).toBeVisible();
     await expect(page.getByTestId("receiving-toggle")).toBeVisible();


### PR DESCRIPTION
## Summary
- Add starter `_dmarc.<domain>` TXT guidance (`v=DMARC1; p=none;`) to generated domain DNS records.
- Teach Cloudflare auto-configure to create DMARC when missing and warn/skip when an existing DMARC policy is present.
- Preserve existing stored domain records during auto-configure and show DMARC as its own dashboard DNS checklist section.
- Refs #188.

## Evidence
- `bun run test tests/domain-service.test.ts tests/cloudflare.test.ts tests/api-domains.test.ts tests/domain-dns-records.test.tsx tests/domain-detail.test.tsx` — 55 passed.
- `make check` — typecheck + Biome passed.
- `make test` — 88 files / 731 tests passed after rerunning one transient broadcast-list failure that passed on focused rerun.
- Push hook: change-scoped typecheck and Biome passed.

## Not tested
- `make test-e2e` / Playwright was not run because the local dev server on port 3015 was not started.

## Residual risk
- DMARC verification remains DNS guidance/status display only; this does not add DMARC aggregate/forensic report ingestion or stricter policy enforcement.
