### PR TITLE
fix(domains): scope domain reads and writes to authenticated user

### DIFF
--- a/packages/core/src/db/repositories/domainRepo.ts
+++ b/packages/core/src/db/repositories/domainRepo.ts
@@ -34,11 +34,14 @@ export const domainRepo = {
       .returning({ id: domains.id });
   },
 
-  async list(options: { limit?: number; after?: string } = {}) {
-    const { limit = 20, after } = options;
+  async list(
+    options: { limit?: number; after?: string; userId?: string | null } = {},
+  ) {
+    const { limit = 20, after, userId } = options;
     const conditions = [];
 
     if (after) conditions.push(lt(domains.id, after));
+    if (userId) conditions.push(eq(domains.userId, userId));
 
     const results = await db
       .select()

--- a/packages/core/src/services/domain.ts
+++ b/packages/core/src/services/domain.ts
@@ -72,7 +72,11 @@ export type DomainListResult = {
 };
 
 export type DomainRepository = {
-  list(options: { limit?: number; after?: string }): Promise<{
+  list(options: {
+    limit?: number;
+    after?: string;
+    userId?: string | null;
+  }): Promise<{
     data: DomainRow[];
     hasMore: boolean;
   }>;
@@ -195,10 +199,12 @@ export function createDomainService({
     async listDomains(options: {
       limit?: number;
       after?: string;
+      userId: string;
     }): Promise<DomainListResult> {
       const result = await repository.list({
         limit: normalizeLimit(options.limit),
         after: options.after || undefined,
+        userId: options.userId,
       });
 
       return {

--- a/src/app/(dashboard)/domains/[id]/page.tsx
+++ b/src/app/(dashboard)/domains/[id]/page.tsx
@@ -1,9 +1,10 @@
 import { DomainDetail } from "@/components/domain-detail";
+import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { domains } from "@/lib/db/schema";
 import { domainRouteParamsSchema } from "@/lib/validation/domains";
-import { eq } from "drizzle-orm";
-import { notFound } from "next/navigation";
+import { and, eq } from "drizzle-orm";
+import { notFound, redirect } from "next/navigation";
 
 interface DomainEvent {
   type: string;
@@ -15,6 +16,12 @@ export default async function DomainDetailPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
+  const session = await getServerSession();
+  if (!session?.user?.id) {
+    redirect("/auth");
+  }
+  const userId = session.user.id;
+
   const parsedParams = domainRouteParamsSchema.safeParse(await params);
   if (!parsedParams.success) {
     notFound();
@@ -25,7 +32,7 @@ export default async function DomainDetailPage({
   const rows = await db
     .select()
     .from(domains)
-    .where(eq(domains.id, id))
+    .where(and(eq(domains.id, id), eq(domains.userId, userId)))
     .limit(1);
 
   if (rows.length === 0) {

--- a/src/app/(dashboard)/domains/page.tsx
+++ b/src/app/(dashboard)/domains/page.tsx
@@ -1,9 +1,17 @@
 import { DomainsPage } from "@/components/domains-page";
+import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { domains } from "@/lib/db/schema";
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
+import { redirect } from "next/navigation";
 
 export default async function DomainsServerPage() {
+  const session = await getServerSession();
+  if (!session?.user?.id) {
+    redirect("/auth");
+  }
+  const userId = session.user.id;
+
   let domainRows: {
     id: string;
     name: string;
@@ -22,6 +30,7 @@ export default async function DomainsServerPage() {
         createdAt: domains.createdAt,
       })
       .from(domains)
+      .where(eq(domains.userId, userId))
       .orderBy(desc(domains.createdAt))
       .limit(200);
 

--- a/src/app/api/domains/[id]/auto-configure/route.ts
+++ b/src/app/api/domains/[id]/auto-configure/route.ts
@@ -1,5 +1,6 @@
 import {
   authorizeDashboardOrApiKey,
+  getServerSession,
   unauthorizedResponse,
 } from "@/lib/api-auth";
 import { autoConfigureDomain } from "@/lib/cloudflare";
@@ -13,7 +14,7 @@ import {
 import { createDomainIdentity } from "@/lib/ses";
 import { autoConfigureDomainParamsSchema } from "@/lib/validation/domains";
 import { DMARC_RECORD_VALUE, buildDmarcRecordName } from "@opensend/core";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
 export async function POST(
@@ -24,6 +25,10 @@ export async function POST(
     _req.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+
+  const session = "dashboard" in auth ? await getServerSession() : null;
+  const userId = "userId" in auth ? auth.userId : session?.user?.id;
+  if (!userId) return unauthorizedResponse();
 
   const parsedParams = autoConfigureDomainParamsSchema.safeParse(await params);
   if (!parsedParams.success) {
@@ -38,7 +43,7 @@ export async function POST(
   try {
     const domain = await getCachedDomainById(id);
 
-    if (!domain) {
+    if (!domain || domain.userId !== userId) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 
@@ -104,7 +109,7 @@ export async function POST(
         records: allRecords,
         status: "pending",
       })
-      .where(eq(domains.id, id));
+      .where(and(eq(domains.id, id), eq(domains.userId, userId)));
 
     await invalidateDomainCaches({ id, name: domain.name });
 

--- a/src/app/api/domains/[id]/route.ts
+++ b/src/app/api/domains/[id]/route.ts
@@ -1,5 +1,6 @@
 import {
   authorizeDashboardOrApiKey,
+  getServerSession,
   unauthorizedResponse,
 } from "@/lib/api-auth";
 import { deleteDNSRecord, listDNSRecords } from "@/lib/cloudflare";
@@ -15,7 +16,7 @@ import {
   updateDomainSchema,
 } from "@/lib/validation/domains";
 import { getEffectiveReturnPathLabel } from "@opensend/core";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
 const defaultCapabilities = [
@@ -32,6 +33,10 @@ export async function GET(
   );
   if (!auth) return unauthorizedResponse();
 
+  const session = "dashboard" in auth ? await getServerSession() : null;
+  const userId = "userId" in auth ? auth.userId : session?.user?.id;
+  if (!userId) return unauthorizedResponse();
+
   const parsedParams = domainRouteParamsSchema.safeParse(await params);
   if (!parsedParams.success) {
     return NextResponse.json(
@@ -44,7 +49,7 @@ export async function GET(
     const { id } = parsedParams.data;
     const domain = await getCachedDomainById(id);
 
-    if (!domain) {
+    if (!domain || domain.userId !== userId) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 
@@ -82,6 +87,10 @@ export async function PATCH(
   );
   if (!auth) return unauthorizedResponse();
 
+  const session = "dashboard" in auth ? await getServerSession() : null;
+  const userId = "userId" in auth ? auth.userId : session?.user?.id;
+  if (!userId) return unauthorizedResponse();
+
   let body: unknown;
   try {
     body = await req.json();
@@ -111,7 +120,7 @@ export async function PATCH(
     const updates: Record<string, unknown> = {};
     const existingDomain = await getCachedDomainById(id);
 
-    if (!existingDomain) {
+    if (!existingDomain || existingDomain.userId !== userId) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 
@@ -154,7 +163,7 @@ export async function PATCH(
     const [updated] = await db
       .update(domains)
       .set(updates)
-      .where(eq(domains.id, id))
+      .where(and(eq(domains.id, id), eq(domains.userId, userId)))
       .returning();
 
     if (!updated) {
@@ -186,6 +195,10 @@ export async function DELETE(
   );
   if (!auth) return unauthorizedResponse();
 
+  const session = "dashboard" in auth ? await getServerSession() : null;
+  const userId = "userId" in auth ? auth.userId : session?.user?.id;
+  if (!userId) return unauthorizedResponse();
+
   const parsedParams = domainRouteParamsSchema.safeParse(await params);
   if (!parsedParams.success) {
     return NextResponse.json(
@@ -198,7 +211,7 @@ export async function DELETE(
     const { id } = parsedParams.data;
     const domain = await getCachedDomainById(id);
 
-    if (!domain) {
+    if (!domain || domain.userId !== userId) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 
@@ -227,7 +240,7 @@ export async function DELETE(
 
     const [deleted] = await db
       .delete(domains)
-      .where(eq(domains.id, id))
+      .where(and(eq(domains.id, id), eq(domains.userId, userId)))
       .returning({ id: domains.id });
 
     await invalidateDomainCaches({ id, name: domain.name });

--- a/src/app/api/domains/[id]/verify/route.ts
+++ b/src/app/api/domains/[id]/verify/route.ts
@@ -1,5 +1,6 @@
 import {
   authorizeDashboardOrApiKey,
+  getServerSession,
   unauthorizedResponse,
 } from "@/lib/api-auth";
 import { db } from "@/lib/db";
@@ -12,7 +13,7 @@ import {
 import { queueEvent } from "@/lib/events";
 import { verifyDomainParamsSchema } from "@/lib/validation/domains";
 import { getEffectiveReturnPathLabel } from "@opensend/core";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 export async function POST(
   request: Request,
@@ -22,6 +23,10 @@ export async function POST(
     request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+
+  const session = "dashboard" in auth ? await getServerSession() : null;
+  const userId = "userId" in auth ? auth.userId : session?.user?.id;
+  if (!userId) return unauthorizedResponse();
 
   const parsedParams = verifyDomainParamsSchema.safeParse(await params);
   if (!parsedParams.success) {
@@ -36,7 +41,7 @@ export async function POST(
   try {
     const domain = await getCachedDomainById(id);
 
-    if (!domain) {
+    if (!domain || domain.userId !== userId) {
       return Response.json({ error: "Domain not found" }, { status: 404 });
     }
 
@@ -79,7 +84,7 @@ export async function POST(
       .set({
         status: verificationStatus,
       })
-      .where(eq(domains.id, id))
+      .where(and(eq(domains.id, id), eq(domains.userId, userId)))
       .returning();
 
     if (!updated) {

--- a/src/app/api/domains/route.ts
+++ b/src/app/api/domains/route.ts
@@ -1,4 +1,9 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import {
+  authorizeDashboardOrApiKey,
+  getServerSession,
+  unauthorizedResponse,
+  validateApiKey,
+} from "@/lib/api-auth";
 import { checkDomainQuota, quotaExceededResponse } from "@/lib/billing/quota";
 import { invalidateDomainCaches } from "@/lib/domain-cache";
 import { createDomainIdentity } from "@/lib/ses";
@@ -83,15 +88,25 @@ export async function POST(request: Request): Promise<Response> {
 }
 
 export async function GET(request: Request): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
   if (!auth) return unauthorizedResponse();
+
+  const session = "dashboard" in auth ? await getServerSession() : null;
+  const userId = "userId" in auth ? auth.userId : session?.user?.id;
+  if (!userId) return unauthorizedResponse();
 
   const url = new URL(request.url);
   const limit = Number(url.searchParams.get("limit")) || 20;
   const after = url.searchParams.get("after") || "";
 
   try {
-    const result = await domainService().listDomains({ limit, after });
+    const result = await domainService().listDomains({
+      limit,
+      after,
+      userId,
+    });
 
     return Response.json({
       object: "list",

--- a/tests/api-domains.test.ts
+++ b/tests/api-domains.test.ts
@@ -50,6 +50,7 @@ const AUTH_RESULT = {
   apiKeyId: "key-uuid",
   permission: "full_access",
   domainId: null,
+  userId: "user-1",
 };
 
 const VALID_DOMAIN_ID = "11111111-1111-4111-8111-111111111111";
@@ -169,6 +170,7 @@ describe("Domain API validation", () => {
     const domain = {
       id: VALID_DOMAIN_ID,
       name: "example.com",
+      userId: "user-1",
       status: "pending",
       records: [
         {
@@ -220,6 +222,30 @@ describe("Domain API validation", () => {
     expect(mockQueueEvent).toHaveBeenCalledTimes(1);
   });
 
+  it("returns 404 when verifying a domain owned by another tenant", async () => {
+    mockDb.query.domains.findFirst.mockResolvedValue({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+      userId: "other-user",
+      status: "pending",
+      records: [],
+    });
+
+    const { POST } = await import("@/app/api/domains/[id]/verify/route");
+    const req = makeRequest(
+      `http://localhost:3015/api/domains/${VALID_DOMAIN_ID}/verify`,
+      "POST",
+    );
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: VALID_DOMAIN_ID }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(mockGetDomainIdentity).not.toHaveBeenCalled();
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
   it("returns 422 for invalid auto-configure params", async () => {
     const { POST } = await import(
       "@/app/api/domains/[id]/auto-configure/route"
@@ -240,10 +266,38 @@ describe("Domain API validation", () => {
     expect(mockDb.query.domains.findFirst).not.toHaveBeenCalled();
   });
 
+  it("returns 404 when auto-configuring a domain owned by another tenant", async () => {
+    mockDb.query.domains.findFirst.mockResolvedValue({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+      userId: "other-user",
+      customReturnPath: "outbound",
+      records: [],
+    });
+
+    const { POST } = await import(
+      "@/app/api/domains/[id]/auto-configure/route"
+    );
+    const req = makeRequest(
+      `http://localhost:3015/api/domains/${VALID_DOMAIN_ID}/auto-configure`,
+      "POST",
+    );
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: VALID_DOMAIN_ID }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(mockCreateDomainIdentity).not.toHaveBeenCalled();
+    expect(mockAutoConfigureDomain).not.toHaveBeenCalled();
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
   it("auto-configures domain when params are valid", async () => {
     mockDb.query.domains.findFirst.mockResolvedValue({
       id: VALID_DOMAIN_ID,
       name: "example.com",
+      userId: "user-1",
       customReturnPath: "outbound",
       records: [
         {

--- a/tests/cache-invalidation-routes.test.ts
+++ b/tests/cache-invalidation-routes.test.ts
@@ -187,6 +187,7 @@ describe("cache invalidation routes", () => {
     mockGetCachedDomainById.mockResolvedValue({
       id: VALID_DOMAIN_ID,
       name: "example.com",
+      userId: "user-1",
       capabilities: [{ name: "sending", enabled: true }],
     });
     mockDb.update.mockReturnValue({
@@ -221,10 +222,36 @@ describe("cache invalidation routes", () => {
     });
   });
 
+  it("returns 404 for cross-tenant domain patch", async () => {
+    mockGetCachedDomainById.mockResolvedValue({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+      userId: "other-user",
+      capabilities: [{ name: "sending", enabled: true }],
+    });
+
+    const route = await import("@/app/api/domains/[id]/route");
+    const response = await route.PATCH(
+      new Request("http://localhost", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ click_tracking: true }),
+      }),
+      {
+        params: Promise.resolve({ id: VALID_DOMAIN_ID }),
+      },
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockDb.update).not.toHaveBeenCalled();
+    expect(mockInvalidateDomainCaches).not.toHaveBeenCalled();
+  });
+
   it("invalidates domain caches after auto-configure", async () => {
     mockGetCachedDomainById.mockResolvedValue({
       id: VALID_DOMAIN_ID,
       name: "example.com",
+      userId: "user-1",
     });
     mockCreateDomainIdentity.mockResolvedValue({
       dkimTokens: ["a", "b", "c"],
@@ -257,6 +284,7 @@ describe("cache invalidation routes", () => {
     mockGetCachedDomainById.mockResolvedValue({
       id: VALID_DOMAIN_ID,
       name: "example.com",
+      userId: "user-1",
       status: "pending",
       records: [],
     });
@@ -298,6 +326,7 @@ describe("cache invalidation routes", () => {
     mockGetCachedDomainById.mockResolvedValue({
       id: VALID_DOMAIN_ID,
       name: "example.com",
+      userId: "user-1",
     });
     mockListDNSRecords.mockResolvedValue([]);
     mockDb.delete.mockReturnValue({

--- a/tests/domain-detail-page.test.tsx
+++ b/tests/domain-detail-page.test.tsx
@@ -8,6 +8,13 @@ const mockNotFound = vi.hoisted(() =>
   }),
 );
 
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockRedirect = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error("NEXT_REDIRECT");
+  }),
+);
+
 const limitMock = vi.hoisted(() => vi.fn());
 const whereMock = vi.hoisted(() => vi.fn(() => ({ limit: limitMock })));
 const fromMock = vi.hoisted(() => vi.fn(() => ({ where: whereMock })));
@@ -17,8 +24,13 @@ vi.mock("@/lib/db", () => ({
   db: { select: selectMock },
 }));
 
+vi.mock("@/lib/api-auth", () => ({
+  getServerSession: mockGetServerSession,
+}));
+
 vi.mock("next/navigation", () => ({
   notFound: mockNotFound,
+  redirect: mockRedirect,
 }));
 
 vi.mock("@/components/domain-detail", () => ({
@@ -39,10 +51,25 @@ describe("DomainDetailPage server component", () => {
     vi.resetModules();
     notFoundCalls.count = 0;
     mockNotFound.mockClear();
+    mockRedirect.mockClear();
+    mockGetServerSession.mockReset();
+    mockGetServerSession.mockResolvedValue({ user: { id: "user-1" } });
     selectMock.mockClear();
     fromMock.mockClear();
     whereMock.mockClear();
     limitMock.mockReset();
+  });
+
+  it("redirects unauthenticated dashboard users before loading a domain", async () => {
+    mockGetServerSession.mockResolvedValueOnce(null);
+
+    const Page = await importPage();
+    await expect(
+      Page({ params: Promise.resolve({ id: VALID_UUID }) }),
+    ).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(mockRedirect).toHaveBeenCalledWith("/auth");
+    expect(selectMock).not.toHaveBeenCalled();
   });
 
   it("calls notFound for non-UUID ids without hitting the database", async () => {

--- a/tests/domain-service.test.ts
+++ b/tests/domain-service.test.ts
@@ -212,7 +212,11 @@ describe("domain service", () => {
   });
 
   it("lists with normalized pagination and maps public list fields", async () => {
-    let listOptions: { limit?: number; after?: string } | null = null;
+    let listOptions: {
+      limit?: number;
+      after?: string;
+      userId?: string | null;
+    } | null = null;
     const service = createDomainService({
       repository: createRepository({
         async list(options) {
@@ -225,9 +229,17 @@ describe("domain service", () => {
       }),
     });
 
-    const result = await service.listDomains({ limit: 500, after: "domain-3" });
+    const result = await service.listDomains({
+      limit: 500,
+      after: "domain-3",
+      userId: "user-1",
+    });
 
-    expect(listOptions).toEqual({ limit: 100, after: "domain-3" });
+    expect(listOptions).toEqual({
+      limit: 100,
+      after: "domain-3",
+      userId: "user-1",
+    });
     expect(result).toEqual({
       data: [
         {


### PR DESCRIPTION
## Summary
The dashboard domains list and the domain API routes ran against every row in the \`domains\` table regardless of caller, so any signed-in user could see and modify other tenants' domains. Reproduced today in prod (a fresh tenant saw \`namuh.co\` and \`foreverbrowsing.com\` in their list — visible in the screenshot).

## What changed
- \`packages/core/src/db/repositories/domainRepo.ts\` — \`list\` accepts a \`userId\` filter
- \`packages/core/src/services/domain.ts\` — \`listDomains\` requires a \`userId\` and forwards it
- \`src/app/api/domains/route.ts\` GET — switches to \`authorizeDashboardOrApiKey\`, resolves the userId from the API key or session, returns 401 if neither exists, and passes it through
- \`src/app/api/domains/[id]/route.ts\` GET/PATCH/DELETE — every handler now requires \`domain.userId === userId\`; PATCH and DELETE also scope their SQL \`WHERE\` clauses to \`userId\` so a stale cache cannot be exploited
- \`src/app/api/domains/[id]/verify/route.ts\` and \`/auto-configure/route.ts\` — same ownership check + UPDATE scoped to userId
- \`src/app/(dashboard)/domains/page.tsx\` and \`/[id]/page.tsx\` — call \`getServerSession()\`, redirect to \`/auth\` when missing, and filter all queries by \`domains.user_id\`
- \`tests/domain-service.test.ts\` — updated the list test to pass and verify \`userId\`

## Test plan
- [x] \`make check\` (typecheck + Biome) green on touched files
- [x] \`bun x vitest run tests/domain-service.test.ts tests/api-domains.test.ts tests/cache-invalidation-routes.test.ts\` green
- [ ] After merge: verify \`/domains\` only shows the signed-in user's domains in prod

## Follow-up
A focused security review found the same class of cross-tenant bug in contacts, emails, broadcasts, webhooks, api-keys, metrics, and a few dashboard pages. Tracking those separately — this PR fixes only the domains surface so it can ship immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)