### PR TITLE
Scope broadcast APIs by tenant

### DIFF
--- a/agent_docs/learnings/active/2026-05-05-issue-200-broadcast-tenant-scope.md
+++ b/agent_docs/learnings/active/2026-05-05-issue-200-broadcast-tenant-scope.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-05
+issue: "#200"
+type: decision
+promoted_to: null
+---
+
+## Broadcast APIs require tenant-owned broadcast predicates
+
+Broadcast list/create/detail/update/delete/send/metrics now resolve a concrete caller `userId` from API-key or dashboard auth, reject requests without one, stamp new broadcasts with that user, and include `broadcasts.user_id` in every ownership read and mutation. Broadcast metrics also verifies broadcast ownership before reading/writing cache, scopes email aggregation by `emails.user_id`, and includes user id in the broadcast metrics cache key.
+
+A real Postgres scenario exposed that the JSONB tag containment predicate must bind a JSON string cast to `jsonb`; passing a JavaScript array directly through Drizzle returned zero matches even for matching tags.

--- a/src/app/api/broadcasts/[id]/metrics/route.ts
+++ b/src/app/api/broadcasts/[id]/metrics/route.ts
@@ -1,4 +1,4 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { unauthorizedResponse } from "@/lib/api-auth";
 import {
   BROADCAST_METRICS_CACHE_TTL_SECONDS,
   getBroadcastMetricsCacheKey,
@@ -7,31 +7,26 @@ import {
 } from "@/lib/cache/dashboard-aggregates";
 import { db } from "@/lib/db";
 import { broadcasts, emails } from "@/lib/db/schema";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
+import { resolveBroadcastRouteUserId } from "../../auth";
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  const userId = await resolveBroadcastRouteUserId(
+    request.headers.get("authorization"),
+  );
+  if (!userId) return unauthorizedResponse();
 
   try {
     const { id } = await params;
-    const cacheKey = getBroadcastMetricsCacheKey(id);
-
-    const cached = await readDashboardAggregateCache<unknown>(cacheKey);
-    if (cached) {
-      return NextResponse.json(cached, {
-        headers: { "x-opensend-cache": "hit" },
-      });
-    }
 
     const [broadcast] = await db
       .select({ id: broadcasts.id })
       .from(broadcasts)
-      .where(eq(broadcasts.id, id))
+      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
       .limit(1);
 
     if (!broadcast) {
@@ -41,7 +36,22 @@ export async function GET(
       );
     }
 
-    const condition = sql`${emails.tags} @> ${[{ name: "broadcast_id", value: id }]}`;
+    const cacheKey = getBroadcastMetricsCacheKey({
+      userId,
+      broadcastId: id,
+    });
+
+    const cached = await readDashboardAggregateCache<unknown>(cacheKey);
+    if (cached) {
+      return NextResponse.json(cached, {
+        headers: { "x-opensend-cache": "hit" },
+      });
+    }
+
+    const condition = and(
+      eq(emails.userId, userId),
+      sql`${emails.tags} @> ${JSON.stringify([{ name: "broadcast_id", value: id }])}::jsonb`,
+    );
 
     const result = await db
       .select({

--- a/src/app/api/broadcasts/[id]/route.ts
+++ b/src/app/api/broadcasts/[id]/route.ts
@@ -1,22 +1,25 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { unauthorizedResponse } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { broadcasts } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
+import { resolveBroadcastRouteUserId } from "../auth";
 
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await validateApiKey(_request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  const userId = await resolveBroadcastRouteUserId(
+    _request.headers.get("authorization"),
+  );
+  if (!userId) return unauthorizedResponse();
 
   try {
     const { id } = await params;
     const [broadcast] = await db
       .select()
       .from(broadcasts)
-      .where(eq(broadcasts.id, id))
+      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
       .limit(1);
 
     if (!broadcast) {
@@ -55,8 +58,10 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  const userId = await resolveBroadcastRouteUserId(
+    request.headers.get("authorization"),
+  );
+  if (!userId) return unauthorizedResponse();
 
   try {
     const { id } = await params;
@@ -88,7 +93,7 @@ export async function PATCH(
     const [updated] = await db
       .update(broadcasts)
       .set(updateData)
-      .where(eq(broadcasts.id, id))
+      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
       .returning();
 
     if (!updated) {
@@ -127,8 +132,10 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await validateApiKey(_request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  const userId = await resolveBroadcastRouteUserId(
+    _request.headers.get("authorization"),
+  );
+  if (!userId) return unauthorizedResponse();
 
   try {
     const { id } = await params;
@@ -137,7 +144,7 @@ export async function DELETE(
     const results = await db
       .select({ status: broadcasts.status })
       .from(broadcasts)
-      .where(eq(broadcasts.id, id))
+      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
       .limit(1);
 
     const existing = results ? results[0] : undefined;
@@ -158,7 +165,7 @@ export async function DELETE(
 
     const deleteResults = await db
       .delete(broadcasts)
-      .where(eq(broadcasts.id, id))
+      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
       .returning();
 
     const deleted = deleteResults ? deleteResults[0] : undefined;

--- a/src/app/api/broadcasts/[id]/send/route.ts
+++ b/src/app/api/broadcasts/[id]/send/route.ts
@@ -1,15 +1,18 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { unauthorizedResponse } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { broadcasts } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
+import { resolveBroadcastRouteUserId } from "../../auth";
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  const userId = await resolveBroadcastRouteUserId(
+    request.headers.get("authorization"),
+  );
+  if (!userId) return unauthorizedResponse();
 
   try {
     const { id } = await params;
@@ -19,7 +22,7 @@ export async function POST(
     const [existing] = await db
       .select({ status: broadcasts.status })
       .from(broadcasts)
-      .where(eq(broadcasts.id, id))
+      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
       .limit(1);
 
     if (!existing) {
@@ -44,7 +47,7 @@ export async function POST(
         status: nextStatus,
         scheduledAt: scheduledAt,
       })
-      .where(eq(broadcasts.id, id))
+      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
       .returning();
 
     return NextResponse.json({

--- a/src/app/api/broadcasts/auth.ts
+++ b/src/app/api/broadcasts/auth.ts
@@ -1,0 +1,23 @@
+import { authorizeDashboardOrApiKey, getServerSession } from "@/lib/api-auth";
+
+type BroadcastRouteAuth = NonNullable<
+  Awaited<ReturnType<typeof authorizeDashboardOrApiKey>>
+>;
+
+async function getUserIdFromAuth(
+  auth: BroadcastRouteAuth,
+): Promise<string | null> {
+  if ("userId" in auth) return auth.userId;
+
+  const session = await getServerSession();
+  return session?.user?.id ?? null;
+}
+
+export async function resolveBroadcastRouteUserId(
+  authHeader: string | null | undefined,
+): Promise<string | null> {
+  const auth = await authorizeDashboardOrApiKey(authHeader);
+  if (!auth) return null;
+
+  return getUserIdFromAuth(auth);
+}

--- a/src/app/api/broadcasts/route.ts
+++ b/src/app/api/broadcasts/route.ts
@@ -1,12 +1,15 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { unauthorizedResponse } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { broadcasts } from "@/lib/db/schema";
 import { type SQL, and, desc, eq, ilike, lt } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
+import { resolveBroadcastRouteUserId } from "./auth";
 
 export async function GET(request: NextRequest) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  const userId = await resolveBroadcastRouteUserId(
+    request.headers.get("authorization"),
+  );
+  if (!userId) return unauthorizedResponse();
 
   try {
     const url = request.nextUrl;
@@ -19,7 +22,7 @@ export async function GET(request: NextRequest) {
     const segmentId = url.searchParams.get("segmentId")?.trim() || "";
     const after = url.searchParams.get("after") || "";
 
-    const conditions: SQL[] = [];
+    const conditions: SQL[] = [eq(broadcasts.userId, userId)];
     if (search) {
       conditions.push(ilike(broadcasts.name, `%${search}%`));
     }
@@ -49,7 +52,7 @@ export async function GET(request: NextRequest) {
         scheduledAt: broadcasts.scheduledAt,
       })
       .from(broadcasts)
-      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .where(and(...conditions))
       .orderBy(desc(broadcasts.id))
       .limit(limit + 1);
 
@@ -79,8 +82,10 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  const userId = await resolveBroadcastRouteUserId(
+    request.headers.get("authorization"),
+  );
+  if (!userId) return unauthorizedResponse();
 
   try {
     const body = await request.json();
@@ -113,6 +118,7 @@ export async function POST(request: NextRequest) {
         topicId: body.topic_id || null,
         status: shouldSend ? (scheduledAt ? "scheduled" : "queued") : "draft",
         scheduledAt,
+        userId,
       })
       .returning();
 

--- a/src/lib/cache/dashboard-aggregates.ts
+++ b/src/lib/cache/dashboard-aggregates.ts
@@ -24,11 +24,15 @@ export function getMetricsAggregateCacheKey(params: {
   ].join(":");
 }
 
-export function getBroadcastMetricsCacheKey(broadcastId: string): string {
+export function getBroadcastMetricsCacheKey(params: {
+  userId: string;
+  broadcastId: string;
+}): string {
   return [
     DASHBOARD_AGGREGATE_CACHE_PREFIX,
     "broadcast-metrics",
-    normalizeCacheSegment(broadcastId),
+    normalizeCacheSegment(params.userId),
+    normalizeCacheSegment(params.broadcastId),
   ].join(":");
 }
 

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -221,6 +221,7 @@ describe("route smoke coverage", () => {
     mockAuthorizeDashboardOrApiKey.mockResolvedValue({
       apiKeyId: "key-1",
       permission: "full_access",
+      userId: "user-1",
     });
     mockGetServerSession.mockResolvedValue({
       session: { id: "session-1" },

--- a/tests/broadcast-metrics-route.test.ts
+++ b/tests/broadcast-metrics-route.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockReadDashboardAggregateCache = vi.hoisted(() => vi.fn());
 const mockWriteDashboardAggregateCache = vi.hoisted(() => vi.fn());
 const mockSelect = vi.hoisted(() => vi.fn());
@@ -23,13 +24,17 @@ vi.mock("@/lib/api-auth", () => ({
       status: 401,
       headers: { "content-type": "application/json" },
     }),
-  validateApiKey: mockValidateApiKey,
+  authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
+  getServerSession: mockGetServerSession,
 }));
 
 vi.mock("@/lib/cache/dashboard-aggregates", () => ({
   BROADCAST_METRICS_CACHE_TTL_SECONDS: 120,
-  getBroadcastMetricsCacheKey: (id: string) =>
-    `dashboard-aggregate:v1:broadcast-metrics:${id}`,
+  getBroadcastMetricsCacheKey: (params: {
+    userId: string;
+    broadcastId: string;
+  }) =>
+    `dashboard-aggregate:v1:broadcast-metrics:${params.userId}:${params.broadcastId}`,
   readDashboardAggregateCache: mockReadDashboardAggregateCache,
   writeDashboardAggregateCache: mockWriteDashboardAggregateCache,
 }));
@@ -50,12 +55,17 @@ describe("broadcast metrics route cache", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    mockValidateApiKey.mockResolvedValue({ apiKeyId: "k1" });
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue({
+      apiKeyId: "k1",
+      userId: "user-1",
+    });
+    mockGetServerSession.mockResolvedValue(null);
     mockReadDashboardAggregateCache.mockResolvedValue(null);
     mockWriteDashboardAggregateCache.mockResolvedValue(undefined);
   });
 
-  it("returns cached broadcast aggregates without querying the database", async () => {
+  it("returns cached broadcast aggregates after verifying broadcast ownership", async () => {
+    mockSelect.mockReturnValueOnce(makeChain([{ id: "b1" }]));
     mockReadDashboardAggregateCache.mockResolvedValue({
       object: "broadcast_metrics",
       broadcast_id: "b1",
@@ -81,7 +91,7 @@ describe("broadcast metrics route cache", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("x-opensend-cache")).toBe("hit");
-    expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockSelect).toHaveBeenCalledOnce();
     expect(mockWriteDashboardAggregateCache).not.toHaveBeenCalled();
   });
 
@@ -113,7 +123,7 @@ describe("broadcast metrics route cache", () => {
     expect(response.headers.get("x-opensend-cache")).toBe("miss");
     expect(mockWriteDashboardAggregateCache).toHaveBeenCalledOnce();
     expect(mockWriteDashboardAggregateCache).toHaveBeenCalledWith(
-      "dashboard-aggregate:v1:broadcast-metrics:b1",
+      "dashboard-aggregate:v1:broadcast-metrics:user-1:b1",
       expect.objectContaining({
         object: "broadcast_metrics",
         broadcast_id: "b1",

--- a/tests/broadcast-tenant-routes.test.ts
+++ b/tests/broadcast-tenant-routes.test.ts
@@ -1,0 +1,302 @@
+import type { SQL } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockReadDashboardAggregateCache = vi.hoisted(() => vi.fn());
+const mockWriteDashboardAggregateCache = vi.hoisted(() => vi.fn());
+const mockDb = vi.hoisted(() => ({
+  select: vi.fn(),
+  insert: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock("@/lib/api-auth", () => ({
+  authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
+  getServerSession: mockGetServerSession,
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/cache/dashboard-aggregates", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/cache/dashboard-aggregates")
+  >("@/lib/cache/dashboard-aggregates");
+  return {
+    ...actual,
+    readDashboardAggregateCache: mockReadDashboardAggregateCache,
+    writeDashboardAggregateCache: mockWriteDashboardAggregateCache,
+  };
+});
+
+vi.mock("@/lib/db", () => ({
+  db: mockDb,
+}));
+
+function deepValues(value: unknown, seen = new WeakSet<object>()): unknown[] {
+  if (value === null || typeof value !== "object") return [value];
+  if (seen.has(value)) return [];
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => deepValues(item, seen));
+  }
+
+  return Object.values(value as Record<string, unknown>).flatMap((item) =>
+    deepValues(item, seen),
+  );
+}
+
+function expectTenantPredicate(
+  clause: SQL<unknown> | undefined,
+  userId = "user-b",
+) {
+  expect(clause).toBeDefined();
+  const values = deepValues(clause);
+  expect(values).toContain("user_id");
+  expect(values).toContain(userId);
+}
+
+function makeNextRequest(url: string, init?: RequestInit): NextRequest {
+  const request = new Request(url, init) as Request & { nextUrl: URL };
+  request.nextUrl = new URL(url);
+  return request as unknown as NextRequest;
+}
+
+function jsonRequest(url: string, body: Record<string, unknown>): NextRequest {
+  return makeNextRequest(url, {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer re_test",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function selectRows<T>(rows: T[], whereClauses: SQL<unknown>[]) {
+  const chain = {
+    from: vi.fn(() => chain),
+    where: vi.fn((clause: SQL<unknown>) => {
+      whereClauses.push(clause);
+      return chain;
+    }),
+    orderBy: vi.fn(() => chain),
+    limit: vi.fn(() => chain),
+    // biome-ignore lint/suspicious/noThenProperty: mocks Drizzle's thenable query builder
+    then: (resolve: (value: T[]) => unknown) => Promise.resolve(resolve(rows)),
+  };
+  return chain;
+}
+
+function insertReturning<T>(rows: T[]) {
+  const returning = vi.fn().mockResolvedValue(rows);
+  const values = vi.fn(() => ({ returning }));
+  mockDb.insert.mockReturnValue({ values });
+  return { values, returning };
+}
+
+function updateReturning<T>(rows: T[], whereClauses: SQL<unknown>[]) {
+  const returning = vi.fn().mockResolvedValue(rows);
+  const where = vi.fn((clause: SQL<unknown>) => {
+    whereClauses.push(clause);
+    return { returning };
+  });
+  const set = vi.fn(() => ({ where }));
+  mockDb.update.mockReturnValue({ set });
+  return { set, where, returning };
+}
+
+function deleteReturning<T>(rows: T[], whereClauses: SQL<unknown>[]) {
+  const returning = vi.fn().mockResolvedValue(rows);
+  const where = vi.fn((clause: SQL<unknown>) => {
+    whereClauses.push(clause);
+    return { returning };
+  });
+  mockDb.delete.mockReturnValue({ where });
+  return { where, returning };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mockAuthorizeDashboardOrApiKey.mockResolvedValue({
+    apiKeyId: "key-user-b",
+    permission: "full_access",
+    domain: null,
+    userId: "user-b",
+  });
+  mockGetServerSession.mockResolvedValue(null);
+  mockReadDashboardAggregateCache.mockResolvedValue(null);
+  mockWriteDashboardAggregateCache.mockResolvedValue(undefined);
+});
+
+describe("broadcast tenant isolation", () => {
+  it("scopes broadcast list queries to the authenticated user", async () => {
+    const whereClauses: SQL<unknown>[] = [];
+    mockDb.select.mockReturnValue(selectRows([], whereClauses));
+
+    const { GET } = await import("@/app/api/broadcasts/route");
+    const response = await GET(
+      makeNextRequest("http://localhost:3015/api/broadcasts"),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.data).toEqual([]);
+    expectTenantPredicate(whereClauses.at(-1));
+  });
+
+  it("stamps created broadcasts with the authenticated user id", async () => {
+    const insertChain = insertReturning([
+      {
+        id: "broadcast-1",
+        name: "Launch",
+        status: "draft",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+      },
+    ]);
+
+    const { POST } = await import("@/app/api/broadcasts/route");
+    const response = await POST(
+      jsonRequest("http://localhost:3015/api/broadcasts", {
+        name: "Launch",
+        from: "team@example.com",
+        subject: "Hello",
+        segment_id: "segment-1",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(insertChain.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Launch",
+        userId: "user-b",
+      }),
+    );
+  });
+
+  it("returns 404 for broadcast detail reads outside the tenant", async () => {
+    const whereClauses: SQL<unknown>[] = [];
+    mockDb.select.mockReturnValue(selectRows([], whereClauses));
+
+    const { GET } = await import("@/app/api/broadcasts/[id]/route");
+    const response = await GET(
+      makeNextRequest("http://localhost:3015/api/broadcasts/broadcast-a", {
+        headers: { Authorization: "Bearer re_test" },
+      }),
+      { params: Promise.resolve({ id: "broadcast-a" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expectTenantPredicate(whereClauses.at(-1));
+  });
+
+  it("scopes broadcast updates and deletes by id plus user id", async () => {
+    const updateWheres: SQL<unknown>[] = [];
+    updateReturning(
+      [
+        {
+          id: "broadcast-1",
+          name: "Renamed",
+          status: "draft",
+        },
+      ],
+      updateWheres,
+    );
+
+    const { PATCH, DELETE } = await import("@/app/api/broadcasts/[id]/route");
+    const patchResponse = await PATCH(
+      jsonRequest("http://localhost:3015/api/broadcasts/broadcast-1", {
+        name: "Renamed",
+      }),
+      { params: Promise.resolve({ id: "broadcast-1" }) },
+    );
+
+    expect(patchResponse.status).toBe(200);
+    expectTenantPredicate(updateWheres.at(-1));
+
+    const selectWheres: SQL<unknown>[] = [];
+    const deleteWheres: SQL<unknown>[] = [];
+    mockDb.select.mockReturnValue(
+      selectRows([{ id: "broadcast-1", status: "draft" }], selectWheres),
+    );
+    deleteReturning([{ id: "broadcast-1" }], deleteWheres);
+
+    const deleteResponse = await DELETE(
+      makeNextRequest("http://localhost:3015/api/broadcasts/broadcast-1", {
+        method: "DELETE",
+        headers: { Authorization: "Bearer re_test" },
+      }),
+      { params: Promise.resolve({ id: "broadcast-1" }) },
+    );
+
+    expect(deleteResponse.status).toBe(200);
+    expectTenantPredicate(selectWheres.at(-1));
+    expectTenantPredicate(deleteWheres.at(-1));
+  });
+
+  it("scopes broadcast send ownership checks and status updates", async () => {
+    const selectWheres: SQL<unknown>[] = [];
+    const updateWheres: SQL<unknown>[] = [];
+    mockDb.select.mockReturnValue(
+      selectRows([{ id: "broadcast-1", status: "draft" }], selectWheres),
+    );
+    updateReturning([{ id: "broadcast-1", status: "queued" }], updateWheres);
+
+    const { POST } = await import("@/app/api/broadcasts/[id]/send/route");
+    const response = await POST(
+      jsonRequest("http://localhost:3015/api/broadcasts/broadcast-1/send", {}),
+      { params: Promise.resolve({ id: "broadcast-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expectTenantPredicate(selectWheres.at(-1));
+    expectTenantPredicate(updateWheres.at(-1));
+  });
+
+  it("scopes broadcast metrics ownership, email aggregation, and cache key", async () => {
+    const broadcastWheres: SQL<unknown>[] = [];
+    const emailWheres: SQL<unknown>[] = [];
+    mockDb.select
+      .mockReturnValueOnce(selectRows([{ id: "broadcast-1" }], broadcastWheres))
+      .mockReturnValueOnce(
+        selectRows(
+          [
+            {
+              total: 2,
+              delivered: 2,
+              bounced: 0,
+              complained: 0,
+              opened: 1,
+              clicked: 1,
+            },
+          ],
+          emailWheres,
+        ),
+      );
+
+    const { GET } = await import("@/app/api/broadcasts/[id]/metrics/route");
+    const response = await GET(
+      makeNextRequest(
+        "http://localhost:3015/api/broadcasts/broadcast-1/metrics",
+        { headers: { Authorization: "Bearer re_test" } },
+      ),
+      { params: Promise.resolve({ id: "broadcast-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expectTenantPredicate(broadcastWheres.at(-1));
+    expectTenantPredicate(emailWheres.at(-1));
+    expect(mockReadDashboardAggregateCache).toHaveBeenCalledWith(
+      "dashboard-aggregate:v1:broadcast-metrics:user-b:broadcast-1",
+    );
+    expect(mockWriteDashboardAggregateCache).toHaveBeenCalledWith(
+      "dashboard-aggregate:v1:broadcast-metrics:user-b:broadcast-1",
+      expect.objectContaining({ object: "broadcast_metrics" }),
+      120,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Scopes broadcast list/create/detail/update/delete/send routes to the resolved caller `userId`.
- Scopes broadcast metrics by tenant before cache reads, includes `userId` in cache keys, and filters email aggregates by `emails.user_id`.
- Adds tenant-isolation unit coverage plus a learning from the real Postgres JSONB tag predicate check.

Part of #200 (broadcast slice only; does not close the parent issue).

## Changes
- **Broadcast auth**: add a route helper that resolves dashboard/API-key auth to a concrete user id and rejects missing-user auth.
- **Broadcast CRUD/send**: stamp created broadcasts and add `broadcasts.user_id` predicates to reads and mutations.
- **Broadcast metrics**: verify owned broadcast before cache lookup, use tenant-aware cache key, scope email aggregation by user, and cast JSON tag containment parameter to `jsonb`.
- **Tests/docs**: add `tests/broadcast-tenant-routes.test.ts`, update cache/smoke tests, and capture the JSONB predicate learning.

## How to Test
- [x] `make check`
- [x] `make test`
- [x] `bun run test -- tests/broadcast-tenant-routes.test.ts tests/broadcast-metrics-route.test.ts tests/api-auth-date-range-routes.test.ts`
- [x] `bun .scratch/issue-200-broadcast-tenant-isolation.ts` against local Postgres (`localhost:5439`); `.scratch/` removed before commit

## Notes
- Contacts and emails slices are already on `staging` via #202 and #204.
- Remaining #200 slices: webhooks/API keys, dashboard metrics/pages, cron hardening, and any approved segment/topic tenant semantics.