### PR TITLE
Fix #227: expose Resend-compatible SDK client

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,6 +1,6 @@
 # opensend
 
-TypeScript SDK for the Opensend email API.
+TypeScript SDK for the OpenSend email API with a Resend-compatible client surface.
 
 ## Installation
 
@@ -10,18 +10,39 @@ bun add opensend
 
 ## Getting Started
 
+Use the Resend-compatible export for the easiest migration path:
+
+```typescript
+import { Resend } from "opensend";
+
+const resend = new Resend("re_your_api_key");
+```
+
+By default the SDK targets OpenSend's hosted API origin, `https://api.opensend.com`.
+Self-hosted deployments can override the origin with `baseUrl`:
+
+```typescript
+import { Resend } from "opensend";
+
+const resend = new Resend("re_your_api_key", {
+  baseUrl: "https://api.your-deployment.example.com",
+});
+```
+
+The existing `Opensend` export is still supported for backwards compatibility:
+
 ```typescript
 import { Opensend } from "opensend";
 
 const client = new Opensend("re_your_api_key", {
-  baseUrl: "https://your-deployment.example.com",
+  baseUrl: "https://api.your-deployment.example.com",
 });
 ```
 
 ## Sending Emails
 
 ```typescript
-const { data, error } = await client.emails.send({
+const { data, error } = await resend.emails.send({
   from: "hello@updates.example.com",
   to: "user@example.com",
   subject: "Welcome!",
@@ -35,17 +56,17 @@ if (error) {
 }
 ```
 
-`client.emails.send()` returns after the API persists the row and queues
-background delivery work. Poll `client.emails.get(id)` or list emails to observe
-the lifecycle: `queued` → `processing` → `sent`, followed by SES delivery events
-such as `delivered`, `bounced`, `opened`, or `clicked`. The `created_at`
-timestamp is queue time; `sent_at` is set by the worker after SES accepts the
-message.
+`resend.emails.send()` posts to the Resend-compatible `/emails` endpoint and
+returns after the API persists the row and queues background delivery work. Poll
+`resend.emails.get(id)` or list emails to observe the lifecycle: `queued` →
+`processing` → `sent`, followed by SES delivery events such as `delivered`,
+`bounced`, `opened`, or `clicked`. The `created_at` timestamp is queue time;
+`sent_at` is set by the worker after SES accepts the message.
 
 ### With React components
 
 ```tsx
-const { data } = await client.emails.send({
+const { data } = await resend.emails.send({
   from: "hello@updates.example.com",
   to: "user@example.com",
   subject: "Invoice",
@@ -53,17 +74,39 @@ const { data } = await client.emails.send({
 });
 ```
 
+## Batch Sending
+
+```typescript
+const { data, error } = await resend.emails.sendBatch([
+  {
+    from: "hello@updates.example.com",
+    to: "a@example.com",
+    subject: "Hi A",
+    html: "<p>A</p>",
+  },
+  {
+    from: "hello@updates.example.com",
+    to: "b@example.com",
+    subject: "Hi B",
+    html: "<p>B</p>",
+  },
+]);
+```
+
+`resend.emails.sendBatch()` posts to the Resend-compatible `/emails/batch`
+endpoint.
+
 ## Idempotency Keys
 
 Pass a per-request `idempotencyKey` option to prevent accidental duplicate
 acceptance when retrying sends. Keys must match the API contract: 1-255
-characters. Opensend preserves the existing send contract for duplicate keys: the
+characters. OpenSend preserves the existing send contract for duplicate keys: the
 API returns `409 idempotency_conflict` with the originally accepted email id in
 `details.id`; batch duplicates are rejected before reserving quota, creating
 additional rows, or publishing more queue jobs.
 
 ```typescript
-await client.emails.send(
+await resend.emails.send(
   {
     from: "hello@updates.example.com",
     to: "user@example.com",
@@ -73,7 +116,7 @@ await client.emails.send(
   { idempotencyKey: "welcome-user-123" },
 );
 
-await client.emails.sendBatch(
+await resend.emails.sendBatch(
   [
     {
       from: "hello@updates.example.com",
@@ -95,59 +138,77 @@ await client.emails.sendBatch(
 ## Listing Emails
 
 ```typescript
