### PR TITLE
Expose Resend-compatible POST /emails alias

### DIFF
--- a/agent_docs/learnings/active/2026-05-05-issue-194-single-send-alias.md
+++ b/agent_docs/learnings/active/2026-05-05-issue-194-single-send-alias.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-05
+issue: "#194"
+type: decision
+promoted_to: null
+---
+
+## Keep /emails POST as a middleware rewrite, not duplicated route logic
+
+**What:** Resend-compatible `POST /emails` is implemented in middleware as a method-specific rewrite to the existing `/api/emails` send handler, while `GET /emails` remains the dashboard page/session flow.
+
+**Why:** The `/emails` URL is already occupied by the dashboard page. A method-specific middleware alias avoids competing App Router page/route files and reuses the existing send handler for payload validation, idempotency, quota, queueing, telemetry, and JSON error envelopes.
+
+**Fix:** When adding root-level API aliases that collide with dashboard pages, keep the alias method-specific in middleware, bypass dashboard session checks only for the API method, and canonicalize rate-limit keys back to the underlying API route when the alias should share a bucket.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -73,11 +73,22 @@ async function checkRate(
 }
 
 // Rate limit tiers by route pattern
+function isSingleSendPostAlias(pathname: string, method: string): boolean {
+  return pathname === "/emails" && method === "POST";
+}
+
 function isSendApiPost(pathname: string, method: string): boolean {
   return (
     method === "POST" &&
-    (pathname === "/api/emails" || pathname === "/api/emails/batch")
+    (pathname === "/api/emails" ||
+      pathname === "/api/emails/batch" ||
+      pathname === "/emails")
   );
+}
+
+function getRateLimitPathname(pathname: string, method: string): string {
+  if (isSingleSendPostAlias(pathname, method)) return "/api/emails";
+  return pathname;
 }
 
 function getLimits(
@@ -85,7 +96,10 @@ function getLimits(
   method: string,
 ): { max: number; windowMs: number } {
   // Email sending — strictest limit
-  if (pathname === "/api/emails" && method === "POST") {
+  if (
+    (pathname === "/api/emails" || pathname === "/emails") &&
+    method === "POST"
+  ) {
     return { max: 20, windowMs: 60_000 };
   }
   if (pathname === "/api/emails/batch" && method === "POST") {
@@ -116,8 +130,10 @@ export async function middleware(request: NextRequest) {
 
   const isPublicUnsubscribeRoute = pathname.startsWith("/unsubscribe/");
 
-  // Protect non-API page routes with session check
-  if (!pathname.startsWith("/api/")) {
+  // Protect non-API page routes with session check. POST /emails is a
+  // Resend-compatible API alias and must bypass dashboard session redirects.
+  const isSingleSendAlias = isSingleSendPostAlias(pathname, request.method);
+  if (!pathname.startsWith("/api/") && !isSingleSendAlias) {
     // Allow auth page, public landing page, and static assets
     if (
       pathname === "/auth" ||
@@ -144,6 +160,12 @@ export async function middleware(request: NextRequest) {
   const responseHeaders = new Headers({ "X-RateLimit-Backend": backend });
 
   if (backend === "disabled") {
+    if (isSingleSendAlias) {
+      return NextResponse.rewrite(new URL("/api/emails", request.url), {
+        headers: responseHeaders,
+      });
+    }
+
     return NextResponse.next({ headers: responseHeaders });
   }
 
@@ -153,7 +175,8 @@ export async function middleware(request: NextRequest) {
     request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "";
   const ip = /^[\d.a-fA-F:]+$/.test(rawIp) ? rawIp : "unknown";
   const authKey = request.headers.get("authorization")?.slice(0, 20) ?? "anon";
-  const rateLimitKey = `${ip}:${authKey}:${pathname}`;
+  const rateLimitPathname = getRateLimitPathname(pathname, request.method);
+  const rateLimitKey = `${ip}:${authKey}:${rateLimitPathname}`;
 
   const { max, windowMs } = getLimits(pathname, request.method);
   const result = await checkRate(rateLimitKey, max, windowMs, rateLimit);
@@ -188,6 +211,12 @@ export async function middleware(request: NextRequest) {
       { error: message },
       { status: result.status, headers },
     );
+  }
+
+  if (isSingleSendAlias) {
+    return NextResponse.rewrite(new URL("/api/emails", request.url), {
+      headers: responseHeaders,
+    });
   }
 
   return NextResponse.next({ headers: responseHeaders });

--- a/tests/e2e/emails-alias.spec.ts
+++ b/tests/e2e/emails-alias.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Resend-compatible /emails alias", () => {
+  test("POST /emails reaches the JSON send API instead of dashboard routing", async ({
+    request,
+  }) => {
+    const response = await request.post("/emails", {
+      headers: {
+        Authorization: "Basic invalid_key",
+        "Content-Type": "application/json",
+        "Idempotency-Key": "alias-e2e-invalid-key",
+      },
+      data: {
+        from: "sender@example.com",
+        to: "recipient@example.com",
+        subject: "Alias",
+        html: "<p>Hello</p>",
+      },
+    });
+
+    expect(response.status()).toBe(401);
+    expect(response.headers()["content-type"]).toContain("application/json");
+    const json = await response.json();
+    expect(json).toMatchObject({
+      name: "malformed_api_key",
+      code: "malformed_api_key",
+      statusCode: 401,
+    });
+  });
+
+  test("GET /emails keeps the dashboard sign-in flow", async ({ page }) => {
+    await page.goto("/emails");
+
+    await expect(page).toHaveURL(/\/auth/);
+  });
+});

--- a/tests/middleware-rate-limit.test.ts
+++ b/tests/middleware-rate-limit.test.ts
@@ -42,6 +42,46 @@ describe("middleware rate limiting", () => {
     expect(response.headers.get("x-ratelimit-backend")).toBe("disabled");
   });
 
+  it("rewrites POST /emails to the existing send API without requiring a dashboard session", async () => {
+    mockGetSessionCookie.mockReturnValue(null);
+    const { middleware } = await import("@/middleware");
+
+    const response = await middleware(
+      makeRequest("https://example.com/emails", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-api-key",
+          "content-type": "application/json",
+          "idempotency-key": "alias-key",
+        },
+        body: JSON.stringify({
+          from: "sender@example.com",
+          to: "recipient@example.com",
+          subject: "Alias",
+          html: "<p>Hello</p>",
+        }),
+      }),
+    );
+
+    expect(mockGetSessionCookie).not.toHaveBeenCalled();
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      "https://example.com/api/emails",
+    );
+    expect(response.headers.get("x-ratelimit-backend")).toBe("disabled");
+  });
+
+  it("preserves dashboard GET /emails session protection", async () => {
+    mockGetSessionCookie.mockReturnValue(null);
+    const { middleware } = await import("@/middleware");
+
+    const response = await middleware(
+      makeRequest("https://example.com/emails", { method: "GET" }),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://example.com/auth");
+  });
+
   it("enforces Redis-backed limits for API routes", async () => {
     process.env.RATE_LIMIT_BACKEND = "redis";
     mockIncrCache.mockResolvedValue(1);
@@ -64,6 +104,32 @@ describe("middleware rate limiting", () => {
     expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
   });
 
+  it("applies the strict send rate-limit bucket to POST /emails", async () => {
+    process.env.RATE_LIMIT_BACKEND = "redis";
+    mockGetSessionCookie.mockReturnValue(null);
+    mockIncrCache.mockResolvedValue(1);
+
+    const { middleware } = await import("@/middleware");
+    const response = await middleware(
+      makeRequest("https://example.com/emails", {
+        method: "POST",
+        headers: {
+          "x-forwarded-for": "203.0.113.10",
+          authorization: "Bearer test-api-key",
+        },
+      }),
+    );
+
+    expect(mockIncrCache).toHaveBeenCalledWith(
+      "ratelimit:203.0.113.10:Bearer test-api-key:/api/emails",
+      60,
+    );
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      "https://example.com/api/emails",
+    );
+    expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
+  });
+
   it("returns 429 with Retry-After once the Redis limit is exceeded", async () => {
     process.env.RATE_LIMIT_BACKEND = "redis";
     mockIncrCache.mockResolvedValue(21);
@@ -77,6 +143,27 @@ describe("middleware rate limiting", () => {
     expect(response.status).toBe(429);
     expect(response.headers.get("retry-after")).toBe("17");
     expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
+    await expect(response.json()).resolves.toEqual({
+      name: "rate_limit_exceeded",
+      code: "rate_limit_exceeded",
+      message: "Rate limit exceeded. Try again later.",
+      statusCode: 429,
+    });
+  });
+
+  it("returns send API-style JSON rate-limit errors for POST /emails", async () => {
+    process.env.RATE_LIMIT_BACKEND = "redis";
+    mockGetSessionCookie.mockReturnValue(null);
+    mockIncrCache.mockResolvedValue(21);
+    mockGetTtl.mockResolvedValue(17);
+
+    const { middleware } = await import("@/middleware");
+    const response = await middleware(
+      makeRequest("https://example.com/emails", { method: "POST" }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("17");
     await expect(response.json()).resolves.toEqual({
       name: "rate_limit_exceeded",
       code: "rate_limit_exceeded",


### PR DESCRIPTION
## Summary
- Add a method-specific middleware rewrite so `POST /emails` reaches the existing `/api/emails` send handler without duplicating send logic.
- Preserve dashboard `GET /emails` session/sign-in behavior.
- Apply the strict send rate-limit tier to the alias and canonicalize its Redis bucket to `/api/emails`.
- Add Vitest and Playwright regressions for the alias, rate limiting, and dashboard GET preservation.

Closes #194

## Validation
- `bun run test tests/middleware-rate-limit.test.ts`
- `bun run test:e2e tests/e2e/emails-alias.spec.ts`
- `make check`
- `make test`

## Notes
- Successful live send via `POST /emails` was not exercised against a real API key/DB/queue in this environment; the alias is a middleware rewrite to the already-tested `/api/emails` handler, whose success response remains `{ "id": "<email id>" }`.
