### PR TITLE
[parity] Add logs/event explorer request logging per email

### DIFF
--- a/agent_docs/learnings/active/2026-05-07-issue-224-api-request-logs.md
+++ b/agent_docs/learnings/active/2026-05-07-issue-224-api-request-logs.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-07
+issue: "#224"
+type: decision
+promoted_to: null
+---
+
+## API request logs use sanitized JSONB metadata, not new relational columns
+
+Issue #224 links accepted email sends back to request logs through `logs.document.emailId` / `logs.document.emailIds` while keeping first-class tenant predicates on `logs.user_id` and `logs.api_key_id`. This avoids a migration for the first parity slice and lets email detail join associated request logs with a bounded JSONB predicate.
+
+Sanitization deliberately redacts bearer/cookie/token/password-like fields plus large message body fields (`html`, `text`, attachment `content`) before persistence. API key UUIDs remain visible as `apiKeyId`; raw API keys and authorization headers must never be persisted.

--- a/agent_docs/resend-parity.md
+++ b/agent_docs/resend-parity.md
@@ -99,7 +99,7 @@ Rows are ordered roughly by priority within each area. The inspector's tie-break
 |---|---|---|---|---|---|---|---|---|---|
 | Sandbox / test mode | dedicated `onboarding@resend.dev` + test API key behavior | TBD | ? | ? | ? | ? | P1 | | |
 | Error message quality | documented error catalog with stable names and suggested actions ([docs](https://resend.com/docs/api-reference/errors)) | partial: send routes return ad hoc string errors/details (`src/app/api/emails/route.ts:93`, `src/app/api/emails/batch/route.ts:102`); SDK exposes only `message`/`statusCode` (`packages/sdk/src/index.ts:30`) | partial | behind | parity | n/a | P0 | #170 | 2026-05-03 |
-| Logs / event explorer | searchable per email | TBD | ? | ? | ? | ? | P0 | #224 | 2026-05-06 |
+| Logs / event explorer | searchable per email | parity: send APIs capture sanitized tenant-scoped request logs for accepted/failed authenticated sends (`src/app/api/emails/route.ts`, `src/app/api/emails/batch/route.ts`, `src/lib/api-logging.ts`); logs list/detail APIs are tenant-scoped and searchable/filterable (`src/app/api/logs/route.ts`, `src/app/api/logs/[id]/route.ts`); dashboard logs search and email-associated request logs are wired (`src/app/(dashboard)/logs/page.tsx`, `src/components/logs-list-page.tsx`, `src/app/(dashboard)/emails/[id]/page.tsx`, `src/components/email-detail.tsx`) | parity | parity | parity | n/a | P0 | #224 | 2026-05-07 |
 | Dashboard quality | polished, fast | TBD | ? | ? | ? | ? | P1 | | |
 | API key scopes | read/write/full per key | TBD | ? | ? | ? | ? | P1 | | |
 

--- a/src/app/(dashboard)/emails/[id]/page.tsx
+++ b/src/app/(dashboard)/emails/[id]/page.tsx
@@ -1,8 +1,8 @@
 import { EmailDetail } from "@/components/email-detail";
 import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
-import { emailEvents, emailSuppressions, emails } from "@/lib/db/schema";
-import { and, desc, eq } from "drizzle-orm";
+import { emailEvents, emailSuppressions, emails, logs } from "@/lib/db/schema";
+import { and, desc, eq, sql } from "drizzle-orm";
 import { notFound, redirect } from "next/navigation";
 
 export default async function EmailDetailPage({
@@ -16,59 +16,80 @@ export default async function EmailDetailPage({
   const { id } = await params;
   const userId = session.user.id;
 
-  try {
-    const [emailResult] = await db
-      .select()
-      .from(emails)
-      .where(and(eq(emails.id, id), eq(emails.userId, userId)))
-      .limit(1);
+  const [emailResult] = await db
+    .select()
+    .from(emails)
+    .where(and(eq(emails.id, id), eq(emails.userId, userId)))
+    .limit(1);
 
-    if (!emailResult) {
-      notFound();
-    }
-
-    const events = await db
-      .select()
-      .from(emailEvents)
-      .where(eq(emailEvents.emailId, id))
-      .orderBy(desc(emailEvents.receivedAt));
-
-    const primaryRecipient = emailResult.to[0]?.toLowerCase();
-    const suppression = primaryRecipient
-      ? await db.query.emailSuppressions.findFirst({
-          where: and(
-            eq(emailSuppressions.userId, userId),
-            eq(emailSuppressions.email, primaryRecipient),
-          ),
-        })
-      : null;
-
-    const emailData = {
-      id: emailResult.id,
-      from: emailResult.from,
-      to: emailResult.to,
-      subject: emailResult.subject,
-      html: emailResult.html,
-      text: emailResult.text,
-      createdAt: emailResult.createdAt.toISOString(),
-      scheduledAt: emailResult.scheduledAt?.toISOString() || null,
-      tags: (emailResult.tags as Array<{ name: string; value: string }>) ?? [],
-      headers: (emailResult.headers as Record<string, string>) ?? {},
-      suppression: suppression
-        ? {
-            email: suppression.email,
-            reason: suppression.reason,
-            suppressedAt: suppression.suppressedAt.toISOString(),
-          }
-        : null,
-      events: events.map((e) => ({
-        type: e.type,
-        timestamp: e.receivedAt.toISOString(),
-      })),
-    };
-
-    return <EmailDetail email={emailData} />;
-  } catch {
+  if (!emailResult) {
     notFound();
   }
+
+  const events = await db
+    .select()
+    .from(emailEvents)
+    .where(and(eq(emailEvents.emailId, id), eq(emailEvents.userId, userId)))
+    .orderBy(desc(emailEvents.receivedAt));
+
+  const associatedLogs = await db
+    .select({
+      id: logs.id,
+      method: logs.method,
+      endpoint: logs.endpoint,
+      status: logs.status,
+      createdAt: logs.createdAt,
+    })
+    .from(logs)
+    .where(
+      and(
+        eq(logs.userId, userId),
+        sql`(${logs.document}->>'emailId' = ${id} OR ${logs.document}->'emailIds' ? ${id})`,
+      ),
+    )
+    .orderBy(desc(logs.createdAt))
+    .limit(10);
+
+  const primaryRecipient = emailResult.to[0]?.toLowerCase();
+  const suppression = primaryRecipient
+    ? await db.query.emailSuppressions.findFirst({
+        where: and(
+          eq(emailSuppressions.userId, userId),
+          eq(emailSuppressions.email, primaryRecipient),
+        ),
+      })
+    : null;
+
+  const emailData = {
+    id: emailResult.id,
+    from: emailResult.from,
+    to: emailResult.to,
+    subject: emailResult.subject,
+    html: emailResult.html,
+    text: emailResult.text,
+    createdAt: emailResult.createdAt.toISOString(),
+    scheduledAt: emailResult.scheduledAt?.toISOString() || null,
+    tags: (emailResult.tags as Array<{ name: string; value: string }>) ?? [],
+    headers: (emailResult.headers as Record<string, string>) ?? {},
+    suppression: suppression
+      ? {
+          email: suppression.email,
+          reason: suppression.reason,
+          suppressedAt: suppression.suppressedAt.toISOString(),
+        }
+      : null,
+    events: events.map((e) => ({
+      type: e.type,
+      timestamp: e.receivedAt.toISOString(),
+    })),
+    logs: associatedLogs.map((log) => ({
+      id: log.id,
+      method: log.method ?? "GET",
+      endpoint: log.endpoint ?? "",
+      statusCode: log.status ?? 0,
+      createdAt: log.createdAt.toISOString(),
+    })),
+  };
+
+  return <EmailDetail email={emailData} />;
 }

--- a/src/app/(dashboard)/logs/[id]/page.tsx
+++ b/src/app/(dashboard)/logs/[id]/page.tsx
@@ -15,37 +15,28 @@ export default async function LogDetailPage({
 
   const { id } = await params;
 
-  try {
-    const [logResult] = await db
-      .select()
-      .from(logs)
-      .where(and(eq(logs.id, id), eq(logs.userId, session.user.id)))
-      .limit(1);
+  const [logResult] = await db
+    .select()
+    .from(logs)
+    .where(and(eq(logs.id, id), eq(logs.userId, session.user.id)))
+    .limit(1);
 
-    if (!logResult) {
-      notFound();
-    }
-
-    const logData = {
-      id: logResult.id,
-      method: logResult.method ?? "GET",
-      path: logResult.endpoint ?? "",
-      statusCode: logResult.status ?? 0,
-      duration: null as number | null,
-      apiKeyId:
-        typeof logResult.document === "object" &&
-        logResult.document !== null &&
-        "apiKeyId" in logResult.document &&
-        typeof logResult.document.apiKeyId === "string"
-          ? logResult.document.apiKeyId
-          : null,
-      requestBody: logResult.requestBody as Record<string, unknown> | null,
-      responseBody: logResult.responseBody as Record<string, unknown> | null,
-      createdAt: logResult.createdAt.toISOString(),
-    };
-
-    return <LogDetail log={logData} />;
-  } catch {
+  if (!logResult) {
     notFound();
   }
+
+  const logData = {
+    id: logResult.id,
+    method: logResult.method ?? "GET",
+    path: logResult.endpoint ?? "",
+    statusCode: logResult.status ?? 0,
+    duration: null as number | null,
+    apiKeyId: logResult.apiKeyId,
+    userAgent: logResult.userAgent,
+    requestBody: logResult.requestBody as Record<string, unknown> | null,
+    responseBody: logResult.responseBody as Record<string, unknown> | null,
+    createdAt: logResult.createdAt.toISOString(),
+  };
+
+  return <LogDetail log={logData} />;
 }

--- a/src/app/(dashboard)/logs/page.tsx
+++ b/src/app/(dashboard)/logs/page.tsx
@@ -13,6 +13,8 @@ export default async function LogsPage(props: {
     before?: string;
     userAgent?: string;
     apiKeyId?: string;
+    q?: string;
+    search?: string;
   }>;
 }) {
   const session = await getServerSession();
@@ -25,6 +27,7 @@ export default async function LogsPage(props: {
   const before = searchParams.before;
   const userAgent = searchParams.userAgent;
   const apiKeyId = searchParams.apiKeyId;
+  const search = (searchParams.q || searchParams.search || "").trim();
 
   const conditions: SQL[] = [eq(logs.userId, session.user.id)];
 
@@ -59,7 +62,13 @@ export default async function LogsPage(props: {
   }
 
   if (apiKeyId) {
-    conditions.push(sql`${logs.document}->>'apiKeyId' = ${apiKeyId}`);
+    conditions.push(eq(logs.apiKeyId, apiKeyId));
+  }
+
+  if (search) {
+    conditions.push(
+      sql`(${logs.id}::text ILIKE ${`%${search}%`} OR ${logs.endpoint} ILIKE ${`%${search}%`} OR ${logs.userAgent} ILIKE ${`%${search}%`} OR ${logs.status}::text ILIKE ${`%${search}%`} OR ${logs.requestBody}::text ILIKE ${`%${search}%`} OR ${logs.responseBody}::text ILIKE ${`%${search}%`} OR ${logs.document}::text ILIKE ${`%${search}%`})`,
+    );
   }
 
   let logRows: {

--- a/src/app/api/emails/batch/route.ts
+++ b/src/app/api/emails/batch/route.ts
@@ -4,6 +4,7 @@ import {
   validateApiKey,
 } from "@/lib/api-auth";
 import { publicApiError, zodValidationDetails } from "@/lib/api-errors";
+import { captureApiResponseLog } from "@/lib/api-logging";
 import { quotaExceededResponse, reserveEmailQuota } from "@/lib/billing/quota";
 import { db } from "@/lib/db";
 import { contacts, emails } from "@/lib/db/schema";
@@ -151,6 +152,22 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
   const userId = auth.userId;
+  let requestBodyForLog: unknown = null;
+  const logResponse = (
+    response: Response,
+    document?: Parameters<typeof captureApiResponseLog>[0]["document"],
+  ) =>
+    captureApiResponseLog({
+      request,
+      auth,
+      requestBody: requestBodyForLog,
+      response,
+      document: {
+        correlationId: telemetry.correlationId,
+        traceparent: telemetry.traceparent,
+        ...document,
+      },
+    });
 
   const idempotencyKey = request.headers.get("idempotency-key");
   if (
@@ -161,14 +178,16 @@ export async function POST(request: Request): Promise<Response> {
       durationMs: performance.now() - startedAt,
       outcome: "invalid",
     });
-    return jsonWithTelemetry(
-      publicApiError(
-        "invalid_idempotency_key",
-        "Idempotency-Key must be between 1 and 255 characters.",
-        400,
+    return await logResponse(
+      jsonWithTelemetry(
+        publicApiError(
+          "invalid_idempotency_key",
+          "Idempotency-Key must be between 1 and 255 characters.",
+          400,
+        ),
+        telemetry,
+        { status: 400 },
       ),
-      telemetry,
-      { status: 400 },
     );
   }
 
@@ -185,15 +204,18 @@ export async function POST(request: Request): Promise<Response> {
         outcome: "accepted",
         count: 0,
       });
-      return jsonWithTelemetry(
-        publicApiError(
-          "idempotency_conflict",
-          "A request with this idempotency key has already been accepted.",
-          409,
-          { id: existing.id },
+      return await logResponse(
+        jsonWithTelemetry(
+          publicApiError(
+            "idempotency_conflict",
+            "A request with this idempotency key has already been accepted.",
+            409,
+            { id: existing.id },
+          ),
+          telemetry,
+          { status: 409 },
         ),
-        telemetry,
-        { status: 409 },
+        { emailId: existing.id },
       );
     }
   }
@@ -206,12 +228,17 @@ export async function POST(request: Request): Promise<Response> {
       durationMs: performance.now() - startedAt,
       outcome: "invalid",
     });
-    return jsonWithTelemetry(
-      publicApiError("invalid_json", "Request body must be valid JSON.", 400),
-      telemetry,
-      { status: 400 },
+    requestBodyForLog = { error: "invalid_json" };
+    return await logResponse(
+      jsonWithTelemetry(
+        publicApiError("invalid_json", "Request body must be valid JSON.", 400),
+        telemetry,
+        { status: 400 },
+      ),
     );
   }
+
+  requestBodyForLog = body;
 
   const result = batchSendEmailSchema.safeParse(body);
   if (!result.success) {
@@ -219,15 +246,17 @@ export async function POST(request: Request): Promise<Response> {
       durationMs: performance.now() - startedAt,
       outcome: "invalid",
     });
-    return jsonWithTelemetry(
-      publicApiError(
-        "validation_error",
-        "Validation failed.",
-        422,
-        zodValidationDetails(result.error),
+    return await logResponse(
+      jsonWithTelemetry(
+        publicApiError(
+          "validation_error",
+          "Validation failed.",
+          422,
+          zodValidationDetails(result.error),
+        ),
+        telemetry,
+        { status: 422 },
       ),
-      telemetry,
-      { status: 422 },
     );
   }
 
@@ -338,12 +367,14 @@ export async function POST(request: Request): Promise<Response> {
         durationMs: performance.now() - startedAt,
         outcome: "invalid",
       });
-      return quotaExceededResponse(reservation.info, {
-        headers: {
-          "x-correlation-id": telemetry.correlationId,
-          traceparent: telemetry.traceparent,
-        },
-      });
+      return await logResponse(
+        quotaExceededResponse(reservation.info, {
+          headers: {
+            "x-correlation-id": telemetry.correlationId,
+            traceparent: telemetry.traceparent,
+          },
+        }),
+      );
     }
 
     const resultByIndex = new Map<number, { id: string }>();
@@ -409,7 +440,9 @@ export async function POST(request: Request): Promise<Response> {
       outcome: "accepted",
       count: acceptedCount,
     });
-    return jsonWithTelemetry({ data: results }, telemetry);
+    return await logResponse(jsonWithTelemetry({ data: results }, telemetry), {
+      emailIds: reservation.emails.map((email) => email.id),
+    });
   } catch (err) {
     recordTelemetryError(telemetry, "email.batch_accept.failed", err);
     emitCloudWatchMetric(telemetry, {
@@ -427,14 +460,16 @@ export async function POST(request: Request): Promise<Response> {
         Outcome: "failed",
       },
     });
-    return jsonWithTelemetry(
-      publicApiError(
-        "internal_server_error",
-        "Failed to send batch emails.",
-        500,
+    return await logResponse(
+      jsonWithTelemetry(
+        publicApiError(
+          "internal_server_error",
+          "Failed to send batch emails.",
+          500,
+        ),
+        telemetry,
+        { status: 500 },
       ),
-      telemetry,
-      { status: 500 },
     );
   }
 }

--- a/src/app/api/emails/route.ts
+++ b/src/app/api/emails/route.ts
@@ -5,6 +5,7 @@ import {
   validateApiKey,
 } from "@/lib/api-auth";
 import { publicApiError, zodValidationDetails } from "@/lib/api-errors";
+import { captureApiResponseLog } from "@/lib/api-logging";
 import {
   quotaExceededResponse,
   releaseEmailQuota,
@@ -156,6 +157,23 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
+  let requestBodyForLog: unknown = null;
+  const logResponse = (
+    response: Response,
+    document?: Parameters<typeof captureApiResponseLog>[0]["document"],
+  ) =>
+    captureApiResponseLog({
+      request,
+      auth,
+      requestBody: requestBodyForLog,
+      response,
+      document: {
+        correlationId: telemetry.correlationId,
+        traceparent: telemetry.traceparent,
+        ...document,
+      },
+    });
+
   const idempotencyKey = request.headers.get("idempotency-key");
   if (
     idempotencyKey &&
@@ -165,14 +183,16 @@ export async function POST(request: Request): Promise<Response> {
       durationMs: performance.now() - startedAt,
       outcome: "invalid",
     });
-    return jsonWithTelemetry(
-      publicApiError(
-        "invalid_idempotency_key",
-        "Idempotency-Key must be between 1 and 255 characters.",
-        400,
+    return await logResponse(
+      jsonWithTelemetry(
+        publicApiError(
+          "invalid_idempotency_key",
+          "Idempotency-Key must be between 1 and 255 characters.",
+          400,
+        ),
+        telemetry,
+        { status: 400 },
       ),
-      telemetry,
-      { status: 400 },
     );
   }
 
@@ -184,12 +204,17 @@ export async function POST(request: Request): Promise<Response> {
       durationMs: performance.now() - startedAt,
       outcome: "invalid",
     });
-    return jsonWithTelemetry(
-      publicApiError("invalid_json", "Request body must be valid JSON.", 400),
-      telemetry,
-      { status: 400 },
+    requestBodyForLog = { error: "invalid_json" };
+    return await logResponse(
+      jsonWithTelemetry(
+        publicApiError("invalid_json", "Request body must be valid JSON.", 400),
+        telemetry,
+        { status: 400 },
+      ),
     );
   }
+
+  requestBodyForLog = body;
 
   const result = sendEmailSchema.safeParse(body);
   if (!result.success) {
@@ -197,15 +222,17 @@ export async function POST(request: Request): Promise<Response> {
       durationMs: performance.now() - startedAt,
       outcome: "invalid",
     });
-    return jsonWithTelemetry(
-      publicApiError(
-        "validation_error",
-        "Validation failed.",
-        422,
-        zodValidationDetails(result.error),
+    return await logResponse(
+      jsonWithTelemetry(
+        publicApiError(
+          "validation_error",
+          "Validation failed.",
+          422,
+          zodValidationDetails(result.error),
+        ),
+        telemetry,
+        { status: 422 },
       ),
-      telemetry,
-      { status: 422 },
     );
   }
 
@@ -224,15 +251,18 @@ export async function POST(request: Request): Promise<Response> {
         durationMs: performance.now() - startedAt,
         outcome: "queued",
       });
-      return jsonWithTelemetry(
-        publicApiError(
-          "idempotency_conflict",
-          "A request with this idempotency key has already been accepted.",
-          409,
-          { id: existing.id },
+      return await logResponse(
+        jsonWithTelemetry(
+          publicApiError(
+            "idempotency_conflict",
+            "A request with this idempotency key has already been accepted.",
+            409,
+            { id: existing.id },
+          ),
+          telemetry,
+          { status: 409 },
         ),
-        telemetry,
-        { status: 409 },
+        { emailId: existing.id },
       );
     }
   }
@@ -254,10 +284,14 @@ export async function POST(request: Request): Promise<Response> {
       durationMs: performance.now() - startedAt,
       outcome: "invalid",
     });
-    return jsonWithTelemetry(
-      suppressedRecipientError(suppressedRecipients),
-      telemetry,
-      { status: 422 },
+    return await logResponse(
+      jsonWithTelemetry(
+        suppressedRecipientError(suppressedRecipients),
+        telemetry,
+        {
+          status: 422,
+        },
+      ),
     );
   }
 
@@ -281,10 +315,12 @@ export async function POST(request: Request): Promise<Response> {
           durationMs: performance.now() - startedAt,
           outcome: "invalid",
         });
-        return jsonWithTelemetry(
-          publicApiError("not_found", "Template not found.", 404),
-          telemetry,
-          { status: 404 },
+        return await logResponse(
+          jsonWithTelemetry(
+            publicApiError("not_found", "Template not found.", 404),
+            telemetry,
+            { status: 404 },
+          ),
         );
       }
 
@@ -305,20 +341,22 @@ export async function POST(request: Request): Promise<Response> {
             durationMs: performance.now() - startedAt,
             outcome: "invalid",
           });
-          return jsonWithTelemetry(
-            publicApiError(
-              "validation_error",
-              `Missing required template variable: ${requiredVar}`,
-              422,
-              {
-                formErrors: [],
-                fieldErrors: {
-                  template: [`Missing required variable: ${requiredVar}`],
+          return await logResponse(
+            jsonWithTelemetry(
+              publicApiError(
+                "validation_error",
+                `Missing required template variable: ${requiredVar}`,
+                422,
+                {
+                  formErrors: [],
+                  fieldErrors: {
+                    template: [`Missing required variable: ${requiredVar}`],
+                  },
                 },
-              },
+              ),
+              telemetry,
+              { status: 422 },
             ),
-            telemetry,
-            { status: 422 },
           );
         }
       }
@@ -402,12 +440,14 @@ export async function POST(request: Request): Promise<Response> {
         durationMs: performance.now() - startedAt,
         outcome: "invalid",
       });
-      return quotaExceededResponse(email.info, {
-        headers: {
-          "x-correlation-id": telemetry.correlationId,
-          traceparent: telemetry.traceparent,
-        },
-      });
+      return await logResponse(
+        quotaExceededResponse(email.info, {
+          headers: {
+            "x-correlation-id": telemetry.correlationId,
+            traceparent: telemetry.traceparent,
+          },
+        }),
+      );
     }
 
     const createdEmail = email.email;
@@ -455,7 +495,12 @@ export async function POST(request: Request): Promise<Response> {
     });
     recordAcceptMetric(telemetry, { durationMs, outcome });
     quotaReserved = false;
-    return jsonWithTelemetry({ id: createdEmail.id }, telemetry);
+    return await logResponse(
+      jsonWithTelemetry({ id: createdEmail.id }, telemetry),
+      {
+        emailId: createdEmail.id,
+      },
+    );
   } catch (err) {
     recordTelemetryError(telemetry, "email.accept.failed", err);
     recordAcceptMetric(telemetry, {
@@ -465,10 +510,12 @@ export async function POST(request: Request): Promise<Response> {
     if (quotaReserved) {
       await releaseEmailQuota(auth.userId, 1);
     }
-    return jsonWithTelemetry(
-      publicApiError("internal_server_error", "Failed to send email.", 500),
-      telemetry,
-      { status: 500 },
+    return await logResponse(
+      jsonWithTelemetry(
+        publicApiError("internal_server_error", "Failed to send email.", 500),
+        telemetry,
+        { status: 500 },
+      ),
     );
   }
 }

--- a/src/app/api/logs/[id]/route.ts
+++ b/src/app/api/logs/[id]/route.ts
@@ -1,20 +1,20 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { logs } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth || !auth.userId) return unauthorizedResponse();
 
   const { id } = await params;
 
   try {
     const log = await db.query.logs.findFirst({
-      where: eq(logs.id, id),
+      where: and(eq(logs.id, id), eq(logs.userId, auth.userId)),
     });
 
     if (!log) {
@@ -28,6 +28,7 @@ export async function GET(
       endpoint: log.endpoint,
       status: log.status,
       user_agent: log.userAgent,
+      api_key_id: log.apiKeyId,
       request_body: log.requestBody,
       response_body: log.responseBody,
       created_at: log.createdAt,

--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -1,11 +1,33 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { logs } from "@/lib/db/schema";
-import { type SQL, and, desc, eq, gt, lt } from "drizzle-orm";
+import {
+  type SQL,
+  and,
+  desc,
+  eq,
+  gt,
+  gte,
+  ilike,
+  lt,
+  lte,
+  or,
+  sql,
+} from "drizzle-orm";
+
+function parseDate(value: string | null, endOfDay = false): Date | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  if (endOfDay && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    date.setHours(23, 59, 59, 999);
+  }
+  return date;
+}
 
 export async function GET(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth || !auth.userId) return unauthorizedResponse();
 
   const url = new URL(request.url);
   const limit = Math.min(
@@ -19,9 +41,23 @@ export async function GET(request: Request): Promise<Response> {
     url.searchParams.get("api_key_id") || url.searchParams.get("apiKeyId");
   const after = url.searchParams.get("after");
   const before = url.searchParams.get("before");
+  const dateFrom = parseDate(
+    url.searchParams.get("date_from") || url.searchParams.get("created_after"),
+  );
+  const dateTo = parseDate(
+    url.searchParams.get("date_to") || url.searchParams.get("created_before"),
+    true,
+  );
+  const userAgent =
+    url.searchParams.get("user_agent") || url.searchParams.get("userAgent");
+  const search = (
+    url.searchParams.get("q") ||
+    url.searchParams.get("search") ||
+    ""
+  ).trim();
 
   try {
-    const conditions: SQL[] = [];
+    const conditions: SQL[] = [eq(logs.userId, auth.userId)];
 
     if (status) {
       conditions.push(eq(logs.status, Number(status)));
@@ -38,8 +74,28 @@ export async function GET(request: Request): Promise<Response> {
     if (before) {
       conditions.push(gt(logs.id, before));
     }
-
-    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+    if (dateFrom) {
+      conditions.push(gte(logs.createdAt, dateFrom));
+    }
+    if (dateTo) {
+      conditions.push(lte(logs.createdAt, dateTo));
+    }
+    if (userAgent) {
+      conditions.push(ilike(logs.userAgent, `%${userAgent}%`));
+    }
+    if (search) {
+      conditions.push(
+        or(
+          sql`${logs.id}::text ILIKE ${`%${search}%`}`,
+          ilike(logs.endpoint, `%${search}%`),
+          ilike(logs.userAgent, `%${search}%`),
+          sql`${logs.status}::text ILIKE ${`%${search}%`}`,
+          sql`${logs.requestBody}::text ILIKE ${`%${search}%`}`,
+          sql`${logs.responseBody}::text ILIKE ${`%${search}%`}`,
+          sql`${logs.document}::text ILIKE ${`%${search}%`}`,
+        ) as SQL,
+      );
+    }
 
     const query = db
       .select({
@@ -48,10 +104,11 @@ export async function GET(request: Request): Promise<Response> {
         endpoint: logs.endpoint,
         status: logs.status,
         userAgent: logs.userAgent,
+        apiKeyId: logs.apiKeyId,
         createdAt: logs.createdAt,
       })
       .from(logs)
-      .where(whereClause);
+      .where(and(...conditions));
 
     const results = await (before
       ? query.orderBy(logs.id).limit(limit + 1)
@@ -71,6 +128,7 @@ export async function GET(request: Request): Promise<Response> {
         endpoint: l.endpoint,
         response_status: l.status,
         user_agent: l.userAgent,
+        api_key_id: l.apiKeyId,
         created_at: l.createdAt,
       })),
       has_more: hasMore,

--- a/src/components/email-detail.tsx
+++ b/src/components/email-detail.tsx
@@ -3,6 +3,7 @@
 import { CopyToClipboard } from "@/components/copy-to-clipboard";
 import { StatusBadge } from "@/components/status-badge";
 import { clsx } from "clsx";
+import Link from "next/link";
 import { useCallback, useRef, useState } from "react";
 
 interface InsightItem {
@@ -109,6 +110,13 @@ export interface EmailDetailData {
     suppressedAt: string;
   } | null;
   events: Array<{ type: string; timestamp: string }>;
+  logs?: Array<{
+    id: string;
+    method: string;
+    endpoint: string;
+    statusCode: number;
+    createdAt: string;
+  }>;
 }
 
 interface EmailDetailProps {
@@ -444,6 +452,45 @@ export function EmailDetail({ email }: EmailDetailProps) {
           ) : (
             <div className="py-4 px-4 rounded-lg bg-[rgba(24,25,28,0.5)] border border-dashed border-[rgba(176,199,217,0.145)] text-center text-[13px] text-[#666]">
               No events recorded yet
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Associated Logs */}
+      <div className="mb-8">
+        <div className="flex items-center justify-between mb-4">
+          <p className="text-[11px] font-medium text-[#A1A4A5] tracking-wider">
+            ASSOCIATED LOGS
+          </p>
+          <Link
+            href={`/logs?q=${encodeURIComponent(email.id)}`}
+            className="text-[12px] text-[#A1A4A5] hover:text-[#F0F0F0] transition-colors"
+          >
+            View all logs
+          </Link>
+        </div>
+        <div className="space-y-3" data-testid="associated-logs">
+          {email.logs && email.logs.length > 0 ? (
+            email.logs.map((log) => (
+              <Link
+                key={log.id}
+                href={`/logs/${log.id}`}
+                className="flex items-center gap-3 rounded-lg border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.5)] px-4 py-3 text-[13px] hover:bg-[rgba(24,25,28,0.8)] transition-colors"
+              >
+                <StatusBadge status={log.method.toUpperCase()} variant="info" />
+                <span className="font-mono text-[#F0F0F0] truncate flex-1">
+                  {log.endpoint || "-"}
+                </span>
+                <StatusBadge
+                  status={String(log.statusCode)}
+                  variant={log.statusCode >= 400 ? "warning" : "success"}
+                />
+              </Link>
+            ))
+          ) : (
+            <div className="py-4 px-4 rounded-lg bg-[rgba(24,25,28,0.5)] border border-dashed border-[rgba(176,199,217,0.145)] text-center text-[13px] text-[#666]">
+              No associated API request logs yet
             </div>
           )}
         </div>

--- a/src/components/log-detail.tsx
+++ b/src/components/log-detail.tsx
@@ -11,6 +11,7 @@ interface LogDetailData {
   statusCode: number;
   duration: number | null;
   apiKeyId: string | null;
+  userAgent: string | null;
   requestBody: Record<string, unknown> | null;
   responseBody: Record<string, unknown> | null;
   createdAt: string;
@@ -162,6 +163,22 @@ export function LogDetail({ log }: { log: LogDetailData }) {
           </p>
           <p className="text-[14px] text-[#F0F0F0]">
             {log.duration != null ? `${log.duration}ms` : "-"}
+          </p>
+        </div>
+        <div>
+          <p className="text-[11px] font-medium text-[#A1A4A5] tracking-wider mb-1">
+            API KEY
+          </p>
+          <p className="text-[14px] text-[#F0F0F0] font-mono">
+            {log.apiKeyId ?? "-"}
+          </p>
+        </div>
+        <div>
+          <p className="text-[11px] font-medium text-[#A1A4A5] tracking-wider mb-1">
+            USER AGENT
+          </p>
+          <p className="text-[14px] text-[#F0F0F0] font-mono break-all">
+            {log.userAgent ?? "-"}
           </p>
         </div>
         <div>

--- a/src/components/logs-list-page.tsx
+++ b/src/components/logs-list-page.tsx
@@ -81,6 +81,9 @@ export function LogsListPage({ logs }: { logs: LogRow[] }) {
   const [dateTo, setDateTo] = useState<string>(
     searchParams.get("before") || "",
   );
+  const [query, setQuery] = useState<string>(
+    searchParams.get("q") || searchParams.get("search") || "",
+  );
 
   const updateFilters = useCallback(
     (updates: Record<string, string>) => {
@@ -189,7 +192,23 @@ export function LogsListPage({ logs }: { logs: LogRow[] }) {
       </div>
 
       {/* Filters */}
-      <div className="flex items-center gap-4 mb-4">
+      <div className="flex flex-wrap items-center gap-4 mb-4">
+        <label htmlFor="log-search" className="sr-only">
+          Search logs
+        </label>
+        <input
+          id="log-search"
+          type="search"
+          value={query}
+          onChange={(e) => {
+            const val = e.target.value;
+            setQuery(val);
+            updateFilters({ q: val });
+          }}
+          placeholder="Search logs by email id, endpoint, status, or body"
+          className="min-w-[320px] bg-[rgba(24,25,28,0.88)] border border-[rgba(176,199,217,0.145)] text-[#F0F0F0] text-[13px] rounded-md px-3 py-1.5 focus:outline-none focus:ring-1 focus:ring-[rgba(176,199,217,0.3)]"
+        />
+
         <select
           value={statusFilter}
           onChange={(e) => {
@@ -239,14 +258,15 @@ export function LogsListPage({ logs }: { logs: LogRow[] }) {
           />
         </div>
 
-        {(statusFilter !== "all" || dateFrom || dateTo) && (
+        {(statusFilter !== "all" || dateFrom || dateTo || query) && (
           <button
             type="button"
             onClick={() => {
               setStatusFilter("all");
               setDateFrom("");
               setDateTo("");
-              updateFilters({ status: "", after: "", before: "" });
+              setQuery("");
+              updateFilters({ status: "", after: "", before: "", q: "" });
             }}
             className="text-[12px] text-[#A1A4A5] hover:text-[#F0F0F0] transition-colors"
           >

--- a/src/lib/api-logging.ts
+++ b/src/lib/api-logging.ts
@@ -1,0 +1,162 @@
+import type { AuthResult } from "@/lib/api-auth";
+import { db } from "@/lib/db";
+import { logs } from "@/lib/db/schema";
+
+type JsonPrimitive = string | number | boolean | null;
+export type JsonValue =
+  | JsonPrimitive
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export interface ApiLogDocument {
+  apiKeyId: string;
+  emailId?: string;
+  emailIds?: string[];
+  correlationId?: string;
+  traceparent?: string;
+  [key: string]: JsonValue | undefined;
+}
+
+interface CaptureApiLogInput {
+  request: Request;
+  auth: AuthResult;
+  status: number;
+  requestBody?: unknown;
+  responseBody?: unknown;
+  document?: Omit<ApiLogDocument, "apiKeyId">;
+}
+
+const REDACTED = "[REDACTED]";
+const MAX_STRING_LENGTH = 2_000;
+const MAX_ARRAY_ITEMS = 50;
+const MAX_OBJECT_KEYS = 80;
+const MAX_DEPTH = 8;
+
+const REDACTED_KEY_PATTERNS = [
+  /authorization/i,
+  /cookie/i,
+  /api[-_]?key/i,
+  /token/i,
+  /secret/i,
+  /password/i,
+  /credential/i,
+  /^html$/i,
+  /^text$/i,
+  /^content$/i,
+  /^content_base64$/i,
+];
+
+function shouldRedactKey(key: string): boolean {
+  if (key === "apiKeyId") return false;
+  return REDACTED_KEY_PATTERNS.some((pattern) => pattern.test(key));
+}
+
+function truncateString(value: string): string {
+  if (value.length <= MAX_STRING_LENGTH) return value;
+  return `${value.slice(0, MAX_STRING_LENGTH)}…[truncated ${
+    value.length - MAX_STRING_LENGTH
+  } chars]`;
+}
+
+export function sanitizeLogValue(value: unknown, depth = 0): JsonValue {
+  if (depth > MAX_DEPTH) return "[truncated-depth]";
+  if (value == null) return null;
+
+  const valueType = typeof value;
+  if (valueType === "string") return truncateString(value as string);
+  if (valueType === "number") {
+    return Number.isFinite(value as number) ? (value as number) : null;
+  }
+  if (valueType === "boolean") return value as boolean;
+  if (value instanceof Date) return value.toISOString();
+
+  if (Array.isArray(value)) {
+    const items = value
+      .slice(0, MAX_ARRAY_ITEMS)
+      .map((item) => sanitizeLogValue(item, depth + 1));
+    if (value.length > MAX_ARRAY_ITEMS) {
+      items.push(`[truncated ${value.length - MAX_ARRAY_ITEMS} items]`);
+    }
+    return items;
+  }
+
+  if (valueType === "object") {
+    const output: { [key: string]: JsonValue } = {};
+    const entries = Object.entries(value as Record<string, unknown>).slice(
+      0,
+      MAX_OBJECT_KEYS,
+    );
+    for (const [key, entryValue] of entries) {
+      output[key] = shouldRedactKey(key)
+        ? REDACTED
+        : sanitizeLogValue(entryValue, depth + 1);
+    }
+    const totalKeys = Object.keys(value as Record<string, unknown>).length;
+    if (totalKeys > MAX_OBJECT_KEYS) {
+      output.__truncated_keys = totalKeys - MAX_OBJECT_KEYS;
+    }
+    return output;
+  }
+
+  return String(value);
+}
+
+export async function captureApiLog(input: CaptureApiLogInput): Promise<void> {
+  if (!input.auth.userId) return;
+
+  try {
+    const url = new URL(input.request.url);
+    const document: ApiLogDocument = {
+      apiKeyId: input.auth.apiKeyId,
+      ...input.document,
+    };
+
+    await db.insert(logs).values({
+      endpoint: `${url.pathname}${url.search}`,
+      status: input.status,
+      method: input.request.method.toUpperCase(),
+      userAgent: input.request.headers.get("user-agent"),
+      requestBody:
+        input.requestBody === undefined
+          ? null
+          : sanitizeLogValue(input.requestBody),
+      responseBody:
+        input.responseBody === undefined
+          ? null
+          : sanitizeLogValue(input.responseBody),
+      document: sanitizeLogValue(document),
+      userId: input.auth.userId,
+      apiKeyId: input.auth.apiKeyId,
+    });
+  } catch (error) {
+    console.error("Failed to capture API request log:", error);
+  }
+}
+
+export async function captureApiResponseLog(
+  input: Omit<CaptureApiLogInput, "status" | "responseBody"> & {
+    response: Response;
+  },
+): Promise<Response> {
+  const responseBody = await readResponseBody(input.response);
+  await captureApiLog({
+    ...input,
+    status: input.response.status,
+    responseBody,
+  });
+  return input.response;
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  try {
+    const text = await response.clone().text();
+    if (!text) return null;
+    try {
+      return JSON.parse(text) as unknown;
+    } catch {
+      return text;
+    }
+  } catch {
+    return null;
+  }
+}

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -148,6 +148,15 @@ function makeRequest(
   return new Request(url, init);
 }
 
+function isLogInsertCall(call: unknown[]): boolean {
+  const table = call[0];
+  return typeof table === "object" && table !== null && "requestBody" in table;
+}
+
+function nonLogInsertCalls(): unknown[][] {
+  return mockDb.insert.mock.calls.filter((call) => !isLogInsertCall(call));
+}
+
 // ── Auth Middleware Tests ──────────────────────────────────────────
 
 describe("API Key Authentication", () => {
@@ -245,7 +254,9 @@ describe("POST /api/emails", () => {
       emails: { findFirst: vi.fn().mockResolvedValue(null) },
       contacts: { findFirst: vi.fn().mockResolvedValue(null) },
     });
-    mockDb.insert = vi.fn();
+    mockDb.insert = vi.fn().mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    });
     mockDb.select = vi.fn().mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue([]),
@@ -362,6 +373,21 @@ describe("POST /api/emails", () => {
       }),
     );
     expect(valuesMock.mock.calls[0][0]).not.toHaveProperty("sentAt");
+    expect(valuesMock.mock.calls[1][0]).toMatchObject({
+      endpoint: "/api/emails",
+      method: "POST",
+      status: 200,
+      userId: AUTH_RESULT.userId,
+      apiKeyId: AUTH_RESULT.apiKeyId,
+      requestBody: expect.objectContaining({
+        html: "[REDACTED]",
+      }),
+      responseBody: { id: emailId },
+      document: expect.objectContaining({
+        emailId,
+        apiKeyId: AUTH_RESULT.apiKeyId,
+      }),
+    });
     expect(mockPublishBackgroundJob).toHaveBeenCalledWith(
       expect.objectContaining({
         id: `email.send:${emailId}`,
@@ -425,7 +451,7 @@ describe("POST /api/emails", () => {
       }),
     });
     expect(mockReserveEmailQuota).not.toHaveBeenCalled();
-    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
   });
 
   it("returns p95 under 50ms when the SES mock takes 500ms", async () => {
@@ -589,7 +615,7 @@ describe("POST /api/emails", () => {
       },
     });
     expect(mockReserveEmailQuota).not.toHaveBeenCalled();
-    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
     expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
   });
 
@@ -657,7 +683,9 @@ describe("POST /api/emails/batch", () => {
       emails: { findFirst: vi.fn().mockResolvedValue(null) },
       contacts: { findFirst: vi.fn().mockResolvedValue(null) },
     });
-    mockDb.insert = vi.fn();
+    mockDb.insert = vi.fn().mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    });
     mockDb.select = vi.fn().mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue([]),
@@ -805,7 +833,7 @@ describe("POST /api/emails/batch", () => {
     });
 
     expect(mockReserveEmailQuota).toHaveBeenCalledTimes(1);
-    expect(mockDb.insert).toHaveBeenCalledTimes(2);
+    expect(nonLogInsertCalls()).toHaveLength(2);
     expect(mockPublishBackgroundJob).toHaveBeenCalledTimes(2);
     expect(findFirst).toHaveBeenNthCalledWith(1, {
       where: expect.objectContaining({
@@ -838,7 +866,9 @@ describe("POST /api/emails/batch", () => {
       }),
     });
     expect(
-      valuesMock.mock.calls.map(([value]) => value.idempotencyKey),
+      valuesMock.mock.calls
+        .map(([value]) => value.idempotencyKey)
+        .filter((value) => value !== undefined),
     ).toEqual(["batch-key-1", null]);
   });
 
@@ -950,7 +980,7 @@ describe("POST /api/emails/batch", () => {
       process.env,
       mockDb,
     );
-    expect(mockDb.insert).toHaveBeenCalledTimes(1);
+    expect(nonLogInsertCalls()).toHaveLength(1);
     expect(mockPublishBackgroundJob).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/api-logs.test.ts
+++ b/tests/api-logs.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockFindFirst = vi.hoisted(() => vi.fn());
+const mockSelect = vi.hoisted(() => vi.fn());
+const recordedWhere = vi.hoisted(() => [] as unknown[]);
+const mockEq = vi.hoisted(() =>
+  vi.fn((left, right) => ({ op: "eq", args: [left, right] })),
+);
+const mockAnd = vi.hoisted(() => vi.fn((...args) => ({ op: "and", args })));
+const mockOr = vi.hoisted(() => vi.fn((...args) => ({ op: "or", args })));
+const mockIlike = vi.hoisted(() =>
+  vi.fn((left, right) => ({ op: "ilike", args: [left, right] })),
+);
+const mockGte = vi.hoisted(() =>
+  vi.fn((left, right) => ({ op: "gte", args: [left, right] })),
+);
+const mockLte = vi.hoisted(() =>
+  vi.fn((left, right) => ({ op: "lte", args: [left, right] })),
+);
+const mockGt = vi.hoisted(() =>
+  vi.fn((left, right) => ({ op: "gt", args: [left, right] })),
+);
+const mockLt = vi.hoisted(() =>
+  vi.fn((left, right) => ({ op: "lt", args: [left, right] })),
+);
+
+vi.mock("@/lib/api-auth", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/api-auth")>("@/lib/api-auth");
+  return {
+    validateApiKey: mockValidateApiKey,
+    unauthorizedResponse: actual.unauthorizedResponse,
+  };
+});
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: { logs: { findFirst: mockFindFirst } },
+    select: mockSelect,
+  },
+}));
+
+vi.mock("drizzle-orm", async () => {
+  const actual = await vi.importActual("drizzle-orm");
+  return {
+    ...actual,
+    and: mockAnd,
+    or: mockOr,
+    eq: mockEq,
+    gt: mockGt,
+    gte: mockGte,
+    lt: mockLt,
+    lte: mockLte,
+    ilike: mockIlike,
+    desc: vi.fn((column) => ({ op: "desc", column })),
+    sql: vi.fn((parts: TemplateStringsArray, ...values: unknown[]) => ({
+      op: "sql",
+      text: Array.from(parts).join("?"),
+      values,
+    })),
+  };
+});
+
+function makeQuery<T>(rows: T[]) {
+  const chain = {
+    from: vi.fn(() => chain),
+    where: vi.fn((condition: unknown) => {
+      recordedWhere.push(condition);
+      return chain;
+    }),
+    orderBy: vi.fn(() => chain),
+    limit: vi.fn(() => Promise.resolve(rows)),
+  };
+  return chain;
+}
+
+describe("/api/logs", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    recordedWhere.length = 0;
+    mockValidateApiKey.mockResolvedValue({
+      apiKeyId: "api-key-a",
+      permission: "full_access",
+      domain: null,
+      userId: "user-a",
+    });
+  });
+
+  it("lists only caller-owned logs and applies search/date/user-agent filters", async () => {
+    mockSelect.mockReturnValue(
+      makeQuery([
+        {
+          id: "log-1",
+          method: "POST",
+          endpoint: "/api/emails",
+          status: 200,
+          userAgent: "opensend-test",
+          apiKeyId: "api-key-a",
+          createdAt: new Date("2026-05-06T00:00:00Z"),
+        },
+      ]),
+    );
+
+    const { GET } = await import("@/app/api/logs/route");
+    const res = await GET(
+      new Request(
+        "http://localhost:3015/api/logs?q=email-1&user_agent=test&date_from=2026-05-01&date_to=2026-05-06&api_key_id=api-key-a",
+        { headers: { Authorization: "Bearer re_test" } },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      object: "list",
+      data: [
+        {
+          id: "log-1",
+          endpoint: "/api/emails",
+          api_key_id: "api-key-a",
+        },
+      ],
+    });
+    expect(mockEq.mock.calls.some(([, right]) => right === "user-a")).toBe(
+      true,
+    );
+    expect(mockEq.mock.calls.some(([, right]) => right === "api-key-a")).toBe(
+      true,
+    );
+    expect(mockIlike).toHaveBeenCalledWith(expect.anything(), "%test%");
+    expect(mockGte).toHaveBeenCalled();
+    expect(mockLte).toHaveBeenCalled();
+    expect(mockOr).toHaveBeenCalled();
+  });
+
+  it("returns 404 for another tenant's log detail", async () => {
+    mockFindFirst.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/logs/[id]/route");
+    const res = await GET(
+      new Request("http://localhost:3015/api/logs/log-b", {
+        headers: { Authorization: "Bearer re_test" },
+      }),
+      { params: Promise.resolve({ id: "log-b" }) },
+    );
+
+    expect(res.status).toBe(404);
+    expect(mockFindFirst).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        op: "and",
+        args: expect.arrayContaining([
+          expect.objectContaining({
+            op: "eq",
+            args: expect.arrayContaining(["log-b"]),
+          }),
+          expect.objectContaining({
+            op: "eq",
+            args: expect.arrayContaining(["user-a"]),
+          }),
+        ]),
+      }),
+    });
+  });
+});

--- a/tests/e2e/logs-search.spec.ts
+++ b/tests/e2e/logs-search.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test("logs dashboard exposes URL-backed search", async ({ page }) => {
+  test.skip(
+    !process.env.DATABASE_URL,
+    "DATABASE_URL is required for dashboard logs",
+  );
+  await page.goto("/logs?q=email-issue-224");
+  if (page.url().includes("/auth")) {
+    test.skip(true, "dashboard auth is required for logs search UI");
+  }
+
+  const search = page.getByRole("searchbox", { name: "Search logs" });
+  await expect(search).toBeVisible();
+  await expect(search).toHaveValue("email-issue-224");
+  await search.fill("POST /api/emails");
+  await expect(page).toHaveURL(
+    /q=POST\+%2Fapi%2Femails|q=POST%20%2Fapi%2Femails/,
+  );
+});

--- a/tests/email-detail.test.tsx
+++ b/tests/email-detail.test.tsx
@@ -102,6 +102,31 @@ describe("EmailDetail", () => {
     expect(timeline.textContent).toMatch(/Mar \d+, \d+:\d+ [AP]M/);
   });
 
+  it("renders associated request logs and links to the logs explorer", () => {
+    render(
+      <EmailDetail
+        email={{
+          ...mockEmail,
+          logs: [
+            {
+              id: "log-123",
+              method: "POST",
+              endpoint: "/api/emails",
+              statusCode: 200,
+              createdAt: "2026-05-06T00:00:00.000Z",
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("ASSOCIATED LOGS")).toBeTruthy();
+    expect(screen.getByText("/api/emails")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: /View all logs/i }).getAttribute("href"),
+    ).toBe(`/logs?q=${mockEmail.id}`);
+  });
+
   it("renders envelope icon in header", () => {
     render(<EmailDetail email={mockEmail} />);
 

--- a/tests/quota-routes.test.ts
+++ b/tests/quota-routes.test.ts
@@ -89,6 +89,15 @@ function jsonRequest(url: string, body: unknown): Request {
   });
 }
 
+function isLogInsertCall(call: unknown[]): boolean {
+  const table = call[0];
+  return typeof table === "object" && table !== null && "requestBody" in table;
+}
+
+function nonLogInsertCalls(): unknown[][] {
+  return mockDb.insert.mock.calls.filter((call) => !isLogInsertCall(call));
+}
+
 describe("quota route gates", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -98,6 +107,9 @@ describe("quota route gates", () => {
     mockCheckApiKeyQuota.mockReset();
     mockCreateDomainIdentity.mockReset();
     mockDb.insert.mockReset();
+    mockDb.insert.mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    });
     mockDb.select.mockReset();
     mockDb.select.mockReturnValue({
       from: vi.fn().mockReturnValue({
@@ -142,7 +154,7 @@ describe("quota route gates", () => {
       process.env,
       mockDb,
     );
-    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
   });
 
   it("returns 402 from POST /api/emails/batch when the batch would overrun quota", async () => {
@@ -174,7 +186,7 @@ describe("quota route gates", () => {
       process.env,
       mockDb,
     );
-    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
   });
 
   it("returns 402 from POST /api/domains before creating an SES identity", async () => {
@@ -194,7 +206,7 @@ describe("quota route gates", () => {
     expect(res.status).toBe(402);
     expect(mockCheckDomainQuota).toHaveBeenCalledWith("user-1");
     expect(mockCreateDomainIdentity).not.toHaveBeenCalled();
-    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
   });
 
   it("returns 402 from POST /api/api-keys before inserting a key", async () => {
@@ -210,6 +222,6 @@ describe("quota route gates", () => {
 
     expect(res.status).toBe(402);
     expect(mockCheckApiKeyQuota).toHaveBeenCalledWith("user-1");
-    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- Closes #224.
- Adds sanitized authenticated send request logging for `POST /api/emails` and `POST /api/emails/batch`, including `userId`, `apiKeyId`, status, method, endpoint, user-agent, bounded/redacted request/response bodies, and `emailId`/`emailIds` association metadata.
- Makes `/api/logs` and `/api/logs/[id]` tenant-scoped by `logs.userId`, with filters for status, method, date range, user-agent, API key, cursor pagination, and search over log id/endpoint/status/body/document snippets.
- Adds dashboard logs search, log detail API key/user-agent metadata, and an Associated Logs section on email detail.
- Updates the parity matrix and captures the no-secret logging decision in learnings.

## Validation
- `make check`
- `make test`
- `bun run vitest run tests/api-emails.test.ts tests/api-logs.test.ts tests/email-detail.test.tsx tests/dashboard-pages-tenant-scope.test.tsx`
- `bunx playwright test tests/e2e/logs-search.spec.ts` — passes locally as skipped because `DATABASE_URL` is not set for authenticated dashboard E2E; the test runs when a dashboard DB/session fixture is available.

## Risk
- Medium: request logging can accidentally expose sensitive data, so the helper redacts authorization/cookie/token/password-like fields and large message body fields (`html`, `text`, attachment `content`) before persistence.
- Low schema risk: this reuses existing `logs` columns and JSONB `document` metadata; no migration required.

## Follow-up not doing
- No observability vendor, tracing backend, CloudWatch UI, retention-tier policy, or broad refactor.
- No replacement of the existing email event timeline; associated logs complement it.
