### PR TITLE
docs(parity): file #191 for suppression list

### DIFF
--- a/agent_docs/resend-parity.md
+++ b/agent_docs/resend-parity.md
@@ -120,7 +120,7 @@ Rows are ordered roughly by priority within each area. The inspector's tie-break
 | SOC2 | yes | TBD | ? | ? | ? | ? | needs Jaeyun | | |
 | GDPR / EU data residency | yes | TBD | ? | ? | ? | ? | needs Jaeyun | | |
 | Audit log | yes | TBD | ? | ? | ? | ? | P1 | | |
-| Suppression list management | yes | TBD | ? | ? | ? | ? | P0 | | |
+| Suppression list management | suppresses recipients after hard bounce or spam complaint; suppression details are visible from email detail and can be removed ([docs](https://resend.com/docs/dashboard/emails/email-suppressions)) | missing: no suppression table/API/dashboard route (`https://opensend.namuh.co/api/suppressions` returned 404 on 2026-05-05); contacts only store manual unsubscribe state (`src/lib/db/schema.ts:192`, `src/lib/db/schema.ts:199`); send routes queue recipients without suppression lookup (`src/app/api/emails/route.ts:344`, `src/app/api/emails/route.ts:358`, `src/app/api/emails/batch/route.ts:264`, `src/app/api/emails/batch/route.ts:278`); SES bounce/complaint events update email status but do not create suppressions (`packages/ingester/src/ses-event-normalization.ts:5`, `packages/ingester/src/ses-event-normalization.ts:6`, `packages/core/src/db/repositories/emailEventRepo.ts:5`) | missing | behind | behind | n/a | P0 | #191 | 2026-05-05 |
 
 ## Pricing
 


### PR DESCRIPTION
## What
- Filed parity spec issue #191 for suppression list management.
- Updated `agent_docs/resend-parity.md` with the new issue number, Resend reference, OpenSend evidence, and 2026-05-05 review date.

## Validation
- `gh issue view #191` confirms issue is open with `spec-ready` and `parity` labels.
- Push guardrails passed: changed-file check, full typecheck, Biome lint.
- Diff is limited to `agent_docs/resend-parity.md`.

## Note
Ever CLI could not attach to Chrome (`Extension not connected`), so the issue records that limitation and uses static Resend doc fetch plus OpenSend prod HTTP observation for this inspector tick.
