### PR TITLE
Fix missed issue #200 tenant isolation route gaps

### DIFF
--- a/agent_docs/learnings/active/2026-05-07-issue-200-missed-tenant-scope.md
+++ b/agent_docs/learnings/active/2026-05-07-issue-200-missed-tenant-scope.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-07
+issue: "#200"
+type: mistake
+promoted_to: null
+---
+
+## Tenant-scope audits must include nested action/detail routes
+
+Issue #200 follow-up found tenant predicates missing outside the main CRUD routes: email cancel, email attachment list/detail, public logs list/detail, and the dashboard contact detail page. These routes looked adjacent to already-scoped email/contact/log work, but still needed explicit `auth.userId` or dashboard session predicates.
+
+For future tenant-isolation sweeps, search by resource table usage (`emails`, `logs`, `contacts`) across nested route directories and dashboard detail pages, not only top-level API route files. Cross-tenant regression tests should assert both 404 detail/mutation behavior and empty list behavior.

--- a/src/app/(dashboard)/audience/contacts/[id]/page.tsx
+++ b/src/app/(dashboard)/audience/contacts/[id]/page.tsx
@@ -1,21 +1,25 @@
 import { ContactDetail } from "@/components/contact-detail";
+import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { contacts } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
-import { notFound } from "next/navigation";
+import { and, eq } from "drizzle-orm";
+import { notFound, redirect } from "next/navigation";
 
 export default async function ContactDetailPage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
