### PR TITLE
Expose Resend batch send alias

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -77,17 +77,30 @@ function isSingleSendPostAlias(pathname: string, method: string): boolean {
   return pathname === "/emails" && method === "POST";
 }
 
+function isBatchSendPostAlias(pathname: string, method: string): boolean {
+  return pathname === "/emails/batch" && method === "POST";
+}
+
+function isSendPostAlias(pathname: string, method: string): boolean {
+  return (
+    isSingleSendPostAlias(pathname, method) ||
+    isBatchSendPostAlias(pathname, method)
+  );
+}
+
 function isSendApiPost(pathname: string, method: string): boolean {
   return (
     method === "POST" &&
     (pathname === "/api/emails" ||
       pathname === "/api/emails/batch" ||
-      pathname === "/emails")
+      pathname === "/emails" ||
+      pathname === "/emails/batch")
   );
 }
 
 function getRateLimitPathname(pathname: string, method: string): string {
   if (isSingleSendPostAlias(pathname, method)) return "/api/emails";
+  if (isBatchSendPostAlias(pathname, method)) return "/api/emails/batch";
   return pathname;
 }
 
@@ -102,7 +115,10 @@ function getLimits(
   ) {
     return { max: 20, windowMs: 60_000 };
   }
-  if (pathname === "/api/emails/batch" && method === "POST") {
+  if (
+    (pathname === "/api/emails/batch" || pathname === "/emails/batch") &&
+    method === "POST"
+  ) {
     return { max: 5, windowMs: 60_000 };
   }
   // API key management — tight limit
@@ -130,10 +146,10 @@ export async function middleware(request: NextRequest) {
 
   const isPublicUnsubscribeRoute = pathname.startsWith("/unsubscribe/");
 
-  // Protect non-API page routes with session check. POST /emails is a
-  // Resend-compatible API alias and must bypass dashboard session redirects.
-  const isSingleSendAlias = isSingleSendPostAlias(pathname, request.method);
-  if (!pathname.startsWith("/api/") && !isSingleSendAlias) {
+  // Protect non-API page routes with session check. Resend-compatible send
+  // aliases must bypass dashboard session redirects and use public API auth.
+  const isSendAlias = isSendPostAlias(pathname, request.method);
+  if (!pathname.startsWith("/api/") && !isSendAlias) {
     // Allow auth page, public landing page, and static assets
     if (
       pathname === "/auth" ||
@@ -160,8 +176,13 @@ export async function middleware(request: NextRequest) {
   const responseHeaders = new Headers({ "X-RateLimit-Backend": backend });
 
   if (backend === "disabled") {
-    if (isSingleSendAlias) {
+    if (isSingleSendPostAlias(pathname, request.method)) {
       return NextResponse.rewrite(new URL("/api/emails", request.url), {
+        headers: responseHeaders,
+      });
+    }
+    if (isBatchSendPostAlias(pathname, request.method)) {
+      return NextResponse.rewrite(new URL("/api/emails/batch", request.url), {
         headers: responseHeaders,
       });
     }
@@ -213,8 +234,13 @@ export async function middleware(request: NextRequest) {
     );
   }
 
-  if (isSingleSendAlias) {
+  if (isSingleSendPostAlias(pathname, request.method)) {
     return NextResponse.rewrite(new URL("/api/emails", request.url), {
+      headers: responseHeaders,
+    });
+  }
+  if (isBatchSendPostAlias(pathname, request.method)) {
+    return NextResponse.rewrite(new URL("/api/emails/batch", request.url), {
       headers: responseHeaders,
     });
   }

--- a/tests/e2e/emails-alias.spec.ts
+++ b/tests/e2e/emails-alias.spec.ts
@@ -28,6 +28,35 @@ test.describe("Resend-compatible /emails alias", () => {
     });
   });
 
+  test("POST /emails/batch reaches the JSON batch API instead of dashboard routing", async ({
+    request,
+  }) => {
+    const response = await request.post("/emails/batch", {
+      headers: {
+        "Content-Type": "application/json",
+        "Idempotency-Key": "batch-alias-e2e-missing-key",
+      },
+      data: [
+        {
+          from: "sender@example.com",
+          to: "recipient@example.com",
+          subject: "Batch alias",
+          html: "<p>Hello</p>",
+        },
+      ],
+    });
+
+    expect(response.status()).toBe(401);
+    expect(response.headers()["content-type"]).toContain("application/json");
+    expect(response.headers().location).toBeUndefined();
+    const json = await response.json();
+    expect(json).toMatchObject({
+      name: "missing_api_key",
+      code: "missing_api_key",
+      statusCode: 401,
+    });
+  });
+
   test("GET /emails keeps the dashboard sign-in flow", async ({ page }) => {
     await page.goto("/emails");
 

--- a/tests/middleware-rate-limit.test.ts
+++ b/tests/middleware-rate-limit.test.ts
@@ -70,6 +70,48 @@ describe("middleware rate limiting", () => {
     expect(response.headers.get("x-ratelimit-backend")).toBe("disabled");
   });
 
+  it("rewrites POST /emails/batch to the existing batch API without requiring a dashboard session", async () => {
+    mockGetSessionCookie.mockReturnValue(null);
+    const { middleware } = await import("@/middleware");
+
+    const response = await middleware(
+      makeRequest("https://example.com/emails/batch", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-api-key",
+          "content-type": "application/json",
+          "idempotency-key": "batch-alias-key",
+        },
+        body: JSON.stringify([
+          {
+            from: "sender@example.com",
+            to: "recipient@example.com",
+            subject: "Batch alias",
+            html: "<p>Hello</p>",
+          },
+        ]),
+      }),
+    );
+
+    expect(mockGetSessionCookie).not.toHaveBeenCalled();
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      "https://example.com/api/emails/batch",
+    );
+    expect(response.headers.get("x-ratelimit-backend")).toBe("disabled");
+  });
+
+  it("preserves dashboard GET /emails/batch session protection", async () => {
+    mockGetSessionCookie.mockReturnValue(null);
+    const { middleware } = await import("@/middleware");
+
+    const response = await middleware(
+      makeRequest("https://example.com/emails/batch", { method: "GET" }),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://example.com/auth");
+  });
+
   it("preserves dashboard GET /emails session protection", async () => {
     mockGetSessionCookie.mockReturnValue(null);
     const { middleware } = await import("@/middleware");
@@ -130,6 +172,32 @@ describe("middleware rate limiting", () => {
     expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
   });
 
+  it("applies the batch send rate-limit bucket to POST /emails/batch", async () => {
+    process.env.RATE_LIMIT_BACKEND = "redis";
+    mockGetSessionCookie.mockReturnValue(null);
+    mockIncrCache.mockResolvedValue(1);
+
+    const { middleware } = await import("@/middleware");
+    const response = await middleware(
+      makeRequest("https://example.com/emails/batch", {
+        method: "POST",
+        headers: {
+          "x-forwarded-for": "203.0.113.10",
+          authorization: "Bearer test-api-key",
+        },
+      }),
+    );
+
+    expect(mockIncrCache).toHaveBeenCalledWith(
+      "ratelimit:203.0.113.10:Bearer test-api-key:/api/emails/batch",
+      60,
+    );
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      "https://example.com/api/emails/batch",
+    );
+    expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
+  });
+
   it("returns 429 with Retry-After once the Redis limit is exceeded", async () => {
     process.env.RATE_LIMIT_BACKEND = "redis";
     mockIncrCache.mockResolvedValue(21);
@@ -160,6 +228,27 @@ describe("middleware rate limiting", () => {
     const { middleware } = await import("@/middleware");
     const response = await middleware(
       makeRequest("https://example.com/emails", { method: "POST" }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("17");
+    await expect(response.json()).resolves.toEqual({
+      name: "rate_limit_exceeded",
+      code: "rate_limit_exceeded",
+      message: "Rate limit exceeded. Try again later.",
+      statusCode: 429,
+    });
+  });
+
+  it("returns send API-style JSON rate-limit errors for POST /emails/batch", async () => {
+    process.env.RATE_LIMIT_BACKEND = "redis";
+    mockGetSessionCookie.mockReturnValue(null);
+    mockIncrCache.mockResolvedValue(6);
+    mockGetTtl.mockResolvedValue(17);
+
+    const { middleware } = await import("@/middleware");
+    const response = await middleware(
+      makeRequest("https://example.com/emails/batch", { method: "POST" }),
     );
 
     expect(response.status).toBe(429);


### PR DESCRIPTION
## Summary
- Add POST /emails/batch as a Resend-compatible middleware rewrite to the existing /api/emails/batch handler
- Keep GET /emails/batch under dashboard auth/session protection
- Share the existing batch send rate-limit bucket and public send API error envelope for the alias

Closes #211

## Validation
- bunx vitest run tests/middleware-rate-limit.test.ts
- bunx playwright test tests/e2e/emails-alias.spec.ts
- bun run typecheck
- bunx biome check src/middleware.ts tests/middleware-rate-limit.test.ts tests/e2e/emails-alias.spec.ts
- make test
- make check: typecheck passed, then Biome failed on pre-existing untracked .scratch/issue-200-api-key-isolation-scenario.ts outside this branch

## Risk
- Narrow middleware-only alias; existing batch handler remains the source of truth.