### PR TITLE
Isolate contacts by tenant for issue 200 slice

### DIFF
--- a/agent_docs/learnings/active/2026-05-05-issue-200-contact-tenant-scope.md
+++ b/agent_docs/learnings/active/2026-05-05-issue-200-contact-tenant-scope.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-05
+issue: "#200"
+type: decision
+promoted_to: null
+---
+
+## Contacts API rejects unowned/unknown-user access
+
+Contact route tenant isolation now treats a resolved caller `userId` as mandatory: API-key flows without `userId` return 401, dashboard-capable contact list/create resolves the Better Auth session user, and contact/segment/topic mutations include `contacts.user_id` predicates. Segment and topic lookups inside contact flows are also scoped to the same user.
+
+This is intentionally slice-only: it does not change the global contacts email unique index, does not add null-owned historical fallback, and does not broaden into emails/broadcasts/webhooks.

--- a/src/app/api/contacts/[id]/route.ts
+++ b/src/app/api/contacts/[id]/route.ts
@@ -1,18 +1,21 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { contacts } from "@/lib/db/schema";
-import { eq, or } from "drizzle-orm";
+import { and, eq, or } from "drizzle-orm";
 
-async function findContact(idOrEmail: string) {
+async function findContact(idOrEmail: string, userId: string) {
   const isUuid =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
       idOrEmail,
     );
 
   return await db.query.contacts.findFirst({
-    where: isUuid
-      ? or(eq(contacts.id, idOrEmail), eq(contacts.email, idOrEmail))
-      : eq(contacts.email, idOrEmail),
+    where: and(
+      isUuid
+        ? or(eq(contacts.id, idOrEmail), eq(contacts.email, idOrEmail))
+        : eq(contacts.email, idOrEmail),
+      eq(contacts.userId, userId),
+    ),
   });
 }
 
