### PR TITLE
Scope webhooks and API keys by tenant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ ralph_to_ralph_archive/
 
 # Local clawhip repo metadata (single-machine only)
 .clawhip/
+
+# Local scenario scripts and scratch data
+.scratch/

--- a/agent_docs/learnings/active/2026-05-06-issue-200-webhook-api-key-tenant-scope.md
+++ b/agent_docs/learnings/active/2026-05-06-issue-200-webhook-api-key-tenant-scope.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-06
+issue: "#200"
+type: decision
+promoted_to: null
+---
+
+## Webhook and API-key management requires caller user scope
+
+Webhook and API-key management routes now reject authenticated API keys that do not resolve to a concrete `userId`. Route calls pass that `userId` through service and repository boundaries for list/get/update/delete operations, and create paths stamp new webhooks/API keys with the caller user.
+
+API-key deletion first looks up the key with the owner predicate and only invalidates the auth cache for an owned key, preventing cross-tenant cache invalidation or deletion by guessed id.

--- a/packages/core/src/db/repositories/apiKeyRepo.ts
+++ b/packages/core/src/db/repositories/apiKeyRepo.ts
@@ -1,11 +1,14 @@
-import { and, desc, eq, lt } from "drizzle-orm";
+import { type SQL, and, desc, eq, lt } from "drizzle-orm";
 import { db } from "../client";
 import { apiKeys } from "../schema";
 
 export const apiKeyRepo = {
-  async findById(id: string) {
+  async findById(id: string, options: { userId?: string } = {}) {
     return await db.query.apiKeys.findFirst({
-      where: eq(apiKeys.id, id),
+      where: and(
+        eq(apiKeys.id, id),
+        ...(options.userId ? [eq(apiKeys.userId, options.userId)] : []),
+      ),
     });
   },
 
@@ -19,17 +22,25 @@ export const apiKeyRepo = {
     return await db.insert(apiKeys).values(data).returning();
   },
 
-  async delete(id: string) {
+  async delete(id: string, options: { userId?: string } = {}) {
     return await db
       .delete(apiKeys)
-      .where(eq(apiKeys.id, id))
+      .where(
+        and(
+          eq(apiKeys.id, id),
+          ...(options.userId ? [eq(apiKeys.userId, options.userId)] : []),
+        ),
+      )
       .returning({ id: apiKeys.id });
   },
 
-  async list(options: { limit?: number; after?: string } = {}) {
-    const { limit = 20, after } = options;
-    const conditions = [];
+  async list(
+    options: { limit?: number; after?: string; userId?: string } = {},
+  ) {
+    const { limit = 20, after, userId } = options;
+    const conditions: SQL[] = [];
 
+    if (userId) conditions.push(eq(apiKeys.userId, userId));
     if (after) conditions.push(lt(apiKeys.id, after));
 
     const results = await db

--- a/packages/core/src/db/repositories/webhookRepo.ts
+++ b/packages/core/src/db/repositories/webhookRepo.ts
@@ -1,11 +1,14 @@
-import { and, desc, eq, lt } from "drizzle-orm";
+import { type SQL, and, desc, eq, lt } from "drizzle-orm";
 import { db } from "../client";
 import { webhooks } from "../schema";
 
 export const webhookRepo = {
-  async findById(id: string) {
+  async findById(id: string, options: { userId?: string } = {}) {
     return await db.query.webhooks.findFirst({
-      where: eq(webhooks.id, id),
+      where: and(
+        eq(webhooks.id, id),
+        ...(options.userId ? [eq(webhooks.userId, options.userId)] : []),
+      ),
     });
   },
 
@@ -13,25 +16,42 @@ export const webhookRepo = {
     return await db.insert(webhooks).values(data).returning();
   },
 
-  async update(id: string, data: Partial<typeof webhooks.$inferInsert>) {
+  async update(
+    id: string,
+    data: Partial<typeof webhooks.$inferInsert>,
+    options: { userId?: string } = {},
+  ) {
     return await db
       .update(webhooks)
       .set(data)
-      .where(eq(webhooks.id, id))
+      .where(
+        and(
+          eq(webhooks.id, id),
+          ...(options.userId ? [eq(webhooks.userId, options.userId)] : []),
+        ),
+      )
       .returning();
   },
 
-  async delete(id: string) {
+  async delete(id: string, options: { userId?: string } = {}) {
     return await db
       .delete(webhooks)
-      .where(eq(webhooks.id, id))
+      .where(
+        and(
+          eq(webhooks.id, id),
+          ...(options.userId ? [eq(webhooks.userId, options.userId)] : []),
+        ),
+      )
       .returning({ id: webhooks.id });
   },
 
-  async list(options: { limit?: number; after?: string } = {}) {
-    const { limit = 20, after } = options;
-    const conditions = [];
+  async list(
+    options: { limit?: number; after?: string; userId?: string } = {},
+  ) {
+    const { limit = 20, after, userId } = options;
+    const conditions: SQL[] = [];
 
+    if (userId) conditions.push(eq(webhooks.userId, userId));
     if (after) conditions.push(lt(webhooks.id, after));
 
     const results = await db

--- a/packages/core/src/services/apiKeys.ts
+++ b/packages/core/src/services/apiKeys.ts
@@ -56,13 +56,19 @@ export class ApiKeyServiceError extends Error {
 }
 
 export type ApiKeyRepository = {
-  list(options: { limit?: number; after?: string }): Promise<{
+  list(options: { limit?: number; after?: string; userId?: string }): Promise<{
     data: ApiKeyRow[];
     hasMore: boolean;
   }>;
   create(data: ApiKeyInsert): Promise<ApiKeyRow[]>;
-  findById(id: string): Promise<ApiKeyRow | undefined>;
-  delete(id: string): Promise<Array<{ id: string }>>;
+  findById(
+    id: string,
+    options?: { userId?: string },
+  ): Promise<ApiKeyRow | undefined>;
+  delete(
+    id: string,
+    options?: { userId?: string },
+  ): Promise<Array<{ id: string }>>;
 };
 
 export type ApiKeyServiceDependencies = {
@@ -96,10 +102,12 @@ export function createApiKeyService({
     async listApiKeys(options: {
       limit?: number;
       after?: string;
+      userId?: string;
     }): Promise<ApiKeyListResult> {
       const result = await repository.list({
         limit: normalizeLimit(options.limit),
         after: options.after || undefined,
+        ...(options.userId ? { userId: options.userId } : {}),
       });
 
       return {
@@ -146,8 +154,11 @@ export function createApiKeyService({
       };
     },
 
-    async getApiKey(id: string): Promise<ApiKeyDetail> {
-      const key = await repository.findById(id);
+    async getApiKey(
+      id: string,
+      options: { userId?: string } = {},
+    ): Promise<ApiKeyDetail> {
+      const key = await repository.findById(id, { userId: options.userId });
       if (!key) {
         throw new ApiKeyServiceError("not_found", "API key not found");
       }
@@ -160,13 +171,18 @@ export function createApiKeyService({
       };
     },
 
-    async deleteApiKey(id: string): Promise<DeleteApiKeyResult> {
-      const existing = await repository.findById(id);
+    async deleteApiKey(
+      id: string,
+      options: { userId?: string } = {},
+    ): Promise<DeleteApiKeyResult> {
+      const existing = await repository.findById(id, {
+        userId: options.userId,
+      });
       if (!existing) {
         throw new ApiKeyServiceError("not_found", "API key not found");
       }
 
-      const [deleted] = await repository.delete(id);
+      const [deleted] = await repository.delete(id, { userId: options.userId });
       await invalidateAuthCache(existing.tokenHash);
 
       return {

--- a/packages/core/src/services/webhook.ts
+++ b/packages/core/src/services/webhook.ts
@@ -30,6 +30,7 @@ export type WebhookListResult = {
 export type CreateWebhookInput = {
   endpoint: string;
   events: string[];
+  userId?: string;
 };
 
 export type UpdateWebhookInput = {
@@ -40,14 +41,24 @@ export type UpdateWebhookInput = {
 };
 
 export type WebhookRepository = {
-  list(options: { limit?: number; after?: string }): Promise<{
+  list(options: { limit?: number; after?: string; userId?: string }): Promise<{
     data: WebhookRow[];
     hasMore: boolean;
   }>;
   create(data: WebhookInsert): Promise<WebhookRow[]>;
-  findById(id: string): Promise<WebhookRow | undefined>;
-  update(id: string, data: Partial<WebhookInsert>): Promise<WebhookRow[]>;
-  delete(id: string): Promise<Array<{ id: string }>>;
+  findById(
+    id: string,
+    options?: { userId?: string },
+  ): Promise<WebhookRow | undefined>;
+  update(
+    id: string,
+    data: Partial<WebhookInsert>,
+    options?: { userId?: string },
+  ): Promise<WebhookRow[]>;
+  delete(
+    id: string,
+    options?: { userId?: string },
+  ): Promise<Array<{ id: string }>>;
 };
 
 export type WebhookServiceDependencies = {
@@ -112,10 +123,12 @@ export function createWebhookService({
     async listWebhooks(options: {
       limit?: number;
       after?: string;
+      userId?: string;
     }): Promise<WebhookListResult> {
       const result = await repository.list({
         limit: normalizeLimit(options.limit),
         after: options.after || undefined,
+        ...(options.userId ? { userId: options.userId } : {}),
       });
 
       return {
@@ -132,26 +145,36 @@ export function createWebhookService({
         url: input.endpoint,
         eventTypes: input.events,
         signingSecret,
+        userId: input.userId ?? null,
       });
 
       return toWebhookCreateResult(row);
     },
 
-    async getWebhook(id: string): Promise<WebhookServiceDetail | undefined> {
-      const row = await repository.findById(id);
+    async getWebhook(
+      id: string,
+      options: { userId?: string } = {},
+    ): Promise<WebhookServiceDetail | undefined> {
+      const row = await repository.findById(id, { userId: options.userId });
       return row ? toWebhookListItem(row) : undefined;
     },
 
     async updateWebhook(
       id: string,
       input: UpdateWebhookInput,
+      options: { userId?: string } = {},
     ): Promise<WebhookServiceDetail | undefined> {
-      const [row] = await repository.update(id, buildUpdateData(input));
+      const [row] = await repository.update(id, buildUpdateData(input), {
+        userId: options.userId,
+      });
       return row ? toWebhookListItem(row) : undefined;
     },
 
-    async deleteWebhook(id: string): Promise<{ id: string } | undefined> {
-      const [deleted] = await repository.delete(id);
+    async deleteWebhook(
+      id: string,
+      options: { userId?: string } = {},
+    ): Promise<{ id: string } | undefined> {
+      const [deleted] = await repository.delete(id, { userId: options.userId });
       return deleted;
     },
   };

--- a/src/app/api/api-keys/[id]/route.ts
+++ b/src/app/api/api-keys/[id]/route.ts
@@ -25,13 +25,13 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth || auth.permission !== "full_access") {
+  if (!auth || auth.permission !== "full_access" || !auth.userId) {
     return unauthorizedResponse();
   }
 
   const { id } = await params;
   try {
-    const key = await apiKeyService().getApiKey(id);
+    const key = await apiKeyService().getApiKey(id, { userId: auth.userId });
 
     return Response.json({
       object: "api_key",
@@ -50,13 +50,13 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth || auth.permission !== "full_access") {
+  if (!auth || auth.permission !== "full_access" || !auth.userId) {
     return unauthorizedResponse();
   }
 
   const { id } = await params;
   try {
-    await apiKeyService().deleteApiKey(id);
+    await apiKeyService().deleteApiKey(id, { userId: auth.userId });
 
     return new Response(null, { status: 200 });
   } catch (err) {

--- a/src/app/api/api-keys/route.ts
+++ b/src/app/api/api-keys/route.ts
@@ -48,7 +48,7 @@ function parseCreateApiKeyBody(body: unknown): {
 
 export async function GET(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth || auth.permission !== "full_access") {
+  if (!auth || auth.permission !== "full_access" || !auth.userId) {
     return unauthorizedResponse();
   }
 
@@ -57,7 +57,11 @@ export async function GET(request: Request): Promise<Response> {
   const after = url.searchParams.get("after") || "";
 
   try {
-    const result = await apiKeyService().listApiKeys({ limit, after });
+    const result = await apiKeyService().listApiKeys({
+      limit,
+      after,
+      userId: auth.userId,
+    });
 
     return Response.json({
       object: "list",
@@ -76,7 +80,7 @@ export async function GET(request: Request): Promise<Response> {
 
 export async function POST(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth || auth.permission !== "full_access") {
+  if (!auth || auth.permission !== "full_access" || !auth.userId) {
     return unauthorizedResponse();
   }
 
@@ -95,7 +99,7 @@ export async function POST(request: Request): Promise<Response> {
 
     const created = await apiKeyService().createApiKey({
       ...parseCreateApiKeyBody(body),
-      userId: auth.userId ?? undefined,
+      userId: auth.userId,
     });
 
     return Response.json(

--- a/src/app/api/webhooks/[id]/route.ts
+++ b/src/app/api/webhooks/[id]/route.ts
@@ -16,12 +16,14 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth || !auth.userId) return unauthorizedResponse();
 
   const { id } = await params;
 
   try {
-    const webhook = await webhookService().getWebhook(id);
+    const webhook = await webhookService().getWebhook(id, {
+      userId: auth.userId,
+    });
 
     if (!webhook) {
       return Response.json({ error: "Webhook not found" }, { status: 404 });
@@ -45,7 +47,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth || !auth.userId) return unauthorizedResponse();
 
   const { id } = await params;
 
@@ -66,12 +68,16 @@ export async function PATCH(
 
   try {
     const validated = result.data;
-    const updated = await webhookService().updateWebhook(id, {
-      endpoint: validated.endpoint ?? validated.url,
-      events: validated.events ?? validated.event_types,
-      status: validated.status,
-      active: validated.active,
-    });
+    const updated = await webhookService().updateWebhook(
+      id,
+      {
+        endpoint: validated.endpoint ?? validated.url,
+        events: validated.events ?? validated.event_types,
+        status: validated.status,
+        active: validated.active,
+      },
+      { userId: auth.userId },
+    );
 
     if (!updated) {
       return Response.json({ error: "Webhook not found" }, { status: 404 });
@@ -95,12 +101,14 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth || !auth.userId) return unauthorizedResponse();
 
   const { id } = await params;
 
   try {
-    const deleted = await webhookService().deleteWebhook(id);
+    const deleted = await webhookService().deleteWebhook(id, {
+      userId: auth.userId,
+    });
 
     if (!deleted) {
       return Response.json({ error: "Webhook not found" }, { status: 404 });

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -13,14 +13,18 @@ function mapWebhookError(error: unknown, fallback: string): Response {
 
 export async function GET(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth || !auth.userId) return unauthorizedResponse();
 
   const url = new URL(request.url);
   const limit = Number(url.searchParams.get("limit")) || 20;
   const after = url.searchParams.get("after") || "";
 
   try {
-    const result = await webhookService().listWebhooks({ limit, after });
+    const result = await webhookService().listWebhooks({
+      limit,
+      after,
+      userId: auth.userId,
+    });
 
     return Response.json({
       object: "list",
@@ -40,7 +44,7 @@ export async function GET(request: Request): Promise<Response> {
 
 export async function POST(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth || !auth.userId) return unauthorizedResponse();
 
   let body: unknown;
   try {
@@ -69,7 +73,11 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   try {
-    const webhook = await webhookService().createWebhook({ endpoint, events });
+    const webhook = await webhookService().createWebhook({
+      endpoint,
+      events,
+      userId: auth.userId,
+    });
 
     return Response.json(
       {

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -773,7 +773,11 @@ describe("route smoke coverage", () => {
       ],
       has_more: true,
     });
-    expect(listWebhooks).toHaveBeenCalledWith({ limit: 500, after: "wh-3" });
+    expect(listWebhooks).toHaveBeenCalledWith({
+      limit: 500,
+      after: "wh-3",
+      userId: "user-1",
+    });
 
     const createRes = await listRoute.POST(
       makeNextRequest("http://localhost/api/webhooks", {
@@ -801,6 +805,7 @@ describe("route smoke coverage", () => {
     expect(createWebhook).toHaveBeenCalledWith({
       endpoint: "https://example.com/created",
       events: ["email.delivered"],
+      userId: "user-1",
     });
 
     const detailGetRes = await detailRoute.GET(
@@ -838,12 +843,16 @@ describe("route smoke coverage", () => {
       events: ["email.sent"],
       status: "disabled",
     });
-    expect(updateWebhook).toHaveBeenCalledWith("wh-1", {
-      endpoint: undefined,
-      events: undefined,
-      status: undefined,
-      active: false,
-    });
+    expect(updateWebhook).toHaveBeenCalledWith(
+      "wh-1",
+      {
+        endpoint: undefined,
+        events: undefined,
+        status: undefined,
+        active: false,
+      },
+      { userId: "user-1" },
+    );
 
     const patchNotFoundRes = await detailRoute.PATCH(
       makeNextRequest("http://localhost/api/webhooks/missing", {

--- a/tests/api-key-service.test.ts
+++ b/tests/api-key-service.test.ts
@@ -136,6 +136,41 @@ describe("api key service", () => {
     });
   });
 
+  it("passes tenant scope to list, get, and delete repository operations", async () => {
+    const list = vi.fn<ApiKeyRepository["list"]>().mockResolvedValue({
+      data: [apiKeyRow()],
+      hasMore: false,
+    });
+    const findById = vi
+      .fn<ApiKeyRepository["findById"]>()
+      .mockResolvedValue(apiKeyRow({ tokenHash: "hash-owned" }));
+    const deleteKey = vi
+      .fn<ApiKeyRepository["delete"]>()
+      .mockResolvedValue([{ id: "key-1" }]);
+    const invalidateAuthCache = vi.fn<(_: string) => Promise<void>>();
+    const service = createApiKeyService({
+      repository: createRepository({
+        list,
+        findById,
+        delete: deleteKey,
+      }),
+      invalidateAuthCache,
+    });
+
+    await service.listApiKeys({ limit: 20, after: "key-0", userId: "user-1" });
+    await service.getApiKey("key-1", { userId: "user-1" });
+    await service.deleteApiKey("key-1", { userId: "user-1" });
+
+    expect(list).toHaveBeenCalledWith({
+      limit: 20,
+      after: "key-0",
+      userId: "user-1",
+    });
+    expect(findById).toHaveBeenCalledWith("key-1", { userId: "user-1" });
+    expect(deleteKey).toHaveBeenCalledWith("key-1", { userId: "user-1" });
+    expect(invalidateAuthCache).toHaveBeenCalledWith("hash-owned");
+  });
+
   it("returns not_found for get and delete misses", async () => {
     const service = createApiKeyService({
       repository: createRepository({

--- a/tests/cache-invalidation-routes.test.ts
+++ b/tests/cache-invalidation-routes.test.ts
@@ -180,7 +180,9 @@ describe("cache invalidation routes", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(mockDeleteApiKey).toHaveBeenCalledWith("key-1");
+    expect(mockDeleteApiKey).toHaveBeenCalledWith("key-1", {
+      userId: "user-1",
+    });
   });
 
   it("invalidates domain caches after patch", async () => {

--- a/tests/webhook-api-key-tenant-routes.test.ts
+++ b/tests/webhook-api-key-tenant-routes.test.ts
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockListApiKeys = vi.hoisted(() => vi.fn());
+const mockGetApiKey = vi.hoisted(() => vi.fn());
+const mockDeleteApiKey = vi.hoisted(() => vi.fn());
+const mockCreateApiKey = vi.hoisted(() => vi.fn());
+const mockListWebhooks = vi.hoisted(() => vi.fn());
+const mockCreateWebhook = vi.hoisted(() => vi.fn());
+const mockGetWebhook = vi.hoisted(() => vi.fn());
+const mockUpdateWebhook = vi.hoisted(() => vi.fn());
+const mockDeleteWebhook = vi.hoisted(() => vi.fn());
+const mockCheckApiKeyQuota = vi.hoisted(() => vi.fn());
+
+class MockApiKeyServiceError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+vi.mock("@/lib/api-auth", () => ({
+  invalidateApiKeyAuthCache: vi.fn(),
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+  validateApiKey: mockValidateApiKey,
+}));
+
+vi.mock("@/lib/billing/quota", () => ({
+  checkApiKeyQuota: mockCheckApiKeyQuota,
+  quotaExceededResponse: () =>
+    Response.json({ error: "quota exceeded" }, { status: 402 }),
+}));
+
+vi.mock("@opensend/core", () => ({
+  ApiKeyServiceError: MockApiKeyServiceError,
+  createApiKeyService: () => ({
+    listApiKeys: mockListApiKeys,
+    getApiKey: mockGetApiKey,
+    deleteApiKey: mockDeleteApiKey,
+    createApiKey: mockCreateApiKey,
+  }),
+  createWebhookService: () => ({
+    listWebhooks: mockListWebhooks,
+    createWebhook: mockCreateWebhook,
+    getWebhook: mockGetWebhook,
+    updateWebhook: mockUpdateWebhook,
+    deleteWebhook: mockDeleteWebhook,
+  }),
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mockValidateApiKey.mockResolvedValue({
+    apiKeyId: "key-user-b",
+    permission: "full_access",
+    domain: null,
+    userId: "user-b",
+  });
+  mockCheckApiKeyQuota.mockResolvedValue({ ok: true });
+  mockListApiKeys.mockResolvedValue({ data: [], hasMore: false });
+  mockGetApiKey.mockResolvedValue({
+    id: "api-key-1",
+    name: "Primary",
+    createdAt: "2026-05-06T00:00:00.000Z",
+    lastUsedAt: null,
+  });
+  mockDeleteApiKey.mockResolvedValue({ id: "api-key-1", tokenHash: "hash-1" });
+  mockCreateApiKey.mockResolvedValue({ id: "api-key-2", token: "re_created" });
+  mockListWebhooks.mockResolvedValue({ data: [], hasMore: false });
+  mockCreateWebhook.mockResolvedValue({
+    id: "webhook-1",
+    endpoint: "https://example.com/webhook",
+    events: ["email.delivered"],
+    status: "enabled",
+    signingSecret: "whsec_secret",
+    createdAt: "2026-05-06T00:00:00.000Z",
+  });
+  mockGetWebhook.mockResolvedValue({
+    id: "webhook-1",
+    endpoint: "https://example.com/webhook",
+    events: ["email.delivered"],
+    status: "enabled",
+    createdAt: "2026-05-06T00:00:00.000Z",
+  });
+  mockUpdateWebhook.mockResolvedValue({
+    id: "webhook-1",
+    endpoint: "https://example.com/webhook",
+    events: ["email.delivered"],
+    status: "disabled",
+    createdAt: "2026-05-06T00:00:00.000Z",
+  });
+  mockDeleteWebhook.mockResolvedValue({ id: "webhook-1" });
+});
+
+describe("API key tenant route scoping", () => {
+  it("passes authenticated user id to list, create, get, and delete operations", async () => {
+    const listRoute = await import("@/app/api/api-keys/route");
+    const detailRoute = await import("@/app/api/api-keys/[id]/route");
+
+    await listRoute.GET(
+      new Request("http://localhost/api/api-keys?limit=10&after=api-key-0", {
+        headers: { Authorization: "Bearer re_test" },
+      }),
+    );
+    await listRoute.POST(
+      new Request("http://localhost/api/api-keys", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer re_test",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "Primary" }),
+      }),
+    );
+    await detailRoute.GET(
+      new Request("http://localhost/api/api-keys/api-key-1", {
+        headers: { Authorization: "Bearer re_test" },
+      }),
+      { params: Promise.resolve({ id: "api-key-1" }) },
+    );
+    await detailRoute.DELETE(
+      new Request("http://localhost/api/api-keys/api-key-1", {
+        method: "DELETE",
+        headers: { Authorization: "Bearer re_test" },
+      }),
+      { params: Promise.resolve({ id: "api-key-1" }) },
+    );
+
+    expect(mockListApiKeys).toHaveBeenCalledWith({
+      limit: 10,
+      after: "api-key-0",
+      userId: "user-b",
+    });
+    expect(mockCreateApiKey).toHaveBeenCalledWith({
+      name: "Primary",
+      permission: undefined,
+      domainId: undefined,
+      userId: "user-b",
+    });
+    expect(mockGetApiKey).toHaveBeenCalledWith("api-key-1", {
+      userId: "user-b",
+    });
+    expect(mockDeleteApiKey).toHaveBeenCalledWith("api-key-1", {
+      userId: "user-b",
+    });
+  });
+
+  it("rejects API key management when auth has no user id", async () => {
+    mockValidateApiKey.mockResolvedValue({
+      apiKeyId: "legacy-key",
+      permission: "full_access",
+      domain: null,
+      userId: null,
+    });
+
+    const { GET } = await import("@/app/api/api-keys/route");
+    const response = await GET(
+      new Request("http://localhost/api/api-keys", {
+        headers: { Authorization: "Bearer re_legacy" },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockListApiKeys).not.toHaveBeenCalled();
+  });
+});
+
+describe("webhook tenant route scoping", () => {
+  it("passes authenticated user id to list, create, get, update, and delete operations", async () => {
+    const listRoute = await import("@/app/api/webhooks/route");
+    const detailRoute = await import("@/app/api/webhooks/[id]/route");
+
+    await listRoute.GET(
+      new Request("http://localhost/api/webhooks?limit=10&after=webhook-0", {
+        headers: { Authorization: "Bearer re_test" },
+      }),
+    );
+    await listRoute.POST(
+      new Request("http://localhost/api/webhooks", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer re_test",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          endpoint: "https://example.com/webhook",
+          events: ["email.delivered"],
+        }),
+      }),
+    );
+    await detailRoute.GET(
+      new Request("http://localhost/api/webhooks/webhook-1", {
+        headers: { Authorization: "Bearer re_test" },
+      }),
+      { params: Promise.resolve({ id: "webhook-1" }) },
+    );
+    await detailRoute.PATCH(
+      new Request("http://localhost/api/webhooks/webhook-1", {
+        method: "PATCH",
+        headers: {
+          Authorization: "Bearer re_test",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ active: false }),
+      }),
+      { params: Promise.resolve({ id: "webhook-1" }) },
+    );
+    await detailRoute.DELETE(
+      new Request("http://localhost/api/webhooks/webhook-1", {
+        method: "DELETE",
+        headers: { Authorization: "Bearer re_test" },
+      }),
+      { params: Promise.resolve({ id: "webhook-1" }) },
+    );
+
+    expect(mockListWebhooks).toHaveBeenCalledWith({
+      limit: 10,
+      after: "webhook-0",
+      userId: "user-b",
+    });
+    expect(mockCreateWebhook).toHaveBeenCalledWith({
+      endpoint: "https://example.com/webhook",
+      events: ["email.delivered"],
+      userId: "user-b",
+    });
+    expect(mockGetWebhook).toHaveBeenCalledWith("webhook-1", {
+      userId: "user-b",
+    });
+    expect(mockUpdateWebhook).toHaveBeenCalledWith(
+      "webhook-1",
+      {
+        endpoint: undefined,
+        events: undefined,
+        status: undefined,
+        active: false,
+      },
+      { userId: "user-b" },
+    );
+    expect(mockDeleteWebhook).toHaveBeenCalledWith("webhook-1", {
+      userId: "user-b",
+    });
+  });
+
+  it("rejects webhook management when auth has no user id", async () => {
+    mockValidateApiKey.mockResolvedValue({
+      apiKeyId: "legacy-key",
+      permission: "full_access",
+      domain: null,
+      userId: null,
+    });
+
+    const { GET } = await import("@/app/api/webhooks/route");
+    const response = await GET(
+      new Request("http://localhost/api/webhooks", {
+        headers: { Authorization: "Bearer re_legacy" },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockListWebhooks).not.toHaveBeenCalled();
+  });
+});

--- a/tests/webhook-service.test.ts
+++ b/tests/webhook-service.test.ts
@@ -87,6 +87,58 @@ describe("webhook service", () => {
     });
   });
 
+  it("passes tenant scope to list, get, update, and delete repository operations", async () => {
+    const list = vi.fn<WebhookRepository["list"]>().mockResolvedValue({
+      data: [webhookRow()],
+      hasMore: false,
+    });
+    const findById = vi
+      .fn<WebhookRepository["findById"]>()
+      .mockResolvedValue(webhookRow());
+    const update = vi
+      .fn<WebhookRepository["update"]>()
+      .mockResolvedValue([webhookRow({ status: "disabled" })]);
+    const deleteWebhook = vi
+      .fn<WebhookRepository["delete"]>()
+      .mockResolvedValue([{ id: "webhook-1" }]);
+    const service = createWebhookService({
+      repository: createRepository({
+        list,
+        findById,
+        update,
+        delete: deleteWebhook,
+      }),
+    });
+
+    await service.listWebhooks({
+      limit: 20,
+      after: "webhook-0",
+      userId: "user-1",
+    });
+    await service.getWebhook("webhook-1", { userId: "user-1" });
+    await service.updateWebhook(
+      "webhook-1",
+      { status: "disabled" },
+      { userId: "user-1" },
+    );
+    await service.deleteWebhook("webhook-1", { userId: "user-1" });
+
+    expect(list).toHaveBeenCalledWith({
+      limit: 20,
+      after: "webhook-0",
+      userId: "user-1",
+    });
+    expect(findById).toHaveBeenCalledWith("webhook-1", { userId: "user-1" });
+    expect(update).toHaveBeenCalledWith(
+      "webhook-1",
+      { status: "disabled" },
+      { userId: "user-1" },
+    );
+    expect(deleteWebhook).toHaveBeenCalledWith("webhook-1", {
+      userId: "user-1",
+    });
+  });
+
   it("creates with an injectable signing secret generator", async () => {
     const inserted: WebhookInsert[] = [];
     const generateSigningSecret = vi.fn(() => "whsec_test_secret");
@@ -118,6 +170,26 @@ describe("webhook service", () => {
       status: "enabled",
       signingSecret: "whsec_test_secret",
     });
+  });
+
+  it("stamps created webhooks with tenant scope when supplied", async () => {
+    const inserted: WebhookInsert[] = [];
+    const service = createWebhookService({
+      repository: createRepository({
+        async create(data) {
+          inserted.push(data);
+          return [webhookRow({ ...data, id: "created-webhook" })];
+        },
+      }),
+    });
+
+    await service.createWebhook({
+      endpoint: "https://example.com/created",
+      events: ["email.delivered"],
+      userId: "user-1",
+    });
+
+    expect(inserted[0]).toMatchObject({ userId: "user-1" });
   });
 
   it("maps update status and active flags to stored status", async () => {


### PR DESCRIPTION
## Summary
- Requires a concrete `userId` for webhook and API-key management routes.
- Passes `userId` through route → service → repository boundaries for list/get/update/delete owner predicates.
- Stamps created webhooks/API keys with the caller user and prevents cross-tenant API-key cache invalidation on guessed deletes.

Part of #200 (webhooks + API-key management slice only; does not close the parent issue).

## Changes
- **API keys**: scope list/get/delete by caller `userId`, reject legacy/null-user auth, and invalidate auth cache only after an owned lookup.
- **Webhooks**: scope list/get/update/delete by caller `userId` and stamp created webhooks.
- **Core services/repos**: add optional `userId` scoping parameters so non-route callers can explicitly opt into tenant predicates without breaking ingester all-webhook listing.
- **Tests/docs**: add route tenant-scoping tests, service propagation tests, update route smoke expectations, and capture a learning note.

## How to Test
- [x] `make check`
- [x] `make test`
- [x] `bun run test -- tests/webhook-api-key-tenant-routes.test.ts tests/api-key-service.test.ts tests/webhook-service.test.ts tests/cache-invalidation-routes.test.ts tests/api-auth-date-range-routes.test.ts`
- [x] `DATABASE_URL=postgresql://opensend:***@localhost:5439/opensend bun .scratch/issue-200-webhook-api-key-tenant-isolation.ts`; `.scratch/` removed before commit

## Notes
- Contacts, emails, and broadcasts slices are already on `staging`.
- Remaining #200 slices after this: dashboard metrics/pages and cron hardening.