-const { data } = await client.emails.list();
+const { data } = await resend.emails.list();
 console.log(data.data); // EmailListItem[]
 
-const queued = await client.emails.list({ status: "queued" });
+const queued = await resend.emails.list({ status: "queued" });
 ```
 
 ## Getting an Email
 
 ```typescript
-const { data } = await client.emails.get("email-id");
+const { data } = await resend.emails.get("email-id");
 ```
 
 ## Domains
 
 ```typescript
 // Create a domain
-await client.domains.create({ name: "example.com" });
+await resend.domains.create({ name: "example.com" });
 
 // List domains
-const { data } = await client.domains.list();
+const { data } = await resend.domains.list();
 
 // Get a domain
-await client.domains.get("domain-id");
+await resend.domains.get("domain-id");
 
 // Verify a domain
-await client.domains.verify("domain-id");
+await resend.domains.verify("domain-id");
 ```
 
 ## API Keys
 
 ```typescript
 // Create an API key
-const { data } = await client.apiKeys.create({ name: "Production Key" });
+const { data } = await resend.apiKeys.create({ name: "Production Key" });
 console.log(data.token); // Only shown once
 
 // List API keys
-await client.apiKeys.list();
+await resend.apiKeys.list();
 
 // Delete an API key
-await client.apiKeys.delete("key-id");
+await resend.apiKeys.delete("key-id");
 ```
 
 ## Contacts
 
 ```typescript
 // Create a contact
-await client.contacts.create({ email: "user@example.com" });
+await resend.contacts.create({ email: "user@example.com" });
 
 // List contacts
-const { data } = await client.contacts.list();
+const { data } = await resend.contacts.list();
 
 // Get a contact
-await client.contacts.get("contact-id");
+await resend.contacts.get("contact-id");
+```
+
+## TypeScript
+
+Public request, response, and error shapes are exported from the package
+entrypoint:
+
+```typescript
+import type {
+  ApiError,
+  ApiResponse,
+  BatchEmailResponse,
+  EmailOptions,
+  EmailResponse,
+  RequestOptions,
+  SendEmailPayload,
+  SDKOptions,
+} from "opensend";
 ```
 
 ## Error Handling
@@ -155,7 +216,7 @@ await client.contacts.get("contact-id");
 All methods return `{ data, error }`. Check `error` before using `data`:
 
 ```typescript
