### PR TITLE
Constrain dashboard metrics and cron tenant surfaces

### DIFF
--- a/src/app/(dashboard)/api-keys/[id]/page.tsx
+++ b/src/app/(dashboard)/api-keys/[id]/page.tsx
@@ -1,15 +1,20 @@
 import { ApiKeyDetail } from "@/components/api-key-detail";
+import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { apiKeys, domains } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
-import { notFound } from "next/navigation";
+import { and, eq } from "drizzle-orm";
+import { notFound, redirect } from "next/navigation";
 
 export default async function ApiKeyDetailPage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
+  const session = await getServerSession();
+  if (!session) redirect("/auth");
+
   const { id } = await params;
+  const userId = session.user.id;
 
   const [keyResult] = await db
     .select({
@@ -21,7 +26,7 @@ export default async function ApiKeyDetailPage({
       createdAt: apiKeys.createdAt,
     })
     .from(apiKeys)
-    .where(eq(apiKeys.id, id))
+    .where(and(eq(apiKeys.id, id), eq(apiKeys.userId, userId)))
     .limit(1);
 
   if (!keyResult) {
@@ -34,12 +39,15 @@ export default async function ApiKeyDetailPage({
       ? db
           .select({ name: domains.name })
           .from(domains)
-          .where(eq(domains.name, keyResult.domain))
+          .where(
+            and(eq(domains.name, keyResult.domain), eq(domains.userId, userId)),
+          )
           .limit(1)
       : Promise.resolve([]),
     db
       .select({ id: domains.id, name: domains.name })
       .from(domains)
+      .where(eq(domains.userId, userId))
       .orderBy(domains.name),
   ]);
 

--- a/src/app/(dashboard)/api-keys/page.tsx
+++ b/src/app/(dashboard)/api-keys/page.tsx
@@ -1,9 +1,15 @@
 import { ApiKeysList } from "@/components/api-keys-list";
+import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { apiKeys, domains } from "@/lib/db/schema";
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
+import { redirect } from "next/navigation";
 
 export default async function ApiKeysPage() {
+  const session = await getServerSession();
+  if (!session) redirect("/auth");
+
+  const userId = session.user.id;
   let keys: {
     id: string;
     name: string;
@@ -26,10 +32,12 @@ export default async function ApiKeysPage() {
           createdAt: apiKeys.createdAt,
         })
         .from(apiKeys)
+        .where(eq(apiKeys.userId, userId))
         .orderBy(desc(apiKeys.createdAt)),
       db
         .select({ id: domains.id, name: domains.name })
         .from(domains)
+        .where(eq(domains.userId, userId))
         .orderBy(domains.name),
     ]);
   } catch {

--- a/src/app/(dashboard)/emails/[id]/page.tsx
+++ b/src/app/(dashboard)/emails/[id]/page.tsx
@@ -1,21 +1,26 @@
 import { EmailDetail } from "@/components/email-detail";
+import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { emailEvents, emailSuppressions, emails } from "@/lib/db/schema";
 import { and, desc, eq } from "drizzle-orm";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 export default async function EmailDetailPage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
+  const session = await getServerSession();
+  if (!session) redirect("/auth");
+
   const { id } = await params;
+  const userId = session.user.id;
 
   try {
     const [emailResult] = await db
       .select()
       .from(emails)
-      .where(eq(emails.id, id))
+      .where(and(eq(emails.id, id), eq(emails.userId, userId)))
       .limit(1);
 
     if (!emailResult) {
@@ -32,7 +37,7 @@ export default async function EmailDetailPage({
     const suppression = primaryRecipient
       ? await db.query.emailSuppressions.findFirst({
           where: and(
-            eq(emailSuppressions.userId, emailResult.userId ?? ""),
+            eq(emailSuppressions.userId, userId),
             eq(emailSuppressions.email, primaryRecipient),
           ),
         })

--- a/src/app/(dashboard)/emails/page.tsx
+++ b/src/app/(dashboard)/emails/page.tsx
@@ -1,9 +1,11 @@
 import { EmailsSendingPage } from "@/components/emails-sending-page";
+import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { apiKeys, emails } from "@/lib/db/schema";
 
 // emails.status maps to lastEvent in the UI
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
+import { redirect } from "next/navigation";
 
 type EmailsPageSearchParams = Record<string, string | string[] | undefined>;
 
@@ -23,6 +25,10 @@ function getSearchParam(
 export default async function EmailsPage({
   searchParams,
 }: EmailsPageProps = {}) {
+  const session = await getServerSession();
+  if (!session) redirect("/auth");
+
+  const userId = session.user.id;
   const resolvedSearchParams = searchParams ? await searchParams : {};
   const statusFilter = (
     getSearchParam(resolvedSearchParams, "status") ||
@@ -40,28 +46,30 @@ export default async function EmailsPage({
   }[] = [];
 
   try {
-    let emailQuery = db
-      .select({
-        id: emails.id,
-        to: emails.to,
-        lastEvent: emails.status,
-        subject: emails.subject,
-        createdAt: emails.createdAt,
-        sentAt: emails.sentAt,
-      })
-      .from(emails);
+    const emailConditions = [eq(emails.userId, userId)];
     if (statusFilter && statusFilter !== "all") {
-      emailQuery = emailQuery.where(
-        eq(emails.status, statusFilter),
-      ) as typeof emailQuery;
+      emailConditions.push(eq(emails.status, statusFilter));
     }
 
     const [keysResult, emailsResult] = await Promise.all([
       db
         .select({ id: apiKeys.id, name: apiKeys.name })
         .from(apiKeys)
+        .where(eq(apiKeys.userId, userId))
         .orderBy(desc(apiKeys.createdAt)),
-      emailQuery.orderBy(desc(emails.createdAt)).limit(100),
+      db
+        .select({
+          id: emails.id,
+          to: emails.to,
+          lastEvent: emails.status,
+          subject: emails.subject,
+          createdAt: emails.createdAt,
+          sentAt: emails.sentAt,
+        })
+        .from(emails)
+        .where(and(...emailConditions))
+        .orderBy(desc(emails.createdAt))
+        .limit(100),
     ]);
     keys = keysResult;
     emailList = emailsResult.map((e) => ({

--- a/src/app/(dashboard)/logs/[id]/page.tsx
+++ b/src/app/(dashboard)/logs/[id]/page.tsx
@@ -1,21 +1,25 @@
 import { LogDetail } from "@/components/log-detail";
+import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { logs } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
-import { notFound } from "next/navigation";
+import { and, eq } from "drizzle-orm";
+import { notFound, redirect } from "next/navigation";
 
 export default async function LogDetailPage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
+  const session = await getServerSession();
+  if (!session) redirect("/auth");
+
   const { id } = await params;
 
   try {
     const [logResult] = await db
       .select()
       .from(logs)
-      .where(eq(logs.id, id))
+      .where(and(eq(logs.id, id), eq(logs.userId, session.user.id)))
       .limit(1);
 
     if (!logResult) {
@@ -28,7 +32,13 @@ export default async function LogDetailPage({
       path: logResult.endpoint ?? "",
       statusCode: logResult.status ?? 0,
       duration: null as number | null,
-      apiKeyId: null as string | null,
+      apiKeyId:
+        typeof logResult.document === "object" &&
+        logResult.document !== null &&
+        "apiKeyId" in logResult.document &&
+        typeof logResult.document.apiKeyId === "string"
+          ? logResult.document.apiKeyId
+          : null,
       requestBody: logResult.requestBody as Record<string, unknown> | null,
       responseBody: logResult.responseBody as Record<string, unknown> | null,
       createdAt: logResult.createdAt.toISOString(),

--- a/src/app/(dashboard)/logs/page.tsx
+++ b/src/app/(dashboard)/logs/page.tsx
@@ -1,7 +1,9 @@
 import { LogsListPage } from "@/components/logs-list-page";
+import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { logs } from "@/lib/db/schema";
 import { type SQL, and, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { redirect } from "next/navigation";
 
 export default async function LogsPage(props: {
   searchParams: Promise<{
@@ -13,6 +15,9 @@ export default async function LogsPage(props: {
     apiKeyId?: string;
   }>;
 }) {
+  const session = await getServerSession();
+  if (!session) redirect("/auth");
+
   const searchParams = await props.searchParams;
   const status = searchParams.status;
   const method = searchParams.method;
@@ -21,7 +26,7 @@ export default async function LogsPage(props: {
   const userAgent = searchParams.userAgent;
   const apiKeyId = searchParams.apiKeyId;
 
-  const conditions: SQL[] = [];
+  const conditions: SQL[] = [eq(logs.userId, session.user.id)];
 
   if (status) {
     if (status === "2xx") {
@@ -54,10 +59,8 @@ export default async function LogsPage(props: {
   }
 
   if (apiKeyId) {
-    conditions.push(eq(logs.apiKeyId, apiKeyId));
+    conditions.push(sql`${logs.document}->>'apiKeyId' = ${apiKeyId}`);
   }
-
-  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
 
   let logRows: {
     id: string;
@@ -77,7 +80,7 @@ export default async function LogsPage(props: {
         createdAt: logs.createdAt,
       })
       .from(logs)
-      .where(whereClause)
+      .where(and(...conditions))
       .orderBy(desc(logs.createdAt))
       .limit(500);
 

--- a/src/app/(dashboard)/webhooks/page.tsx
+++ b/src/app/(dashboard)/webhooks/page.tsx
@@ -1,13 +1,19 @@
 import { WebhooksList } from "@/components/webhooks-list";
+import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { webhooks } from "@/lib/db/schema";
 import { SUPPORTED_WEBHOOK_EVENT_TYPES } from "@opensend/core/src/webhook-events";
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
+import { redirect } from "next/navigation";
 
 export default async function WebhooksPage() {
+  const session = await getServerSession();
+  if (!session) redirect("/auth");
+
   const allWebhooks = await db
     .select()
     .from(webhooks)
+    .where(eq(webhooks.userId, session.user.id))
     .orderBy(desc(webhooks.createdAt));
 
   const data = allWebhooks.map((w) => ({

--- a/src/app/api/internal/cron/process-scheduled/route.ts
+++ b/src/app/api/internal/cron/process-scheduled/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: Request) {
   const authHeader = request.headers.get("x-cron-auth");
   const expectedToken = process.env.CRON_AUTH_TOKEN;
 
-  if (expectedToken && authHeader !== expectedToken) {
+  if (!expectedToken || authHeader !== expectedToken) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -52,7 +52,13 @@ export async function GET(request: NextRequest) {
     const range = searchParams.get("range") || "last_15_days";
     const domain = searchParams.get("domain");
     const eventType = searchParams.get("event_type");
-    const cacheKey = getMetricsAggregateCacheKey({ range, domain, eventType });
+    const userId = session.user.id;
+    const cacheKey = getMetricsAggregateCacheKey({
+      userId,
+      range,
+      domain,
+      eventType,
+    });
 
     const cached = await readDashboardAggregateCache<unknown>(cacheKey);
     if (cached) {
@@ -64,6 +70,7 @@ export async function GET(request: NextRequest) {
     const { start, end } = getMetricsDateRange(range);
 
     const conditions = [
+      eq(emails.userId, userId),
       gte(emails.createdAt, start),
       lte(emails.createdAt, end),
     ];

--- a/src/lib/cache/dashboard-aggregates.ts
+++ b/src/lib/cache/dashboard-aggregates.ts
@@ -11,6 +11,7 @@ function normalizeCacheSegment(value: string | null | undefined): string {
 }
 
 export function getMetricsAggregateCacheKey(params: {
+  userId: string;
   range: string;
   domain: string | null;
   eventType: string | null;
@@ -18,6 +19,7 @@ export function getMetricsAggregateCacheKey(params: {
   return [
     DASHBOARD_AGGREGATE_CACHE_PREFIX,
     "metrics",
+    normalizeCacheSegment(params.userId),
     normalizeCacheSegment(params.range),
     normalizeCacheSegment(params.domain),
     normalizeCacheSegment(params.eventType),

--- a/tests/cron-process-scheduled.test.ts
+++ b/tests/cron-process-scheduled.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockProcessScheduledAutomations = vi.hoisted(() => vi.fn());
 const mockProcessScheduledBroadcasts = vi.hoisted(() => vi.fn());
@@ -15,6 +15,56 @@ vi.mock("@/lib/workers/scheduled-emails", () => ({
 }));
 
 describe("process-scheduled cron route", () => {
+  const originalCronAuthToken = process.env.CRON_AUTH_TOKEN;
+
+  beforeEach(() => {
+    process.env.CRON_AUTH_TOKEN = "cron-secret";
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalCronAuthToken === undefined) {
+      Reflect.deleteProperty(process.env, "CRON_AUTH_TOKEN");
+    } else {
+      process.env.CRON_AUTH_TOKEN = originalCronAuthToken;
+    }
+  });
+
+  it("returns 401 and does not process jobs when CRON_AUTH_TOKEN is unset", async () => {
+    Reflect.deleteProperty(process.env, "CRON_AUTH_TOKEN");
+
+    const { GET } = await import(
+      "@/app/api/internal/cron/process-scheduled/route"
+    );
+    const response = await GET(
+      new Request("http://localhost/api/internal/cron/process-scheduled", {
+        headers: { "x-cron-auth": "cron-secret" },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockProcessScheduledEmails).not.toHaveBeenCalled();
+    expect(mockProcessScheduledBroadcasts).not.toHaveBeenCalled();
+    expect(mockProcessScheduledAutomations).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 and does not process jobs when the cron token mismatches", async () => {
+    const { GET } = await import(
+      "@/app/api/internal/cron/process-scheduled/route"
+    );
+    const response = await GET(
+      new Request("http://localhost/api/internal/cron/process-scheduled", {
+        headers: { "x-cron-auth": "wrong" },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockProcessScheduledEmails).not.toHaveBeenCalled();
+    expect(mockProcessScheduledBroadcasts).not.toHaveBeenCalled();
+    expect(mockProcessScheduledAutomations).not.toHaveBeenCalled();
+  });
+
   it("includes automation runner summary next to emails and broadcasts", async () => {
     vi.resetModules();
     mockProcessScheduledEmails.mockResolvedValue({ processed: 1, enqueued: 1 });
@@ -30,7 +80,9 @@ describe("process-scheduled cron route", () => {
       "@/app/api/internal/cron/process-scheduled/route"
     );
     const response = await GET(
-      new Request("http://localhost/api/internal/cron/process-scheduled"),
+      new Request("http://localhost/api/internal/cron/process-scheduled", {
+        headers: { "x-cron-auth": "cron-secret" },
+      }),
     );
 
     expect(response.status).toBe(200);

--- a/tests/dashboard-pages-tenant-scope.test.tsx
+++ b/tests/dashboard-pages-tenant-scope.test.tsx
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockRedirect = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error("NEXT_REDIRECT");
+  }),
+);
+const mockNotFound = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+);
+const mockSelect = vi.hoisted(() => vi.fn());
+const mockFindSuppression = vi.hoisted(() => vi.fn());
+const mockEq = vi.hoisted(() =>
+  vi.fn((left, right) => ({ kind: "eq", left, right })),
+);
+const mockAnd = vi.hoisted(() =>
+  vi.fn((...conditions) => ({ kind: "and", conditions })),
+);
+const mockDesc = vi.hoisted(() =>
+  vi.fn((column) => ({ kind: "desc", column })),
+);
+const recordedWhere = vi.hoisted(() => [] as unknown[]);
+
+vi.mock("@/lib/api-auth", () => ({
+  getServerSession: mockGetServerSession,
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: mockNotFound,
+  redirect: mockRedirect,
+}));
+
+vi.mock("drizzle-orm", async () => {
+  const actual =
+    await vi.importActual<typeof import("drizzle-orm")>("drizzle-orm");
+  return {
+    ...actual,
+    and: mockAnd,
+    desc: mockDesc,
+    eq: mockEq,
+  };
+});
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      emailSuppressions: {
+        findFirst: mockFindSuppression,
+      },
+    },
+    select: mockSelect,
+  },
+}));
+
+vi.mock("@/components/emails-sending-page", () => ({
+  EmailsSendingPage: (props: { emails: unknown[]; apiKeys: unknown[] }) => (
+    <div data-testid="emails-page" data-props={JSON.stringify(props)} />
+  ),
+}));
+
+vi.mock("@/components/email-detail", () => ({
+  EmailDetail: (props: { email: { id: string } }) => (
+    <div data-testid="email-detail" data-props={JSON.stringify(props)} />
+  ),
+}));
+
+vi.mock("@/components/api-keys-list", () => ({
+  ApiKeysList: (props: { keys: unknown[]; domains: unknown[] }) => (
+    <div data-testid="api-keys-page" data-props={JSON.stringify(props)} />
+  ),
+}));
+
+vi.mock("@/components/api-key-detail", () => ({
+  ApiKeyDetail: (props: { apiKey: { id: string }; domains: unknown[] }) => (
+    <div data-testid="api-key-detail" data-props={JSON.stringify(props)} />
+  ),
+}));
+
+vi.mock("@/components/webhooks-list", () => ({
+  WebhooksList: (props: { webhooks: unknown[] }) => (
+    <div data-testid="webhooks-page" data-props={JSON.stringify(props)} />
+  ),
+}));
+
+vi.mock("@/components/logs-list-page", () => ({
+  LogsListPage: (props: { logs: unknown[] }) => (
+    <div data-testid="logs-page" data-props={JSON.stringify(props)} />
+  ),
+}));
+
+vi.mock("@/components/log-detail", () => ({
+  LogDetail: (props: { log: { id: string } }) => (
+    <div data-testid="log-detail" data-props={JSON.stringify(props)} />
+  ),
+}));
+
+function makeQuery<T>(rows: T[]) {
+  const chain = {
+    from: vi.fn(() => chain),
+    where: vi.fn((condition: unknown) => {
+      recordedWhere.push(condition);
+      return chain;
+    }),
+    orderBy: vi.fn(() => chain),
+    limit: vi.fn(() => Promise.resolve(rows)),
+    // biome-ignore lint/suspicious/noThenProperty: mocks Drizzle's thenable query builder
+    then: (resolve: (value: T[]) => unknown) => Promise.resolve(resolve(rows)),
+  };
+  return chain;
+}
+
+function queueRows(...rowSets: unknown[][]) {
+  mockSelect.mockReset();
+  for (const rows of rowSets) {
+    mockSelect.mockReturnValueOnce(makeQuery(rows));
+  }
+}
+
+type TestElement = { props: Record<string, unknown> };
+
+function isTestElement(value: unknown): value is TestElement {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "props" in value &&
+    typeof value.props === "object" &&
+    value.props !== null
+  );
+}
+
+function parsedProps<T>(element: TestElement): T {
+  const child = element.props.children ?? element;
+  if (Array.isArray(child)) {
+    const match = child.find(
+      (item) => isTestElement(item) && item.props["data-props"] !== undefined,
+    );
+    if (isTestElement(match)) {
+      return JSON.parse(match.props["data-props"] as string) as T;
+    }
+    const propChild = child.find(
+      (item) =>
+        isTestElement(item) &&
+        [
+          "emails",
+          "apiKeys",
+          "keys",
+          "domains",
+          "webhooks",
+          "logs",
+          "log",
+          "apiKey",
+          "email",
+        ].some((key) => item.props[key] !== undefined),
+    );
+    if (!isTestElement(propChild)) throw new Error("Expected props child");
+    return propChild.props as T;
+  }
+  if (!isTestElement(child)) throw new Error("Expected test element");
+  if (child.props["data-props"] !== undefined) {
+    return JSON.parse(child.props["data-props"] as string) as T;
+  }
+  return child.props as T;
+}
+
+type DashboardPageFn = (props: {
+  params?: Promise<{ id: string }>;
+  searchParams?: Promise<Record<string, string>>;
+}) => Promise<unknown>;
+
+async function expectRedirectsToAuth(
+  importer: () => Promise<{ default: unknown }>,
+) {
+  mockGetServerSession.mockResolvedValueOnce(null);
+  const Page = (await importer()).default as DashboardPageFn;
+
+  await expect(
+    Page({
+      params: Promise.resolve({ id: "owned-id" }),
+      searchParams: Promise.resolve({}),
+    }),
+  ).rejects.toThrow("NEXT_REDIRECT");
+
+  expect(mockRedirect).toHaveBeenCalledWith("/auth");
+  expect(mockSelect).not.toHaveBeenCalled();
+}
+
+describe("dashboard pages tenant scoping", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    recordedWhere.length = 0;
+    mockGetServerSession.mockResolvedValue({ user: { id: "user-b" } });
+    mockFindSuppression.mockResolvedValue(null);
+  });
+
+  it("redirects unauthenticated dashboard pages before querying", async () => {
+    await expectRedirectsToAuth(() => import("@/app/(dashboard)/emails/page"));
+    await expectRedirectsToAuth(
+      () => import("@/app/(dashboard)/api-keys/page"),
+    );
+    await expectRedirectsToAuth(
+      () => import("@/app/(dashboard)/webhooks/page"),
+    );
+    await expectRedirectsToAuth(() => import("@/app/(dashboard)/logs/page"));
+  });
+
+  it("renders empty list data for user B when scoped page queries return no owned rows", async () => {
+    queueRows([], []);
+    const EmailsPage = (await import("@/app/(dashboard)/emails/page")).default;
+    const emailsResult = await EmailsPage({
+      searchParams: Promise.resolve({}),
+    });
+    expect(
+      parsedProps<{ emails: unknown[]; apiKeys: unknown[] }>(emailsResult)
+        .emails,
+    ).toEqual([]);
+
+    queueRows([], []);
+    const ApiKeysPage = (await import("@/app/(dashboard)/api-keys/page"))
+      .default;
+    const apiKeysResult = await ApiKeysPage();
+    expect(parsedProps<{ keys: unknown[] }>(apiKeysResult).keys).toEqual([]);
+
+    queueRows([]);
+    const WebhooksPage = (await import("@/app/(dashboard)/webhooks/page"))
+      .default;
+    const webhooksResult = await WebhooksPage();
+    expect(
+      parsedProps<{ webhooks: unknown[] }>(webhooksResult).webhooks,
+    ).toEqual([]);
+
+    queueRows([]);
+    const LogsPage = (await import("@/app/(dashboard)/logs/page")).default;
+    const logsResult = await LogsPage({ searchParams: Promise.resolve({}) });
+    expect(parsedProps<{ logs: unknown[] }>(logsResult).logs).toEqual([]);
+
+    expect(mockEq.mock.calls.some(([, right]) => right === "user-b")).toBe(
+      true,
+    );
+  });
+
+  it("404s detail pages for user B when owned-row predicates return no rows", async () => {
+    queueRows([]);
+    const EmailDetailPage = (await import("@/app/(dashboard)/emails/[id]/page"))
+      .default;
+    await expect(
+      EmailDetailPage({ params: Promise.resolve({ id: "email-a" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    queueRows([]);
+    const ApiKeyDetailPage = (
+      await import("@/app/(dashboard)/api-keys/[id]/page")
+    ).default;
+    await expect(
+      ApiKeyDetailPage({ params: Promise.resolve({ id: "key-a" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    queueRows([]);
+    const LogDetailPage = (await import("@/app/(dashboard)/logs/[id]/page"))
+      .default;
+    await expect(
+      LogDetailPage({ params: Promise.resolve({ id: "log-a" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(
+      mockEq.mock.calls.filter(([, right]) => right === "user-b").length,
+    ).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/tests/metrics-route.test.ts
+++ b/tests/metrics-route.test.ts
@@ -55,15 +55,17 @@ vi.mock("@/lib/api-auth", () => ({
 vi.mock("@/lib/cache/dashboard-aggregates", () => ({
   DASHBOARD_METRICS_CACHE_TTL_SECONDS: 60,
   getMetricsAggregateCacheKey: ({
+    userId,
     range,
     domain,
     eventType,
   }: {
+    userId: string;
     range: string;
     domain: string | null;
     eventType: string | null;
   }) =>
-    `dashboard-aggregate:v1:metrics:${range}:${domain ?? "all"}:${eventType ?? "all"}`,
+    `dashboard-aggregate:v1:metrics:${userId}:${range}:${domain ?? "all"}:${eventType ?? "all"}`,
   readDashboardAggregateCache: mockReadDashboardAggregateCache,
   writeDashboardAggregateCache: mockWriteDashboardAggregateCache,
 }));
@@ -174,6 +176,36 @@ describe("metrics route filters", () => {
     vi.useRealTimers();
   });
 
+  it("scopes every aggregate query and cache key to the dashboard user", async () => {
+    const whereArgs: unknown[] = [];
+    queueMetricsQueries(whereArgs);
+
+    const metricsRoute = await import("@/app/api/metrics/route");
+    const response = await metricsRoute.GET(
+      makeNextRequest(
+        "http://localhost/api/metrics?range=last_7_days",
+      ) as never,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockReadDashboardAggregateCache).toHaveBeenCalledWith(
+      "dashboard-aggregate:v1:metrics:user-1:last_7_days:all:all",
+    );
+    expect(mockEq.mock.calls.some(([, right]) => right === "user-1")).toBe(
+      true,
+    );
+    expect(whereArgs).toHaveLength(5);
+    for (const whereArg of whereArgs) {
+      const condition = whereArg as {
+        kind: string;
+        conds: Array<{ kind: string; right: unknown }>;
+      };
+      expect(condition.conds.some((cond) => cond.right === "user-1")).toBe(
+        true,
+      );
+    }
+  });
+
   it("matches Yesterday exactly instead of leaking into today", async () => {
     const whereArgs: unknown[] = [];
     queueMetricsQueries(whereArgs);
@@ -267,8 +299,12 @@ describe("metrics route filters", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mockEq).toHaveBeenCalledOnce();
-    expect(mockEq.mock.calls[0]?.[1]).toBe("example.com");
+    expect(mockEq.mock.calls.some(([, right]) => right === "user-1")).toBe(
+      true,
+    );
+    expect(mockEq.mock.calls.some(([, right]) => right === "example.com")).toBe(
+      true,
+    );
     expect(mockLike).not.toHaveBeenCalled();
 
     const firstWhere = whereArgs[0] as {
@@ -313,7 +349,7 @@ describe("metrics route filters", () => {
     const json = await response.json();
     expect(json.totalEmails).toBe(99);
     expect(mockReadDashboardAggregateCache).toHaveBeenCalledWith(
-      "dashboard-aggregate:v1:metrics:last_7_days:example.com:delivered",
+      "dashboard-aggregate:v1:metrics:user-1:last_7_days:example.com:delivered",
     );
   });
 
@@ -331,7 +367,7 @@ describe("metrics route filters", () => {
     expect(response.status).toBe(200);
     expect(mockWriteDashboardAggregateCache).toHaveBeenCalledOnce();
     expect(mockWriteDashboardAggregateCache.mock.calls[0]?.[0]).toBe(
-      "dashboard-aggregate:v1:metrics:last_7_days:all:opened",
+      "dashboard-aggregate:v1:metrics:user-1:last_7_days:all:opened",
     );
     expect(mockWriteDashboardAggregateCache.mock.calls[0]?.[2]).toBe(60);
   });


### PR DESCRIPTION
## Summary
- Scope dashboard metrics queries and aggregate cache keys to the authenticated dashboard user.
- Require dashboard sessions on /emails, /api-keys, /webhooks, and /logs pages, redirect unauthenticated users to /auth, and scope page queries/details to session.user.id.
- Require CRON_AUTH_TOKEN to be configured and matched before internal scheduled processing runs.

Part of #200.

## Verification
- make check
- bun run test tests/metrics-route.test.ts tests/cron-process-scheduled.test.ts tests/dashboard-pages-tenant-scope.test.tsx
- make test

## Scenario note
- Real local app/database .scratch scenario was not run: DATABASE_URL is unset in this session and no safe local app DB was already available to mutate.

Commit: ede91ee4490b3eab7778c5e79d6ac9c9b9de9442
