### PR TITLE
fix(deploy): re-expose cli-plugins so buildx works under isolated DOCKER_CONFIG

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,4 +25,15 @@ jobs:
           # runner does not hit the keychain-bound credsStore helper.
           # The runner host owns ~/.docker-actions/config.json.
           export DOCKER_CONFIG="${HOME}/.docker-actions"
+          # Re-expose cli-plugins (buildx) since DOCKER_CONFIG overrides the
+          # plugin search path away from ~/.docker/cli-plugins.
+          mkdir -p "${DOCKER_CONFIG}/cli-plugins"
+          for src in "${HOME}/.docker/cli-plugins" "/Applications/Docker.app/Contents/Resources/cli-plugins"; do
+            [ -d "${src}" ] || continue
+            for plugin in "${src}"/*; do
+              [ -e "${plugin}" ] || continue
+              ln -sfn "${plugin}" "${DOCKER_CONFIG}/cli-plugins/$(basename "${plugin}")"
+            done
+          done
+          docker buildx version
           bash scripts/deploy.sh all


### PR DESCRIPTION
## Summary
- PR #203's `DOCKER_CONFIG=~/.docker-actions` isolation also moved Docker's plugin search path away from `~/.docker/cli-plugins`, so `docker buildx` could not be found.
- Resulting deploy run hit `unknown flag: --platform` (exit 125) because `buildx` was missing and `docker build` does not accept `--platform`.

## Fix
- Symlink existing cli-plugins from `~/.docker/cli-plugins` and the Docker Desktop bundle into `${DOCKER_CONFIG}/cli-plugins` at deploy time.
- Add `docker buildx version` as a smoke test so a missing plugin fails loudly before the build.

## Test plan
- [ ] Deploy workflow on main reaches `docker buildx build --push` and pushes both images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)