### PR TITLE
Implement contact and domain lifecycle webhooks

### DIFF
--- a/agent_docs/learnings/active/2026-05-06-issue-218-lifecycle-webhooks.md
+++ b/agent_docs/learnings/active/2026-05-06-issue-218-lifecycle-webhooks.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-06
+issue: "#218"
+type: decision
+promoted_to: null
+---
+
+## Lifecycle webhook events use nullable email_events.email_id
+
+Contact/domain lifecycle webhooks reuse the existing `email_events` + `webhook_deliveries` dispatcher path instead of adding a parallel event table. `email_events.email_id` is nullable for non-email lifecycle rows and `email_events.user_id` scopes event enqueue to active webhook subscriptions owned by the same tenant.
+
+Why: the dispatcher already loads deliveries by event id and serializes `{ id, type, created_at, data }`; making the event store generic enough for contact/domain payloads preserves email delivery behavior while replacing the old console-only `queueEvent` path with real pending delivery rows.

--- a/drizzle/0013_clammy_plazm.sql
+++ b/drizzle/0013_clammy_plazm.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "email_events" ALTER COLUMN "email_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "email_events" ADD COLUMN "user_id" text;--> statement-breakpoint
+CREATE INDEX "email_events_user_id_idx" ON "email_events" USING btree ("user_id");

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,3028 @@
+{
+  "id": "f97518b7-58cd-40ec-967b-3df70fd202f2",
+  "prevId": "4fb1596d-58ca-447e-aa9e-4269fbcd4228",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_preview": {
+          "name": "token_preview",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_access'"
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_token_hash_idx": {
+          "name": "api_keys_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_runs": {
+      "name": "automation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_event_id": {
+          "name": "trigger_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "current_step_key": {
+          "name": "current_step_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_states": {
+          "name": "step_states",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_step_at": {
+          "name": "next_step_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "automation_runs_status_next_step_at_idx": {
+          "name": "automation_runs_status_next_step_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_step_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_automation_id_created_at_idx": {
+          "name": "automation_runs_automation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_runs_automation_id_automations_id_fk": {
+          "name": "automation_runs_automation_id_automations_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_steps": {
+      "name": "automation_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_steps_automation_id_key_idx": {
+          "name": "automation_steps_automation_id_key_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_steps_automation_id_position_idx": {
+          "name": "automation_steps_automation_id_position_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_steps_automation_id_automations_id_fk": {
+          "name": "automation_steps_automation_id_automations_id_fk",
+          "tableFrom": "automation_steps",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automations": {
+      "name": "automations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "trigger_event_name": {
+          "name": "trigger_event_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connections": {
+          "name": "connections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "automations_status_trigger_idx": {
+          "name": "automations_status_trigger_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automations_user_id_idx": {
+          "name": "automations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.broadcasts": {
+      "name": "broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_id": {
+          "name": "audience_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_properties": {
+      "name": "contact_properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'string'"
+        },
+        "fallback_value": {
+          "name": "fallback_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_properties_key_idx": {
+          "name": "contact_properties_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed": {
+          "name": "unsubscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "custom_properties": {
+          "name": "custom_properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segments": {
+          "name": "segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_subscriptions": {
+          "name": "topic_subscriptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contacts_email_idx": {
+          "name": "contacts_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_unsubscribed_idx": {
+          "name": "contacts_unsubscribed_idx",
+          "columns": [
+            {
+              "expression": "unsubscribed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_created_at_idx": {
+          "name": "contacts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts_to_segments": {
+      "name": "contacts_to_segments",
+      "schema": "",
+      "columns": {
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contacts_to_segments_idx": {
+          "name": "contacts_to_segments_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "segment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_to_segments_segment_id_idx": {
+          "name": "contacts_to_segments_segment_id_idx",
+          "columns": [
+            {
+              "expression": "segment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contacts_to_segments_contact_id_contacts_id_fk": {
+          "name": "contacts_to_segments_contact_id_contacts_id_fk",
+          "tableFrom": "contacts_to_segments",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contacts_to_segments_segment_id_segments_id_fk": {
+          "name": "contacts_to_segments_segment_id_segments_id_fk",
+          "tableFrom": "contacts_to_segments",
+          "tableTo": "segments",
+          "columnsFrom": [
+            "segment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_event_deliveries": {
+      "name": "custom_event_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "custom_event_deliveries_event_name_idx": {
+          "name": "custom_event_deliveries_event_name_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_event_deliveries_received_at_idx": {
+          "name": "custom_event_deliveries_received_at_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_events": {
+      "name": "custom_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "custom_events_user_name_idx": {
+          "name": "custom_events_user_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domains": {
+      "name": "domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'us-east-1'"
+        },
+        "dkim_tokens": {
+          "name": "dkim_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "records": {
+          "name": "records",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_clicks": {
+          "name": "track_clicks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "track_opens": {
+          "name": "track_opens",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tls": {
+          "name": "tls",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opportunistic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_return_path": {
+          "name": "custom_return_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_subdomain": {
+          "name": "tracking_subdomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_events": {
+      "name": "email_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_events_email_id_idx": {
+          "name": "email_events_email_id_idx",
+          "columns": [
+            {
+              "expression": "email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_events_user_id_idx": {
+          "name": "email_events_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_events_source_id_idx": {
+          "name": "email_events_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_events_email_id_emails_id_fk": {
+          "name": "email_events_email_id_emails_id_fk",
+          "tableFrom": "email_events",
+          "tableTo": "emails",
+          "columnsFrom": [
+            "email_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_email_id": {
+          "name": "source_email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed_at": {
+          "name": "suppressed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_suppressions_user_email_idx": {
+          "name": "email_suppressions_user_email_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_user_idx": {
+          "name": "email_suppressions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_email_idx": {
+          "name": "email_suppressions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.emails": {
+      "name": "emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc": {
+          "name": "cc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "emails_status_idx": {
+          "name": "emails_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_created_at_idx": {
+          "name": "emails_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_status_created_at_idx": {
+          "name": "emails_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_user_created_at_idx": {
+          "name": "emails_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_user_id_idempotency_key_idx": {
+          "name": "emails_user_id_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_price_cents": {
+          "name": "monthly_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthly_email_quota": {
+          "name": "monthly_email_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_domains": {
+          "name": "max_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_api_keys": {
+          "name": "max_api_keys",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plans_slug_idx": {
+          "name": "plans_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.received_emails": {
+      "name": "received_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "received_emails_created_at_idx": {
+          "name": "received_emails_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segments": {
+      "name": "segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contacts_count": {
+          "name": "contacts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unsubscribed_count": {
+          "name": "unsubscribed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_customers": {
+      "name": "stripe_customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_customers_user_id_idx": {
+          "name": "stripe_customers_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_customers_stripe_customer_id_idx": {
+          "name": "stripe_customers_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events_processed": {
+      "name": "stripe_events_processed",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_processed_processed_at_idx": {
+          "name": "stripe_events_processed_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_subscription_id_idx": {
+          "name": "subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_status_idx": {
+          "name": "subscriptions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_plan_id_plans_id_fk": {
+          "name": "subscriptions_plan_id_plans_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled Template'"
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_unpublished_versions": {
+          "name": "has_unpublished_versions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_subscription": {
+          "name": "default_subscription",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opt_out'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_periods": {
+      "name": "usage_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emails_sent": {
+          "name": "emails_sent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_increment_at": {
+          "name": "last_increment_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_periods_user_period_idx": {
+          "name": "usage_periods_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_periods_user_id_idx": {
+          "name": "usage_periods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_webhook_id_idx": {
+          "name": "webhook_deliveries_webhook_id_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_status_idx": {
+          "name": "webhook_deliveries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_deliveries_event_id_email_events_id_fk": {
+          "name": "webhook_deliveries_event_id_email_events_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "email_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "signing_secret": {
+          "name": "signing_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1777987647765,
       "tag": "0012_same_famine",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1778051377947,
+      "tag": "0013_clammy_plazm",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/repositories/emailEventRepo.ts
+++ b/packages/core/src/db/repositories/emailEventRepo.ts
@@ -20,7 +20,7 @@ export const emailEventRepo = {
       const [event] = await tx.insert(emailEvents).values(data).returning();
       const nextStatus = STATUS_BY_EVENT_TYPE[data.type];
 
-      if (nextStatus) {
+      if (nextStatus && data.emailId) {
         await tx
           .update(emails)
           .set({ status: nextStatus })
@@ -55,7 +55,7 @@ export const emailEventRepo = {
 
       const nextStatus = STATUS_BY_EVENT_TYPE[data.type];
 
-      if (nextStatus) {
+      if (nextStatus && data.emailId) {
         await tx
           .update(emails)
           .set({ status: nextStatus })

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -379,18 +379,18 @@ export const emailEvents = pgTable(
   "email_events",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    emailId: uuid("email_id")
-      .notNull()
-      .references(() => emails.id),
+    emailId: uuid("email_id").references(() => emails.id),
     sourceId: varchar("source_id", { length: 255 }),
     type: varchar("type", { length: 50 }).notNull(),
     payload: jsonb("payload").notNull(),
+    userId: text("user_id"),
     receivedAt: timestamp("received_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
   },
   (t) => [
     index("email_events_email_id_idx").on(t.emailId),
+    index("email_events_user_id_idx").on(t.userId),
     uniqueIndex("email_events_source_id_idx").on(t.sourceId),
   ],
 );

--- a/packages/core/src/webhook-events.ts
+++ b/packages/core/src/webhook-events.ts
@@ -7,6 +7,12 @@ export const SUPPORTED_WEBHOOK_EVENT_TYPES = [
   "email.opened",
   "email.clicked",
   "email.failed",
+  "contact.created",
+  "contact.updated",
+  "contact.deleted",
+  "domain.created",
+  "domain.updated",
+  "domain.deleted",
 ] as const;
 
 export type SupportedWebhookEventType =

--- a/src/app/api/contacts/[id]/route.ts
+++ b/src/app/api/contacts/[id]/route.ts
@@ -1,7 +1,28 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { contacts } from "@/lib/db/schema";
+import { queueEvent } from "@/lib/events";
 import { and, eq, or } from "drizzle-orm";
+
+type ContactWebhookRow = typeof contacts.$inferSelect;
+
+function toContactWebhookPayload(contact: ContactWebhookRow) {
+  return {
+    id: contact.id,
+    email: contact.email,
+    first_name: contact.firstName,
+    last_name: contact.lastName,
+    unsubscribed: contact.unsubscribed,
+    properties: contact.customProperties ?? {},
+    segments: contact.segments ?? [],
+    topics: contact.topicSubscriptions ?? [],
+    created_at: contact.createdAt?.toISOString?.() ?? contact.createdAt,
+  };
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
 
 async function findContact(idOrEmail: string, userId: string) {
   const isUuid =
@@ -101,6 +122,42 @@ export async function PATCH(
     if (body.properties !== undefined)
       updateData.customProperties = body.properties;
 
+    const changedFields = Object.entries({
+      email: updateData.email,
+      first_name: updateData.firstName,
+      last_name: updateData.lastName,
+      unsubscribed: updateData.unsubscribed,
+      properties: updateData.customProperties,
+    })
+      .filter(([, value]) => value !== undefined)
+      .filter(([field, value]) => {
+        const currentValue =
+          field === "first_name"
+            ? contact.firstName
+            : field === "last_name"
+              ? contact.lastName
+              : field === "properties"
+                ? contact.customProperties
+                : field === "unsubscribed"
+                  ? contact.unsubscribed
+                  : contact.email;
+        return !valuesEqual(currentValue, value);
+      })
+      .map(([field]) => field);
+
+    if (changedFields.length === 0) {
+      return Response.json({
+        object: "contact",
+        id: contact.id,
+        email: contact.email,
+        first_name: contact.firstName,
+        last_name: contact.lastName,
+        unsubscribed: contact.unsubscribed,
+        properties: contact.customProperties,
+        created_at: contact.createdAt,
+      });
+    }
+
     const [updated] = await db
       .update(contacts)
       .set(updateData)
@@ -110,6 +167,16 @@ export async function PATCH(
     if (!updated) {
       return Response.json({ error: "Contact not found" }, { status: 404 });
     }
+
+    await queueEvent({
+      type: "contact.updated",
+      userId,
+      payload: {
+        id: updated.id,
+        changed_fields: changedFields,
+        contact: toContactWebhookPayload(updated),
+      },
+    });
 
     return Response.json({
       object: "contact",
@@ -148,11 +215,20 @@ export async function DELETE(
     const [deleted] = await db
       .delete(contacts)
       .where(and(eq(contacts.id, contact.id), eq(contacts.userId, userId)))
-      .returning({ id: contacts.id });
+      .returning({ id: contacts.id, email: contacts.email });
 
     if (!deleted) {
       return Response.json({ error: "Contact not found" }, { status: 404 });
     }
+
+    await queueEvent({
+      type: "contact.deleted",
+      userId,
+      payload: {
+        id: deleted.id,
+        email: deleted.email,
+      },
+    });
 
     return Response.json({
       object: "contact",

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -5,6 +5,7 @@ import {
 } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { contacts, segments, topics } from "@/lib/db/schema";
+import { queueEvent } from "@/lib/events";
 import { createContactSchema } from "@/lib/validation/contacts";
 import { type SQL, and, desc, eq, ilike, lt, or, sql } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
@@ -12,6 +13,22 @@ import { type NextRequest, NextResponse } from "next/server";
 type ContactRouteAuth = NonNullable<
   Awaited<ReturnType<typeof authorizeDashboardOrApiKey>>
 >;
+
+type ContactWebhookRow = typeof contacts.$inferSelect;
+
+function toContactWebhookPayload(contact: ContactWebhookRow) {
+  return {
+    id: contact.id,
+    email: contact.email,
+    first_name: contact.firstName,
+    last_name: contact.lastName,
+    unsubscribed: contact.unsubscribed,
+    properties: contact.customProperties ?? {},
+    segments: contact.segments ?? [],
+    topics: contact.topicSubscriptions ?? [],
+    created_at: contact.createdAt?.toISOString?.() ?? contact.createdAt,
+  };
+}
 
 async function resolveUserId(auth: ContactRouteAuth): Promise<string | null> {
   if ("userId" in auth) return auth.userId;
@@ -98,7 +115,13 @@ export async function POST(request: NextRequest) {
           topicSubscriptions: resolvedTopics.length > 0 ? resolvedTopics : null,
           userId,
         })
-        .returning({ id: contacts.id });
+        .returning();
+
+      await queueEvent({
+        type: "contact.created",
+        userId,
+        payload: toContactWebhookPayload(inserted),
+      });
 
       return NextResponse.json(
         {

--- a/src/app/api/domains/[id]/route.ts
+++ b/src/app/api/domains/[id]/route.ts
@@ -10,6 +10,7 @@ import {
   getCachedDomainById,
   invalidateDomainCaches,
 } from "@/lib/domain-cache";
+import { queueEvent } from "@/lib/events";
 import { deleteDomainIdentity } from "@/lib/ses";
 import {
   domainRouteParamsSchema,
@@ -19,10 +20,31 @@ import { getEffectiveReturnPathLabel } from "@opensend/core";
 import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
+type DomainWebhookRow = typeof domains.$inferSelect;
+
 const defaultCapabilities = [
   { name: "sending", enabled: true },
   { name: "receiving", enabled: false },
 ];
+
+function toDomainWebhookPayload(domain: DomainWebhookRow) {
+  return {
+    id: domain.id,
+    name: domain.name,
+    status: domain.status,
+    region: domain.region,
+    records: domain.records ?? [],
+    capabilities: domain.capabilities ?? [],
+    created_at:
+      domain.createdAt instanceof Date
+        ? domain.createdAt.toISOString()
+        : domain.createdAt,
+  };
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
 
 export async function GET(
   _req: Request,
@@ -160,6 +182,36 @@ export async function PATCH(
       updates.tls = validated.tls;
     }
 
+    const changedFields = Object.entries({
+      open_tracking: updates.trackOpens,
+      click_tracking: updates.trackClicks,
+      tracking_subdomain: updates.trackingSubdomain,
+      capabilities: updates.capabilities,
+      tls: updates.tls,
+    })
+      .filter(([, value]) => value !== undefined)
+      .filter(([field, value]) => {
+        const currentValue =
+          field === "open_tracking"
+            ? existingDomain.trackOpens
+            : field === "click_tracking"
+              ? existingDomain.trackClicks
+              : field === "tracking_subdomain"
+                ? existingDomain.trackingSubdomain
+                : field === "capabilities"
+                  ? existingDomain.capabilities
+                  : existingDomain.tls;
+        return !valuesEqual(currentValue, value);
+      })
+      .map(([field]) => field);
+
+    if (changedFields.length === 0) {
+      return NextResponse.json({
+        object: "domain",
+        id: existingDomain.id,
+      });
+    }
+
     const [updated] = await db
       .update(domains)
       .set(updates)
@@ -172,6 +224,16 @@ export async function PATCH(
     }
 
     await invalidateDomainCaches({ id: updated.id, name: updated.name });
+
+    await queueEvent({
+      type: "domain.updated",
+      userId,
+      payload: {
+        id: updated.id,
+        changed_fields: changedFields,
+        domain: toDomainWebhookPayload(updated),
+      },
+    });
 
     return NextResponse.json({
       object: "domain",
@@ -241,13 +303,22 @@ export async function DELETE(
     const [deleted] = await db
       .delete(domains)
       .where(and(eq(domains.id, id), eq(domains.userId, userId)))
-      .returning({ id: domains.id });
+      .returning({ id: domains.id, name: domains.name });
 
     await invalidateDomainCaches({ id, name: domain.name });
 
     if (!deleted) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
+
+    await queueEvent({
+      type: "domain.deleted",
+      userId,
+      payload: {
+        id: deleted.id,
+        name: deleted.name,
+      },
+    });
 
     return NextResponse.json({
       object: "domain",

--- a/src/app/api/domains/[id]/verify/route.ts
+++ b/src/app/api/domains/[id]/verify/route.ts
@@ -97,11 +97,14 @@ export async function POST(
     if (updated.status !== previousStatus) {
       await queueEvent({
         type: "domain.updated",
+        userId,
         payload: {
           id: updated.id,
           name: updated.name,
           status: updated.status,
           previous_status: previousStatus,
+          records: updated.records || [],
+          capabilities: updated.capabilities || [],
         },
       });
     }

--- a/src/app/api/domains/route.ts
+++ b/src/app/api/domains/route.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/api-auth";
 import { checkDomainQuota, quotaExceededResponse } from "@/lib/billing/quota";
 import { invalidateDomainCaches } from "@/lib/domain-cache";
+import { queueEvent } from "@/lib/events";
 import { createDomainIdentity } from "@/lib/ses";
 import { createDomainSchema } from "@/lib/validation/domains";
 import {
@@ -20,6 +21,31 @@ function domainService() {
   });
 }
 
+type DomainWebhookPayload = {
+  id: string;
+  name: string;
+  status: string;
+  region?: string;
+  records?: unknown;
+  capabilities?: unknown;
+  created_at?: unknown;
+};
+
+function toDomainWebhookPayload(row: DomainWebhookPayload) {
+  return {
+    id: row.id,
+    name: row.name,
+    status: row.status,
+    region: row.region,
+    records: row.records ?? [],
+    capabilities: row.capabilities ?? [],
+    created_at:
+      row.created_at instanceof Date
+        ? row.created_at.toISOString()
+        : row.created_at,
+  };
+}
+
 function mapDomainError(error: unknown, fallback: string): Response {
   console.error(`${fallback}:`, error);
   return Response.json({ error: fallback }, { status: 500 });
@@ -28,6 +54,7 @@ function mapDomainError(error: unknown, fallback: string): Response {
 export async function POST(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  if (!auth.userId) return unauthorizedResponse();
 
   let body: unknown;
   try {
@@ -61,6 +88,20 @@ export async function POST(request: Request): Promise<Response> {
       tls: validated.tls,
       capabilities: validated.capabilities,
       userId: auth.userId,
+    });
+
+    await queueEvent({
+      type: "domain.created",
+      userId: auth.userId,
+      payload: toDomainWebhookPayload({
+        id: row.id,
+        name: row.name,
+        status: row.status,
+        region: row.region,
+        records: row.records,
+        capabilities: row.capabilities,
+        created_at: row.createdAt,
+      }),
     });
 
     return Response.json(

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -387,18 +387,18 @@ export const emailEvents = pgTable(
   "email_events",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    emailId: uuid("email_id")
-      .notNull()
-      .references(() => emails.id),
+    emailId: uuid("email_id").references(() => emails.id),
     sourceId: varchar("source_id", { length: 255 }),
     type: varchar("type", { length: 50 }).notNull(),
     payload: jsonb("payload").notNull(),
+    userId: text("user_id"),
     receivedAt: timestamp("received_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
   },
   (t) => [
     index("email_events_email_id_idx").on(t.emailId),
+    index("email_events_user_id_idx").on(t.userId),
     uniqueIndex("email_events_source_id_idx").on(t.sourceId),
   ],
 );

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,59 +1,84 @@
 import { db } from "@/lib/db";
-import { emailEvents, emails, webhooks } from "@/lib/db/schema";
-import { eq, sql } from "drizzle-orm";
+import { emailEvents, webhookDeliveries, webhooks } from "@/lib/db/schema";
+import {
+  type SupportedWebhookEventType,
+  isSupportedWebhookEventType,
+} from "@opensend/core/src/webhook-events";
+import { and, eq, sql } from "drizzle-orm";
 
-export type SystemEventType =
-  | "domain.created"
-  | "domain.updated"
-  | "domain.deleted"
-  | "email.sent"
-  | "email.delivered"
-  | "email.bounced"
-  | "email.complained";
+export type SystemEventType = SupportedWebhookEventType;
 
 export interface QueueEventOptions {
   type: SystemEventType;
+  userId: string;
   payload: Record<string, unknown>;
   emailId?: string;
+  sourceId?: string;
 }
 
+export type QueuedWebhookEvent = {
+  eventId: string;
+  deliveryIds: string[];
+};
+
 /**
- * queueEvent
- *
- * Enqueues a system event for webhook delivery.
+ * Persists a webhook event and enqueues pending deliveries for active,
+ * same-tenant webhook subscriptions. Email events may include emailId; contact
+ * and domain lifecycle events intentionally use the same durable event store
+ * with a null email_id so the existing dispatcher can deliver them.
  */
-export async function queueEvent(options: QueueEventOptions) {
-  const { type, payload, emailId } = options;
+export async function queueEvent(
+  options: QueueEventOptions,
+): Promise<QueuedWebhookEvent> {
+  const { type, payload, emailId, sourceId, userId } = options;
 
-  await db.transaction(async (tx) => {
-    // 1. If it's an email event, log it in email_events
-    let internalEventId: string | undefined;
+  if (!isSupportedWebhookEventType(type)) {
+    throw new Error(`Unsupported webhook event type: ${type}`);
+  }
 
-    if (emailId) {
-      const [evt] = await tx
-        .insert(emailEvents)
-        .values({
-          emailId,
-          type,
-          payload,
-        })
-        .returning({ id: emailEvents.id });
-      internalEventId = evt.id;
-    }
+  return await db.transaction(async (tx) => {
+    const [event] = await tx
+      .insert(emailEvents)
+      .values({
+        emailId: emailId ?? null,
+        sourceId: sourceId ?? null,
+        type,
+        payload,
+        userId,
+      })
+      .returning({ id: emailEvents.id });
 
-    // 2. Scan for matching webhooks and enqueue deliveries
-    // In a real implementation, we'd insert into a 'webhook_deliveries' table.
-    // For now, we log the intent.
     const matchingWebhooks = await tx
-      .select()
+      .select({ id: webhooks.id })
       .from(webhooks)
-      .where(sql`${webhooks.eventTypes} ? ${type}`);
-
-    for (const webhook of matchingWebhooks) {
-      console.log(
-        `[Event] Queuing ${type} for webhook ${webhook.id} (${webhook.url})`,
+      .where(
+        and(
+          eq(webhooks.userId, userId),
+          eq(webhooks.status, "active"),
+          sql`${webhooks.eventTypes} ? ${type}`,
+        ),
       );
-      // tx.insert(webhookDeliveries).values(...)
+
+    if (matchingWebhooks.length === 0) {
+      return { eventId: event.id, deliveryIds: [] };
     }
+
+    const deliveries = await tx
+      .insert(webhookDeliveries)
+      .values(
+        matchingWebhooks.map((webhook) => ({
+          webhookId: webhook.id,
+          eventId: event.id,
+          status: "pending",
+          attempt: 0,
+          nextRetryAt: null,
+        })),
+      )
+      .returning({ id: webhookDeliveries.id });
+
+    return {
+      eventId: event.id,
+      deliveryIds: deliveries.map((delivery) => delivery.id),
+    };
   });
 }

--- a/tests/api-domains.test.ts
+++ b/tests/api-domains.test.ts
@@ -8,9 +8,12 @@ const mockQueueEvent = vi.hoisted(() => vi.fn());
 const mockDeleteDomainIdentity = vi.hoisted(() => vi.fn());
 const mockGetDomainIdentity = vi.hoisted(() => vi.fn());
 const mockCreateDomainIdentity = vi.hoisted(() => vi.fn());
+const mockCheckDomainQuota = vi.hoisted(() => vi.fn());
+const mockCreateDomain = vi.hoisted(() => vi.fn());
 const mockDb = vi.hoisted(() => ({
   insert: vi.fn(),
   update: vi.fn(),
+  delete: vi.fn(),
   select: vi.fn(),
   query: {
     domains: {
@@ -28,6 +31,23 @@ vi.mock("@/lib/api-auth", () => ({
   authorizeDashboardOrApiKey: mockValidateApiKey,
   unauthorizedResponse: () =>
     Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/billing/quota", () => ({
+  checkDomainQuota: mockCheckDomainQuota,
+  quotaExceededResponse: () =>
+    Response.json({ error: "Domain quota exceeded" }, { status: 402 }),
+}));
+
+vi.mock("@opensend/core", () => ({
+  DMARC_RECORD_VALUE: "v=DMARC1; p=none;",
+  buildDmarcRecordName: (domain: string) => `_dmarc.${domain}`,
+  createDomainService: () => ({
+    createDomain: mockCreateDomain,
+    listDomains: vi.fn(),
+  }),
+  getEffectiveReturnPathLabel: (value: string | null | undefined) =>
+    value?.trim() || "send",
 }));
 
 vi.mock("@/lib/cloudflare", () => ({
@@ -86,10 +106,151 @@ describe("Domain API validation", () => {
     mockDeleteDomainIdentity.mockReset();
     mockGetDomainIdentity.mockReset();
     mockCreateDomainIdentity.mockReset();
+    mockCheckDomainQuota.mockResolvedValue({
+      ok: true,
+      info: { limit: 10, used: 0 },
+    });
+    mockCreateDomain.mockReset();
     mockDb.insert.mockReset();
     mockDb.update.mockReset();
+    mockDb.delete.mockReset();
     mockDb.select.mockReset();
     mockDb.query.domains.findFirst.mockReset();
+  });
+
+  it("creates a domain and enqueues domain.created for the caller tenant", async () => {
+    const createdAt = new Date("2026-05-06T00:00:00.000Z");
+    mockCreateDomain.mockResolvedValueOnce({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+      status: "not_started",
+      region: "us-east-1",
+      records: [
+        {
+          type: "TXT",
+          name: "_dmarc.example.com",
+          value: "v=DMARC1; p=none;",
+          status: "pending",
+          ttl: "Auto",
+        },
+      ],
+      customReturnPath: null,
+      trackOpens: false,
+      trackClicks: false,
+      trackingSubdomain: null,
+      tls: "opportunistic",
+      capabilities: [{ name: "sending", enabled: true }],
+      createdAt,
+    });
+
+    const { POST } = await import("@/app/api/domains/route");
+    const req = makeRequest("http://localhost:3015/api/domains", "POST", {
+      name: "Example.com",
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(201);
+    expect(mockCreateDomain).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Example.com", userId: "user-1" }),
+    );
+    expect(mockQueueEvent).toHaveBeenCalledWith({
+      type: "domain.created",
+      userId: "user-1",
+      payload: expect.objectContaining({
+        id: VALID_DOMAIN_ID,
+        name: "example.com",
+        status: "not_started",
+        records: expect.any(Array),
+        capabilities: expect.any(Array),
+      }),
+    });
+  });
+
+  it("updates a domain and enqueues domain.updated for the caller tenant", async () => {
+    const existing = {
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+      userId: "user-1",
+      status: "not_started",
+      region: "us-east-1",
+      records: [],
+      trackOpens: false,
+      trackClicks: false,
+      trackingSubdomain: null,
+      tls: "opportunistic",
+      capabilities: [{ name: "sending", enabled: true }],
+      createdAt: new Date("2026-05-06T00:00:00.000Z"),
+    };
+    const updated = { ...existing, trackOpens: true };
+    mockDb.query.domains.findFirst.mockResolvedValueOnce(existing);
+    mockDb.update.mockReturnValueOnce({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([updated]),
+        }),
+      }),
+    });
+
+    const { PATCH } = await import("@/app/api/domains/[id]/route");
+    const req = makeRequest(
+      `http://localhost:3015/api/domains/${VALID_DOMAIN_ID}`,
+      "PATCH",
+      { open_tracking: true },
+    );
+
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: VALID_DOMAIN_ID }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockQueueEvent).toHaveBeenCalledWith({
+      type: "domain.updated",
+      userId: "user-1",
+      payload: expect.objectContaining({
+        id: VALID_DOMAIN_ID,
+        changed_fields: ["open_tracking"],
+        domain: expect.objectContaining({
+          id: VALID_DOMAIN_ID,
+          name: "example.com",
+        }),
+      }),
+    });
+  });
+
+  it("deletes a domain and enqueues domain.deleted for the caller tenant", async () => {
+    mockDb.query.domains.findFirst.mockResolvedValueOnce({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+      userId: "user-1",
+      status: "not_started",
+      records: [],
+    });
+    mockListDNSRecords.mockResolvedValueOnce([]);
+    mockDb.delete.mockReturnValueOnce({
+      where: vi.fn().mockReturnValue({
+        returning: vi
+          .fn()
+          .mockResolvedValue([{ id: VALID_DOMAIN_ID, name: "example.com" }]),
+      }),
+    });
+
+    const { DELETE } = await import("@/app/api/domains/[id]/route");
+    const req = makeRequest(
+      `http://localhost:3015/api/domains/${VALID_DOMAIN_ID}`,
+      "DELETE",
+    );
+
+    const res = await DELETE(req, {
+      params: Promise.resolve({ id: VALID_DOMAIN_ID }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockQueueEvent).toHaveBeenCalledWith({
+      type: "domain.deleted",
+      userId: "user-1",
+      payload: { id: VALID_DOMAIN_ID, name: "example.com" },
+    });
   });
 
   it("returns 422 for invalid domain create payload", async () => {
@@ -219,7 +380,16 @@ describe("Domain API validation", () => {
       ttl: "Auto",
     });
     expect(mockDb.query.domains.findFirst).toHaveBeenCalledTimes(1);
-    expect(mockQueueEvent).toHaveBeenCalledTimes(1);
+    expect(mockQueueEvent).toHaveBeenCalledWith({
+      type: "domain.updated",
+      userId: "user-1",
+      payload: expect.objectContaining({
+        id: VALID_DOMAIN_ID,
+        name: "example.com",
+        status: "verified",
+        previous_status: "pending",
+      }),
+    });
   });
 
   it("returns 404 when verifying a domain owned by another tenant", async () => {

--- a/tests/contact-tenant-isolation.test.ts
+++ b/tests/contact-tenant-isolation.test.ts
@@ -11,6 +11,7 @@ const mockSelect = vi.hoisted(() => vi.fn());
 const mockInsert = vi.hoisted(() => vi.fn());
 const mockUpdate = vi.hoisted(() => vi.fn());
 const mockDelete = vi.hoisted(() => vi.fn());
+const mockQueueEvent = vi.hoisted(() => vi.fn());
 
 function makeRequest(url: string, init?: RequestInit) {
   const request = new Request(url, init) as Request & { nextUrl: URL };
@@ -77,6 +78,10 @@ vi.mock("@/lib/api-auth", () => ({
     Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
 }));
 
+vi.mock("@/lib/events", () => ({
+  queueEvent: mockQueueEvent,
+}));
+
 vi.mock("@/lib/db", () => ({
   db: {
     query: {
@@ -111,6 +116,176 @@ describe("contact API tenant isolation", () => {
       userId: "user-b",
     });
     mockGetServerSession.mockResolvedValue(null);
+    mockQueueEvent.mockResolvedValue({
+      eventId: "event-1",
+      deliveryIds: ["delivery-1"],
+    });
+  });
+
+  it("enqueues contact.created for the caller tenant after creating a contact", async () => {
+    const insertedContact = {
+      id: "contact-b",
+      email: "b@example.com",
+      firstName: "B",
+      lastName: "User",
+      unsubscribed: false,
+      customProperties: { plan: "pro" },
+      segments: null,
+      topicSubscriptions: null,
+      createdAt: new Date("2026-05-06T00:00:00.000Z"),
+      document: null,
+      userId: "user-b",
+    };
+    const insertChain = makeChain([insertedContact]);
+    mockInsert.mockReturnValueOnce(insertChain);
+
+    const route = await import("@/app/api/contacts/route");
+    const response = await route.POST(
+      makeRequest("http://localhost/api/contacts", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer user-b-key",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          email: "B@Example.com",
+          first_name: "B",
+          last_name: "User",
+          properties: { plan: "pro" },
+        }),
+      }) as never,
+    );
+
+    expect(response.status).toBe(201);
+    expect(insertChain.values.mock.calls[0]?.[0]).toMatchObject({
+      email: "b@example.com",
+      userId: "user-b",
+    });
+    expect(mockQueueEvent).toHaveBeenCalledWith({
+      type: "contact.created",
+      userId: "user-b",
+      payload: expect.objectContaining({
+        id: "contact-b",
+        email: "b@example.com",
+        first_name: "B",
+        properties: { plan: "pro" },
+      }),
+    });
+  });
+
+  it("enqueues contact.updated only when the caller-owned contact changes", async () => {
+    mockContactFindFirst.mockResolvedValueOnce({
+      id: "contact-b",
+      email: "b@example.com",
+      firstName: "Before",
+      lastName: null,
+      unsubscribed: false,
+      customProperties: null,
+      segments: null,
+      topicSubscriptions: null,
+      createdAt: new Date("2026-05-06T00:00:00.000Z"),
+      document: null,
+      userId: "user-b",
+    });
+    const updateChain = makeChain([
+      {
+        id: "contact-b",
+        email: "b@example.com",
+        firstName: "After",
+        lastName: null,
+        unsubscribed: false,
+        customProperties: null,
+        segments: null,
+        topicSubscriptions: null,
+        createdAt: new Date("2026-05-06T00:00:00.000Z"),
+        document: null,
+        userId: "user-b",
+      },
+    ]);
+    mockUpdate.mockReturnValueOnce(updateChain);
+
+    const route = await import("@/app/api/contacts/[id]/route");
+    const response = await route.PATCH(
+      makeRequest("http://localhost/api/contacts/contact-b", {
+        method: "PATCH",
+        headers: { authorization: "Bearer user-b-key" },
+        body: JSON.stringify({ first_name: "After" }),
+      }),
+      { params: Promise.resolve({ id: "contact-b" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockQueueEvent).toHaveBeenCalledWith({
+      type: "contact.updated",
+      userId: "user-b",
+      payload: expect.objectContaining({
+        id: "contact-b",
+        changed_fields: ["first_name"],
+        contact: expect.objectContaining({ first_name: "After" }),
+      }),
+    });
+
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue({
+      apiKeyId: "key-b",
+      permission: "full_access",
+      domain: null,
+      userId: "user-b",
+    });
+    mockContactFindFirst.mockResolvedValueOnce({
+      id: "contact-b",
+      email: "b@example.com",
+      firstName: "After",
+      lastName: null,
+      unsubscribed: false,
+      customProperties: null,
+      segments: null,
+      topicSubscriptions: null,
+      createdAt: new Date("2026-05-06T00:00:00.000Z"),
+      document: null,
+      userId: "user-b",
+    });
+
+    const unchanged = await route.PATCH(
+      makeRequest("http://localhost/api/contacts/contact-b", {
+        method: "PATCH",
+        headers: { authorization: "Bearer user-b-key" },
+        body: JSON.stringify({ first_name: "After" }),
+      }),
+      { params: Promise.resolve({ id: "contact-b" }) },
+    );
+
+    expect(unchanged.status).toBe(200);
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockQueueEvent).not.toHaveBeenCalled();
+  });
+
+  it("enqueues contact.deleted for the caller tenant after deletion", async () => {
+    mockContactFindFirst.mockResolvedValueOnce({
+      id: "contact-b",
+      email: "b@example.com",
+      userId: "user-b",
+    });
+    const deleteChain = makeChain([
+      { id: "contact-b", email: "b@example.com" },
+    ]);
+    mockDelete.mockReturnValueOnce(deleteChain);
+
+    const route = await import("@/app/api/contacts/[id]/route");
+    const response = await route.DELETE(
+      makeRequest("http://localhost/api/contacts/contact-b", {
+        method: "DELETE",
+        headers: { authorization: "Bearer user-b-key" },
+      }),
+      { params: Promise.resolve({ id: "contact-b" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockQueueEvent).toHaveBeenCalledWith({
+      type: "contact.deleted",
+      userId: "user-b",
+      payload: { id: "contact-b", email: "b@example.com" },
+    });
   });
 
   it("returns an empty contact list scoped to the caller user", async () => {

--- a/tests/webhook-dispatcher.test.ts
+++ b/tests/webhook-dispatcher.test.ts
@@ -26,6 +26,12 @@ vi.mock("@opensend/core", () => ({
       "email.opened",
       "email.clicked",
       "email.failed",
+      "contact.created",
+      "contact.updated",
+      "contact.deleted",
+      "domain.created",
+      "domain.updated",
+      "domain.deleted",
     ].includes(candidate)
       ? candidate
       : null;
@@ -173,7 +179,7 @@ describe("WebhookDispatcher", () => {
     });
     mockFindEventById.mockResolvedValue({
       id: "event-unsupported",
-      type: "domain.updated",
+      type: "email.unknown",
       payload: {},
     });
     const fetchMock = vi.fn();
@@ -194,7 +200,7 @@ describe("WebhookDispatcher", () => {
       "delivery-unsupported",
       expect.objectContaining({
         status: "failed",
-        responseBody: "Unsupported webhook event type: domain.updated",
+        responseBody: "Unsupported webhook event type: email.unknown",
         nextRetryAt: null,
       }),
     );

--- a/tests/webhook-lifecycle-queue.test.ts
+++ b/tests/webhook-lifecycle-queue.test.ts
@@ -1,0 +1,91 @@
+import { getTableName } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockTransaction = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    transaction: mockTransaction,
+  },
+}));
+
+describe("lifecycle webhook event queue", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("persists a tenant-scoped lifecycle event and pending delivery rows", async () => {
+    const selectWhere = vi.fn(() => Promise.resolve([{ id: "hook-1" }]));
+    const tx = {
+      insert: vi.fn((table: unknown) => {
+        const tableName = getTableName(table as never);
+        if (tableName === "email_events") {
+          return {
+            values: vi.fn((value: unknown) => ({
+              returning: vi.fn(async () => [{ id: "event-1", value }]),
+            })),
+          };
+        }
+        if (tableName === "webhook_deliveries") {
+          return {
+            values: vi.fn((value: unknown) => ({
+              returning: vi.fn(async () => [{ id: "delivery-1", value }]),
+            })),
+          };
+        }
+        throw new Error(`Unexpected insert table: ${tableName}`);
+      }),
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: selectWhere,
+        })),
+      })),
+    };
+    mockTransaction.mockImplementation(async (callback) => await callback(tx));
+
+    const { queueEvent } = await import("@/lib/events");
+    const result = await queueEvent({
+      type: "contact.created",
+      userId: "user-1",
+      payload: { id: "contact-1", email: "a@example.com" },
+    });
+
+    expect(result).toEqual({ eventId: "event-1", deliveryIds: ["delivery-1"] });
+    expect(tx.insert).toHaveBeenCalledTimes(2);
+    const eventValues =
+      tx.insert.mock.results[0]?.value.values.mock.calls[0]?.[0];
+    expect(eventValues).toMatchObject({
+      emailId: null,
+      sourceId: null,
+      type: "contact.created",
+      payload: { id: "contact-1", email: "a@example.com" },
+      userId: "user-1",
+    });
+    const deliveryValues =
+      tx.insert.mock.results[1]?.value.values.mock.calls[0]?.[0];
+    expect(deliveryValues).toEqual([
+      {
+        webhookId: "hook-1",
+        eventId: "event-1",
+        status: "pending",
+        attempt: 0,
+        nextRetryAt: null,
+      },
+    ]);
+    expect(selectWhere).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects unsupported event types before writing", async () => {
+    const { queueEvent } = await import("@/lib/events");
+
+    await expect(
+      queueEvent({
+        type: "email.unknown" as never,
+        userId: "user-1",
+        payload: {},
+      }),
+    ).rejects.toThrow("Unsupported webhook event type: email.unknown");
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds Resend-compatible lifecycle webhook event types for contacts and domains to the shared `SUPPORTED_WEBHOOK_EVENT_TYPES` source used by API validation and dashboard labels.
- Generalizes webhook event persistence so non-email lifecycle rows use `email_events` with nullable `email_id` plus `user_id`, then enqueue real pending `webhook_deliveries` scoped to active same-tenant webhook subscriptions.
- Emits `contact.created`, `contact.updated`, `contact.deleted`, `domain.created`, `domain.updated`, and `domain.deleted`; domain verify/status changes now use the real queue path instead of console-only intent logging.
- Adds Drizzle migration `0013_clammy_plazm` for nullable `email_events.email_id` and `email_events.user_id` index.

## Validation
- `bun run test -- tests/webhook-event-types.test.tsx tests/webhook-lifecycle-queue.test.ts tests/contact-tenant-isolation.test.ts tests/api-domains.test.ts tests/webhook-dispatcher.test.ts` — passed, 34 tests.
- `make check && make test` — passed: TypeScript, Biome, and 95 Vitest files / 791 tests.
- Push guardrails — passed: changed-file guard, full-project typecheck, changed-file Biome lint.

## Issue
- Refs #218

## Residual risks
- Lifecycle events are queued as pending deliveries; actual outbound delivery still depends on the existing webhook dispatcher worker/job processing path.
- `email_events` is now a generic webhook event store for lifecycle rows; future email-event-only queries should continue filtering by `email_id` when they need email-specific history.

## Intentional not-doing
- No inbound `email.received` support.
- No `email.scheduled` or scheduled-send lifecycle support.
- No retry cadence, signing-header, replay UI, pricing, SLO, or infrastructure redesign.
- No Playwright added because no dashboard interaction flow changed; dashboard label coverage remains in Vitest through the shared event source.