+  const session = await getServerSession();
+  if (!session) redirect("/auth");
+
   const { id } = await params;
 
   try {
     const [contact] = await db
       .select()
       .from(contacts)
-      .where(eq(contacts.id, id))
+      .where(and(eq(contacts.id, id), eq(contacts.userId, session.user.id)))
       .limit(1);
 
     if (!contact) {

--- a/src/app/api/emails/[id]/attachments/[attachmentId]/route.ts
+++ b/src/app/api/emails/[id]/attachments/[attachmentId]/route.ts
@@ -2,7 +2,7 @@ import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { emails } from "@/lib/db/schema";
 import { getPresignedUrl } from "@/lib/s3";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
 export async function GET(
@@ -10,14 +10,14 @@ export async function GET(
   { params }: { params: Promise<{ id: string; attachmentId: string }> },
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth || !auth.userId) return unauthorizedResponse();
 
   try {
     const { id, attachmentId } = await params;
     const [email] = await db
       .select({ attachments: emails.attachments })
       .from(emails)
-      .where(eq(emails.id, id))
+      .where(and(eq(emails.id, id), eq(emails.userId, auth.userId)))
       .limit(1);
 
     if (!email) {

--- a/src/app/api/emails/[id]/attachments/route.ts
+++ b/src/app/api/emails/[id]/attachments/route.ts
@@ -1,7 +1,7 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { emails } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
 export async function GET(
@@ -9,14 +9,14 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth || !auth.userId) return unauthorizedResponse();
 
   try {
     const { id } = await params;
     const [email] = await db
       .select({ attachments: emails.attachments })
       .from(emails)
-      .where(eq(emails.id, id))
+      .where(and(eq(emails.id, id), eq(emails.userId, auth.userId)))
       .limit(1);
 
     if (!email) {

--- a/src/app/api/emails/[id]/cancel/route.ts
+++ b/src/app/api/emails/[id]/cancel/route.ts
@@ -1,7 +1,7 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { emails } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
 export async function POST(
@@ -9,13 +9,13 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth || !auth.userId) return unauthorizedResponse();
 
   try {
     const { id } = await params;
 
     const existing = await db.query.emails.findFirst({
-      where: eq(emails.id, id),
+      where: and(eq(emails.id, id), eq(emails.userId, auth.userId)),
     });
 
     if (!existing) {
@@ -32,7 +32,7 @@ export async function POST(
     const [updated] = await db
       .update(emails)
       .set({ status: "canceled" })
-      .where(eq(emails.id, id))
+      .where(and(eq(emails.id, id), eq(emails.userId, auth.userId)))
       .returning();
 
     return NextResponse.json({

--- a/src/app/api/logs/[id]/route.ts
+++ b/src/app/api/logs/[id]/route.ts
@@ -1,20 +1,20 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { logs } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth || !auth.userId) return unauthorizedResponse();
 
   const { id } = await params;
 
   try {
     const log = await db.query.logs.findFirst({
-      where: eq(logs.id, id),
+      where: and(eq(logs.id, id), eq(logs.userId, auth.userId)),
     });
 
     if (!log) {

--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -5,7 +5,7 @@ import { type SQL, and, desc, eq, gt, lt } from "drizzle-orm";
 
 export async function GET(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
+  if (!auth || !auth.userId) return unauthorizedResponse();
 
   const url = new URL(request.url);
   const limit = Math.min(
@@ -21,7 +21,7 @@ export async function GET(request: Request): Promise<Response> {
   const before = url.searchParams.get("before");
 
   try {
-    const conditions: SQL[] = [];
+    const conditions: SQL[] = [eq(logs.userId, auth.userId)];
 
     if (status) {
       conditions.push(eq(logs.status, Number(status)));

--- a/tests/issue-200-missed-tenant-scope.test.tsx
+++ b/tests/issue-200-missed-tenant-scope.test.tsx
@@ -1,0 +1,245 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockFindEmail = vi.hoisted(() => vi.fn());
+const mockFindLog = vi.hoisted(() => vi.fn());
+const mockSelect = vi.hoisted(() => vi.fn());
+const mockUpdate = vi.hoisted(() => vi.fn());
+const mockGetPresignedUrl = vi.hoisted(() => vi.fn());
+const mockRedirect = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error("NEXT_REDIRECT");
+  }),
+);
+const mockNotFound = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+);
+const mockEq = vi.hoisted(() =>
+  vi.fn((left, right) => ({ kind: "eq", left, right })),
+);
+const mockAnd = vi.hoisted(() =>
+  vi.fn((...conditions) => ({ kind: "and", conditions })),
+);
+const mockDesc = vi.hoisted(() =>
+  vi.fn((column) => ({ kind: "desc", column })),
+);
+const mockLt = vi.hoisted(() =>
+  vi.fn((left, right) => ({ kind: "lt", left, right })),
+);
+const mockGt = vi.hoisted(() =>
+  vi.fn((left, right) => ({ kind: "gt", left, right })),
+);
+const recordedWhere = vi.hoisted(() => [] as unknown[]);
+
+vi.mock("@/lib/api-auth", () => ({
+  validateApiKey: mockValidateApiKey,
+  getServerSession: mockGetServerSession,
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      emails: { findFirst: mockFindEmail },
+      logs: { findFirst: mockFindLog },
+    },
+    select: mockSelect,
+    update: mockUpdate,
+  },
+}));
+
+vi.mock("@/lib/s3", () => ({
+  getPresignedUrl: mockGetPresignedUrl,
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: mockNotFound,
+  redirect: mockRedirect,
+}));
+
+vi.mock("@/components/contact-detail", () => ({
+  ContactDetail: (props: { contact: { id: string } }) => (
+    <div data-testid="contact-detail" data-props={JSON.stringify(props)} />
+  ),
+}));
+
+vi.mock("drizzle-orm", async () => {
+  const actual =
+    await vi.importActual<typeof import("drizzle-orm")>("drizzle-orm");
+  return {
+    ...actual,
+    and: mockAnd,
+    desc: mockDesc,
+    eq: mockEq,
+    gt: mockGt,
+    lt: mockLt,
+  };
+});
+
+const AUTH_RESULT = {
+  apiKeyId: "key-b",
+  permission: "full_access",
+  domain: null,
+  userId: "user-b",
+};
+
+function makeRequest(url: string, method = "GET"): NextRequest {
+  return new Request(url, {
+    method,
+    headers: { Authorization: "Bearer re_user_b" },
+  }) as unknown as NextRequest;
+}
+
+function makeQuery<T>(rows: T[]) {
+  const chain = {
+    from: vi.fn(() => chain),
+    where: vi.fn((condition: unknown) => {
+      recordedWhere.push(condition);
+      return chain;
+    }),
+    orderBy: vi.fn(() => chain),
+    limit: vi.fn(() => Promise.resolve(rows)),
+    // biome-ignore lint/suspicious/noThenProperty: mocks Drizzle's thenable query builder
+    then: (resolve: (value: T[]) => unknown) => Promise.resolve(resolve(rows)),
+  };
+  return chain;
+}
+
+function queueSelectRows(...rowSets: unknown[][]) {
+  mockSelect.mockReset();
+  for (const rows of rowSets) {
+    mockSelect.mockReturnValueOnce(makeQuery(rows));
+  }
+}
+
+function expectConditionIncludes(value: string) {
+  expect(mockEq.mock.calls.some(([, right]) => right === value)).toBe(true);
+}
+
+describe("issue #200 missed tenant isolation gaps", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    recordedWhere.length = 0;
+    mockValidateApiKey.mockResolvedValue(AUTH_RESULT);
+    mockGetServerSession.mockResolvedValue({ user: { id: "user-b" } });
+    mockFindEmail.mockResolvedValue(null);
+    mockFindLog.mockResolvedValue(null);
+    mockGetPresignedUrl.mockResolvedValue("https://download.example/att-1");
+  });
+
+  it("404s email cancel for another tenant and does not update", async () => {
+    const { POST } = await import("@/app/api/emails/[id]/cancel/route");
+
+    const response = await POST(
+      makeRequest("http://localhost:3015/api/emails/email-a/cancel", "POST"),
+      { params: Promise.resolve({ id: "email-a" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Email not found" });
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expectConditionIncludes("email-a");
+    expectConditionIncludes(AUTH_RESULT.userId);
+  });
+
+  it("404s email attachment list for another tenant", async () => {
+    queueSelectRows([]);
+    const { GET } = await import("@/app/api/emails/[id]/attachments/route");
+
+    const response = await GET(
+      makeRequest("http://localhost:3015/api/emails/email-a/attachments"),
+      { params: Promise.resolve({ id: "email-a" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Email not found" });
+    expect(recordedWhere).toHaveLength(1);
+    expectConditionIncludes("email-a");
+    expectConditionIncludes(AUTH_RESULT.userId);
+  });
+
+  it("404s email attachment detail for another tenant without issuing a download URL", async () => {
+    queueSelectRows([]);
+    const { GET } = await import(
+      "@/app/api/emails/[id]/attachments/[attachmentId]/route"
+    );
+
+    const response = await GET(
+      makeRequest("http://localhost:3015/api/emails/email-a/attachments/att-1"),
+      { params: Promise.resolve({ id: "email-a", attachmentId: "att-1" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Email not found" });
+    expect(mockGetPresignedUrl).not.toHaveBeenCalled();
+    expect(recordedWhere).toHaveLength(1);
+    expectConditionIncludes("email-a");
+    expectConditionIncludes(AUTH_RESULT.userId);
+  });
+
+  it("returns an empty public logs list when user-scoped predicates find no owned rows", async () => {
+    queueSelectRows([]);
+    const { GET } = await import("@/app/api/logs/route");
+
+    const response = await GET(
+      makeRequest("http://localhost:3015/api/logs?api_key_id=key-a"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      object: "list",
+      data: [],
+      has_more: false,
+    });
+    expect(recordedWhere).toHaveLength(1);
+    expectConditionIncludes(AUTH_RESULT.userId);
+    expectConditionIncludes("key-a");
+  });
+
+  it("404s public log detail for another tenant", async () => {
+    const { GET } = await import("@/app/api/logs/[id]/route");
+
+    const response = await GET(
+      makeRequest("http://localhost:3015/api/logs/log-a"),
+      { params: Promise.resolve({ id: "log-a" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Log not found" });
+    expectConditionIncludes("log-a");
+    expectConditionIncludes(AUTH_RESULT.userId);
+  });
+
+  it("redirects unauthenticated contact detail dashboard access before querying", async () => {
+    mockGetServerSession.mockResolvedValueOnce(null);
+    const Page = (await import("@/app/(dashboard)/audience/contacts/[id]/page"))
+      .default;
+
+    await expect(
+      Page({ params: Promise.resolve({ id: "contact-a" }) }),
+    ).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(mockRedirect).toHaveBeenCalledWith("/auth");
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("404s dashboard contact detail for another tenant", async () => {
+    queueSelectRows([]);
+    const Page = (await import("@/app/(dashboard)/audience/contacts/[id]/page"))
+      .default;
+
+    await expect(
+      Page({ params: Promise.resolve({ id: "contact-a" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(recordedWhere).toHaveLength(1);
+    expectConditionIncludes("contact-a");
+    expectConditionIncludes(AUTH_RESULT.userId);
+  });
+});


### PR DESCRIPTION
## What changed
- Scope email cancel by authenticated API-key owner on both the preflight read and update.
- Scope sent-email attachment list/detail routes by authenticated API-key owner before returning attachment metadata or issuing presigned URLs.
- Scope public logs list/detail API routes by authenticated API-key owner.
- Require a dashboard session on `/audience/contacts/[id]` and scope the contact detail lookup by `contacts.userId`.
- Add focused issue #200 regression coverage for cross-tenant 404/empty behavior.
- Record the missed-route tenant-scope audit learning for future sweeps.

## Why
Issue #200's earlier tenant-isolation slices scoped the main CRUD paths, but several nested action/detail routes still performed owner-blind reads. That could expose another tenant's email/log/contact data or allow owner-blind scheduled-email cancellation if a caller knew an id.

## Root cause
The original issue #200 sweeps focused on top-level route files and common dashboard pages. Nested action routes (`cancel`, `attachments`) and public logs API/detail plus the dashboard contact detail page were not included in the first pass.

## Impact
Cross-tenant callers now receive the expected not-found or empty-list behavior, and dashboard contact detail access redirects before querying when no session exists.

## Validation
- `make check`
- `bun run test tests/issue-200-missed-tenant-scope.test.tsx tests/api-emails.test.ts tests/dashboard-pages-tenant-scope.test.tsx`
- Push guardrail: `node scripts/check-changed-files.mjs` via pre-push hook

## Notes
Playwright E2E was not added in this patch. Follow-up issue #229 tracks stronger deterministic E2E standards and fixtures for agent close-loop validation.

Related: #200, #229
