### PR TITLE
chore(ci): scope GITHUB_TOKEN to contents:read and bump checkout to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches: [main, staging]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -19,7 +22,7 @@ jobs:
     env:
       SKIP_STAR_PROMPT: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -37,7 +40,7 @@ jobs:
     env:
       SKIP_STAR_PROMPT: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # scripts/check-changed-files.mjs needs origin/main history to compute the merge base.
           fetch-depth: 0
@@ -58,7 +61,7 @@ jobs:
     env:
       SKIP_STAR_PROMPT: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -76,7 +79,7 @@ jobs:
     env:
       SKIP_STAR_PROMPT: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: deploy-prod
   cancel-in-progress: false
@@ -17,7 +20,7 @@ jobs:
     runs-on: [self-hosted, opensend-deploy]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Deploy app + ingester to ECS
         run: bash scripts/deploy.sh all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

- Add `permissions: contents: read` at workflow level for `ci.yml` and `deploy.yml`. Neither writes via `GITHUB_TOKEN` — deploy uses the runner's AWS creds, CI only runs tests — so least-privilege the token. `release.yml` already correctly declares `contents: write` for `gh release create`.
- Bump every `actions/checkout@v4` → `@v5` (7 call sites across `ci.yml`, `deploy.yml`, `release.yml`). Clears the Node 20 deprecation warning surfaced on the most recent Deploy run and pre-empts the forced Node 24 cutover in June 2026.

No behaviour change for the deploy itself. Came out of a quick security review of the recent deploy-script iterations (#201 / #203 / #206).

## Test plan

- [ ] CI on this PR runs and passes (typecheck, lint, tests, onboarding) on the v5 checkout
- [ ] After merge to `staging`, the staging→main release PR runs Deploy cleanly with the new token scope and v5 checkout
- [ ] Confirm the `actions/checkout@v4` deprecation warning no longer appears in the Deploy run annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)