### PR TITLE
Add suppression list management

### DIFF
--- a/agent_docs/learnings/active/2026-05-05-issue-191-user-scoped-suppressions.md
+++ b/agent_docs/learnings/active/2026-05-05-issue-191-user-scoped-suppressions.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-05
+issue: 191
+type: decision
+promoted_to: null
+---
+
+# User-scoped suppression list first slice
+
+Issue #191 implements suppression records keyed by `(user_id, email)` rather than global/provider scope. SES hard-bounce (`Bounce` with `bounceType: Permanent`) and complaint notifications refresh the row from the ingester after the email event is created; exact SNS redeliveries remain idempotent through `email_events.source_id`, so suppression refresh only runs on newly-created event rows.
+
+Send acceptance checks only `to` recipients before quota reservation and email-row insertion. Single sends return the stable `recipient_suppressed` public error; batch sends preserve input order and return per-item `{ error }` entries for suppressed items while quota/queueing only accepted items.

--- a/docs/suppressions.md
+++ b/docs/suppressions.md
@@ -1,0 +1,7 @@
+# Suppression list scope
+
+OpenSend suppresses recipient addresses after SES reports a hard bounce or a complaint. For this first parity slice, suppression records are scoped to the OpenSend account/user that sent the original email. Future sends for that same user skip or reject suppressed `to` recipients before queueing delivery.
+
+Operators can remove a recipient from the suppression list with `DELETE /api/suppressions/{email}`. Removal is not permanent: if SES reports another hard bounce or complaint for the same user and recipient, OpenSend creates or refreshes the suppression again.
+
+Region-wide, provider-wide, and automatic time-based unsuppression policies are intentionally deferred.