@@ -22,11 +25,13 @@ export async function GET(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  if (!auth.userId) return unauthorizedResponse();
+  const userId = auth.userId;
 
   const { id } = await params;
 
   try {
-    const contact = await findContact(id);
+    const contact = await findContact(id, userId);
 
     if (!contact) {
       return Response.json({ error: "Contact not found" }, { status: 404 });
@@ -69,6 +74,8 @@ export async function PATCH(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  if (!auth.userId) return unauthorizedResponse();
+  const userId = auth.userId;
 
   const { id } = await params;
 
@@ -80,7 +87,7 @@ export async function PATCH(
   }
 
   try {
-    const contact = await findContact(id);
+    const contact = await findContact(id, userId);
     if (!contact) {
       return Response.json({ error: "Contact not found" }, { status: 404 });
     }
@@ -97,8 +104,12 @@ export async function PATCH(
     const [updated] = await db
       .update(contacts)
       .set(updateData)
-      .where(eq(contacts.id, contact.id))
+      .where(and(eq(contacts.id, contact.id), eq(contacts.userId, userId)))
       .returning();
+
+    if (!updated) {
+      return Response.json({ error: "Contact not found" }, { status: 404 });
+    }
 
     return Response.json({
       object: "contact",
@@ -123,18 +134,20 @@ export async function DELETE(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  if (!auth.userId) return unauthorizedResponse();
+  const userId = auth.userId;
 
   const { id } = await params;
 
   try {
-    const contact = await findContact(id);
+    const contact = await findContact(id, userId);
     if (!contact) {
       return Response.json({ error: "Contact not found" }, { status: 404 });
     }
 
     const [deleted] = await db
       .delete(contacts)
-      .where(eq(contacts.id, contact.id))
+      .where(and(eq(contacts.id, contact.id), eq(contacts.userId, userId)))
       .returning({ id: contacts.id });
 
     if (!deleted) {

--- a/src/app/api/contacts/[id]/segments/[segment_id]/route.ts
+++ b/src/app/api/contacts/[id]/segments/[segment_id]/route.ts
@@ -4,16 +4,19 @@ import { contacts, contactsToSegments, segments } from "@/lib/db/schema";
 import { and, eq, or } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
-async function findContact(idOrEmail: string) {
+async function findContact(idOrEmail: string, userId: string) {
   const isUuid =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
       idOrEmail,
     );
 
   return await db.query.contacts.findFirst({
-    where: isUuid
-      ? or(eq(contacts.id, idOrEmail), eq(contacts.email, idOrEmail))
-      : eq(contacts.email, idOrEmail),
+    where: and(
+      isUuid
+        ? or(eq(contacts.id, idOrEmail), eq(contacts.email, idOrEmail))
+        : eq(contacts.email, idOrEmail),
+      eq(contacts.userId, userId),
+    ),
   });
 }
 
@@ -23,13 +26,17 @@ export async function POST(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  if (!auth.userId) return unauthorizedResponse();
+  const userId = auth.userId;
 
   try {
     const { id: idOrEmail, segment_id } = await params;
 
     const [contact, segment] = await Promise.all([
-      findContact(idOrEmail),
-      db.query.segments.findFirst({ where: eq(segments.id, segment_id) }),
+      findContact(idOrEmail, userId),
+      db.query.segments.findFirst({
+        where: and(eq(segments.id, segment_id), eq(segments.userId, userId)),
+      }),
     ]);
 
     if (!contact) {
@@ -55,7 +62,7 @@ export async function POST(
       await db
         .update(contacts)
         .set({ segments: updatedSegments })
-        .where(eq(contacts.id, contact.id));
+        .where(and(eq(contacts.id, contact.id), eq(contacts.userId, userId)));
     }
 
     return NextResponse.json({
@@ -79,13 +86,17 @@ export async function DELETE(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  if (!auth.userId) return unauthorizedResponse();
+  const userId = auth.userId;
 
   try {
     const { id: idOrEmail, segment_id } = await params;
 
     const [contact, segment] = await Promise.all([
-      findContact(idOrEmail),
-      db.query.segments.findFirst({ where: eq(segments.id, segment_id) }),
+      findContact(idOrEmail, userId),
+      db.query.segments.findFirst({
+        where: and(eq(segments.id, segment_id), eq(segments.userId, userId)),
+      }),
     ]);
 
     if (!contact) {
@@ -114,7 +125,7 @@ export async function DELETE(
       await db
         .update(contacts)
         .set({ segments: updatedSegments })
-        .where(eq(contacts.id, contact.id));
+        .where(and(eq(contacts.id, contact.id), eq(contacts.userId, userId)));
     }
 
     return NextResponse.json({

--- a/src/app/api/contacts/[id]/segments/route.ts
+++ b/src/app/api/contacts/[id]/segments/route.ts
@@ -1,19 +1,22 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { contacts, segments } from "@/lib/db/schema";
-import { eq, or, sql } from "drizzle-orm";
+import { and, eq, or } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
-async function findContact(idOrEmail: string) {
+async function findContact(idOrEmail: string, userId: string) {
   const isUuid =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
       idOrEmail,
     );
 
   return await db.query.contacts.findFirst({
-    where: isUuid
-      ? or(eq(contacts.id, idOrEmail), eq(contacts.email, idOrEmail))
-      : eq(contacts.email, idOrEmail),
+    where: and(
+      isUuid
+        ? or(eq(contacts.id, idOrEmail), eq(contacts.email, idOrEmail))
+        : eq(contacts.email, idOrEmail),
+      eq(contacts.userId, userId),
+    ),
   });
 }
 
@@ -23,10 +26,12 @@ export async function GET(
 ) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  if (!auth.userId) return unauthorizedResponse();
+  const userId = auth.userId;
 
   try {
     const { id: idOrEmail } = await params;
-    const contact = await findContact(idOrEmail);
+    const contact = await findContact(idOrEmail, userId);
 
     if (!contact) {
       return NextResponse.json({ error: "Contact not found" }, { status: 404 });
@@ -44,7 +49,7 @@ export async function GET(
             createdAt: segments.createdAt,
           })
           .from(segments)
-          .where(eq(segments.name, name))
+          .where(and(eq(segments.name, name), eq(segments.userId, userId)))
           .limit(1);
         return seg
           ? { id: seg.id, name: seg.name, created_at: seg.createdAt }

--- a/src/app/api/contacts/[id]/topics/route.ts
+++ b/src/app/api/contacts/[id]/topics/route.ts
@@ -1,19 +1,22 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { contacts, topics } from "@/lib/db/schema";
-import { eq, or } from "drizzle-orm";
+import { and, eq, or } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
-async function findContact(idOrEmail: string) {
+async function findContact(idOrEmail: string, userId: string) {
   const isUuid =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
       idOrEmail,
     );
 
   return await db.query.contacts.findFirst({
-    where: isUuid
-      ? or(eq(contacts.id, idOrEmail), eq(contacts.email, idOrEmail))
-      : eq(contacts.email, idOrEmail),
+    where: and(
+      isUuid
+        ? or(eq(contacts.id, idOrEmail), eq(contacts.email, idOrEmail))
+        : eq(contacts.email, idOrEmail),
+      eq(contacts.userId, userId),
+    ),
   });
 }
 
@@ -35,10 +38,12 @@ export async function GET(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  if (!auth.userId) return unauthorizedResponse();
+  const userId = auth.userId;
 
   try {
     const { id: idOrEmail } = await params;
-    const contact = await findContact(idOrEmail);
+    const contact = await findContact(idOrEmail, userId);
 
     if (!contact) {
       return NextResponse.json({ error: "Contact not found" }, { status: 404 });
@@ -53,7 +58,7 @@ export async function GET(
     const data = await Promise.all(
       subscriptions.map(async (sub) => {
         const topic = await db.query.topics.findFirst({
-          where: eq(topics.id, sub.topicId),
+          where: and(eq(topics.id, sub.topicId), eq(topics.userId, userId)),
         });
         if (!topic) return null;
         return {
@@ -83,10 +88,12 @@ export async function PATCH(
 ) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  if (!auth.userId) return unauthorizedResponse();
+  const userId = auth.userId;
 
   try {
     const { id: idOrEmail } = await params;
-    const contact = await findContact(idOrEmail);
+    const contact = await findContact(idOrEmail, userId);
 
     if (!contact) {
       return NextResponse.json({ error: "Contact not found" }, { status: 404 });
@@ -114,7 +121,7 @@ export async function PATCH(
     await db
       .update(contacts)
       .set({ topicSubscriptions: updatedSubscriptions })
-      .where(eq(contacts.id, contact.id));
+      .where(and(eq(contacts.id, contact.id), eq(contacts.userId, userId)));
 
     return NextResponse.json({
       object: "contact_topics",

--- a/src/app/api/contacts/bulk/route.ts
+++ b/src/app/api/contacts/bulk/route.ts
@@ -1,12 +1,14 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { contacts, segments, topics } from "@/lib/db/schema";
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  if (!auth.userId) return unauthorizedResponse();
+  const userId = auth.userId;
 
   try {
     const body = await request.json();
@@ -27,7 +29,7 @@ export async function POST(request: NextRequest) {
         );
 
       const segment = await db.query.segments.findFirst({
-        where: eq(segments.id, segment_id),
+        where: and(eq(segments.id, segment_id), eq(segments.userId, userId)),
       });
       if (!segment)
         return NextResponse.json(
@@ -36,7 +38,10 @@ export async function POST(request: NextRequest) {
         );
 
       const targetContacts = await db.query.contacts.findMany({
-        where: inArray(contacts.id, contact_ids),
+        where: and(
+          inArray(contacts.id, contact_ids),
+          eq(contacts.userId, userId),
+        ),
       });
 
       await Promise.all(
@@ -46,7 +51,7 @@ export async function POST(request: NextRequest) {
             await db
               .update(contacts)
               .set({ segments: [...currentSegments, segment.name] })
-              .where(eq(contacts.id, c.id));
+              .where(and(eq(contacts.id, c.id), eq(contacts.userId, userId)));
           }
         }),
       );
@@ -66,13 +71,16 @@ export async function POST(request: NextRequest) {
         );
 
       const topic = await db.query.topics.findFirst({
-        where: eq(topics.id, topic_id),
+        where: and(eq(topics.id, topic_id), eq(topics.userId, userId)),
       });
       if (!topic)
         return NextResponse.json({ error: "Topic not found" }, { status: 404 });
 
       const targetContacts = await db.query.contacts.findMany({
-        where: inArray(contacts.id, contact_ids),
+        where: and(
+          inArray(contacts.id, contact_ids),
+          eq(contacts.userId, userId),
+        ),
       });
 
       await Promise.all(
@@ -92,7 +100,7 @@ export async function POST(request: NextRequest) {
                   { topicId: topic.id, subscribed: true },
                 ],
               })
-              .where(eq(contacts.id, c.id));
+              .where(and(eq(contacts.id, c.id), eq(contacts.userId, userId)));
           } else {
             const updated = currentTopics.map((t) =>
               t.topicId === topic.id ? { ...t, subscribed: true } : t,
@@ -100,7 +108,7 @@ export async function POST(request: NextRequest) {
             await db
               .update(contacts)
               .set({ topicSubscriptions: updated })
-              .where(eq(contacts.id, c.id));
+              .where(and(eq(contacts.id, c.id), eq(contacts.userId, userId)));
           }
         }),
       );

--- a/src/app/api/contacts/import/route.ts
+++ b/src/app/api/contacts/import/route.ts
@@ -1,13 +1,15 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { db } from "@/lib/db";
-import { contacts, segments, topics } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { contacts, segments } from "@/lib/db/schema";
+import { and, eq } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 import Papa from "papaparse";
 
 export async function POST(request: NextRequest) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  if (!auth.userId) return unauthorizedResponse();
+  const userId = auth.userId;
 
   try {
     const formData = await request.formData();
@@ -31,7 +33,7 @@ export async function POST(request: NextRequest) {
     let segmentName = "";
     if (segmentId) {
       const seg = await db.query.segments.findFirst({
-        where: eq(segments.id, segmentId),
+        where: and(eq(segments.id, segmentId), eq(segments.userId, userId)),
       });
       if (seg) segmentName = seg.name;
     }
@@ -58,7 +60,7 @@ export async function POST(request: NextRequest) {
 
       // Simple upsert logic
       const existing = await db.query.contacts.findFirst({
-        where: eq(contacts.email, data.email),
+        where: and(eq(contacts.email, data.email), eq(contacts.userId, userId)),
       });
 
       if (existing) {
@@ -79,7 +81,9 @@ export async function POST(request: NextRequest) {
               ...customProps,
             },
           })
-          .where(eq(contacts.id, existing.id));
+          .where(
+            and(eq(contacts.id, existing.id), eq(contacts.userId, userId)),
+          );
         createdIds.push(existing.id);
       } else {
         const [inserted] = await db
@@ -90,6 +94,7 @@ export async function POST(request: NextRequest) {
             lastName: data.lastName || null,
             segments: segmentName ? [segmentName] : null,
             customProperties: customProps,
+            userId: userId,
           })
           .returning({ id: contacts.id });
         createdIds.push(inserted.id);

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -1,5 +1,6 @@
 import {
   authorizeDashboardOrApiKey,
+  getServerSession,
   unauthorizedResponse,
 } from "@/lib/api-auth";
 import { db } from "@/lib/db";
@@ -8,11 +9,24 @@ import { createContactSchema } from "@/lib/validation/contacts";
 import { type SQL, and, desc, eq, ilike, lt, or, sql } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
+type ContactRouteAuth = NonNullable<
+  Awaited<ReturnType<typeof authorizeDashboardOrApiKey>>
+>;
+
+async function resolveUserId(auth: ContactRouteAuth): Promise<string | null> {
+  if ("userId" in auth) return auth.userId;
+
+  const session = await getServerSession();
+  return session?.user?.id ?? null;
+}
+
 export async function POST(request: NextRequest) {
   const auth = await authorizeDashboardOrApiKey(
     request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const userId = await resolveUserId(auth);
+  if (!userId) return unauthorizedResponse();
 
   try {
     const body = await request.json();
@@ -33,7 +47,10 @@ export async function POST(request: NextRequest) {
       resolvedSegments = await Promise.all(
         validated.segments.map(async (s: string) => {
           const seg = await db.query.segments.findFirst({
-            where: or(eq(segments.id, s), eq(segments.name, s)),
+            where: and(
+              or(eq(segments.id, s), eq(segments.name, s)),
+              eq(segments.userId, userId),
+            ),
           });
           return seg ? seg.name : null;
         }),
@@ -50,7 +67,7 @@ export async function POST(request: NextRequest) {
             const subscription =
               typeof t === "string" ? "opt_in" : t.subscription || "opt_in";
             const found = await db.query.topics.findFirst({
-              where: eq(topics.id, topicId),
+              where: and(eq(topics.id, topicId), eq(topics.userId, userId)),
             });
             if (!found) return null;
             return {
@@ -79,6 +96,7 @@ export async function POST(request: NextRequest) {
             (validated.properties as Record<string, string>) || null,
           segments: resolvedSegments.length > 0 ? resolvedSegments : null,
           topicSubscriptions: resolvedTopics.length > 0 ? resolvedTopics : null,
+          userId,
         })
         .returning({ id: contacts.id });
 
@@ -118,6 +136,8 @@ export async function GET(request: Request) {
     request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const userId = await resolveUserId(auth);
+  if (!userId) return unauthorizedResponse();
 
   const url = new URL(request.url);
   const search = url.searchParams.get("search") || "";
@@ -135,7 +155,7 @@ export async function GET(request: Request) {
       const [seg] = await db
         .select({ name: segments.name })
         .from(segments)
-        .where(eq(segments.id, segmentId))
+        .where(and(eq(segments.id, segmentId), eq(segments.userId, userId)))
         .limit(1);
       if (seg) {
         segmentName = seg.name;
@@ -148,7 +168,7 @@ export async function GET(request: Request) {
       }
     }
 
-    const conditions: SQL[] = [];
+    const conditions: SQL[] = [eq(contacts.userId, userId)];
 
     if (search) {
       conditions.push(

--- a/src/app/api/segments/[id]/contacts/route.ts
+++ b/src/app/api/segments/[id]/contacts/route.ts
@@ -10,6 +10,8 @@ export async function GET(
 ) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  if (!auth.userId) return unauthorizedResponse();
+  const userId = auth.userId;
 
   try {
     const { id: segmentId } = await params;
@@ -18,7 +20,7 @@ export async function GET(
     const [segment] = await db
       .select({ id: segments.id, name: segments.name })
       .from(segments)
-      .where(eq(segments.id, segmentId));
+      .where(and(eq(segments.id, segmentId), eq(segments.userId, userId)));
 
     if (!segment) {
       return NextResponse.json({ error: "Segment not found" }, { status: 404 });
@@ -46,7 +48,12 @@ export async function GET(
         contactsToSegments,
         eq(contacts.id, contactsToSegments.contactId),
       )
-      .where(eq(contactsToSegments.segmentId, segmentId));
+      .where(
+        and(
+          eq(contactsToSegments.segmentId, segmentId),
+          eq(contacts.userId, userId),
+        ),
+      );
 
     const rows = await query.orderBy(desc(contacts.id)).limit(limit + 1);
 

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -216,6 +216,7 @@ describe("route smoke coverage", () => {
     mockValidateApiKey.mockResolvedValue({
       apiKeyId: "key-1",
       permission: "full_access",
+      userId: "user-1",
     });
     mockAuthorizeDashboardOrApiKey.mockResolvedValue({
       apiKeyId: "key-1",

--- a/tests/broadcasts-list.test.ts
+++ b/tests/broadcasts-list.test.ts
@@ -5,14 +5,13 @@ const mockRouter = {
   refresh: vi.fn(),
   replace: vi.fn(),
 };
+const emptySearchParams = new URLSearchParams();
 
 // Mock next/navigation
 vi.mock("next/navigation", () => ({
   useRouter: () => mockRouter,
   usePathname: () => "/broadcasts",
-  useSearchParams: () => ({
-    get: () => null,
-  }),
+  useSearchParams: () => emptySearchParams,
 }));
 
 // Mock next/link

--- a/tests/contact-tenant-isolation.test.ts
+++ b/tests/contact-tenant-isolation.test.ts
@@ -1,0 +1,286 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockContactFindFirst = vi.hoisted(() => vi.fn());
+const mockContactFindMany = vi.hoisted(() => vi.fn());
+const mockSegmentFindFirst = vi.hoisted(() => vi.fn());
+const mockTopicFindFirst = vi.hoisted(() => vi.fn());
+const mockSelect = vi.hoisted(() => vi.fn());
+const mockInsert = vi.hoisted(() => vi.fn());
+const mockUpdate = vi.hoisted(() => vi.fn());
+const mockDelete = vi.hoisted(() => vi.fn());
+
+function makeRequest(url: string, init?: RequestInit) {
+  const request = new Request(url, init) as Request & { nextUrl: URL };
+  request.nextUrl = new URL(url);
+  return request;
+}
+
+type Chain<T> = {
+  from: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  orderBy: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+  innerJoin: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  values: ReturnType<typeof vi.fn>;
+  onConflictDoNothing: ReturnType<typeof vi.fn>;
+  returning: ReturnType<typeof vi.fn>;
+  then: (resolve: (value: T[]) => unknown) => Promise<unknown>;
+};
+
+function makeChain<T>(rows: T[]): Chain<T> {
+  const chain = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    orderBy: vi.fn(() => chain),
+    limit: vi.fn(() => chain),
+    innerJoin: vi.fn(() => chain),
+    set: vi.fn(() => chain),
+    values: vi.fn(() => chain),
+    onConflictDoNothing: vi.fn(() => Promise.resolve()),
+    returning: vi.fn(() => Promise.resolve(rows)),
+    // biome-ignore lint/suspicious/noThenProperty: mocks Drizzle's thenable query builder
+    then: (resolve: (value: T[]) => unknown) => Promise.resolve(resolve(rows)),
+  };
+  return chain;
+}
+
+function expressionContains(value: unknown, expected: string): boolean {
+  const seen = new Set<object>();
+
+  function visit(node: unknown): boolean {
+    if (node === expected) return true;
+    if (typeof node === "string") return node.includes(expected);
+    if (!node || typeof node !== "object") return false;
+    if (seen.has(node)) return false;
+    seen.add(node);
+
+    for (const key of Reflect.ownKeys(node)) {
+      const child = (node as Record<PropertyKey, unknown>)[key];
+      if (visit(child)) return true;
+    }
+
+    return false;
+  }
+
+  return visit(value);
+}
+
+vi.mock("@/lib/api-auth", () => ({
+  authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
+  getServerSession: mockGetServerSession,
+  validateApiKey: mockValidateApiKey,
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      contacts: {
+        findFirst: mockContactFindFirst,
+        findMany: mockContactFindMany,
+      },
+      segments: { findFirst: mockSegmentFindFirst },
+      topics: { findFirst: mockTopicFindFirst },
+    },
+    select: mockSelect,
+    insert: mockInsert,
+    update: mockUpdate,
+    delete: mockDelete,
+  },
+}));
+
+describe("contact API tenant isolation", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue({
+      apiKeyId: "key-b",
+      permission: "full_access",
+      domain: null,
+      userId: "user-b",
+    });
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue({
+      apiKeyId: "key-b",
+      permission: "full_access",
+      domain: null,
+      userId: "user-b",
+    });
+    mockGetServerSession.mockResolvedValue(null);
+  });
+
+  it("returns an empty contact list scoped to the caller user", async () => {
+    const listChain = makeChain([]);
+    mockSelect.mockReturnValueOnce(listChain);
+
+    const route = await import("@/app/api/contacts/route");
+    const response = await route.GET(
+      makeRequest("http://localhost/api/contacts", {
+        headers: { authorization: "Bearer user-b-key" },
+      }),
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      object: "list",
+      data: [],
+      has_more: false,
+    });
+    expect(response.status).toBe(200);
+    expect(
+      expressionContains(listChain.where.mock.calls[0]?.[0], "user_id"),
+    ).toBe(true);
+    expect(
+      expressionContains(listChain.where.mock.calls[0]?.[0], "user-b"),
+    ).toBe(true);
+  });
+
+  it("returns 404 when user B requests user A's contact detail", async () => {
+    mockContactFindFirst.mockResolvedValueOnce(null);
+
+    const route = await import("@/app/api/contacts/[id]/route");
+    const response = await route.GET(
+      makeRequest("http://localhost/api/contacts/contact-a", {
+        headers: { authorization: "Bearer user-b-key" },
+      }),
+      { params: Promise.resolve({ id: "contact-a" }) },
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      error: "Contact not found",
+    });
+    expect(response.status).toBe(404);
+    expect(
+      expressionContains(
+        mockContactFindFirst.mock.calls[0]?.[0]?.where,
+        "user_id",
+      ),
+    ).toBe(true);
+    expect(
+      expressionContains(
+        mockContactFindFirst.mock.calls[0]?.[0]?.where,
+        "user-b",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not update user A's contact when called as user B", async () => {
+    mockContactFindFirst.mockResolvedValueOnce(null);
+
+    const route = await import("@/app/api/contacts/[id]/route");
+    const response = await route.PATCH(
+      makeRequest("http://localhost/api/contacts/contact-a", {
+        method: "PATCH",
+        headers: { authorization: "Bearer user-b-key" },
+        body: JSON.stringify({ first_name: "Mallory" }),
+      }),
+      { params: Promise.resolve({ id: "contact-a" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("does not delete user A's contact when called as user B", async () => {
+    mockContactFindFirst.mockResolvedValueOnce(null);
+
+    const route = await import("@/app/api/contacts/[id]/route");
+    const response = await route.DELETE(
+      makeRequest("http://localhost/api/contacts/contact-a", {
+        method: "DELETE",
+        headers: { authorization: "Bearer user-b-key" },
+      }),
+      { params: Promise.resolve({ id: "contact-a" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("does not bulk-mutate contacts outside the caller tenant", async () => {
+    mockSegmentFindFirst.mockResolvedValueOnce({ id: "seg-b", name: "VIP" });
+    mockContactFindMany.mockResolvedValueOnce([]);
+
+    const route = await import("@/app/api/contacts/bulk/route");
+    const response = await route.POST(
+      makeRequest("http://localhost/api/contacts/bulk", {
+        method: "POST",
+        headers: { authorization: "Bearer user-b-key" },
+        body: JSON.stringify({
+          action: "add_to_segment",
+          segment_id: "seg-b",
+          contact_ids: ["contact-a"],
+        }),
+      }) as never,
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      object: "bulk_action",
+      success: true,
+      count: 0,
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(
+      expressionContains(
+        mockContactFindMany.mock.calls[0]?.[0]?.where,
+        "user_id",
+      ),
+    ).toBe(true);
+    expect(
+      expressionContains(
+        mockContactFindMany.mock.calls[0]?.[0]?.where,
+        "user-b",
+      ),
+    ).toBe(true);
+  });
+
+  it("stamps imported contacts with the caller user", async () => {
+    mockContactFindFirst.mockResolvedValueOnce(null);
+    const insertChain = makeChain([{ id: "contact-b" }]);
+    mockInsert.mockReturnValueOnce(insertChain);
+
+    const formData = {
+      get: (key: string) => {
+        if (key === "file")
+          return { text: async () => "Email\nb@example.com\n" };
+        if (key === "mapping") return JSON.stringify({ Email: "email" });
+        return null;
+      },
+    };
+
+    const route = await import("@/app/api/contacts/import/route");
+    const response = await route.POST({
+      headers: new Headers({ authorization: "Bearer user-b-key" }),
+      formData: async () => formData,
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(insertChain.values.mock.calls[0]?.[0]).toMatchObject({
+      email: "b@example.com",
+      userId: "user-b",
+    });
+  });
+
+  it("rejects contact routes when the caller user cannot be resolved", async () => {
+    mockValidateApiKey.mockResolvedValueOnce({
+      apiKeyId: "legacy-key",
+      permission: "full_access",
+      domain: null,
+      userId: null,
+    });
+
+    const route = await import("@/app/api/contacts/[id]/route");
+    const response = await route.GET(
+      makeRequest("http://localhost/api/contacts/contact-a", {
+        headers: { authorization: "Bearer legacy-key" },
+      }),
+      { params: Promise.resolve({ id: "contact-a" }) },
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockContactFindFirst).not.toHaveBeenCalled();
+  });
+});

--- a/tests/contacts-list.test.ts
+++ b/tests/contacts-list.test.ts
@@ -31,6 +31,12 @@ vi.mock("@/lib/api-auth", () => ({
       apiKeyId: "test",
       permission: "full_access",
       domainId: null,
+      userId: "user-1",
+    }),
+  getServerSession: () =>
+    Promise.resolve({
+      session: { id: "session-1" },
+      user: { id: "user-1" },
     }),
   unauthorizedResponse: () =>
     Response.json({ error: "Missing or invalid API key" }, { status: 401 }),


### PR DESCRIPTION
## Summary

Slice 1/5 for issue #200: contacts tenant isolation only.

- Requires a resolved caller `userId` for contact API access; legacy API keys without `userId` are rejected.
- Stamps new/imported contacts with the caller user.
- Scopes contact list/detail/update/delete/bulk/import flows by `contacts.user_id`.
- Scopes segment/topic lookups used inside contact flows to the caller user.
- Adds negative tenant-isolation tests proving user B gets an empty list/404 and cannot mutate user A contacts.

## Validation

- `bunx vitest run tests/contact-tenant-isolation.test.ts tests/contacts-list.test.ts tests/api-auth-date-range-routes.test.ts`
- `make check`
- `make test`
- Push guardrails: typecheck + changed-file Biome lint passed during `git push`

## Out of scope / remaining issue #200 slices

This PR intentionally does not close issue #200. Remaining slices include:

1. Emails tenant isolation
2. Broadcasts tenant isolation
3. Webhooks/API keys tenant isolation
4. Dashboard metrics/pages tenant isolation
5. Cron/worker and broader historical data cleanup follow-ups

Also intentionally out of scope: contacts unique-index migration and null-owned historical row fallback.