-const { data, error } = await client.emails.send({ ... });
+const { data, error } = await resend.emails.send({ ... });
 
 if (error) {
   console.error(`Error ${error.statusCode}: ${error.message}`);
@@ -168,11 +229,11 @@ console.log(data.id);
 
 ## Configuration
 
-The SDK is publish-ready and does not assume a local dev server. Pass your
-deployment origin explicitly:
+`new Resend(apiKey, options?)` accepts an optional `baseUrl`. Use this for
+self-hosted OpenSend deployments:
 
 ```typescript
-const client = new Opensend("re_your_api_key", {
+const resend = new Resend("re_your_api_key", {
   baseUrl: "https://api.your-deployment.example.com",
 });
 ```

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,18 +1,25 @@
 import type {
+  ApiKeyListItem,
   ApiKeyListResponse,
   ApiKeyResponse,
   AutoConfigureDomainResponse,
+  BatchEmailItemError,
+  BatchEmailItemResponse,
   BatchEmailResponse,
   ContactListItem,
   ContactListResponse,
   ContactResponse,
+  ContactTopicPreference,
   CreateApiKeyPayload,
   CreateContactPayload,
   CreateContactResponse,
+  DomainCapability,
   DomainListItem,
   DomainListResponse,
   DomainOptions,
+  DomainRecord,
   DomainResponse,
+  EmailAttachment,
   EmailDetailResponse,
   EmailListItem,
   EmailListOptions,
@@ -20,22 +27,28 @@ import type {
   EmailOptions,
   EmailResponse,
   EmailStatus,
+  EmailTag,
+  EmailTemplateReference,
+  SendEmailResponse,
   UpdateDomainPayload,
 } from "../../core/src/dto";
 
 interface SDKOptions {
-  baseUrl: string;
+  baseUrl?: string;
 }
 
 export interface RequestOptions {
   idempotencyKey?: string;
 }
 
+export const DEFAULT_BASE_URL = "https://api.opensend.com";
+
 interface ApiError {
   message: string;
   statusCode: number;
   name?: string;
   code?: string;
+  details?: Record<string, unknown>;
 }
 
 interface ApiResponse<T> {
@@ -100,9 +113,9 @@ export interface AutomationRunListOptions extends ListOptions {
   status?: string;
 }
 
-function normalizeBaseUrl(baseUrl?: string): string {
-  if (!baseUrl?.trim()) {
-    throw new Error("A non-empty baseUrl is required");
+function normalizeBaseUrl(baseUrl: string = DEFAULT_BASE_URL): string {
+  if (!baseUrl.trim()) {
+    throw new Error("baseUrl must be a non-empty string when provided");
   }
 
   let normalized: URL;
@@ -127,6 +140,16 @@ function getStringProperty(
   return typeof property === "string" ? property : null;
 }
 
+function getRecordProperty(
+  value: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | null {
+  const property = value[key];
+  return property && typeof property === "object" && !Array.isArray(property)
+    ? (property as Record<string, unknown>)
+    : null;
+}
+
 function parseApiErrorBody(parsedBody: unknown, response: Response): ApiError {
   const errorBody =
     parsedBody && typeof parsedBody === "object"
@@ -147,12 +170,14 @@ function parseApiErrorBody(parsedBody: unknown, response: Response): ApiError {
     "Request failed";
   const name = getStringProperty(errorBody, "name");
   const code = getStringProperty(errorBody, "code");
+  const details = getRecordProperty(errorBody, "details");
 
   return {
     message,
     statusCode: response.status,
     ...(name ? { name } : {}),
     ...(code ? { code } : {}),
+    ...(details ? { details } : {}),
   };
 }
 
@@ -235,12 +260,7 @@ class Emails {
       }
     }
 
-    return this.http.request<EmailResponse>(
-      "POST",
-      "/api/emails",
-      rest,
-      options,
-    );
+    return this.http.request<EmailResponse>("POST", "/emails", rest, options);
   }
 
   async sendBatch(
@@ -249,7 +269,7 @@ class Emails {
   ): Promise<ApiResponse<BatchEmailResponse>> {
     return this.http.request<BatchEmailResponse>(
       "POST",
-      "/api/emails/batch",
+      "/emails/batch",
       payload,
       options,
     );
@@ -465,7 +485,7 @@ class Opensend {
   public readonly automations: Automations;
   public readonly events: Events;
 
-  constructor(apiKey: string, options: SDKOptions) {
+  constructor(apiKey: string, options: SDKOptions = {}) {
     if (!apiKey) {
       throw new Error("API key is required");
     }
@@ -481,20 +501,30 @@ class Opensend {
   }
 }
 
-export { Opensend };
+class Resend extends Opensend {}
+
+export { Opensend, Resend };
 export type {
   SDKOptions,
   ApiError,
   ApiResponse,
+  EmailAttachment,
   EmailOptions,
   EmailResponse,
+  SendEmailResponse,
   EmailStatus,
   EmailListOptions,
+  BatchEmailItemError,
+  BatchEmailItemResponse,
   BatchEmailResponse,
   EmailListItem,
   EmailListResponse,
+  EmailTag,
+  EmailTemplateReference,
   EmailDetailResponse,
+  DomainCapability,
   DomainOptions,
+  DomainRecord,
   UpdateDomainPayload,
   DomainResponse,
   DomainListItem,
@@ -502,10 +532,12 @@ export type {
   AutoConfigureDomainResponse,
   CreateApiKeyPayload,
   ApiKeyResponse,
+  ApiKeyListItem,
   ApiKeyListResponse,
   CreateContactPayload,
   CreateContactResponse,
   ContactResponse,
+  ContactTopicPreference,
   ContactListItem,
   ContactListResponse,
 };

--- a/tests/sdk-client.test.tsx
+++ b/tests/sdk-client.test.tsx
@@ -1,18 +1,60 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { Opensend } from "../packages/sdk/src";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { DEFAULT_BASE_URL, Opensend, Resend } from "../packages/sdk/src";
+import type {
+  ApiError,
+  ApiResponse,
+  BatchEmailResponse,
+  EmailOptions,
+  EmailResponse,
+  RequestOptions,
+  SDKOptions,
+  SendEmailPayload,
+} from "../packages/sdk/src";
 
 describe("Opensend SDK", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("requires an explicit baseUrl", () => {
-    expect(() => new Opensend("re_test", {} as never)).toThrow(
-      "A non-empty baseUrl is required",
+  it("constructs Resend and Opensend clients with the hosted default baseUrl", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ id: "email_default" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resend = new Resend("re_test");
+    const opensend = new Opensend("re_test");
+
+    expect(resend).toBeInstanceOf(Resend);
+    expect(opensend).toBeInstanceOf(Opensend);
+
+    await resend.emails.send({
+      from: "hello@example.com",
+      to: "user@example.com",
+      subject: "Hello",
+      html: "<p>Hello</p>",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${DEFAULT_BASE_URL}/emails`,
+      expect.objectContaining({ method: "POST" }),
     );
   });
 
-  it("normalizes the baseUrl and sends requests to the HTTP API", async () => {
+  it("validates invalid baseUrl overrides", () => {
+    expect(() => new Resend("re_test", { baseUrl: "" })).toThrow(
+      "baseUrl must be a non-empty string when provided",
+    );
+    expect(
+      () => new Resend("re_test", { baseUrl: "ftp://example.com" }),
+    ).toThrow("baseUrl must use http or https");
+  });
+
+  it("normalizes the baseUrl and sends requests to the Resend-compatible root email API", async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(JSON.stringify({ id: "email_123" }), {
         status: 200,
@@ -34,7 +76,7 @@ describe("Opensend SDK", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.example.com/api/emails",
+      "https://api.example.com/emails",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
@@ -73,7 +115,7 @@ describe("Opensend SDK", () => {
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      "https://api.example.com/api/emails",
+      "https://api.example.com/emails",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
@@ -83,7 +125,7 @@ describe("Opensend SDK", () => {
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      "https://api.example.com/api/emails/batch",
+      "https://api.example.com/emails/batch",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
@@ -91,6 +133,19 @@ describe("Opensend SDK", () => {
         }),
       }),
     );
+  });
+
+  it("keeps SDK public type exports available from the entrypoint", () => {
+    expectTypeOf<SDKOptions>().toMatchTypeOf<{ baseUrl?: string }>();
+    expectTypeOf<RequestOptions>().toMatchTypeOf<{ idempotencyKey?: string }>();
+    expectTypeOf<SendEmailPayload>().toMatchTypeOf<
+      EmailOptions & { react?: unknown }
+    >();
+    expectTypeOf<ApiResponse<EmailResponse>>().toEqualTypeOf<{
+      data: EmailResponse | null;
+      error: ApiError | null;
+    }>();
+    expectTypeOf<BatchEmailResponse>().toMatchTypeOf<{ data: unknown[] }>();
   });
 
   it("renders react payloads to html before sending", async () => {
@@ -178,6 +233,7 @@ describe("Opensend SDK", () => {
         code: "validation_error",
         message: "Validation failed.",
         statusCode: 422,
+        details: { fieldErrors: { to: ["Required"] }, formErrors: [] },
       },
     });
   });


### PR DESCRIPTION
## Summary
- Closes #227 by adding a public `Resend` constructor/export while preserving `Opensend`.
- Makes SDK `baseUrl` optional with default `https://api.opensend.com` and documents self-hosted overrides.
- Routes SDK send/batch calls through `/emails` and `/emails/batch`, re-exports public request/response/error DTO types, and updates README examples.

## Validation
- `bunx vitest run tests/sdk-client.test.tsx` — 11 tests passed.
- `bun run --cwd packages/sdk build` — TypeScript SDK declaration/build passed.
- `make check && make test` — typecheck passed; Biome checked 406 files with no fixes; Vitest passed 96 test files / 799 tests.

## Scope
- SDK package/docs/tests only for issue #227. No API auth, SES, dashboard, billing, unrelated route, or package rename changes.