--- a/drizzle/0011_pretty_reavers.sql
+++ b/drizzle/0011_pretty_reavers.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "email_suppressions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"email" varchar(512) NOT NULL,
+	"reason" varchar(50) NOT NULL,
+	"source_event_id" varchar(255),
+	"source_email_id" uuid,
+	"source_message_id" varchar(255),
+	"metadata" jsonb,
+	"suppressed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "email_suppressions_user_email_idx" ON "email_suppressions" USING btree ("user_id","email");--> statement-breakpoint
+CREATE INDEX "email_suppressions_user_idx" ON "email_suppressions" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "email_suppressions_email_idx" ON "email_suppressions" USING btree ("email");

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,2980 @@
+{
+  "id": "76cd160b-55d3-4ee0-ab40-e0b8b7e5e324",
+  "prevId": "9daead14-7023-401b-beac-6a5212734691",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_preview": {
+          "name": "token_preview",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_access'"
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_token_hash_idx": {
+          "name": "api_keys_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_runs": {
+      "name": "automation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_event_id": {
+          "name": "trigger_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "current_step_key": {
+          "name": "current_step_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_states": {
+          "name": "step_states",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_step_at": {
+          "name": "next_step_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "automation_runs_status_next_step_at_idx": {
+          "name": "automation_runs_status_next_step_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_step_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_automation_id_created_at_idx": {
+          "name": "automation_runs_automation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_runs_automation_id_automations_id_fk": {
+          "name": "automation_runs_automation_id_automations_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_steps": {
+      "name": "automation_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_steps_automation_id_key_idx": {
+          "name": "automation_steps_automation_id_key_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_steps_automation_id_position_idx": {
+          "name": "automation_steps_automation_id_position_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_steps_automation_id_automations_id_fk": {
+          "name": "automation_steps_automation_id_automations_id_fk",
+          "tableFrom": "automation_steps",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automations": {
+      "name": "automations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "trigger_event_name": {
+          "name": "trigger_event_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connections": {
+          "name": "connections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "automations_status_trigger_idx": {
+          "name": "automations_status_trigger_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automations_user_id_idx": {
+          "name": "automations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.broadcasts": {
+      "name": "broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_id": {
+          "name": "audience_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_properties": {
+      "name": "contact_properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'string'"
+        },
+        "fallback_value": {
+          "name": "fallback_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_properties_key_idx": {
+          "name": "contact_properties_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed": {
+          "name": "unsubscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "custom_properties": {
+          "name": "custom_properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segments": {
+          "name": "segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_subscriptions": {
+          "name": "topic_subscriptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contacts_email_idx": {
+          "name": "contacts_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_unsubscribed_idx": {
+          "name": "contacts_unsubscribed_idx",
+          "columns": [
+            {
+              "expression": "unsubscribed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_created_at_idx": {
+          "name": "contacts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts_to_segments": {
+      "name": "contacts_to_segments",
+      "schema": "",
+      "columns": {
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contacts_to_segments_idx": {
+          "name": "contacts_to_segments_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "segment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_to_segments_segment_id_idx": {
+          "name": "contacts_to_segments_segment_id_idx",
+          "columns": [
+            {
+              "expression": "segment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contacts_to_segments_contact_id_contacts_id_fk": {
+          "name": "contacts_to_segments_contact_id_contacts_id_fk",
+          "tableFrom": "contacts_to_segments",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contacts_to_segments_segment_id_segments_id_fk": {
+          "name": "contacts_to_segments_segment_id_segments_id_fk",
+          "tableFrom": "contacts_to_segments",
+          "tableTo": "segments",
+          "columnsFrom": [
+            "segment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_event_deliveries": {
+      "name": "custom_event_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "custom_event_deliveries_event_name_idx": {
+          "name": "custom_event_deliveries_event_name_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_event_deliveries_received_at_idx": {
+          "name": "custom_event_deliveries_received_at_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_events": {
+      "name": "custom_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "custom_events_user_name_idx": {
+          "name": "custom_events_user_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domains": {
+      "name": "domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'us-east-1'"
+        },
+        "dkim_tokens": {
+          "name": "dkim_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "records": {
+          "name": "records",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_clicks": {
+          "name": "track_clicks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "track_opens": {
+          "name": "track_opens",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tls": {
+          "name": "tls",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opportunistic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_return_path": {
+          "name": "custom_return_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_subdomain": {
+          "name": "tracking_subdomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_events": {
+      "name": "email_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_events_email_id_idx": {
+          "name": "email_events_email_id_idx",
+          "columns": [
+            {
+              "expression": "email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_events_source_id_idx": {
+          "name": "email_events_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_events_email_id_emails_id_fk": {
+          "name": "email_events_email_id_emails_id_fk",
+          "tableFrom": "email_events",
+          "tableTo": "emails",
+          "columnsFrom": [
+            "email_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_email_id": {
+          "name": "source_email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed_at": {
+          "name": "suppressed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_suppressions_user_email_idx": {
+          "name": "email_suppressions_user_email_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_user_idx": {
+          "name": "email_suppressions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_email_idx": {
+          "name": "email_suppressions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.emails": {
+      "name": "emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc": {
+          "name": "cc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "emails_status_idx": {
+          "name": "emails_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_created_at_idx": {
+          "name": "emails_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_status_created_at_idx": {
+          "name": "emails_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_idempotency_key_idx": {
+          "name": "emails_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_price_cents": {
+          "name": "monthly_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthly_email_quota": {
+          "name": "monthly_email_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_domains": {
+          "name": "max_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_api_keys": {
+          "name": "max_api_keys",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plans_slug_idx": {
+          "name": "plans_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.received_emails": {
+      "name": "received_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "received_emails_created_at_idx": {
+          "name": "received_emails_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segments": {
+      "name": "segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contacts_count": {
+          "name": "contacts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unsubscribed_count": {
+          "name": "unsubscribed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_customers": {
+      "name": "stripe_customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_customers_user_id_idx": {
+          "name": "stripe_customers_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_customers_stripe_customer_id_idx": {
+          "name": "stripe_customers_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events_processed": {
+      "name": "stripe_events_processed",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_processed_processed_at_idx": {
+          "name": "stripe_events_processed_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_subscription_id_idx": {
+          "name": "subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_status_idx": {
+          "name": "subscriptions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_plan_id_plans_id_fk": {
+          "name": "subscriptions_plan_id_plans_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled Template'"
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_unpublished_versions": {
+          "name": "has_unpublished_versions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_subscription": {
+          "name": "default_subscription",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opt_out'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_periods": {
+      "name": "usage_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emails_sent": {
+          "name": "emails_sent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_increment_at": {
+          "name": "last_increment_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_periods_user_period_idx": {
+          "name": "usage_periods_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_periods_user_id_idx": {
+          "name": "usage_periods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_webhook_id_idx": {
+          "name": "webhook_deliveries_webhook_id_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_status_idx": {
+          "name": "webhook_deliveries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_deliveries_event_id_email_events_id_fk": {
+          "name": "webhook_deliveries_event_id_email_events_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "email_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "signing_secret": {
+          "name": "signing_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1777939200001,
       "tag": "0010_repair_domain_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1777950543196,
+      "tag": "0011_pretty_reavers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/repositories/suppressionRepo.ts
+++ b/packages/core/src/db/repositories/suppressionRepo.ts
@@ -1,0 +1,142 @@
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { db } from "../client";
+import {
+  type SuppressionReason,
+  type SuppressionSourceMetadata,
+  emailSuppressions,
+  emails,
+} from "../schema";
+
+export type SuppressionRecord = typeof emailSuppressions.$inferSelect;
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export const suppressionRepo = {
+  async findByUserAndEmails(
+    userId: string | null | undefined,
+    recipients: string[],
+  ) {
+    if (!userId || recipients.length === 0) return [];
+    const normalized = [...new Set(recipients.map(normalizeEmail))];
+    return await db
+      .select()
+      .from(emailSuppressions)
+      .where(
+        and(
+          eq(emailSuppressions.userId, userId),
+          inArray(emailSuppressions.email, normalized),
+        ),
+      );
+  },
+
+  async list(options: { userId: string; limit?: number; after?: string }) {
+    const limit = options.limit ?? 50;
+    const conditions = [eq(emailSuppressions.userId, options.userId)];
+    if (options.after)
+      conditions.push(sql`${emailSuppressions.id} < ${options.after}`);
+
+    const rows = await db
+      .select()
+      .from(emailSuppressions)
+      .where(and(...conditions))
+      .orderBy(desc(emailSuppressions.updatedAt))
+      .limit(limit + 1);
+
+    return {
+      data: rows.slice(0, limit),
+      hasMore: rows.length > limit,
+    };
+  },
+
+  async removeForUser(userId: string, email: string) {
+    const normalized = normalizeEmail(email);
+    return await db
+      .delete(emailSuppressions)
+      .where(
+        and(
+          eq(emailSuppressions.userId, userId),
+          eq(emailSuppressions.email, normalized),
+        ),
+      )
+      .returning({ id: emailSuppressions.id });
+  },
+
+  async suppress(input: {
+    userId: string;
+    email: string;
+    reason: SuppressionReason;
+    sourceEventId?: string | null;
+    sourceEmailId?: string | null;
+    sourceMessageId?: string | null;
+    metadata?: SuppressionSourceMetadata | null;
+  }) {
+    const now = new Date();
+    const [record] = await db
+      .insert(emailSuppressions)
+      .values({
+        userId: input.userId,
+        email: normalizeEmail(input.email),
+        reason: input.reason,
+        sourceEventId: input.sourceEventId ?? null,
+        sourceEmailId: input.sourceEmailId ?? null,
+        sourceMessageId: input.sourceMessageId ?? null,
+        metadata: input.metadata ?? null,
+        suppressedAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [emailSuppressions.userId, emailSuppressions.email],
+        set: {
+          reason: input.reason,
+          sourceEventId: input.sourceEventId ?? null,
+          sourceEmailId: input.sourceEmailId ?? null,
+          sourceMessageId: input.sourceMessageId ?? null,
+          metadata: input.metadata ?? null,
+          suppressedAt: now,
+          updatedAt: now,
+        },
+      })
+      .returning();
+    return record;
+  },
+
+  async suppressFromSesEvent(input: {
+    emailId: string;
+    recipients: string[];
+    reason: SuppressionReason;
+    sourceEventId: string;
+    sourceMessageId: string;
+    metadata?: SuppressionSourceMetadata | null;
+  }) {
+    if (input.recipients.length === 0) return [];
+    const email = await db.query.emails.findFirst({
+      where: eq(emails.id, input.emailId),
+    });
+    if (!email?.userId) return [];
+
+    const records: SuppressionRecord[] = [];
+    for (const recipient of [
+      ...new Set(input.recipients.map(normalizeEmail)),
+    ]) {
+      const record = await this.suppress({
+        userId: email.userId,
+        email: recipient,
+        reason: input.reason,
+        sourceEventId: input.sourceEventId,
+        sourceEmailId: input.emailId,
+        sourceMessageId: input.sourceMessageId,
+        metadata: {
+          source: "ses",
+          sourceEventId: input.sourceEventId,
+          sourceEmailId: input.emailId,
+          sourceMessageId: input.sourceMessageId,
+          ...input.metadata,
+        },
+      });
+      records.push(record);
+    }
+    return records;
+  },
+};

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -187,6 +187,47 @@ export const topics = pgTable("topics", {
   userId: text("user_id"),
 });
 
+export type SuppressionReason = "bounced" | "complained";
+
+export type SuppressionSourceMetadata = {
+  source?: "ses" | "operator";
+  sourceEventId?: string;
+  sourceEmailId?: string;
+  sourceMessageId?: string;
+  bounceType?: string;
+  complaintFeedbackType?: string;
+};
+
+export const emailSuppressions = pgTable(
+  "email_suppressions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    email: varchar("email", { length: 512 }).notNull(),
+    reason: varchar("reason", { length: 50 })
+      .$type<SuppressionReason>()
+      .notNull(),
+    sourceEventId: varchar("source_event_id", { length: 255 }),
+    sourceEmailId: uuid("source_email_id"),
+    sourceMessageId: varchar("source_message_id", { length: 255 }),
+    metadata: jsonb("metadata").$type<SuppressionSourceMetadata>(),
+    suppressedAt: timestamp("suppressed_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("email_suppressions_user_email_idx").on(
+      table.userId,
+      table.email,
+    ),
+    index("email_suppressions_user_idx").on(table.userId),
+    index("email_suppressions_email_idx").on(table.email),
+  ],
+);
+
 export const contacts = pgTable(
   "contacts",
   {

--- a/packages/core/src/dto/index.ts
+++ b/packages/core/src/dto/index.ts
@@ -64,8 +64,20 @@ export interface EmailListOptions {
   status?: EmailStatus;
 }
 
+export interface BatchEmailItemError {
+  error: {
+    name?: string;
+    code: string;
+    message: string;
+    statusCode: number;
+    details?: Record<string, string | number | boolean | null>;
+  };
+}
+
+export type BatchEmailItemResponse = EmailResponse | BatchEmailItemError;
+
 export interface BatchEmailResponse {
-  data: EmailResponse[];
+  data: BatchEmailItemResponse[];
 }
 
 export interface EmailListItem {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export * from "./db/repositories/contactRepo";
 export * from "./db/repositories/domainRepo";
 export * from "./db/repositories/emailRepo";
 export * from "./db/repositories/emailEventRepo";
+export * from "./db/repositories/suppressionRepo";
 export * from "./db/repositories/webhookRepo";
 export * from "./db/repositories/webhookDeliveryRepo";
 export * from "./db/repositories/logRepo";

--- a/packages/core/src/services/email.ts
+++ b/packages/core/src/services/email.ts
@@ -1,8 +1,24 @@
 import { emailRepo } from "../db/repositories/emailRepo";
+import { suppressionRepo } from "../db/repositories/suppressionRepo";
 import {
   createBackgroundJob,
   publishBackgroundJob,
 } from "../jobs/background-jobs";
+
+export class SuppressedRecipientError extends Error {
+  readonly code = "recipient_suppressed";
+  readonly statusCode = 422;
+
+  constructor(readonly recipients: Array<{ email: string; reason: string }>) {
+    const first = recipients[0];
+    super(
+      first
+        ? `Recipient ${first.email} is suppressed because it ${first.reason}.`
+        : "One or more recipients are suppressed.",
+    );
+    this.name = "SuppressedRecipientError";
+  }
+}
 
 export class EmailService {
   async send(params: {
@@ -28,6 +44,19 @@ export class EmailService {
         params.idempotencyKey,
       );
       if (existing) return { id: existing.id, duplicate: true };
+    }
+
+    const suppressed = await suppressionRepo.findByUserAndEmails(
+      params.userId,
+      params.to,
+    );
+    if (suppressed.length > 0) {
+      throw new SuppressedRecipientError(
+        suppressed.map((entry) => ({
+          email: entry.email,
+          reason: entry.reason,
+        })),
+      );
     }
 
     const shouldQueueNow =
@@ -81,7 +110,18 @@ export class EmailService {
     const results = [];
     for (let i = 0; i < items.length; i += CONCURRENCY) {
       const chunk = items.slice(i, i + CONCURRENCY);
-      const chunkRes = await Promise.all(chunk.map((item) => this.send(item)));
+      const chunkRes = await Promise.all(
+        chunk.map(async (item) => {
+          try {
+            return await this.send(item);
+          } catch (error) {
+            if (error instanceof SuppressedRecipientError) {
+              return { error };
+            }
+            throw error;
+          }
+        }),
+      );
       results.push(...chunkRes);
     }
     return results;

--- a/packages/ingester/src/index.ts
+++ b/packages/ingester/src/index.ts
@@ -8,6 +8,7 @@ import {
   logTelemetry,
   publishBackgroundJob,
   recordTelemetryError,
+  suppressionRepo,
   toWebhookEventType,
   webhookRepo,
 } from "@opensend/core";
@@ -28,6 +29,60 @@ import {
 } from "./stripe-webhook";
 
 const app = new Hono();
+
+type SesSuppressionOutcome = {
+  reason: "bounced" | "complained";
+  recipients: string[];
+  metadata: { bounceType?: string; complaintFeedbackType?: string };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readRecipientEmails(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((recipient) => {
+      if (!isRecord(recipient)) return null;
+      const emailAddress = recipient.emailAddress;
+      return typeof emailAddress === "string" && emailAddress.length > 0
+        ? emailAddress
+        : null;
+    })
+    .filter((email): email is string => Boolean(email));
+}
+
+function getSesSuppressionOutcome(
+  eventType: string,
+  payload: unknown,
+): SesSuppressionOutcome | null {
+  if (!isRecord(payload)) return null;
+
+  if (eventType === "Bounce") {
+    const bounceType = payload.bounceType;
+    if (bounceType !== "Permanent") return null;
+    return {
+      reason: "bounced",
+      recipients: readRecipientEmails(payload.bouncedRecipients),
+      metadata: { bounceType },
+    };
+  }
+
+  if (eventType === "Complaint") {
+    const complaintFeedbackType = payload.complaintFeedbackType;
+    return {
+      reason: "complained",
+      recipients: readRecipientEmails(payload.complainedRecipients),
+      metadata:
+        typeof complaintFeedbackType === "string"
+          ? { complaintFeedbackType }
+          : {},
+    };
+  }
+
+  return null;
+}
 
 function isAuthorizedJobRequest(authHeader: string | undefined): boolean {
   const token = process.env.INGESTER_JOB_TOKEN?.trim();
@@ -250,6 +305,26 @@ app.post("/events/ses", async (c) => {
         email_id: emailId,
       });
       return c.text("OK");
+    }
+
+    const suppressionOutcome = getSesSuppressionOutcome(
+      eventType,
+      sesMessage[normalizedEvent.payloadKey],
+    );
+    if (suppressionOutcome) {
+      const suppressions = await suppressionRepo.suppressFromSesEvent({
+        emailId,
+        recipients: suppressionOutcome.recipients,
+        reason: suppressionOutcome.reason,
+        sourceEventId: snsMessage.MessageId,
+        sourceMessageId: sesId,
+        metadata: suppressionOutcome.metadata,
+      });
+      logTelemetry("info", "ses.suppressions.refreshed", telemetry, {
+        email_id: emailId,
+        reason: suppressionOutcome.reason,
+        suppression_count: suppressions.length,
+      });
     }
 
     emitCloudWatchMetric(telemetry, {

--- a/src/app/(dashboard)/emails/[id]/page.tsx
+++ b/src/app/(dashboard)/emails/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { EmailDetail } from "@/components/email-detail";
 import { db } from "@/lib/db";
-import { emailEvents, emails } from "@/lib/db/schema";
-import { desc, eq } from "drizzle-orm";
+import { emailEvents, emailSuppressions, emails } from "@/lib/db/schema";
+import { and, desc, eq } from "drizzle-orm";
 import { notFound } from "next/navigation";
 
 export default async function EmailDetailPage({
@@ -28,6 +28,16 @@ export default async function EmailDetailPage({
       .where(eq(emailEvents.emailId, id))
       .orderBy(desc(emailEvents.receivedAt));
 
+    const primaryRecipient = emailResult.to[0]?.toLowerCase();
+    const suppression = primaryRecipient
+      ? await db.query.emailSuppressions.findFirst({
+          where: and(
+            eq(emailSuppressions.userId, emailResult.userId ?? ""),
+            eq(emailSuppressions.email, primaryRecipient),
+          ),
+        })
+      : null;
+
     const emailData = {
       id: emailResult.id,
       from: emailResult.from,
@@ -39,6 +49,13 @@ export default async function EmailDetailPage({
       scheduledAt: emailResult.scheduledAt?.toISOString() || null,
       tags: (emailResult.tags as Array<{ name: string; value: string }>) ?? [],
       headers: (emailResult.headers as Record<string, string>) ?? {},
+      suppression: suppression
+        ? {
+            email: suppression.email,
+            reason: suppression.reason,
+            suppressedAt: suppression.suppressedAt.toISOString(),
+          }
+        : null,
       events: events.map((e) => ({
         type: e.type,
         timestamp: e.receivedAt.toISOString(),

--- a/src/app/api/emails/batch/route.ts
+++ b/src/app/api/emails/batch/route.ts
@@ -9,6 +9,10 @@ import { db } from "@/lib/db";
 import { contacts, emails } from "@/lib/db/schema";
 import { normalizeAttachmentsForStorage } from "@/lib/email-attachments";
 import {
+  findSuppressedRecipients,
+  suppressedRecipientError,
+} from "@/lib/suppressions";
+import {
   buildOneClickUnsubscribeHeaders,
   createUnsubscribeUrl,
   getPublicBaseUrl,
@@ -224,6 +228,28 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   const validatedItems = result.data;
+  const itemRecipients = validatedItems.map(
+    (item) => normalizeToArray(item.to) as string[],
+  );
+  const suppressedByEmail = new Map(
+    (
+      await findSuppressedRecipients({
+        userId: auth.userId,
+        recipients: itemRecipients.flat(),
+      })
+    ).map((entry) => [entry.email, entry]),
+  );
+  const suppressedResults = itemRecipients.map((recipients) =>
+    recipients
+      .map((recipient) => suppressedByEmail.get(recipient.toLowerCase()))
+      .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry)),
+  );
+  const acceptedCount = suppressedResults.filter(
+    (entries) => entries.length === 0,
+  ).length;
+  const firstAcceptedIndex = suppressedResults.findIndex(
+    (entries) => entries.length === 0,
+  );
 
   try {
     const reservation = await db.transaction(async (tx) => {
@@ -232,7 +258,7 @@ export async function POST(request: Request): Promise<Response> {
       // inserted and the whole request returns 402.
       const quota = await reserveEmailQuota(
         auth.userId,
-        validatedItems.length,
+        acceptedCount,
         new Date(),
         process.env,
         tx,
@@ -240,9 +266,16 @@ export async function POST(request: Request): Promise<Response> {
       if (!quota.ok) {
         return quota;
       }
-      const persisted: Array<{ id: string; shouldQueueNow: boolean }> = [];
+      const persisted: Array<{
+        index: number;
+        id: string;
+        shouldQueueNow: boolean;
+      }> = [];
 
       for (const [index, item] of validatedItems.entries()) {
+        if (suppressedResults[index]?.length) {
+          continue;
+        }
         const to = normalizeToArray(item.to) as string[];
         const cc = normalizeToArray(item.cc);
         const bcc = normalizeToArray(item.bcc);
@@ -278,12 +311,13 @@ export async function POST(request: Request): Promise<Response> {
             status: shouldQueueNow ? "queued" : "scheduled",
             scheduledAt: scheduledAt,
             topicId: item.topic_id || null,
-            idempotencyKey: index === 0 ? idempotencyKey : null,
+            idempotencyKey:
+              index === firstAcceptedIndex ? idempotencyKey : null,
             userId: auth.userId,
           })
           .returning({ id: emails.id });
 
-        persisted.push({ id: email.id, shouldQueueNow });
+        persisted.push({ index, id: email.id, shouldQueueNow });
       }
 
       return { ok: true as const, emails: persisted };
@@ -294,7 +328,7 @@ export async function POST(request: Request): Promise<Response> {
         plan: reservation.info.plan,
         limit: reservation.info.limit,
         used: reservation.info.used,
-        requested: validatedItems.length,
+        requested: acceptedCount,
       });
       recordBatchMetric(telemetry, {
         durationMs: performance.now() - startedAt,
@@ -308,7 +342,7 @@ export async function POST(request: Request): Promise<Response> {
       });
     }
 
-    const results: Array<{ id: string }> = [];
+    const resultByIndex = new Map<number, { id: string }>();
     const CONCURRENCY = 5;
     const queuedEmails = reservation.emails.filter(
       (email) => email.shouldQueueNow,
@@ -349,17 +383,27 @@ export async function POST(request: Request): Promise<Response> {
       );
     }
 
-    results.push(...reservation.emails.map((email) => ({ id: email.id })));
+    for (const email of reservation.emails) {
+      resultByIndex.set(email.index, { id: email.id });
+    }
+
+    const results = validatedItems.map((_, index) => {
+      const success = resultByIndex.get(index);
+      if (success) return success;
+      return {
+        error: suppressedRecipientError(suppressedResults[index] ?? []),
+      };
+    });
 
     const durationMs = performance.now() - startedAt;
     logTelemetry("info", "email.batch_accepted", telemetry, {
-      email_count: results.length,
+      email_count: acceptedCount,
       duration_ms: Math.round(durationMs),
     });
     recordBatchMetric(telemetry, {
       durationMs,
       outcome: "accepted",
-      count: results.length,
+      count: acceptedCount,
     });
     return jsonWithTelemetry({ data: results }, telemetry);
   } catch (err) {

--- a/src/app/api/emails/route.ts
+++ b/src/app/api/emails/route.ts
@@ -14,6 +14,10 @@ import { db } from "@/lib/db";
 import { contacts, emails, templates } from "@/lib/db/schema";
 import { normalizeAttachmentsForStorage } from "@/lib/email-attachments";
 import {
+  findSuppressedRecipients,
+  suppressedRecipientError,
+} from "@/lib/suppressions";
+import {
   buildOneClickUnsubscribeHeaders,
   createUnsubscribeUrl,
   getPublicBaseUrl,
@@ -237,6 +241,22 @@ export async function POST(request: Request): Promise<Response> {
   const scheduledAt = validated.scheduled_at
     ? new Date(validated.scheduled_at)
     : null;
+
+  const suppressedRecipients = await findSuppressedRecipients({
+    userId: auth.userId,
+    recipients: to,
+  });
+  if (suppressedRecipients.length > 0) {
+    recordAcceptMetric(telemetry, {
+      durationMs: performance.now() - startedAt,
+      outcome: "invalid",
+    });
+    return jsonWithTelemetry(
+      suppressedRecipientError(suppressedRecipients),
+      telemetry,
+      { status: 422 },
+    );
+  }
 
   let quotaReserved = false;
   try {

--- a/src/app/api/suppressions/[email]/route.ts
+++ b/src/app/api/suppressions/[email]/route.ts
@@ -1,0 +1,36 @@
+import {
+  authorizeDashboardOrApiKey,
+  getServerSession,
+  unauthorizedResponse,
+} from "@/lib/api-auth";
+import { removeSuppression } from "@/lib/suppressions";
+import { NextResponse } from "next/server";
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ email: string }> },
+) {
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
+  if (!auth) return unauthorizedResponse();
+  const session = "dashboard" in auth ? await getServerSession() : null;
+  const userId = "userId" in auth ? auth.userId : session?.user?.id;
+  if (!userId) return unauthorizedResponse();
+
+  const { email } = await params;
+  const decodedEmail = decodeURIComponent(email);
+  const removed = await removeSuppression({
+    userId,
+    email: decodedEmail,
+  });
+
+  if (!removed) {
+    return NextResponse.json(
+      { error: "Suppression not found", code: "not_found" },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({ object: "suppression", deleted: true });
+}

--- a/src/app/api/suppressions/route.ts
+++ b/src/app/api/suppressions/route.ts
@@ -1,0 +1,33 @@
+import {
+  authorizeDashboardOrApiKey,
+  getServerSession,
+  unauthorizedResponse,
+} from "@/lib/api-auth";
+import { listSuppressions, serializeSuppression } from "@/lib/suppressions";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
+  if (!auth) return unauthorizedResponse();
+  const session = "dashboard" in auth ? await getServerSession() : null;
+  const userId = "userId" in auth ? auth.userId : session?.user?.id;
+  if (!userId) return unauthorizedResponse();
+
+  const url = new URL(request.url);
+  const limit = Math.min(
+    100,
+    Math.max(1, Number(url.searchParams.get("limit")) || 50),
+  );
+  const after = url.searchParams.get("after") || undefined;
+
+  const result = await listSuppressions({ userId, limit, after });
+
+  return NextResponse.json({
+    object: "list",
+    scope: "user",
+    data: result.data.map(serializeSuppression),
+    has_more: result.hasMore,
+  });
+}

--- a/src/components/email-detail.tsx
+++ b/src/components/email-detail.tsx
@@ -103,6 +103,11 @@ export interface EmailDetailData {
   scheduledAt: string | null;
   tags: Array<{ name: string; value: string }>;
   headers: Record<string, string>;
+  suppression?: {
+    email: string;
+    reason: "bounced" | "complained";
+    suppressedAt: string;
+  } | null;
   events: Array<{ type: string; timestamp: string }>;
 }
 
@@ -126,6 +131,8 @@ function getStatusVariant(
     case "delivery_delayed":
     case "complained":
       return "warning";
+    case "suppressed":
+      return "default";
     default:
       return "default";
   }
@@ -305,6 +312,32 @@ export function EmailDetail({ email }: EmailDetailProps) {
           </button>
         </div>
       </div>
+
+      {email.suppression && (
+        <div
+          data-testid="suppression-guidance"
+          className="mb-8 rounded-xl border border-amber-500/30 bg-amber-500/10 p-4"
+        >
+          <div className="flex items-center gap-2 mb-2">
+            <StatusBadge status="Suppressed" variant="warning" />
+            <span className="text-[13px] text-[#F0F0F0]">
+              {email.suppression.email} is suppressed for this account because
+              it{" "}
+              {email.suppression.reason === "bounced"
+                ? "hard bounced"
+                : "reported a complaint"}
+              .
+            </span>
+          </div>
+          <p className="text-[13px] text-[#A1A4A5] leading-relaxed">
+            OpenSend will skip future sends to this recipient for your account
+            until an operator removes the suppression. If the recipient bounces
+            or complains again after removal, OpenSend will suppress it again.
+            Region-wide and provider-wide suppression scope is deferred for this
+            first slice.
+          </p>
+        </div>
+      )}
 
       {/* Metadata Grid */}
       <div className="grid grid-cols-4 gap-6 mb-8">

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -10,6 +10,7 @@ export type PublicApiErrorCode =
   | "idempotency_conflict"
   | "not_found"
   | "quota_exceeded"
+  | "recipient_suppressed"
   | "rate_limit_exceeded"
   | "rate_limit_unavailable"
   | "internal_server_error";

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -189,6 +189,47 @@ export const topics = pgTable("topics", {
   userId: text("user_id"),
 });
 
+export type SuppressionReason = "bounced" | "complained";
+
+export type SuppressionSourceMetadata = {
+  source?: "ses" | "operator";
+  sourceEventId?: string;
+  sourceEmailId?: string;
+  sourceMessageId?: string;
+  bounceType?: string;
+  complaintFeedbackType?: string;
+};
+
+export const emailSuppressions = pgTable(
+  "email_suppressions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    email: varchar("email", { length: 512 }).notNull(),
+    reason: varchar("reason", { length: 50 })
+      .$type<SuppressionReason>()
+      .notNull(),
+    sourceEventId: varchar("source_event_id", { length: 255 }),
+    sourceEmailId: uuid("source_email_id"),
+    sourceMessageId: varchar("source_message_id", { length: 255 }),
+    metadata: jsonb("metadata").$type<SuppressionSourceMetadata>(),
+    suppressedAt: timestamp("suppressed_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("email_suppressions_user_email_idx").on(
+      table.userId,
+      table.email,
+    ),
+    index("email_suppressions_user_idx").on(table.userId),
+    index("email_suppressions_email_idx").on(table.email),
+  ],
+);
+
 export const contacts = pgTable(
   "contacts",
   {

--- a/src/lib/suppressions.ts
+++ b/src/lib/suppressions.ts
@@ -1,0 +1,136 @@
+import { publicApiError } from "@/lib/api-errors";
+import { db } from "@/lib/db";
+import {
+  type SuppressionReason,
+  type SuppressionSourceMetadata,
+  emailSuppressions,
+} from "@/lib/db/schema";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+
+export type SuppressionRecord = typeof emailSuppressions.$inferSelect;
+
+export type SuppressedRecipient = {
+  email: string;
+  reason: SuppressionReason;
+  suppressedAt: Date;
+};
+
+export function normalizeSuppressionEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export async function findSuppressedRecipients(input: {
+  userId: string | null | undefined;
+  recipients: string[];
+}): Promise<SuppressedRecipient[]> {
+  if (!input.userId || input.recipients.length === 0) return [];
+
+  const normalized = [
+    ...new Set(input.recipients.map(normalizeSuppressionEmail)),
+  ];
+  const records = await db
+    .select({
+      email: emailSuppressions.email,
+      reason: emailSuppressions.reason,
+      suppressedAt: emailSuppressions.suppressedAt,
+    })
+    .from(emailSuppressions)
+    .where(
+      and(
+        eq(emailSuppressions.userId, input.userId),
+        inArray(emailSuppressions.email, normalized),
+      ),
+    );
+
+  return records;
+}
+
+export function suppressedRecipientError(
+  suppressed: SuppressedRecipient[],
+  statusCode = 422,
+) {
+  const first = suppressed[0];
+  return publicApiError(
+    "recipient_suppressed",
+    first
+      ? `Recipient ${first.email} is suppressed because it ${first.reason === "bounced" ? "bounced" : "complained"}. Remove the suppression before sending again.`
+      : "One or more recipients are suppressed.",
+    statusCode,
+    {
+      recipients: suppressed.map((entry) => entry.email).join(","),
+      reason: first?.reason ?? null,
+      scope: "user",
+    },
+  );
+}
+
+export async function listSuppressions(input: {
+  userId: string;
+  limit: number;
+  after?: string;
+}) {
+  const conditions = [eq(emailSuppressions.userId, input.userId)];
+  if (input.after) {
+    conditions.push(sql`${emailSuppressions.id} < ${input.after}`);
+  }
+
+  const rows = await db
+    .select()
+    .from(emailSuppressions)
+    .where(and(...conditions))
+    .orderBy(desc(emailSuppressions.updatedAt))
+    .limit(input.limit + 1);
+
+  return {
+    data: rows.slice(0, input.limit),
+    hasMore: rows.length > input.limit,
+  };
+}
+
+export async function removeSuppression(input: {
+  userId: string;
+  email: string;
+}) {
+  const [removed] = await db
+    .delete(emailSuppressions)
+    .where(
+      and(
+        eq(emailSuppressions.userId, input.userId),
+        eq(emailSuppressions.email, normalizeSuppressionEmail(input.email)),
+      ),
+    )
+    .returning({ id: emailSuppressions.id });
+  return removed ?? null;
+}
+
+export type SuppressionResponse = {
+  id: string;
+  object: "suppression";
+  email: string;
+  reason: SuppressionReason;
+  scope: "user";
+  source_event_id: string | null;
+  source_email_id: string | null;
+  source_message_id: string | null;
+  metadata: SuppressionSourceMetadata | null;
+  suppressed_at: string;
+  updated_at: string;
+};
+
+export function serializeSuppression(
+  suppression: SuppressionRecord,
+): SuppressionResponse {
+  return {
+    id: suppression.id,
+    object: "suppression",
+    email: suppression.email,
+    reason: suppression.reason,
+    scope: "user",
+    source_event_id: suppression.sourceEventId,
+    source_email_id: suppression.sourceEmailId,
+    source_message_id: suppression.sourceMessageId,
+    metadata: suppression.metadata ?? null,
+    suppressed_at: suppression.suppressedAt.toISOString(),
+    updated_at: suppression.updatedAt.toISOString(),
+  };
+}

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -244,6 +244,11 @@ describe("POST /api/emails", () => {
       contacts: { findFirst: vi.fn().mockResolvedValue(null) },
     });
     mockDb.insert = vi.fn();
+    mockDb.select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
     mockDb.transaction.mockImplementation(
       async (callback: (tx: typeof mockDb) => unknown) => callback(mockDb),
     );
@@ -495,6 +500,49 @@ describe("POST /api/emails", () => {
     });
   });
 
+  it("rejects suppressed to recipients before quota, persistence, or queueing", async () => {
+    mockDb.select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([
+          {
+            email: "blocked@test.com",
+            reason: "bounced",
+            suppressedAt: new Date("2026-05-05T00:00:00Z"),
+          },
+        ]),
+      }),
+    });
+
+    const { POST } = await import("@/app/api/emails/route");
+    const req = makeRequest(
+      "POST",
+      {
+        from: "sender@domain.com",
+        to: ["blocked@test.com"],
+        subject: "Suppressed",
+        html: "<p>No send</p>",
+      },
+      { Authorization: "Bearer re_test123" },
+    );
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "recipient_suppressed",
+      code: "recipient_suppressed",
+      statusCode: 422,
+      details: {
+        recipients: "blocked@test.com",
+        reason: "bounced",
+        scope: "user",
+      },
+    });
+    expect(mockReserveEmailQuota).not.toHaveBeenCalled();
+    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
+  });
+
   it("stores attachment ids and queues delivery without direct SES", async () => {
     mockSendEmail.mockResolvedValue({ id: "ses-msg-id" });
     const valuesMock = vi.fn().mockReturnValue({
@@ -560,6 +608,11 @@ describe("POST /api/emails/batch", () => {
       contacts: { findFirst: vi.fn().mockResolvedValue(null) },
     });
     mockDb.insert = vi.fn();
+    mockDb.select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
     mockDb.transaction.mockImplementation(
       async (callback: (tx: typeof mockDb) => unknown) => callback(mockDb),
     );
@@ -752,6 +805,73 @@ describe("POST /api/emails/batch", () => {
       ),
       "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
     });
+  });
+
+  it("returns per-item suppression errors while preserving accepted batch sends", async () => {
+    mockDb.select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([
+          {
+            email: "blocked@test.com",
+            reason: "complained",
+            suppressedAt: new Date("2026-05-05T00:00:00Z"),
+          },
+        ]),
+      }),
+    });
+    const valuesMock = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: "email-accepted-1" }]),
+    });
+    mockDb.insert = vi.fn().mockReturnValue({ values: valuesMock });
+
+    const { POST } = await import("@/app/api/emails/batch/route");
+    const req = makeRequest(
+      "POST",
+      [
+        {
+          from: "sender@domain.com",
+          to: ["ok@test.com"],
+          subject: "OK",
+          html: "<p>OK</p>",
+        },
+        {
+          from: "sender@domain.com",
+          to: ["blocked@test.com"],
+          subject: "Blocked",
+          html: "<p>Blocked</p>",
+        },
+      ],
+      { Authorization: "Bearer re_test123" },
+    );
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      data: [
+        { id: "email-accepted-1" },
+        {
+          error: {
+            code: "recipient_suppressed",
+            statusCode: 422,
+            details: {
+              recipients: "blocked@test.com",
+              reason: "complained",
+              scope: "user",
+            },
+          },
+        },
+      ],
+    });
+    expect(mockReserveEmailQuota).toHaveBeenCalledWith(
+      "user-1",
+      1,
+      expect.any(Date),
+      process.env,
+      mockDb,
+    );
+    expect(mockDb.insert).toHaveBeenCalledTimes(1);
+    expect(mockPublishBackgroundJob).toHaveBeenCalledTimes(1);
   });
 
   it("sends batch and returns array of ids", async () => {

--- a/tests/ingester-ses-route.test.ts
+++ b/tests/ingester-ses-route.test.ts
@@ -9,6 +9,7 @@ const mockPublishBackgroundJob = vi.fn();
 const mockEmitCloudWatchMetric = vi.fn();
 const mockLogTelemetry = vi.fn();
 const mockRecordTelemetryError = vi.fn();
+const mockSuppressFromSesEvent = vi.fn();
 
 vi.mock("@opensend/core", () => {
   const testTraceparent =
@@ -64,6 +65,9 @@ vi.mock("@opensend/core", () => {
     logTelemetry: mockLogTelemetry,
     publishBackgroundJob: mockPublishBackgroundJob,
     recordTelemetryError: mockRecordTelemetryError,
+    suppressionRepo: {
+      suppressFromSesEvent: mockSuppressFromSesEvent,
+    },
     toWebhookEventType: (eventType: string) => {
       const candidate = eventType.includes(".")
         ? eventType
@@ -244,6 +248,7 @@ describe("SES SNS ingestion route", () => {
     mockEmitCloudWatchMetric.mockReset();
     mockLogTelemetry.mockReset();
     mockRecordTelemetryError.mockReset();
+    mockSuppressFromSesEvent.mockResolvedValue([]);
 
     vi.stubGlobal(
       "fetch",
@@ -308,6 +313,64 @@ describe("SES SNS ingestion route", () => {
       }),
     );
     expect(mockDispatchDelivery).not.toHaveBeenCalled();
+  });
+
+  it("creates user-scoped suppressions for permanent bounce recipients", async () => {
+    const persistedEvent = {
+      id: "evt-bounce-1",
+      emailId: "550e8400-e29b-41d4-a716-446655440000",
+      sourceId: "sns-msg-1",
+      type: "bounced",
+      payload: {
+        bounceType: "Permanent",
+        bouncedRecipients: [{ emailAddress: "blocked@test.com" }],
+      },
+    };
+    mockCreateOrIgnoreDuplicate.mockResolvedValue({
+      event: persistedEvent,
+      created: true,
+    });
+    mockWebhookList.mockResolvedValue({ data: [] });
+    mockSuppressFromSesEvent.mockResolvedValue([{ id: "suppression-1" }]);
+
+    const app = (await import("../packages/ingester/src/index")).default;
+    const envelope = createSignedEnvelope({
+      sesMessage: {
+        eventType: "Bounce",
+        mail: {
+          messageId: "ses-msg-bounce-1",
+          headers: [
+            {
+              name: "X-Entity-ID",
+              value: "550e8400-e29b-41d4-a716-446655440000",
+            },
+          ],
+        },
+        bounce: {
+          bounceType: "Permanent",
+          bouncedRecipients: [{ emailAddress: "blocked@test.com" }],
+        },
+      },
+    });
+
+    const response = await app.request("http://localhost/events/ses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-amz-sns-message-type": "Notification",
+      },
+      body: JSON.stringify(envelope),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockSuppressFromSesEvent).toHaveBeenCalledWith({
+      emailId: "550e8400-e29b-41d4-a716-446655440000",
+      recipients: ["blocked@test.com"],
+      reason: "bounced",
+      sourceEventId: "sns-msg-1",
+      sourceMessageId: "ses-msg-bounce-1",
+      metadata: { bounceType: "Permanent" },
+    });
   });
 
   it("rejects invalid SNS signatures before touching persistence", async () => {

--- a/tests/quota-routes.test.ts
+++ b/tests/quota-routes.test.ts
@@ -7,6 +7,7 @@ const mockCheckApiKeyQuota = vi.hoisted(() => vi.fn());
 const mockCreateDomainIdentity = vi.hoisted(() => vi.fn());
 const mockDb = vi.hoisted(() => ({
   insert: vi.fn(),
+  select: vi.fn(),
   transaction: vi.fn(async (callback: (tx: typeof mockDb) => unknown) =>
     callback(mockDb),
   ),
@@ -97,6 +98,12 @@ describe("quota route gates", () => {
     mockCheckApiKeyQuota.mockReset();
     mockCreateDomainIdentity.mockReset();
     mockDb.insert.mockReset();
+    mockDb.select.mockReset();
+    mockDb.select.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
     mockDb.transaction.mockImplementation(
       async (callback: (tx: typeof mockDb) => unknown) => callback(mockDb),
     );

--- a/tests/suppressions-route.test.ts
+++ b/tests/suppressions-route.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockRemoveSuppression = vi.hoisted(() => vi.fn());
+const mockListSuppressions = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api-auth", () => ({
+  authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
+  getServerSession: mockGetServerSession,
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/suppressions", () => ({
+  listSuppressions: mockListSuppressions,
+  removeSuppression: mockRemoveSuppression,
+  serializeSuppression: (row: {
+    id: string;
+    email: string;
+    reason: string;
+  }) => ({
+    id: row.id,
+    object: "suppression",
+    email: row.email,
+    reason: row.reason,
+    scope: "user",
+  }),
+}));
+
+describe("suppression management routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue({
+      apiKeyId: "key-1",
+      permission: "full_access",
+      domain: null,
+      userId: "user-1",
+    });
+  });
+
+  it("lists user-scoped suppression records", async () => {
+    mockListSuppressions.mockResolvedValue({
+      data: [{ id: "supp-1", email: "blocked@test.com", reason: "bounced" }],
+      hasMore: false,
+    });
+
+    const { GET } = await import("@/app/api/suppressions/route");
+    const res = await GET(
+      new Request("http://localhost:3015/api/suppressions?limit=10", {
+        headers: { Authorization: "Bearer re_test" },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      object: "list",
+      scope: "user",
+      data: [
+        {
+          id: "supp-1",
+          object: "suppression",
+          email: "blocked@test.com",
+          reason: "bounced",
+          scope: "user",
+        },
+      ],
+      has_more: false,
+    });
+    expect(mockListSuppressions).toHaveBeenCalledWith({
+      userId: "user-1",
+      limit: 10,
+      after: undefined,
+    });
+  });
+
+  it("removes a suppression for the authenticated user", async () => {
+    mockRemoveSuppression.mockResolvedValue({ id: "supp-1" });
+
+    const { DELETE } = await import("@/app/api/suppressions/[email]/route");
+    const res = await DELETE(
+      new Request("http://localhost:3015/api/suppressions/blocked%40test.com", {
+        method: "DELETE",
+        headers: { Authorization: "Bearer re_test" },
+      }),
+      { params: Promise.resolve({ email: "blocked%40test.com" }) },
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      object: "suppression",
+      deleted: true,
+    });
+    expect(mockRemoveSuppression).toHaveBeenCalledWith({
+      userId: "user-1",
+      email: "blocked@test.com",
+    });
+  });
+});


### PR DESCRIPTION
## Issue

Links #191

## Summary

- Adds a user-scoped `email_suppressions` table/repository and suppression management APIs (`GET /api/suppressions`, `DELETE /api/suppressions/{email}`).
- Creates/refreshes suppression records from SES hard-bounce (`Bounce` + `bounceType=Permanent`) and complaint events, preserving SNS/event/email metadata.
- Gates `POST /api/emails` and `POST /api/emails/batch` before quota reservation, email-row insertion, queueing, or SES delivery; single sends return stable `recipient_suppressed`, and batch sends return per-item errors while preserving accepted items.
- Shows suppression guidance on email detail pages and documents this first slice as account/user-scoped only.

## Validation

- `make check` ✅
- `git diff --check` ✅
- `bunx vitest run tests/api-emails.test.ts tests/ingester-ses-route.test.ts tests/suppressions-route.test.ts tests/email-detail.test.tsx tests/email-detail-insights.test.tsx tests/quota-routes.test.ts` ✅ (50 tests)
- `bunx vitest run tests/api-auth-date-range-routes.test.ts tests/api-domains.test.ts tests/api-emails.test.ts tests/billing-quota.test.ts tests/quota-routes.test.ts` ✅ (55 tests; exact rerun of suites that timed out under full-suite load)
- `make test` ⚠️ ran 729/734 passing, then 5 tests hit Vitest 5s timeouts under full-suite load; each timed-out suite passed in the exact rerun above.
- Push guardrails: changed-file check, full-project typecheck, changed-file Biome ✅

## Residual risk

- Playwright E2E not run in this lane; dev server was not started.
- Suppression scope is intentionally user/account scoped. Region-wide/provider-wide suppression and automatic unsuppression timers are deferred.
