### PR TITLE
Scope webhooks and API keys to authenticated tenants

### DIFF
--- a/agent_docs/learnings/active/2026-05-05-issue-200-webhooks-apikeys-tenant-scope.md
+++ b/agent_docs/learnings/active/2026-05-05-issue-200-webhooks-apikeys-tenant-scope.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-05
+issue: "#200"
+type: decision
+promoted_to: null
+---
+
+## Public webhook/API-key routes require caller-owned predicates
+
+Webhook API list/create/detail/update/delete now require a resolved API-key `userId`, stamp new webhook rows with that user, and pass `userId` through the service/repository layer so public CRUD predicates include `webhooks.user_id`. API-key list/get/delete similarly require a resolved owner and pass `userId` through service/repository calls, so delete invalidates cache only after finding an owned key.
+
+Webhook dispatch still needs service-owned lookup of subscribed hooks after SES ingestion, so the repository exposes explicit `findByIdForDispatch`/`listForDispatch` helpers for that worker path instead of letting public route operations fall back to unscoped reads.

--- a/packages/core/src/db/repositories/apiKeyRepo.ts
+++ b/packages/core/src/db/repositories/apiKeyRepo.ts
@@ -2,10 +2,14 @@ import { and, desc, eq, lt } from "drizzle-orm";
 import { db } from "../client";
 import { apiKeys } from "../schema";
 
