### PR TITLE
fix(deploy): drop docker login step in favor of ECR credential helper

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -49,13 +49,6 @@ ok()    { color 32 "$*"; }
 warn()  { color 33 "$*"; }
 err()   { color 31 "$*" >&2; }
 
-ecr_login() {
-  info "→ ECR login (${AWS_REGION})"
-  aws ecr get-login-password --region "${AWS_REGION}" \
-    | docker login --username AWS --password-stdin "${ECR_BASE}" >/dev/null
-  ok "  logged in"
-}
-
 build_and_push() {
   local repo="$1" dockerfile="$2" target="${3:-}" tag="${4:-${IMAGE_TAG}}"
   local image="${ECR_BASE}/${repo}:${tag}"
@@ -287,8 +280,6 @@ deploy_ingester() {
 }
 
 target="${1:-all}"
-
-ecr_login
 
 case "${target}" in
   app)


### PR DESCRIPTION
## Summary
- Self-hosted macOS runner (`macmini-opensend`) was hitting the 30-min timeout twice in a row at the `docker login` step in `scripts/deploy.sh` (run IDs 25364640789, 25368011488). Cause: Docker Desktop's `credsStore: "desktop"` helper requires a live GUI session that launchd-spawned shells don't have, so the helper blocks indefinitely.
- Installed `docker-credential-ecr-login` on the runner and configured `~/.docker/config.json` `credHelpers` to mint ECR tokens on demand from `~/.aws/credentials`. With that in place, the explicit `aws ecr get-login-password | docker login` step is unnecessary — `docker buildx ... --push` authenticates transparently via the helper.
- Drops the `ecr_login()` function and its top-level call from `scripts/deploy.sh`.

## Test plan
- [x] `bash -n scripts/deploy.sh` — syntax OK
- [x] `docker pull <ecr>/opensend-app:latest` from the runner box succeeds with auth (only fails on platform mismatch, proving auth worked)
- [ ] Deploy workflow run on main completes the build/push step without the 30-min hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)