+function ownedApiKeyWhere(id: string, userId: string) {
+  return and(eq(apiKeys.id, id), eq(apiKeys.userId, userId));
+}
+
 export const apiKeyRepo = {
-  async findById(id: string) {
+  async findById(id: string, userId: string) {
     return await db.query.apiKeys.findFirst({
-      where: eq(apiKeys.id, id),
+      where: ownedApiKeyWhere(id, userId),
     });
   },
 
@@ -19,23 +23,23 @@ export const apiKeyRepo = {
     return await db.insert(apiKeys).values(data).returning();
   },
 
-  async delete(id: string) {
+  async delete(id: string, userId: string) {
     return await db
       .delete(apiKeys)
-      .where(eq(apiKeys.id, id))
+      .where(ownedApiKeyWhere(id, userId))
       .returning({ id: apiKeys.id });
   },
 
-  async list(options: { limit?: number; after?: string } = {}) {
-    const { limit = 20, after } = options;
-    const conditions = [];
+  async list(options: { userId: string; limit?: number; after?: string }) {
+    const { userId, limit = 20, after } = options;
+    const conditions = [eq(apiKeys.userId, userId)];
 
     if (after) conditions.push(lt(apiKeys.id, after));
 
     const results = await db
       .select()
       .from(apiKeys)
-      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .where(and(...conditions))
       .orderBy(desc(apiKeys.id))
       .limit(limit + 1);
 

--- a/packages/core/src/db/repositories/webhookRepo.ts
+++ b/packages/core/src/db/repositories/webhookRepo.ts
@@ -2,8 +2,18 @@ import { and, desc, eq, lt } from "drizzle-orm";
 import { db } from "../client";
 import { webhooks } from "../schema";
 
+function ownedWebhookWhere(id: string, userId: string) {
+  return and(eq(webhooks.id, id), eq(webhooks.userId, userId));
+}
+
 export const webhookRepo = {
-  async findById(id: string) {
+  async findById(id: string, userId: string) {
+    return await db.query.webhooks.findFirst({
+      where: ownedWebhookWhere(id, userId),
+    });
+  },
+
+  async findByIdForDispatch(id: string) {
     return await db.query.webhooks.findFirst({
       where: eq(webhooks.id, id),
     });
@@ -13,22 +23,45 @@ export const webhookRepo = {
     return await db.insert(webhooks).values(data).returning();
   },
 
-  async update(id: string, data: Partial<typeof webhooks.$inferInsert>) {
+  async update(
+    id: string,
+    userId: string,
+    data: Partial<typeof webhooks.$inferInsert>,
+  ) {
     return await db
       .update(webhooks)
       .set(data)
-      .where(eq(webhooks.id, id))
+      .where(ownedWebhookWhere(id, userId))
       .returning();
   },
 
-  async delete(id: string) {
+  async delete(id: string, userId: string) {
     return await db
       .delete(webhooks)
-      .where(eq(webhooks.id, id))
+      .where(ownedWebhookWhere(id, userId))
       .returning({ id: webhooks.id });
   },
 
-  async list(options: { limit?: number; after?: string } = {}) {
+  async list(options: { userId: string; limit?: number; after?: string }) {
+    const { userId, limit = 20, after } = options;
+    const conditions = [eq(webhooks.userId, userId)];
+
+    if (after) conditions.push(lt(webhooks.id, after));
+
+    const results = await db
+      .select()
+      .from(webhooks)
+      .where(and(...conditions))
+      .orderBy(desc(webhooks.id))
+      .limit(limit + 1);
+
+    const hasMore = results.length > limit;
+    const data = hasMore ? results.slice(0, limit) : results;
+
+    return { data, hasMore };
+  },
+
+  async listForDispatch(options: { limit?: number; after?: string } = {}) {
     const { limit = 20, after } = options;
     const conditions = [];
 

--- a/packages/core/src/services/apiKeys.ts
+++ b/packages/core/src/services/apiKeys.ts
@@ -56,13 +56,13 @@ export class ApiKeyServiceError extends Error {
 }
 
 export type ApiKeyRepository = {
-  list(options: { limit?: number; after?: string }): Promise<{
+  list(options: { userId: string; limit?: number; after?: string }): Promise<{
     data: ApiKeyRow[];
     hasMore: boolean;
   }>;
   create(data: ApiKeyInsert): Promise<ApiKeyRow[]>;
-  findById(id: string): Promise<ApiKeyRow | undefined>;
-  delete(id: string): Promise<Array<{ id: string }>>;
+  findById(id: string, userId: string): Promise<ApiKeyRow | undefined>;
+  delete(id: string, userId: string): Promise<Array<{ id: string }>>;
 };
 
 export type ApiKeyServiceDependencies = {
@@ -94,10 +94,12 @@ export function createApiKeyService({
 }: ApiKeyServiceDependencies = {}) {
   return {
     async listApiKeys(options: {
+      userId: string;
       limit?: number;
       after?: string;
     }): Promise<ApiKeyListResult> {
       const result = await repository.list({
+        userId: options.userId,
         limit: normalizeLimit(options.limit),
         after: options.after || undefined,
       });
@@ -146,8 +148,8 @@ export function createApiKeyService({
       };
     },
 
-    async getApiKey(id: string): Promise<ApiKeyDetail> {
-      const key = await repository.findById(id);
+    async getApiKey(id: string, userId: string): Promise<ApiKeyDetail> {
+      const key = await repository.findById(id, userId);
       if (!key) {
         throw new ApiKeyServiceError("not_found", "API key not found");
       }
@@ -160,13 +162,16 @@ export function createApiKeyService({
       };
     },
 
-    async deleteApiKey(id: string): Promise<DeleteApiKeyResult> {
-      const existing = await repository.findById(id);
+    async deleteApiKey(
+      id: string,
+      userId: string,
+    ): Promise<DeleteApiKeyResult> {
+      const existing = await repository.findById(id, userId);
       if (!existing) {
         throw new ApiKeyServiceError("not_found", "API key not found");
       }
 
-      const [deleted] = await repository.delete(id);
+      const [deleted] = await repository.delete(id, userId);
       await invalidateAuthCache(existing.tokenHash);
 
       return {

--- a/packages/core/src/services/webhook.ts
+++ b/packages/core/src/services/webhook.ts
@@ -28,6 +28,7 @@ export type WebhookListResult = {
 };
 
 export type CreateWebhookInput = {
+  userId: string;
   endpoint: string;
   events: string[];
 };
@@ -40,14 +41,18 @@ export type UpdateWebhookInput = {
 };
 
 export type WebhookRepository = {
-  list(options: { limit?: number; after?: string }): Promise<{
+  list(options: { userId: string; limit?: number; after?: string }): Promise<{
     data: WebhookRow[];
     hasMore: boolean;
   }>;
   create(data: WebhookInsert): Promise<WebhookRow[]>;
-  findById(id: string): Promise<WebhookRow | undefined>;
-  update(id: string, data: Partial<WebhookInsert>): Promise<WebhookRow[]>;
-  delete(id: string): Promise<Array<{ id: string }>>;
+  findById(id: string, userId: string): Promise<WebhookRow | undefined>;
+  update(
+    id: string,
+    userId: string,
+    data: Partial<WebhookInsert>,
+  ): Promise<WebhookRow[]>;
+  delete(id: string, userId: string): Promise<Array<{ id: string }>>;
 };
 
 export type WebhookServiceDependencies = {
@@ -110,10 +115,12 @@ export function createWebhookService({
 }: WebhookServiceDependencies = {}) {
   return {
     async listWebhooks(options: {
+      userId: string;
       limit?: number;
       after?: string;
     }): Promise<WebhookListResult> {
       const result = await repository.list({
+        userId: options.userId,
         limit: normalizeLimit(options.limit),
         after: options.after || undefined,
       });
@@ -132,26 +139,34 @@ export function createWebhookService({
         url: input.endpoint,
         eventTypes: input.events,
         signingSecret,
+        userId: input.userId,
       });
 
       return toWebhookCreateResult(row);
     },
 
-    async getWebhook(id: string): Promise<WebhookServiceDetail | undefined> {
-      const row = await repository.findById(id);
+    async getWebhook(
+      id: string,
+      userId: string,
+    ): Promise<WebhookServiceDetail | undefined> {
+      const row = await repository.findById(id, userId);
       return row ? toWebhookListItem(row) : undefined;
     },
 
     async updateWebhook(
       id: string,
+      userId: string,
       input: UpdateWebhookInput,
     ): Promise<WebhookServiceDetail | undefined> {
-      const [row] = await repository.update(id, buildUpdateData(input));
+      const [row] = await repository.update(id, userId, buildUpdateData(input));
       return row ? toWebhookListItem(row) : undefined;
     },
 
-    async deleteWebhook(id: string): Promise<{ id: string } | undefined> {
-      const [deleted] = await repository.delete(id);
+    async deleteWebhook(
+      id: string,
+      userId: string,
+    ): Promise<{ id: string } | undefined> {
+      const [deleted] = await repository.delete(id, userId);
       return deleted;
     },
   };
@@ -164,7 +179,7 @@ export class WebhookService {
     this.service = createWebhookService(dependencies);
   }
 
-  async list(options: { limit?: number; after?: string }) {
+  async list(options: { userId: string; limit?: number; after?: string }) {
     return await this.service.listWebhooks(options);
   }
 
@@ -172,16 +187,16 @@ export class WebhookService {
     return await this.service.createWebhook(input);
   }
 
-  async get(id: string) {
-    return await this.service.getWebhook(id);
+  async get(id: string, userId: string) {
+    return await this.service.getWebhook(id, userId);
   }
 
-  async update(id: string, input: UpdateWebhookInput) {
-    return await this.service.updateWebhook(id, input);
+  async update(id: string, userId: string, input: UpdateWebhookInput) {
+    return await this.service.updateWebhook(id, userId, input);
   }
 
-  async delete(id: string) {
-    return await this.service.deleteWebhook(id);
+  async delete(id: string, userId: string) {
+    return await this.service.deleteWebhook(id, userId);
   }
 }
 

--- a/packages/ingester/src/dispatcher.ts
+++ b/packages/ingester/src/dispatcher.ts
@@ -50,7 +50,7 @@ export class WebhookDispatcher {
     if (!delivery) return null;
 
     const [webhook, event] = await Promise.all([
-      webhookRepo.findById(delivery.webhookId),
+      webhookRepo.findByIdForDispatch(delivery.webhookId),
       emailEventRepo.findById(delivery.eventId),
     ]);
 

--- a/packages/ingester/src/index.ts
+++ b/packages/ingester/src/index.ts
@@ -342,7 +342,7 @@ app.post("/events/ses", async (c) => {
       return c.text("OK");
     }
 
-    const { data: hooks } = await webhookRepo.list({ limit: 100 });
+    const { data: hooks } = await webhookRepo.listForDispatch({ limit: 100 });
     for (const hook of hooks) {
       const types = hook.eventTypes as string[];
       if (hook.status === "active" && types.includes(webhookEventType)) {

--- a/src/app/api/api-keys/[id]/route.ts
+++ b/src/app/api/api-keys/[id]/route.ts
@@ -25,13 +25,13 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth || auth.permission !== "full_access") {
+  if (!auth?.userId || auth.permission !== "full_access") {
     return unauthorizedResponse();
   }
 
   const { id } = await params;
   try {
-    const key = await apiKeyService().getApiKey(id);
+    const key = await apiKeyService().getApiKey(id, auth.userId);
 
     return Response.json({
       object: "api_key",
@@ -50,13 +50,13 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth || auth.permission !== "full_access") {
+  if (!auth?.userId || auth.permission !== "full_access") {
     return unauthorizedResponse();
   }
 
   const { id } = await params;
   try {
-    await apiKeyService().deleteApiKey(id);
+    await apiKeyService().deleteApiKey(id, auth.userId);
 
     return new Response(null, { status: 200 });
   } catch (err) {

--- a/src/app/api/api-keys/route.ts
+++ b/src/app/api/api-keys/route.ts
@@ -48,7 +48,7 @@ function parseCreateApiKeyBody(body: unknown): {
 
 export async function GET(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth || auth.permission !== "full_access") {
+  if (!auth?.userId || auth.permission !== "full_access") {
     return unauthorizedResponse();
   }
 
@@ -57,7 +57,11 @@ export async function GET(request: Request): Promise<Response> {
   const after = url.searchParams.get("after") || "";
 
   try {
-    const result = await apiKeyService().listApiKeys({ limit, after });
+    const result = await apiKeyService().listApiKeys({
+      userId: auth.userId,
+      limit,
+      after,
+    });
 
     return Response.json({
       object: "list",
@@ -76,7 +80,7 @@ export async function GET(request: Request): Promise<Response> {
 
 export async function POST(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth || auth.permission !== "full_access") {
+  if (!auth?.userId || auth.permission !== "full_access") {
     return unauthorizedResponse();
   }
 
@@ -95,7 +99,7 @@ export async function POST(request: Request): Promise<Response> {
 
     const created = await apiKeyService().createApiKey({
       ...parseCreateApiKeyBody(body),
-      userId: auth.userId ?? undefined,
+      userId: auth.userId,
     });
 
     return Response.json(

--- a/src/app/api/webhooks/[id]/route.ts
+++ b/src/app/api/webhooks/[id]/route.ts
@@ -16,12 +16,12 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth?.userId) return unauthorizedResponse();
 
   const { id } = await params;
 
   try {
-    const webhook = await webhookService().getWebhook(id);
+    const webhook = await webhookService().getWebhook(id, auth.userId);
 
     if (!webhook) {
       return Response.json({ error: "Webhook not found" }, { status: 404 });
@@ -45,7 +45,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth?.userId) return unauthorizedResponse();
 
   const { id } = await params;
 
@@ -66,7 +66,7 @@ export async function PATCH(
 
   try {
     const validated = result.data;
-    const updated = await webhookService().updateWebhook(id, {
+    const updated = await webhookService().updateWebhook(id, auth.userId, {
       endpoint: validated.endpoint ?? validated.url,
       events: validated.events ?? validated.event_types,
       status: validated.status,
@@ -95,12 +95,12 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth?.userId) return unauthorizedResponse();
 
   const { id } = await params;
 
   try {
-    const deleted = await webhookService().deleteWebhook(id);
+    const deleted = await webhookService().deleteWebhook(id, auth.userId);
 
     if (!deleted) {
       return Response.json({ error: "Webhook not found" }, { status: 404 });

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -13,14 +13,18 @@ function mapWebhookError(error: unknown, fallback: string): Response {
 
 export async function GET(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth?.userId) return unauthorizedResponse();
 
   const url = new URL(request.url);
   const limit = Number(url.searchParams.get("limit")) || 20;
   const after = url.searchParams.get("after") || "";
 
   try {
-    const result = await webhookService().listWebhooks({ limit, after });
+    const result = await webhookService().listWebhooks({
+      userId: auth.userId,
+      limit,
+      after,
+    });
 
     return Response.json({
       object: "list",
@@ -40,7 +44,7 @@ export async function GET(request: Request): Promise<Response> {
 
 export async function POST(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth?.userId) return unauthorizedResponse();
 
   let body: unknown;
   try {
@@ -69,7 +73,11 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   try {
-    const webhook = await webhookService().createWebhook({ endpoint, events });
+    const webhook = await webhookService().createWebhook({
+      userId: auth.userId,
+      endpoint,
+      events,
+    });
 
     return Response.json(
       {

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -773,7 +773,11 @@ describe("route smoke coverage", () => {
       ],
       has_more: true,
     });
-    expect(listWebhooks).toHaveBeenCalledWith({ limit: 500, after: "wh-3" });
+    expect(listWebhooks).toHaveBeenCalledWith({
+      userId: "user-1",
+      limit: 500,
+      after: "wh-3",
+    });
 
     const createRes = await listRoute.POST(
       makeNextRequest("http://localhost/api/webhooks", {
@@ -799,6 +803,7 @@ describe("route smoke coverage", () => {
       created_at: "2026-04-23T00:00:00.000Z",
     });
     expect(createWebhook).toHaveBeenCalledWith({
+      userId: "user-1",
       endpoint: "https://example.com/created",
       events: ["email.delivered"],
     });
@@ -838,7 +843,7 @@ describe("route smoke coverage", () => {
       events: ["email.sent"],
       status: "disabled",
     });
-    expect(updateWebhook).toHaveBeenCalledWith("wh-1", {
+    expect(updateWebhook).toHaveBeenCalledWith("wh-1", "user-1", {
       endpoint: undefined,
       events: undefined,
       status: undefined,

--- a/tests/api-key-service.test.ts
+++ b/tests/api-key-service.test.ts
@@ -107,7 +107,8 @@ describe("api key service", () => {
   });
 
   it("lists with normalized pagination and maps only public list fields", async () => {
-    let listOptions: { limit?: number; after?: string } | null = null;
+    let listOptions: { userId: string; limit?: number; after?: string } | null =
+      null;
     const service = createApiKeyService({
       repository: createRepository({
         async list(options) {
@@ -120,9 +121,17 @@ describe("api key service", () => {
       }),
     });
 
-    const result = await service.listApiKeys({ limit: 500, after: "key-3" });
+    const result = await service.listApiKeys({
+      userId: "user-1",
+      limit: 500,
+      after: "key-3",
+    });
 
-    expect(listOptions).toEqual({ limit: 100, after: "key-3" });
+    expect(listOptions).toEqual({
+      userId: "user-1",
+      limit: 100,
+      after: "key-3",
+    });
     expect(result).toEqual({
       data: [
         {
@@ -145,13 +154,40 @@ describe("api key service", () => {
       }),
     });
 
-    await expect(service.getApiKey("missing")).rejects.toMatchObject({
+    await expect(service.getApiKey("missing", "user-1")).rejects.toMatchObject({
       code: "not_found",
       message: "API key not found",
     } satisfies Partial<ApiKeyServiceError>);
-    await expect(service.deleteApiKey("missing")).rejects.toMatchObject({
+    await expect(
+      service.deleteApiKey("missing", "user-1"),
+    ).rejects.toMatchObject({
       code: "not_found",
       message: "API key not found",
     } satisfies Partial<ApiKeyServiceError>);
+  });
+  it("does not delete or invalidate cache for an unowned API key", async () => {
+    const findById = vi
+      .fn<ApiKeyRepository["findById"]>()
+      .mockResolvedValue(undefined);
+    const deleteKey = vi.fn<ApiKeyRepository["delete"]>();
+    const invalidateAuthCache = vi.fn<(_: string) => Promise<void>>();
+    const service = createApiKeyService({
+      invalidateAuthCache,
+      repository: createRepository({
+        findById,
+        delete: deleteKey,
+      }),
+    });
+
+    await expect(
+      service.deleteApiKey("key-user-a", "user-b"),
+    ).rejects.toMatchObject({
+      code: "not_found",
+      message: "API key not found",
+    } satisfies Partial<ApiKeyServiceError>);
+
+    expect(findById).toHaveBeenCalledWith("key-user-a", "user-b");
+    expect(deleteKey).not.toHaveBeenCalled();
+    expect(invalidateAuthCache).not.toHaveBeenCalled();
   });
 });

--- a/tests/cache-invalidation-routes.test.ts
+++ b/tests/cache-invalidation-routes.test.ts
@@ -29,6 +29,8 @@ vi.mock("@opensend/core", () => ({
   createApiKeyService: () => ({
     createApiKey: mockCreateApiKey,
     deleteApiKey: mockDeleteApiKey,
+    getApiKey: vi.fn(),
+    listApiKeys: vi.fn(),
   }),
   createDomainService: () => ({
     createDomain: mockCreateDomain,
@@ -180,7 +182,7 @@ describe("cache invalidation routes", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(mockDeleteApiKey).toHaveBeenCalledWith("key-1");
+    expect(mockDeleteApiKey).toHaveBeenCalledWith("key-1", "user-1");
   });
 
   it("invalidates domain caches after patch", async () => {

--- a/tests/ingester-ses-route.test.ts
+++ b/tests/ingester-ses-route.test.ts
@@ -86,7 +86,7 @@ vi.mock("@opensend/core", () => {
         : null;
     },
     webhookRepo: {
-      list: mockWebhookList,
+      listForDispatch: mockWebhookList,
     },
   };
 });

--- a/tests/webhook-dispatcher.test.ts
+++ b/tests/webhook-dispatcher.test.ts
@@ -37,7 +37,7 @@ vi.mock("@opensend/core", () => ({
     findDispatchable: mockFindDispatchable,
   },
   webhookRepo: {
-    findById: mockFindWebhookById,
+    findByIdForDispatch: mockFindWebhookById,
   },
 }));
 

--- a/tests/webhook-service.test.ts
+++ b/tests/webhook-service.test.ts
@@ -34,7 +34,7 @@ function createRepository(overrides: Partial<WebhookRepository> = {}) {
     async findById() {
       return webhookRow();
     },
-    async update(id, data) {
+    async update(id, _userId, data) {
       return [webhookRow({ id, ...data })];
     },
     async delete(id: string) {
@@ -48,7 +48,8 @@ function createRepository(overrides: Partial<WebhookRepository> = {}) {
 
 describe("webhook service", () => {
   it("lists with normalized pagination and maps public list fields", async () => {
-    let listOptions: { limit?: number; after?: string } | null = null;
+    let listOptions: { userId: string; limit?: number; after?: string } | null =
+      null;
     const service = createWebhookService({
       repository: createRepository({
         async list(options) {
@@ -68,11 +69,16 @@ describe("webhook service", () => {
     });
 
     const result = await service.listWebhooks({
+      userId: "user-1",
       limit: 500,
       after: "webhook-3",
     });
 
-    expect(listOptions).toEqual({ limit: 100, after: "webhook-3" });
+    expect(listOptions).toEqual({
+      userId: "user-1",
+      limit: 100,
+      after: "webhook-3",
+    });
     expect(result).toEqual({
       data: [
         {
@@ -101,12 +107,14 @@ describe("webhook service", () => {
     });
 
     const result = await service.createWebhook({
+      userId: "user-1",
       endpoint: "https://example.com/created",
       events: ["email.delivered"],
     });
 
     expect(generateSigningSecret).toHaveBeenCalledOnce();
     expect(inserted[0]).toMatchObject({
+      userId: "user-1",
       url: "https://example.com/created",
       eventTypes: ["email.delivered"],
       signingSecret: "whsec_test_secret",
@@ -124,19 +132,21 @@ describe("webhook service", () => {
     const updates: Array<Partial<WebhookInsert>> = [];
     const service = createWebhookService({
       repository: createRepository({
-        async update(id, data) {
+        async update(id, _userId, data) {
           updates.push(data);
           return [webhookRow({ id, ...data })];
         },
       }),
     });
 
-    const disabled = await service.updateWebhook("webhook-1", {
+    const disabled = await service.updateWebhook("webhook-1", "user-1", {
       endpoint: "https://example.com/new",
       events: ["email.bounced"],
       status: "disabled",
     });
-    const enabled = await service.updateWebhook("webhook-1", { active: true });
+    const enabled = await service.updateWebhook("webhook-1", "user-1", {
+      active: true,
+    });
 
     expect(updates).toEqual([
       {
@@ -169,10 +179,14 @@ describe("webhook service", () => {
       }),
     });
 
-    await expect(service.getWebhook("missing")).resolves.toBeUndefined();
     await expect(
-      service.updateWebhook("missing", { status: "enabled" }),
+      service.getWebhook("missing", "user-1"),
     ).resolves.toBeUndefined();
-    await expect(service.deleteWebhook("missing")).resolves.toBeUndefined();
+    await expect(
+      service.updateWebhook("missing", "user-1", { status: "enabled" }),
+    ).resolves.toBeUndefined();
+    await expect(
+      service.deleteWebhook("missing", "user-1"),
+    ).resolves.toBeUndefined();
   });
 });

--- a/tests/webhooks-api-keys-tenant-isolation.test.ts
+++ b/tests/webhooks-api-keys-tenant-isolation.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockListWebhooks = vi.hoisted(() => vi.fn());
+const mockCreateWebhook = vi.hoisted(() => vi.fn());
+const mockGetWebhook = vi.hoisted(() => vi.fn());
+const mockUpdateWebhook = vi.hoisted(() => vi.fn());
+const mockDeleteWebhook = vi.hoisted(() => vi.fn());
+const mockListApiKeys = vi.hoisted(() => vi.fn());
+const mockCreateApiKey = vi.hoisted(() => vi.fn());
+const mockGetApiKey = vi.hoisted(() => vi.fn());
+const mockDeleteApiKey = vi.hoisted(() => vi.fn());
+const MockApiKeyServiceError = vi.hoisted(
+  () =>
+    class ApiKeyServiceError extends Error {
+      constructor(
+        readonly code: string,
+        message: string,
+      ) {
+        super(message);
+        this.name = "ApiKeyServiceError";
+      }
+    },
+);
+
+vi.mock("@/lib/api-auth", () => ({
+  invalidateApiKeyAuthCache: vi.fn(),
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+  validateApiKey: mockValidateApiKey,
+}));
+
+vi.mock("@/lib/billing/quota", () => ({
+  checkApiKeyQuota: vi.fn().mockResolvedValue({ ok: true }),
+  quotaExceededResponse: vi.fn(),
+}));
+
+vi.mock("@opensend/core", () => ({
+  ApiKeyServiceError: MockApiKeyServiceError,
+  createApiKeyService: () => ({
+    listApiKeys: mockListApiKeys,
+    createApiKey: mockCreateApiKey,
+    getApiKey: mockGetApiKey,
+    deleteApiKey: mockDeleteApiKey,
+  }),
+  createWebhookService: () => ({
+    listWebhooks: mockListWebhooks,
+    createWebhook: mockCreateWebhook,
+    getWebhook: mockGetWebhook,
+    updateWebhook: mockUpdateWebhook,
+    deleteWebhook: mockDeleteWebhook,
+  }),
+}));
+
+function request(url: string, init?: RequestInit) {
+  return new Request(url, {
+    ...init,
+    headers: { authorization: "Bearer user-b-key", ...init?.headers },
+  });
+}
+
+function notFound(message: string) {
+  return new MockApiKeyServiceError("not_found", message);
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mockValidateApiKey.mockResolvedValue({
+    apiKeyId: "key-b",
+    permission: "full_access",
+    domain: null,
+    userId: "user-b",
+  });
+});
+
+describe("webhook API tenant isolation", () => {
+  it("returns an empty webhook list scoped to the caller", async () => {
+    mockListWebhooks.mockResolvedValue({ data: [], hasMore: false });
+
+    const route = await import("@/app/api/webhooks/route");
+    const response = await route.GET(
+      request("http://localhost/api/webhooks?limit=50&after=wh-a"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      object: "list",
+      data: [],
+      has_more: false,
+    });
+    expect(mockListWebhooks).toHaveBeenCalledWith({
+      userId: "user-b",
+      limit: 50,
+      after: "wh-a",
+    });
+  });
+
+  it("stamps created webhooks with the caller user", async () => {
+    mockCreateWebhook.mockResolvedValue({
+      id: "wh-b",
+      endpoint: "https://example.com/b",
+      events: ["email.delivered"],
+      status: "enabled",
+      signingSecret: "whsec_b",
+      createdAt: "2026-05-05T00:00:00.000Z",
+    });
+
+    const route = await import("@/app/api/webhooks/route");
+    const response = await route.POST(
+      request("http://localhost/api/webhooks", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          endpoint: "https://example.com/b",
+          events: ["email.delivered"],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockCreateWebhook).toHaveBeenCalledWith({
+      userId: "user-b",
+      endpoint: "https://example.com/b",
+      events: ["email.delivered"],
+    });
+  });
+
+  it("returns 404 and cannot mutate user A's webhook as user B", async () => {
+    mockGetWebhook.mockResolvedValue(undefined);
+    mockUpdateWebhook.mockResolvedValue(undefined);
+    mockDeleteWebhook.mockResolvedValue(undefined);
+
+    const route = await import("@/app/api/webhooks/[id]/route");
+    const params = { params: Promise.resolve({ id: "wh-user-a" }) };
+
+    const getResponse = await route.GET(
+      request("http://localhost/api/webhooks/wh-user-a"),
+      params,
+    );
+    expect(getResponse.status).toBe(404);
+    expect(mockGetWebhook).toHaveBeenCalledWith("wh-user-a", "user-b");
+
+    const patchResponse = await route.PATCH(
+      request("http://localhost/api/webhooks/wh-user-a", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ active: false }),
+      }),
+      params,
+    );
+    expect(patchResponse.status).toBe(404);
+    expect(mockUpdateWebhook).toHaveBeenCalledWith(
+      "wh-user-a",
+      "user-b",
+      expect.objectContaining({ active: false }),
+    );
+
+    const deleteResponse = await route.DELETE(
+      request("http://localhost/api/webhooks/wh-user-a", { method: "DELETE" }),
+      params,
+    );
+    expect(deleteResponse.status).toBe(404);
+    expect(mockDeleteWebhook).toHaveBeenCalledWith("wh-user-a", "user-b");
+  });
+
+  it("rejects webhook routes when caller user ownership cannot be resolved", async () => {
+    mockValidateApiKey.mockResolvedValueOnce({
+      apiKeyId: "legacy-key",
+      permission: "full_access",
+      domain: null,
+      userId: null,
+    });
+
+    const route = await import("@/app/api/webhooks/route");
+    const response = await route.GET(request("http://localhost/api/webhooks"));
+
+    expect(response.status).toBe(401);
+    expect(mockListWebhooks).not.toHaveBeenCalled();
+  });
+});
+
+describe("API key API tenant isolation", () => {
+  it("returns an empty API-key list scoped to the caller", async () => {
+    mockListApiKeys.mockResolvedValue({ data: [], hasMore: false });
+
+    const route = await import("@/app/api/api-keys/route");
+    const response = await route.GET(
+      request("http://localhost/api/api-keys?limit=50&after=key-a"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      object: "list",
+      data: [],
+      has_more: false,
+    });
+    expect(mockListApiKeys).toHaveBeenCalledWith({
+      userId: "user-b",
+      limit: 50,
+      after: "key-a",
+    });
+  });
+
+  it("returns 404 and cannot delete user A's API key as user B", async () => {
+    mockGetApiKey.mockRejectedValue(notFound("API key not found"));
+    mockDeleteApiKey.mockRejectedValue(notFound("API key not found"));
+
+    const route = await import("@/app/api/api-keys/[id]/route");
+    const params = { params: Promise.resolve({ id: "key-user-a" }) };
+
+    const getResponse = await route.GET(
+      request("http://localhost/api/api-keys/key-user-a"),
+      params,
+    );
+    expect(getResponse.status).toBe(404);
+    expect(mockGetApiKey).toHaveBeenCalledWith("key-user-a", "user-b");
+
+    const deleteResponse = await route.DELETE(
+      request("http://localhost/api/api-keys/key-user-a", { method: "DELETE" }),
+      params,
+    );
+    expect(deleteResponse.status).toBe(404);
+    expect(mockDeleteApiKey).toHaveBeenCalledWith("key-user-a", "user-b");
+  });
+
+  it("rejects API-key routes when caller user ownership cannot be resolved", async () => {
+    mockValidateApiKey.mockResolvedValueOnce({
+      apiKeyId: "legacy-key",
+      permission: "full_access",
+      domain: null,
+      userId: null,
+    });
+
+    const route = await import("@/app/api/api-keys/route");
+    const response = await route.GET(request("http://localhost/api/api-keys"));
+
+    expect(response.status).toBe(401);
+    expect(mockListApiKeys).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- require resolved API-key user ownership for public webhook CRUD and API-key list/get/delete routes
- pass userId through webhook/API-key services and repositories so owned predicates gate reads and mutations
- keep webhook dispatcher fanout on explicit dispatch-only repository helpers
- add focused tenant-isolation tests and an issue #200 learning note

## Validation
- make check
- make test
- bun run test tests/webhook-service.test.ts tests/api-key-service.test.ts tests/api-auth-date-range-routes.test.ts tests/cache-invalidation-routes.test.ts tests/webhooks-api-keys-tenant-isolation.test.ts tests/webhook-dispatcher.test.ts tests/ingester-ses-route.test.ts

## Not tested
- Playwright E2E; this slice is covered by route/service/repository unit tests.

Closes part of #200.