### PR TITLE
Improve self-hosting docs and strip team-prod runbook from agent guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
 
 - Repo: `github.com/namuh-eng/opensend`
 - License: Elastic License 2.0 (ELv2)
-- Primary deploy: Docker Compose for self-hosters; team production runs on **AWS ECS Fargate** (the multi-stage Dockerfile also runs on Cloud Run, Fly, Railway, etc.)
+- Primary deploy: Docker Compose for self-hosters (the multi-stage Dockerfile also runs on Cloud Run, Fly, Railway, ECS, etc.)
 
 ## Tech Stack
 - **Framework**: Next.js 16 (App Router, Turbopack) — pre-installed, do not change
@@ -34,7 +34,7 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
 - `tests/` — Vitest unit tests
 - `tests/e2e/` — Playwright E2E tests
 - `drizzle/` — generated migration SQL
-- `scripts/` — infra/deploy scripts (gitignored except `start.sh`, `postinstall-star.sh`, `seed.ts`)
+- `scripts/` — infra/deploy scripts (most entries gitignored to keep environment-specific values out of the repo)
 - `agent_docs/learnings/` — decisions, mistakes, patterns captured by `/shipit`, `/retro`, the `docs-keeper` agent
 - `docs/assets/` — README images (`screenshot-dashboard.png` only; don't add orphans)
 
@@ -47,7 +47,6 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
 - `bun run build` — production build
 - `bun run db:generate` — Drizzle migration files
 - `bun run db:migrate` — apply migrations for the configured `DATABASE_URL`
-- `bash scripts/deploy.sh migrate` — team prod: build/push the migrator image and run an ECS one-off migration task only
 - `bun run db:push` — push schema (dev)
 - `bun run db:seed` — seed sample data
 - `docker compose up -d` — full stack with Postgres + auto-migration
@@ -73,41 +72,21 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
   - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` — SES + S3
   - `S3_BUCKET_NAME` — email attachment storage
   - Google OAuth client credentials for Better Auth
-- **Deployment**: Docker Compose is the reference deploy. Team production uses `bash scripts/deploy.sh` (ECS/Fargate); `app`, `ingester`, and `all` run migrations before service redeploy, and `migrate` runs migrations only.
+- **Deployment**: Docker Compose is the reference deploy. The standalone ingester service (`packages/ingester/`) handles SES/SNS event ingestion — point SES SNS topics at the ingester's `/events/ses` endpoint, not the app URL.
 
 ## Security — Secrets Management
 - **Never hardcode** passwords, tokens, or API keys in scripts or source.
-- **Contributors / local dev**: use `.env` (gitignored).
-- **Team production**: secrets live in **AWS Secrets Manager** (region `us-east-1`). Ask Jaeyun or Ashley for the current secret IDs and access.
-- Retrieve at runtime:
-  ```bash
-  aws secretsmanager get-secret-value --secret-id <id> --region us-east-1 --query SecretString --output text
-  ```
-- `scripts/` is gitignored (except `start.sh`, `postinstall-star.sh`, `seed.ts`) because infra scripts carry environment-specific values. Do not re-commit them.
+- **Local dev**: use `.env` (gitignored). Production deployments should source secrets from a secrets manager (AWS Secrets Manager, Doppler, Vault, etc.) and inject them at runtime.
+- `scripts/` is largely gitignored because infra scripts carry environment-specific values. Do not re-commit them.
 - **Rate limiting** is enforced via Next.js middleware (`src/middleware.ts`) on all `/api/*` routes with tiered limits (strictest on email sending).
 
-## Team Production — AWS ECS Fargate (namuh.co)
-Team prod runs on **ECS Fargate**, not App Runner. App Runner deployment is deprecated and the old `resend-clone-*` resources are being torn down.
-
-- **Region**: `us-east-1`. **Cluster**: `namuh`. **ALB**: `namuh-alb` (shared across all products via host-based listener rules).
-- **Subdomain pattern per product**:
-  - `<product>.namuh.co` → app/dashboard target group (port 8080)
-  - `api.<product>.namuh.co` → app target group (same service handles `/api/*`)
-  - `events.<product>.namuh.co` → ingester target group (port 3016)
-- **ACM cert** has SANs for `namuh.co`, `*.namuh.co`, `*.opensend.namuh.co`. Add new SANs and re-validate when adding products.
-- **DNS authoritative on Cloudflare**, NOT Route53. Zone `namuh.co` ID = `182dba68b02c180d4eb127eb0b025284`. Always use the Cloudflare API for namuh.co records. Do not create Route53 hosted zones for it.
-- **Deploy**: `bash scripts/deploy.sh [app|ingester|all|migrate]` — builds/pushes images, runs the migrator ECS task before app/ingester redeploys, force-redeploys selected ECS services, waits until stable. Use `migrate` alone for DB-only repairs.
-- **ECR repos**: `<product>-app`, `<product>-ingester`. The app repo also carries the `<tag>-migrator` image built from the Dockerfile `migrator` target. **ECS services**: `<product>-app`, `<product>-ingester`. **Log groups**: `/ecs/<product>-app`, `/ecs/<product>-ingester`.
-
 ## Production Gotchas (must-know)
-- **Run prod migrations before redeploying app code that expects new columns**: `scripts/deploy.sh` now does this automatically, but never bypass it with a raw `aws ecs update-service` after schema changes. Use `bash scripts/deploy.sh migrate` for DB-only fixes. The migrator image runs `src/lib/db/migrate.ts` via the Drizzle migrator API; avoid switching back to `drizzle-kit migrate` without re-testing in ECS. If a dashboard list page works but a detail page 404s, suspect swallowed DB/schema errors before assuming a missing route.
-- **Cloudflare zone ID secret was wrong historically**: `resend-clone/cloudflare/zone-id` previously pointed at the wrong zone (`foreverbrowsing.com`), causing both ACM validation CNAMEs and customer DKIM auto-setup records to be silently written to the wrong zone. Fixed 2026-04-30; verify the secret value matches the namuh.co zone ID before trusting `cloudflare.ts` output.
-- **Docker build platform**: Fargate is `linux/amd64`. M-chip Macs default to `arm64`, which silently produces tasks that fail to start. Always `docker buildx build --platform linux/amd64 ... --push`.
+- **Run migrations before redeploying app code that expects new columns**. The migrator runs `src/lib/db/migrate.ts` via the Drizzle migrator API. If a dashboard list page works but a detail page 404s, suspect swallowed DB/schema errors before assuming a missing route.
+- **Docker build platform**: production typically runs `linux/amd64`. M-chip Macs default to `arm64`, which silently produces images that fail to start. Always `docker buildx build --platform linux/amd64 ... --push`.
 - **`bun install` in containers needs `--ignore-scripts`**: postinstall calls `node scripts/install-git-hooks.mjs` which is not present at the `deps` Dockerfile stage. Without `--ignore-scripts` the build fails.
-- **Next.js middleware cannot import the `redis` npm package directly**: it pulls in `node:crypto` which is unavailable in the default Edge Runtime, causing every request (including ALB health checks) to 500. Fix is `experimental.nodeMiddleware: true` in `next.config.js` plus `runtime: "nodejs"` on `export const config` in `src/middleware.ts`. Same trap applies to any node-only npm package imported from middleware.
+- **Next.js middleware cannot import the `redis` npm package directly**: it pulls in `node:crypto` which is unavailable in the default Edge Runtime, causing every request (including health checks) to 500. Fix is `experimental.nodeMiddleware: true` in `next.config.js` plus `runtime: "nodejs"` on `export const config` in `src/middleware.ts`. Same trap applies to any node-only npm package imported from middleware.
 - **`curl` and `wget` are denied** by the agent settings deny-list. For HTTPS calls in scripts, use `bun -e "const r = await fetch(...); console.log(await r.text())"` instead.
 - **Long unconditional `sleep` is blocked**. To poll a long-running condition, use `until <check>; do sleep 20; done` and pair it with `run_in_background` so you get a notification when it resolves.
-- **`scripts/` is gitignored except for** `start.sh`, `postinstall-star.sh`, `seed.ts`, `install-git-hooks.mjs`, `check-changed-files.mjs`, `deploy.sh`. Anything else under `scripts/` (including `aws-bootstrap.sh`, ad-hoc deploy helpers, task-definition JSON) stays out of git by design — those carry env-specific ARNs.
 
 ## Learnings Workflow (namuhflow)
 - **Before starting work**: read `agent_docs/learnings/` for prior decisions, mistakes, and patterns.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
 
 - Repo: `github.com/namuh-eng/opensend`
 - License: Elastic License 2.0 (ELv2)
-- Primary deploy: Docker Compose for self-hosters; team production runs on **AWS ECS Fargate** (the multi-stage Dockerfile also runs on Cloud Run, Fly, Railway, etc.)
+- Primary deploy: Docker Compose for self-hosters (the multi-stage Dockerfile also runs on Cloud Run, Fly, Railway, ECS, etc.)
 
 ## Tech Stack
 - **Framework**: Next.js 16 (App Router, Turbopack) — pre-installed, do not change
@@ -33,7 +33,7 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
 - `tests/` — Vitest unit tests
 - `tests/e2e/` — Playwright E2E tests
 - `drizzle/` — generated migration SQL
-- `scripts/` — infra/deploy scripts (gitignored except `start.sh`, `postinstall-star.sh`, `seed.ts`)
+- `scripts/` — infra/deploy scripts (most entries gitignored to keep environment-specific values out of the repo)
 - `agent_docs/learnings/` — decisions, mistakes, patterns captured by `/shipit`, `/retro`, the `docs-keeper` agent
 - `docs/assets/` — README images (`screenshot-dashboard.png` only; don't add orphans)
 
@@ -46,7 +46,6 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
 - `bun run build` — production build
 - `bun run db:generate` — Drizzle migration files
 - `bun run db:migrate` — apply migrations for the configured `DATABASE_URL`
-- `bash scripts/deploy.sh migrate` — team prod: build/push the migrator image and run an ECS one-off migration task only
 - `bun run db:push` — push schema (dev)
 - `bun run db:seed` — seed sample data
 - `docker compose up -d` — full stack with Postgres + auto-migration
@@ -72,43 +71,21 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
   - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` — SES + S3
   - `S3_BUCKET_NAME` — email attachment storage
   - Google OAuth client credentials for Better Auth
-- **Deployment**: Docker Compose is the reference deploy. Team production uses `bash scripts/deploy.sh` for the Next.js app and standalone ingester on ECS/Fargate; `app`, `ingester`, and `all` run migrations before service redeploy, and `migrate` runs migrations only.
-- **Ingester cutover**: SES SNS should point at `https://<ingester-service-url>/events/ses`, not the app URL. See `docs/ingester-deploy.md` for the split-service runbook, CloudWatch log tailing, and replay instructions.
+- **Deployment**: Docker Compose is the reference deploy. The standalone ingester service (`packages/ingester/`) handles SES/SNS event ingestion — point SES SNS topics at the ingester's `/events/ses` endpoint, not the app URL.
 
 ## Security — Secrets Management
 - **Never hardcode** passwords, tokens, or API keys in scripts or source.
-- **Contributors / local dev**: use `.env` (gitignored).
-- **Team production**: secrets live in **AWS Secrets Manager** (region `us-east-1`). Ask Jaeyun or Ashley for the current secret IDs and access.
-- **Shared service wiring**: app, ingester, and migrator ECS tasks must receive the same database/credential secrets; keep the actual secret IDs external to the repo and inject them through the ECS task definition (`secrets` block, referenced via Secrets Manager ARN).
-- Retrieve at runtime:
-  ```bash
-  aws secretsmanager get-secret-value --secret-id <id> --region us-east-1 --query SecretString --output text
-  ```
-- `scripts/` is gitignored (except `start.sh`, `postinstall-star.sh`, `seed.ts`) because infra scripts carry environment-specific values. Do not re-commit them.
+- **Local dev**: use `.env` (gitignored). Production deployments should source secrets from a secrets manager (AWS Secrets Manager, Doppler, Vault, etc.) and inject them at runtime.
+- `scripts/` is largely gitignored because infra scripts carry environment-specific values. Do not re-commit them.
 - **Rate limiting** is enforced via Next.js middleware (`src/middleware.ts`) on all `/api/*` routes with tiered limits (strictest on email sending).
 
-## Team Production — AWS ECS Fargate (namuh.co)
-Team prod runs on **ECS Fargate**, not App Runner. App Runner deployment is deprecated and the old `resend-clone-*` resources are being torn down.
-
-- **Region**: `us-east-1`. **Cluster**: `namuh`. **ALB**: `namuh-alb` (shared across all products via host-based listener rules).
-- **Subdomain pattern per product**:
-  - `<product>.namuh.co` → app/dashboard target group (port 8080)
-  - `api.<product>.namuh.co` → app target group (same service handles `/api/*`)
-  - `events.<product>.namuh.co` → ingester target group (port 3016)
-- **ACM cert** has SANs for `namuh.co`, `*.namuh.co`, `*.opensend.namuh.co`. Add new SANs and re-validate when adding products.
-- **DNS authoritative on Cloudflare**, NOT Route53. Zone `namuh.co` ID = `182dba68b02c180d4eb127eb0b025284`. Always use the Cloudflare API for namuh.co records. Do not create Route53 hosted zones for it.
-- **Deploy**: `bash scripts/deploy.sh [app|ingester|all|migrate]` — builds/pushes images, runs the migrator ECS task before app/ingester redeploys, force-redeploys selected ECS services, waits until stable. Use `migrate` alone for DB-only repairs.
-- **ECR repos**: `<product>-app`, `<product>-ingester`. The app repo also carries the `<tag>-migrator` image built from the Dockerfile `migrator` target. **ECS services**: `<product>-app`, `<product>-ingester`. **Log groups**: `/ecs/<product>-app`, `/ecs/<product>-ingester`.
-
 ## Production Gotchas (must-know)
-- **Run prod migrations before redeploying app code that expects new columns**: `scripts/deploy.sh` now does this automatically, but never bypass it with a raw `aws ecs update-service` after schema changes. Use `bash scripts/deploy.sh migrate` for DB-only fixes. The migrator image runs `src/lib/db/migrate.ts` via the Drizzle migrator API; avoid switching back to `drizzle-kit migrate` without re-testing in ECS. If a dashboard list page works but a detail page 404s, suspect swallowed DB/schema errors before assuming a missing route.
-- **Cloudflare zone ID secret was wrong historically**: `resend-clone/cloudflare/zone-id` previously pointed at the wrong zone (`foreverbrowsing.com`), causing both ACM validation CNAMEs and customer DKIM auto-setup records to be silently written to the wrong zone. Fixed 2026-04-30; verify the secret value matches the namuh.co zone ID before trusting `cloudflare.ts` output.
-- **Docker build platform**: Fargate is `linux/amd64`. M-chip Macs default to `arm64`, which silently produces tasks that fail to start. Always `docker buildx build --platform linux/amd64 ... --push`.
+- **Run migrations before redeploying app code that expects new columns**. The migrator runs `src/lib/db/migrate.ts` via the Drizzle migrator API. If a dashboard list page works but a detail page 404s, suspect swallowed DB/schema errors before assuming a missing route.
+- **Docker build platform**: production typically runs `linux/amd64`. M-chip Macs default to `arm64`, which silently produces images that fail to start. Always `docker buildx build --platform linux/amd64 ... --push`.
 - **`bun install` in containers needs `--ignore-scripts`**: postinstall calls `node scripts/install-git-hooks.mjs` which is not present at the `deps` Dockerfile stage. Without `--ignore-scripts` the build fails.
-- **Next.js middleware cannot import the `redis` npm package directly**: it pulls in `node:crypto` which is unavailable in the default Edge Runtime, causing every request (including ALB health checks) to 500. Fix is `experimental.nodeMiddleware: true` in `next.config.js` plus `runtime: "nodejs"` on `export const config` in `src/middleware.ts`. Same trap applies to any node-only npm package imported from middleware.
+- **Next.js middleware cannot import the `redis` npm package directly**: it pulls in `node:crypto` which is unavailable in the default Edge Runtime, causing every request (including health checks) to 500. Fix is `experimental.nodeMiddleware: true` in `next.config.js` plus `runtime: "nodejs"` on `export const config` in `src/middleware.ts`. Same trap applies to any node-only npm package imported from middleware.
 - **`curl` and `wget` are denied** by the agent settings deny-list. For HTTPS calls in scripts, use `bun -e "const r = await fetch(...); console.log(await r.text())"` instead.
 - **Long unconditional `sleep` is blocked**. To poll a long-running condition, use `until <check>; do sleep 20; done` and pair it with `run_in_background` so you get a notification when it resolves.
-- **`scripts/` is gitignored except for** `start.sh`, `postinstall-star.sh`, `seed.ts`, `install-git-hooks.mjs`, `check-changed-files.mjs`, `deploy.sh`. Anything else under `scripts/` (including `aws-bootstrap.sh`, ad-hoc deploy helpers, task-definition JSON) stays out of git by design — those carry env-specific ARNs.
 
 ## Learnings Workflow (namuhflow)
 - **Before starting work**: read `agent_docs/learnings/` for prior decisions, mistakes, and patterns.

--- a/README.md
+++ b/README.md
@@ -63,9 +63,7 @@ That's it. Open **http://localhost:3015** and sign in with Google (configure `GO
 
 > The `migrate` service runs database migrations automatically on first boot. Compose also launches the standalone ingester on port `3016` (`http://localhost:3016/health`) for SES/SNS events and background workers.
 >
-> Outside Docker Compose, migrations are not automatic unless your deploy path
-> runs the migrator. Team ECS/Fargate production uses `bash scripts/deploy.sh`,
-> which runs a one-off migrator task before service redeploys.
+> Outside Docker Compose, migrations are not automatic — your deploy path needs to run the `migrator` Dockerfile target (or `bun run db:migrate`) before rolling out app code that expects new columns. See [`docs/self-hosting.md`](docs/self-hosting.md#upgrades--migrations).
 
 ## Features
 
@@ -149,8 +147,8 @@ Full SDK docs: [`packages/sdk/README.md`](./packages/sdk/README.md)
 ### Requirements
 
 - Docker & Docker Compose
-- AWS account with SES access (for sending emails)
-- *(Optional)* Cloudflare account (for automatic DNS record setup)
+- AWS account with SES access (for sending real emails — local dev works without it)
+- *(Optional)* Cloudflare account for automatic DKIM/SPF/DMARC setup
 
 ### Docker Compose (recommended)
 
@@ -158,154 +156,49 @@ Full SDK docs: [`packages/sdk/README.md`](./packages/sdk/README.md)
 git clone https://github.com/namuh-eng/opensend.git
 cd opensend
 cp .env.example .env
-```
-
-Edit `.env` with your configuration:
-
-```bash
-# Required for sending emails
-AWS_ACCESS_KEY_ID=your-aws-key
-AWS_SECRET_ACCESS_KEY=your-aws-secret
-AWS_REGION=us-east-1
-
-# Optional
-POSTGRES_PASSWORD=your-db-password     # Default: opensend
-POSTGRES_PORT=5432                     # Change this and DATABASE_URL together if 5432 is taken
-PORT=3015                              # Default: 3015
-CLOUDFLARE_API_TOKEN=your-cf-token     # For auto DNS setup
-CLOUDFLARE_ZONE_ID=your-zone-id
-S3_BUCKET_NAME=your-bucket             # For email attachments
-BACKGROUND_JOBS_QUEUE_URL=...          # Optional locally; required for async production sending
-BACKGROUND_WORKER_POLL=true            # Set on the ingester worker when SQS is configured
-CLOUDWATCH_METRICS_NAMESPACE=Opensend  # Optional CloudWatch EMF namespace override
-```
-
-`.env.example` keeps `DATABASE_URL` on `localhost` for host-run commands like `bun run dev` and `bun run db:push`. Docker Compose injects its own internal `postgres` hostname for the containerized app and migration services.
-
-Start everything:
-
-```bash
+# Edit .env — at minimum set BETTER_AUTH_SECRET and (for sending) AWS credentials
 docker compose up -d
 ```
 
-This starts PostgreSQL, runs migrations, launches the app, and launches the standalone SES/SNS ingester on port `3016`. Open **http://localhost:3015** for the dashboard/API and `http://localhost:3016/health` for the ingester health endpoint.
+This starts PostgreSQL, runs migrations, launches the app on `:3015`, and the
+standalone SES/SNS ingester on `:3016`. Open **http://localhost:3015** for the
+dashboard/API and `http://localhost:3016/health` for the ingester.
 
-### Manual Setup
+### Manual setup (without Docker)
 
-If you prefer running without Docker (requires [Bun](https://bun.sh)):
+Requires [Bun](https://bun.sh) and a running Postgres instance:
 
 ```bash
 git clone https://github.com/namuh-eng/opensend.git
 cd opensend
 bun install
 cp .env.example .env
-# Edit .env — leave DATABASE_URL as localhost unless you're using another Postgres instance.
 bun run db:push
-bun run db:seed          # Optional: creates sample data
-bun run dev              # Development (port 3015)
+bun run db:seed          # Optional: sample data
+bun run dev              # Development on port 3015
 # or
-bun run build && bun start  # Production
+bun run build && bun start
 ```
 
-To suppress the optional GitHub star prompt during install, use `SKIP_STAR_PROMPT=1 bun install`.
+### Production deployments
 
-### AWS SES Sandbox
+For production setup — managed Postgres, AWS SES IAM, S3 attachments, reverse
+proxy + TLS, SQS-backed background jobs, Redis rate limiting, observability,
+and the split app/ingester service shape — read the dedicated guides:
 
-New AWS accounts start in SES **sandbox mode** — emails can only be sent to verified addresses. To send to anyone:
+- **[`docs/self-hosting.md`](docs/self-hosting.md)** — full self-hosting deep dive (environment variables, database, SES, DNS, auth, reverse proxy, background jobs, Redis, upgrades, troubleshooting)
+- **[`docs/ingester-deploy.md`](docs/ingester-deploy.md)** — running the ingester as a separate service with SNS cutover and replay runbook
+- **[`docs/observability.md`](docs/observability.md)** — log/metric/trace catalog and the API-to-provider tracing runbook
 
-1. Verify a sender domain in the Opensend dashboard
-2. Request production access in [AWS SES Console](https://console.aws.amazon.com/ses/) → Account dashboard → Request production access
-
-### Production Deployment
-
-For production, we recommend:
-
-- **Database**: Use a managed PostgreSQL (AWS RDS, Supabase, Neon, etc.) instead of the Docker Compose Postgres
-- **Migrations**: Run committed Drizzle migrations before deploying app code that expects new columns. The Dockerfile has a `migrator` target that runs `src/lib/db/migrate.ts`; team ECS deploys run it automatically via `bash scripts/deploy.sh`.
-- **Reverse proxy**: Put Nginx or Caddy in front for TLS termination
-- **Secrets**: Store credentials in your cloud provider's secrets manager
-- **Rate limiting**: Use a shared Redis/ElastiCache instance instead of the disabled local default
-- **Background jobs**: Use SQS with a redrive policy/DLQ, plus EventBridge to trigger scheduled-email and webhook retry scans
-- **Observability**: Emit structured JSON logs, trace/correlation headers, and CloudWatch EMF metrics for send and worker flows
-
-Team production on AWS ECS/Fargate:
-
-```bash
-bash scripts/deploy.sh migrate   # DB-only migration/repair
-bash scripts/deploy.sh app       # app image + migrations + app redeploy
-bash scripts/deploy.sh ingester  # ingester image + migrations + ingester redeploy
-bash scripts/deploy.sh all       # app + ingester images + migrations + both redeploys
-```
-
-If a list page works but a detail page shows 404 after a deploy, check for
-schema drift before assuming a missing Next.js route. A server component may be
-catching a database error and rendering `notFound()`.
-
-### Shared rate limiting (staging/production)
-
-Opensend now treats API rate limiting as an explicit runtime contract:
-
-- `RATE_LIMIT_BACKEND=disabled` skips API rate limiting entirely. This is the default for local single-process development only.
-- `RATE_LIMIT_BACKEND=redis` enables the middleware-backed shared limiter. If Redis is misconfigured or unavailable, API requests fail with `503` instead of silently falling back to per-process memory.
-- `REDIS_URL` must point at a TLS-enabled Redis endpoint such as `rediss://default:<password>@<primary-endpoint>:6379`.
-
-For AWS ElastiCache, enable **in-transit encryption** on the replication group/serverless cache and use the TLS endpoint that AWS exposes. AWS documents both the `TransitEncryptionEnabled=true` requirement and TLS client connections to the primary/configuration endpoint.
-
-### AWS-native background jobs
-
-Email sending is queue-first: `POST /api/emails` validates and persists the email row, then publishes an `email.send` job instead of calling SES on the request path. The ingester service owns background job execution.
-
-Configure these variables for staging/production:
-
-- `BACKGROUND_JOBS_QUEUE_URL` — SQS queue URL used for `email.send`, `webhook.dispatch`, scheduled scan, and webhook retry scan jobs.
-- `BACKGROUND_JOBS_REQUIRE_QUEUE=true` — fail API publishing if the queue URL is missing instead of silently skipping publish. Use this in staging/production.
-- `BACKGROUND_JOBS_EVENT_BUS_NAME` — optional EventBridge bus for job lifecycle events/automation hooks.
-- `BACKGROUND_WORKER_POLL=true` — set on the ingester service to long-poll SQS and execute jobs.
-- `INGESTER_JOB_TOKEN` — optional bearer token required by ingester `/jobs/*` endpoints when EventBridge invokes them over HTTP.
-
-Operational shape:
-
-1. App/control plane: persist intent in Postgres as `queued`, publish SQS job, return `{ id }`.
-2. Ingester/worker: long-poll SQS, execute SES sends, set `sent_at` when SES accepts the message, and delete messages only after success.
-3. Scheduled sends: EventBridge should call `POST /jobs/scheduled-emails` on the ingester every minute, or publish a `scheduled-email.scan` job, to enqueue due `email.send` jobs.
-4. Webhook retries: failed webhook deliveries stay `pending` with `next_retry_at`; EventBridge can call `POST /jobs/webhooks` or publish `webhook-delivery.scan` to retry due deliveries.
-5. Retries/DLQ: configure the SQS queue redrive policy with a DLQ. Worker failures leave messages undeleted so SQS retry/redrive owns retry exhaustion.
-
-Local dev remains Docker-friendly if no queue is configured: publishes are logged/skipped and API calls still persist rows. To exercise the real worker locally, set `BACKGROUND_JOBS_QUEUE_URL` and `BACKGROUND_WORKER_POLL=true` on the ingester.
-
-### Observability
-
-Email accept and worker flows emit structured JSON logs with `x-correlation-id`, W3C/OpenTelemetry-compatible `traceparent`, sanitized span events, and CloudWatch EMF metrics for accept latency, send outcomes, queue depth, retries, and worker failures. Set `CLOUDWATCH_METRICS_NAMESPACE` to override the default `Opensend` namespace.
-
-See [`docs/observability.md`](docs/observability.md) for PII-safe logging rules, metric names, alarms, and the runbook for tracing an email from API acceptance to SES/provider result.
-
-### Redis-backed auth/domain metadata cache
-
-The same `REDIS_URL` is also used for hot-path metadata caching:
-
-- API key auth lookups are cached by token hash for 5 minutes.
-- Domain DB detail lookups are cached by domain id for 5 minutes.
-- SES domain identity lookups are cached by domain name for 2 minutes.
-- API key create/delete and domain create/update/delete/verify/auto-configure flows invalidate affected cache entries immediately.
-
-Local dev stays safe if Redis is absent: requests fall back to Postgres/SES as the source of truth. In staging/production, point `REDIS_URL` at a shared TLS-enabled Redis/ElastiCache endpoint so multiple app instances see the same cache state.
-
-Quick verification after deploy:
-
-```bash
-curl -i http://localhost:3015/api/auth/verify \
-  -H 'x-forwarded-for: 203.0.113.10'
-# Expect: X-RateLimit-Backend: redis when enabled
-```
-
-The included `Dockerfile` produces an optimized multi-stage build suitable for any container platform (AWS ECS Fargate, Google Cloud Run, Fly.io, Railway, etc.):
+The included multi-stage `Dockerfile` builds the app, the migrator, and (via
+`packages/ingester/Dockerfile`) the ingester. Images run on any container
+platform — ECS Fargate, Google Cloud Run, Fly.io, Railway, Kubernetes, or a
+plain Docker host.
 
 ```bash
 docker build -t opensend .
 docker run -p 3015:8080 --env-file .env opensend
 ```
-
-For the ECS Fargate split-service shape, ALB host-based events routing, SNS cutover, and ingester log/replay runbook, see [`docs/ingester-deploy.md`](docs/ingester-deploy.md).
 
 ## Architecture
 

--- a/docs/ingester-deploy.md
+++ b/docs/ingester-deploy.md
@@ -1,10 +1,20 @@
-# Ingester deployment runbook
+# Ingester service deployment
 
-The standalone ingester receives SES/SNS events and owns background worker execution so webhook bursts and queued email sends do not contend with the Next.js app. Team production runs the ingester as an AWS ECS Fargate service behind the shared `namuh-alb` Application Load Balancer.
+The ingester is a standalone process that handles two things:
 
-## Local docker-compose
+1. SES/SNS event ingestion at `POST /events/ses`
+2. Background job execution (queued email sends, scheduled-email scans,
+   webhook dispatch, webhook retry scans)
 
-Start the full stack:
+In Docker Compose it runs side-by-side with the app. In production we strongly
+recommend running it as a **separate service** so webhook bursts and worker
+stalls don't contend with dashboard requests.
+
+For the broader self-host setup, see [`self-hosting.md`](self-hosting.md).
+This document focuses on the operational shape of the split-service
+deployment.
+
+## Local Docker Compose
 
 ```bash
 docker compose up --build app ingester postgres migrate
@@ -16,186 +26,166 @@ Endpoints:
 - Ingester health: `http://localhost:${INGESTER_PORT:-3016}/health`
 - SES SNS webhook target: `http://localhost:${INGESTER_PORT:-3016}/events/ses`
 
-Check the ingester container:
-
 ```bash
 docker compose ps ingester
 docker compose logs -f ingester
 ```
 
-## Production ECS Fargate shape
+## Production shape
 
-Production is AWS ECS Fargate in `us-east-1`:
+Two services from the same repo, both connecting to the same Postgres, Redis,
+and SQS:
 
-- ECS cluster: `namuh`
-- ALB: `namuh-alb`, shared across products with host-based listener rules
-- ECR repos: `<product>-app` and `<product>-ingester`
-- ECS services: `<product>-app` and `<product>-ingester`
-- CloudWatch log groups: `/ecs/<product>-app` and `/ecs/<product>-ingester`
+| Service | Image source | Public host (example) | Port |
+| --- | --- | --- | --- |
+| App | `Dockerfile` (default target) | `app.yourdomain.com` and `api.app.yourdomain.com` | `8080` |
+| Ingester | `packages/ingester/Dockerfile` | `events.app.yourdomain.com` | `3016` |
 
-The ALB listener routes by hostname:
+If your platform has host-based routing (AWS ALB, GCP Load Balancer, Cloudflare
+Spectrum), point each hostname at its target service. The events host has to
+be reachable from the public internet so SES SNS can deliver to it.
 
-| Host | Target service | Target port |
-| --- | --- | --- |
-| `<product>.namuh.co` | app/dashboard | `8080` |
-| `api.<product>.namuh.co` | app/API | `8080` |
-| `events.<product>.namuh.co` | ingester | `3016` |
-
-For the current Opensend deployment, the ingester public endpoint is:
-
-```text
-https://events.opensend.namuh.co/events/ses
-```
-
-The Fargate task definition must expose/container-map the ingester on port `3016`, and the `events.<product>.namuh.co` ALB rule must forward to the ingester target group on port `3016`.
-
-## Deploy the ingester
-
-Use `scripts/deploy.sh` rather than a raw `aws ecs update-service`. The script
-runs migrations before service redeploys so app code does not start against an
-older database schema. The Fargate deploy script contract is:
-
-- build `packages/ingester/Dockerfile` for `linux/amd64`
-- push the image to ECR repo `<product>-ingester`
-- run a one-off migrator task before service redeploys
-- force a new deployment of ECS service `<product>-ingester` in cluster `namuh`
-- wait for `aws ecs wait services-stable` before reporting success
-
-Supported deploy targets:
+Build images for `linux/amd64` even from M-chip Macs:
 
 ```bash
-bash scripts/deploy.sh migrate   # DB-only migration/repair
-bash scripts/deploy.sh app       # app image + migrations + app service redeploy
-bash scripts/deploy.sh ingester  # ingester image + migrations + ingester service redeploy
-bash scripts/deploy.sh all       # app + ingester images + migrations + both redeploys
+docker buildx build --platform linux/amd64 \
+  -t yourorg/opensend-app:latest --push .
+
+docker buildx build --platform linux/amd64 \
+  -f packages/ingester/Dockerfile \
+  -t yourorg/opensend-ingester:latest --push .
 ```
 
-Override names when production service or repository names differ from repo defaults:
+Run a one-shot migrator container against the production `DATABASE_URL`
+**before** redeploying the app or ingester when the change includes schema
+migrations:
 
 ```bash
-PRODUCT=opensend \
-ECS_CLUSTER=namuh \
-IMAGE_TAG=latest \
-PLATFORM=linux/amd64 \
-bash scripts/deploy.sh ingester
-```
+docker buildx build --platform linux/amd64 --target migrator \
+  -t yourorg/opensend-migrator:latest --push .
 
-The deploy script assumes the ECS services, target groups, listener rules, log groups, ECR repositories, and Secrets Manager wiring already exist. Use this runbook's external residuals checklist when bringing up a new product or debugging a failed deployment.
+# Run once against production DB
+docker run --rm --env DATABASE_URL=... yourorg/opensend-migrator:latest
+```
 
 ## Background job worker
 
-The app publishes jobs to SQS after persisting rows; the ingester service consumes and executes them. Email rows start as `queued`, transition through worker-owned `processing`/`sent`, and get `sent_at` only after SES accepts the message.
+The app publishes jobs to SQS after persisting rows; the ingester consumes
+them. Email rows start as `queued`, transition through worker-owned
+`processing`/`sent`, and get `sent_at` only after SES accepts the message.
 
-Required production environment for both app and ingester:
+Required environment for **both** the app and ingester:
 
 ```bash
-BACKGROUND_JOBS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/<account>/<product>-background
+BACKGROUND_JOBS_QUEUE_URL=https://sqs.<region>.amazonaws.com/<account>/<queue-name>
 BACKGROUND_JOBS_REQUIRE_QUEUE=true
-BACKGROUND_JOBS_EVENT_BUS_NAME=<product>-background-jobs # optional lifecycle/event hook bus
-CLOUDWATCH_METRICS_NAMESPACE=Opensend # optional EMF namespace override
+BACKGROUND_JOBS_EVENT_BUS_NAME=<event-bus-name>   # optional lifecycle bus
+CLOUDWATCH_METRICS_NAMESPACE=Opensend             # optional EMF namespace
 ```
 
-Set this only on the ingester worker service when SQS is ready:
+Set this **only** on the ingester service:
 
 ```bash
 BACKGROUND_WORKER_POLL=true
-INGESTER_JOB_TOKEN=<random-bearer-token-for-eventbridge-http-targets>
+INGESTER_JOB_TOKEN=<random-bearer-token>
 ```
 
-SQS requirements:
+### SQS requirements
 
-- configure a redrive policy and DLQ; worker failures leave messages undeleted so SQS owns retry exhaustion
-- use a standard queue by default; FIFO is supported if the queue URL ends in `.fifo`
-- grant the app `sqs:SendMessage` and optional `events:PutEvents`
-- grant the ingester `sqs:ReceiveMessage`, `sqs:DeleteMessage`, `sqs:ChangeMessageVisibility`, and SES send permissions
+- Configure a redrive policy with a DLQ. Worker failures leave messages
+  undeleted so SQS owns retry exhaustion.
+- Standard queue is fine; FIFO works if the URL ends in `.fifo`.
+- Grant the **app** principal `sqs:SendMessage` and (if used) `events:PutEvents`.
+- Grant the **ingester** principal `sqs:ReceiveMessage`, `sqs:DeleteMessage`,
+  `sqs:ChangeMessageVisibility`, and the SES send permissions.
 
-EventBridge scheduling:
+### Periodic scans
 
-- call `POST /jobs/scheduled-emails` every minute to enqueue due scheduled sends
-- call `POST /jobs/webhooks` every minute to retry webhook deliveries whose `next_retry_at` has arrived
-- alternatively publish `scheduled-email.scan` and `webhook-delivery.scan` jobs into SQS
+Two scans need to run every minute. Either pattern works:
 
-Manual probes:
+**HTTP-driven** (e.g. AWS EventBridge schedule rule with HTTP target, or any
+cron driver that can issue authenticated POSTs):
 
 ```bash
-INGESTER_URL="https://events.<product>.namuh.co"
-curl -i -X POST "${INGESTER_URL}/jobs/poll" \
-  -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
+INGESTER_URL="https://events.yourdomain.com"
 curl -i -X POST "${INGESTER_URL}/jobs/scheduled-emails" \
   -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
 curl -i -X POST "${INGESTER_URL}/jobs/webhooks" \
   -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
 ```
 
+**Queue-driven**: publish `scheduled-email.scan` and `webhook-delivery.scan`
+SQS messages on the same minute cadence; the ingester picks them up via the
+normal long-poll loop.
+
+Manual probes during a deploy:
+
+```bash
+INGESTER_URL="https://events.yourdomain.com"
+curl -i -X POST "${INGESTER_URL}/jobs/poll" \
+  -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
+```
+
 ## SNS cutover
 
-After the Fargate ingester service is healthy behind the ALB, SES SNS should point at the host-based `events` route:
+After the ingester service is healthy and reachable on a public host:
 
 ```text
-https://events.<product>.namuh.co/events/ses
+https://events.yourdomain.com/events/ses
 ```
 
-For Opensend production:
+Update the SES configuration set's SNS topic subscription to point at this
+URL. The ingester verifies the SNS signature, so no shared secret is needed.
 
-```text
-https://events.opensend.namuh.co/events/ses
-```
-
-Do not leave SES pointed at the Next.js app/API host once the split is active.
+Don't leave SES pointing at the app/API host once the split is active —
+events would be processed by the dashboard's request loop instead of the
+worker.
 
 ## Observability
 
-The app and ingester emit structured JSON logs, W3C/OpenTelemetry-compatible trace context, and CloudWatch EMF metrics for queue depth, worker failures, retry count, send latency, send outcomes, and SES ingest results. Use `docs/observability.md` for metric names, PII-safe logging rules, and the full API-to-provider tracing runbook.
+The app and ingester emit structured JSON logs, W3C/OpenTelemetry-compatible
+trace context, and CloudWatch EMF metrics for queue depth, worker failures,
+retry counts, send latency, send outcomes, and SES ingest results. See
+[`observability.md`](observability.md) for the metric catalog, PII rules, and
+end-to-end tracing runbook.
 
-## Tail ingester logs
-
-Tail the ECS CloudWatch log group for the ingester service:
-
-```bash
-PRODUCT=opensend
-aws logs tail "/ecs/${PRODUCT}-ingester" \
-  --region us-east-1 \
-  --since 10m \
-  --follow
-```
-
-Check recent ECS service events when a deploy or health check is failing:
+If you're on AWS, tail the ingester logs:
 
 ```bash
-PRODUCT=opensend
-aws ecs describe-services \
-  --cluster namuh \
-  --services "${PRODUCT}-ingester" \
-  --region us-east-1 \
-  --query 'services[0].events[0:10].message' \
-  --output table
+aws logs tail /ecs/<ingester-log-group> --since 10m --follow
 ```
 
 ## Replay a missed SES SNS event
 
-The ingester verifies the original SNS signature, so the safe replay path is to resend the exact SNS notification body that AWS originally delivered to the Fargate endpoint.
+The ingester verifies the original SNS signature, so the safe replay path is
+to resend the exact SNS notification body that AWS originally delivered.
 
 ```bash
-INGESTER_URL="https://events.<product>.namuh.co/events/ses"
+INGESTER_URL="https://events.yourdomain.com/events/ses"
 curl -i "${INGESTER_URL}" \
   -H "Content-Type: text/plain; charset=UTF-8" \
   -H "x-amz-sns-message-type: Notification" \
   --data @sns-notification.json
 ```
 
-`sns-notification.json` must be a real captured SNS envelope, including the original `Signature`, `SigningCertURL`, and `MessageId` fields. Because `email_events.source_id` is idempotent on the SNS `MessageId`, an already-processed notification will return `200 OK` and no-op.
+`sns-notification.json` must be a captured SNS envelope, including the
+original `Signature`, `SigningCertURL`, and `MessageId` fields. Because
+`email_events.source_id` is idempotent on the SNS `MessageId`, an
+already-processed notification returns `200 OK` and no-ops.
 
-## External residuals
+## Pre-cutover checklist
 
-This repo change does not create or mutate external AWS resources on its own. Before production cutover or a new product launch, verify:
+Before pointing production SES SNS at a freshly stood-up ingester, verify:
 
-- the `<product>-ingester` ECR repository exists
-- the `<product>-ingester` ECS service exists in cluster `namuh`
-- the ingester task definition has the same RDS, AWS, Cloudflare, queue, and token secrets as production requires
-- the app, ingester, and migrator ECS tasks have shared RDS and Secrets Manager wiring
-- the ALB listener has a host-based rule for `events.<product>.namuh.co`
-- the ingester target group forwards to port `3016` and has a passing health check
-- the SQS queue exists with a redrive policy and DLQ
-- EventBridge schedule/rules exist for scheduled-email and webhook retry scans
-- IAM grants app publish permissions and ingester consume/delete/change-visibility permissions
-- the SES SNS subscription has been updated to `https://events.<product>.namuh.co/events/ses`
+- The ingester image is built for `linux/amd64` and pushed to your registry.
+- The ingester service has the same `DATABASE_URL`, AWS credentials, SQS
+  config, Redis URL, and `INGESTER_JOB_TOKEN` as the app.
+- The events host (`events.<your-domain>`) resolves and serves a 200 on
+  `/health`.
+- The SQS queue exists with a redrive policy + DLQ.
+- Periodic scan rules (`/jobs/scheduled-emails`, `/jobs/webhooks`) are
+  scheduled on a 1-minute cadence.
+- Migrations ran successfully against the production database before the new
+  image started.
+- Rolling back is possible: keep the previous image tag pinned somewhere you
+  can redeploy from.

--- a/docs/ingester-deploy.md
+++ b/docs/ingester-deploy.md
@@ -128,14 +128,15 @@ curl -i -X POST "${INGESTER_URL}/jobs/poll" \
 
 ## SNS cutover
 
-After the ingester service is healthy and reachable on a public host:
+After the ingester service is healthy and reachable on a public host, the
+SES SNS should point at the ingester's events host:
 
 ```text
 https://events.yourdomain.com/events/ses
 ```
 
-Update the SES configuration set's SNS topic subscription to point at this
-URL. The ingester verifies the SNS signature, so no shared secret is needed.
+Update the SES configuration set's SNS topic subscription accordingly. The
+ingester verifies the SNS signature, so no shared secret is needed.
 
 Don't leave SES pointing at the app/API host once the split is active —
 events would be processed by the dashboard's request loop instead of the

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,435 @@
+# Self-hosting Opensend
+
+Opensend is built to run on your own infrastructure. This guide walks through
+the practical deployment paths from a single-machine Docker Compose setup to a
+production-ready, multi-process deployment with managed Postgres, SES, Redis,
+and SQS-backed background workers.
+
+If you just want to try it locally, the README quickstart is enough — start
+there. This document is for production deployments.
+
+## Contents
+
+- [Deployment options](#deployment-options)
+- [Requirements](#requirements)
+- [Quickstart: Docker Compose](#quickstart-docker-compose)
+- [Environment variables](#environment-variables)
+- [Database](#database)
+- [AWS SES](#aws-ses)
+- [Domain verification & DNS](#domain-verification--dns)
+- [Email attachments (S3)](#email-attachments-s3)
+- [Auth](#auth)
+- [Reverse proxy & TLS](#reverse-proxy--tls)
+- [Background jobs (SQS + EventBridge)](#background-jobs-sqs--eventbridge)
+- [Shared rate limiting (Redis)](#shared-rate-limiting-redis)
+- [Splitting the ingester service](#splitting-the-ingester-service)
+- [Observability](#observability)
+- [Upgrades & migrations](#upgrades--migrations)
+- [Troubleshooting](#troubleshooting)
+
+## Deployment options
+
+| Option | Best for | Tradeoffs |
+| --- | --- | --- |
+| **Docker Compose, single host** | Trial deploys, small workloads, internal tools | App, ingester, and Postgres on one box. No HA. |
+| **Single VM + managed Postgres** | Small production, predictable cost | One container per service, managed DB, external Redis/SQS optional |
+| **Container platform** (AWS ECS, Google Cloud Run, Fly.io, Railway) | Production at scale | Multi-replica, autoscaling, requires managed Postgres + Redis + SQS |
+| **Kubernetes** | Large teams already on k8s | Most flexibility, most operational surface area |
+
+The Dockerfile in this repo is multi-stage and builds three artifacts:
+
+- `app` — Next.js dashboard + REST API (default target)
+- `migrator` — runs `src/lib/db/migrate.ts` once and exits
+- The standalone ingester is built from `packages/ingester/Dockerfile`
+
+You can run all three on the same machine via Docker Compose, or split them
+across separate services on a container platform.
+
+## Requirements
+
+| Component | Minimum | Recommended for production |
+| --- | --- | --- |
+| Docker | 24+ with buildx | 24+ |
+| PostgreSQL | 14 | 15+ managed (RDS, Supabase, Neon, Cloud SQL) |
+| Node/Bun | Bun 1.1+ | Bun 1.1+ (only needed if running outside Docker) |
+| AWS account | SES + IAM | SES + S3 + SQS + EventBridge + Secrets Manager |
+| DNS provider | Any (manual records) | Cloudflare (auto-configures DKIM/SPF/DMARC) |
+| Redis | none for dev | Managed Redis 6+ with TLS (ElastiCache, Upstash) |
+
+AWS credentials are **optional for local dev** — without them, send calls log
+to the console and the rest of the API still works.
+
+## Quickstart: Docker Compose
+
+```bash
+git clone https://github.com/namuh-eng/opensend.git
+cd opensend
+cp .env.example .env
+# Edit .env — see "Environment variables" below
+docker compose up -d
+```
+
+This launches:
+
+- `postgres` (5432) — local Postgres, persisted in a named volume
+- `migrate` — runs Drizzle migrations once and exits
+- `app` (3015 → 8080 in container) — dashboard + REST API
+- `ingester` (3016) — SES/SNS event handler and background worker
+
+Open `http://localhost:3015`. The first sign-in creates an organization and
+makes you the owner.
+
+To wipe the database volume and start clean: `docker compose down -v`.
+
+## Environment variables
+
+All configuration is via environment variables. `.env.example` ships with the
+contributor-facing set; the table below adds the production-only entries.
+
+### Required
+
+| Variable | Purpose |
+| --- | --- |
+| `DATABASE_URL` | Postgres connection string. In Docker Compose the app/migrator containers override this to use the internal `postgres` host. |
+| `BETTER_AUTH_SECRET` | Random 32-byte hex string for session signing. Generate with `openssl rand -hex 32`. |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Better Auth Google OAuth credentials. Set the redirect URI to `https://<your-host>/api/auth/callback/google`. |
+
+### Required for sending email
+
+| Variable | Purpose |
+| --- | --- |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | IAM credentials with SES + (optionally) S3, SQS, EventBridge permissions. Prefer IAM roles when available. |
+| `AWS_REGION` | SES region. Use `us-east-1` unless you have a reason to pick another. |
+
+### Optional
+
+| Variable | Purpose |
+| --- | --- |
+| `PORT` | Dashboard/API port. Default `3015`. |
+| `INGESTER_PORT` | Ingester port. Default `3016`. |
+| `POSTGRES_PORT` | Compose-only Postgres host port. Default `5432`. Change this AND `DATABASE_URL` if 5432 is taken. |
+| `S3_BUCKET_NAME` | Email attachment storage. Without this, attachments are rejected. |
+| `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ZONE_ID` | If set, the dashboard auto-writes DKIM/SPF/DMARC records when a domain is added. |
+| `SKIP_STAR_PROMPT=1` | Suppresses the optional GitHub star prompt during `bun install`. |
+
+### Production-only (background jobs, cache, rate limiting)
+
+| Variable | Purpose |
+| --- | --- |
+| `BACKGROUND_JOBS_QUEUE_URL` | SQS queue URL used for `email.send`, `webhook.dispatch`, scheduled-email scan, and webhook retry scan jobs. |
+| `BACKGROUND_JOBS_REQUIRE_QUEUE=true` | Fail API publish when the queue URL is missing instead of silently skipping. Required in production. |
+| `BACKGROUND_JOBS_EVENT_BUS_NAME` | Optional EventBridge bus for job lifecycle events. |
+| `BACKGROUND_WORKER_POLL=true` | Set on the **ingester** service only. Enables long-poll SQS consumer. |
+| `INGESTER_JOB_TOKEN` | Bearer token required for `/jobs/*` endpoints when EventBridge invokes them over HTTP. |
+| `RATE_LIMIT_BACKEND` | `disabled` (single-process dev), or `redis` (production). |
+| `REDIS_URL` | TLS Redis endpoint, e.g. `rediss://default:<password>@<endpoint>:6379`. Used for rate limiting AND auth/domain metadata cache. |
+| `CLOUDWATCH_METRICS_NAMESPACE` | Override the default `Opensend` EMF metrics namespace. |
+
+## Database
+
+### Local
+
+`docker compose up postgres` is enough for development. The data lives in a
+named volume; `docker compose down -v` wipes it.
+
+### Managed Postgres (recommended for production)
+
+Any Postgres 14+ instance works: AWS RDS, Supabase, Neon, Cloud SQL, etc. Set
+`DATABASE_URL` to its connection string. If your provider requires SSL, the
+client opts in via `?sslmode=require` in the URL.
+
+### Migrations
+
+Migrations are committed Drizzle SQL files in `drizzle/`. The Dockerfile has a
+`migrator` target that runs `src/lib/db/migrate.ts` once and exits.
+
+```bash
+# Apply migrations to the configured DATABASE_URL
+bun run db:migrate
+
+# Or run the migrator container
+docker run --rm --env-file .env $(docker build -q --target migrator .)
+```
+
+**Always run migrations before deploying app code that expects new columns.**
+A list page that works while a detail page 404s after a deploy is usually a
+swallowed schema error, not a missing route.
+
+### Schema push (dev only)
+
+`bun run db:push` writes the current schema directly without going through
+migrations. Use it for local iteration; never for production.
+
+## AWS SES
+
+### Sandbox vs production
+
+New AWS accounts start in **SES sandbox mode** — emails only go to verified
+addresses. To send to anyone, request production access from the SES console:
+**Account dashboard → Request production access**.
+
+### IAM minimum
+
+The IAM principal Opensend uses needs:
+
+- `ses:SendEmail`, `ses:SendRawEmail`
+- `ses:GetAccount`, `ses:GetIdentity*`, `ses:VerifyDomainIdentity`,
+  `ses:VerifyDomainDkim`, `ses:SetIdentityMailFromDomain`
+- `ses:CreateConfigurationSet*`, `ses:PutConfigurationSet*` (used for
+  click/open tracking domains and event publishing)
+
+If you also use S3 for attachments and SQS for background jobs, grant
+`s3:GetObject`/`PutObject` on the bucket prefix and the relevant SQS
+`SendMessage` (app) / `ReceiveMessage`/`DeleteMessage`/`ChangeMessageVisibility`
+(ingester) actions.
+
+### SNS for delivery events
+
+Email delivery, bounce, complaint, open, and click events come back via SNS.
+Configure an SES configuration set with an SNS topic, then point the topic at
+the ingester's `/events/ses` endpoint:
+
+- Local: `http://localhost:3016/events/ses`
+- Production: `https://<your-ingester-host>/events/ses`
+
+The ingester verifies the SNS signature, so direct HTTP delivery from SNS is
+sufficient — no shared secret needed.
+
+## Domain verification & DNS
+
+Adding a domain in the dashboard generates DKIM, SPF, DMARC, MAIL FROM, and
+optional click-tracking records.
+
+- **Cloudflare**: set `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ZONE_ID` and the
+  records are written automatically when you click "Auto-configure".
+- **Other DNS providers**: copy the rendered records from the dashboard into
+  your DNS provider manually. The dashboard polls SES until verification
+  passes.
+
+For a production setup we recommend a dedicated subdomain like
+`mail.yourdomain.com` so DMARC alignment doesn't conflict with your apex
+domain's existing SPF policy.
+
+## Email attachments (S3)
+
+Attachments larger than ~5 KB are stored in S3 instead of Postgres. Set
+`S3_BUCKET_NAME` to a bucket your IAM principal can read and write to.
+Lifecycle rules to expire objects after 30–90 days are recommended.
+
+## Auth
+
+Better Auth handles sessions, organizations, and Google OAuth.
+
+1. Create a Google Cloud project, enable the OAuth Consent Screen, and create
+   an OAuth Client ID for "Web application".
+2. Add `https://<your-host>/api/auth/callback/google` (and the localhost
+   variant for dev) to **Authorized redirect URIs**.
+3. Copy the client ID and secret into `GOOGLE_CLIENT_ID` /
+   `GOOGLE_CLIENT_SECRET`.
+
+Sessions are signed with `BETTER_AUTH_SECRET`. Rotate this only when you're
+prepared to log every user out — there's no key rollover yet.
+
+## Reverse proxy & TLS
+
+The container listens on plain HTTP. Put a reverse proxy in front of it for
+TLS termination.
+
+### Caddy (simplest)
+
+```caddy
+yourdomain.com {
+  reverse_proxy localhost:3015
+}
+
+events.yourdomain.com {
+  reverse_proxy localhost:3016
+}
+```
+
+### Nginx
+
+```nginx
+server {
+  server_name yourdomain.com;
+  listen 443 ssl http2;
+  ssl_certificate /etc/letsencrypt/live/yourdomain.com/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/yourdomain.com/privkey.pem;
+
+  location / {
+    proxy_pass http://127.0.0.1:3015;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}
+```
+
+Mirror the block for `events.yourdomain.com → 127.0.0.1:3016` if you've split
+out the ingester service.
+
+## Background jobs (SQS + EventBridge)
+
+Email sending is queue-first: `POST /api/emails` validates and persists the
+email row as `queued`, then publishes an `email.send` job. The ingester
+consumes the queue and calls SES.
+
+This means **you need SQS in production**. Without it, sends never leave
+`queued`.
+
+### Required setup
+
+1. Create an SQS queue (standard queue is fine; FIFO is supported if the URL
+   ends in `.fifo`).
+2. Configure a redrive policy with a DLQ. Worker failures leave messages
+   undeleted so SQS retry/redrive owns retry exhaustion.
+3. Set `BACKGROUND_JOBS_QUEUE_URL` on **both** the app and ingester services.
+4. Set `BACKGROUND_WORKER_POLL=true` on the **ingester only**.
+5. Set `BACKGROUND_JOBS_REQUIRE_QUEUE=true` on the app to fail loudly when the
+   queue is misconfigured instead of silently dropping publishes.
+
+### Scheduled jobs
+
+Two periodic scans need to run every minute:
+
+- **Scheduled emails**: enqueue due `email.send` jobs.
+- **Webhook retry**: re-attempt failed webhook deliveries whose
+  `next_retry_at` has arrived.
+
+Two ways to drive them:
+
+**Option 1: EventBridge → HTTP**. Schedule rules that POST to the ingester
+with the `INGESTER_JOB_TOKEN` bearer:
+
+```bash
+INGESTER_URL="https://events.yourdomain.com"
+curl -i -X POST "${INGESTER_URL}/jobs/scheduled-emails" \
+  -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
+curl -i -X POST "${INGESTER_URL}/jobs/webhooks" \
+  -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
+```
+
+**Option 2: SQS scan jobs**. Publish `scheduled-email.scan` and
+`webhook-delivery.scan` messages on a schedule. The ingester picks them up via
+the same long-poll loop.
+
+### Local dev fallback
+
+If `BACKGROUND_JOBS_QUEUE_URL` is unset, sends and webhook dispatches log a
+"queue not configured" warning and skip publish. Rows are still persisted, so
+the dashboard works for development.
+
+## Shared rate limiting (Redis)
+
+API rate limiting is enforced by `src/middleware.ts`. There are two backends:
+
+- `RATE_LIMIT_BACKEND=disabled` — skip rate limiting entirely. Default. Safe
+  for single-process local dev only.
+- `RATE_LIMIT_BACKEND=redis` — use a shared Redis token bucket. Required for
+  any deployment with more than one app instance.
+
+When `redis` is selected, `REDIS_URL` must point at a TLS endpoint
+(`rediss://...`). If Redis is unreachable, requests fail closed with HTTP 503
+rather than silently falling back to per-process memory.
+
+The same Redis is reused for hot-path metadata caching:
+
+- API key auth lookups by token hash (5 min TTL)
+- Domain DB detail lookups by id (5 min TTL)
+- SES domain identity lookups by domain name (2 min TTL)
+
+Cache invalidation is automatic on create/update/delete/verify flows.
+
+## Splitting the ingester service
+
+In Docker Compose the app and ingester run side by side. In production they
+should be **separate processes** so a webhook burst or worker stall doesn't
+stall the dashboard.
+
+Build them from the same repo:
+
+```bash
+docker buildx build --platform linux/amd64 \
+  -t yourorg/opensend-app:latest --push .
+
+docker buildx build --platform linux/amd64 \
+  -f packages/ingester/Dockerfile \
+  -t yourorg/opensend-ingester:latest --push .
+```
+
+Run them as separate services on whatever platform you use (ECS, Cloud Run,
+Fly Machines, Kubernetes deployments). Both connect to the same Postgres,
+Redis, and SQS.
+
+For the ALB/Cloud-Run/Fly host-based routing details, SES SNS cutover, and
+ingester replay, see [`ingester-deploy.md`](ingester-deploy.md).
+
+## Observability
+
+The app and ingester emit:
+
+- **Structured JSON logs** with `x-correlation-id` and W3C-compatible
+  `traceparent` headers. PII (recipient addresses, subjects) is redacted by
+  default.
+- **CloudWatch EMF metrics** for accept latency, send outcomes, queue depth,
+  worker retries, and SES ingest results. Set `CLOUDWATCH_METRICS_NAMESPACE`
+  to override the namespace.
+
+See [`observability.md`](observability.md) for the metric catalog, alarm
+recommendations, and the API-to-provider tracing runbook.
+
+A simple `/api/health` endpoint is exposed for uptime probes; the ingester has
+`/health` on the same shape.
+
+## Upgrades & migrations
+
+1. Pull the new code (`git pull`) or update your image tag.
+2. Run `bun run db:migrate` (or the migrator container) **before** rolling out
+   the new app/ingester image.
+3. Roll the app and ingester forward.
+
+Compose users get this automatically — the `migrate` service runs on every
+`docker compose up` before `app` starts.
+
+If your deploy path doesn't run migrations automatically, schema-drifted dashboards
+typically present as detail-page 404s while list pages work. Re-run the
+migrator and inspect logs before assuming missing routes.
+
+## Troubleshooting
+
+### Sign-in redirects loop
+
+The OAuth redirect URI registered with Google must exactly match
+`https://<host>/api/auth/callback/google`. Check the host casing and the
+trailing slash.
+
+### Emails stuck in `queued`
+
+Either `BACKGROUND_JOBS_QUEUE_URL` isn't set, the ingester isn't running with
+`BACKGROUND_WORKER_POLL=true`, or the IAM principal is missing
+`sqs:ReceiveMessage`/`DeleteMessage`. Tail the ingester logs.
+
+### `bun install` fails inside a Docker build
+
+Use `--ignore-scripts` at the `deps` stage. The repo's postinstall calls
+`node scripts/install-git-hooks.mjs`, which isn't present in the minimal deps
+layer.
+
+### `redis` import in middleware crashes
+
+Next.js middleware runs on the Edge runtime by default, which can't import the
+`redis` npm package (it pulls in `node:crypto`). The repo opts in to the Node
+runtime via `experimental.nodeMiddleware` in `next.config.js` and
+`runtime: "nodejs"` on the middleware export. Don't remove these.
+
+### M-chip Mac builds fail in production
+
+Always pass `--platform linux/amd64` to `docker buildx build` and make sure
+you `--push` (not `--load`) so a multi-arch manifest doesn't fall back to your
+local arm64 layer.
+
+### Detail page 404s after a deploy
+
+Schema drift. The detail server component caught a missing-column error and
+called `notFound()`. Run migrations before redeploying app code that expects
+new columns.


### PR DESCRIPTION
## Summary
Two-commit docs cleanup. Production deploys now run through a CI workflow on a self-hosted runner, so the public files no longer need the manual deploy runbook.

1. **CLAUDE.md / AGENTS.md** — drop the team-prod section (namuh.co, ECS cluster/ALB names, ACM SANs, Cloudflare zone IDs, `scripts/deploy.sh`, "ask Jaeyun or Ashley" pointers, Cloudflare-zone-id-historical-bug). Keep all generic engineering gotchas (linux/amd64 build platform, `--ignore-scripts`, middleware redis, denied curl/wget, blocked sleeps).
2. **README.md / docs** — replace the inline ~150-line production runbook with a quickstart that links to a new `docs/self-hosting.md` deep dive; rewrite `docs/ingester-deploy.md` as a generic split-service runbook.

## Changes
- **`docs/self-hosting.md` (new, 435 lines)** — comprehensive self-hosting guide: deployment options table, requirements, env var reference, database/migrations, AWS SES (IAM minimums + sandbox + SNS), domain verification, S3 attachments, Better Auth + Google OAuth, reverse proxy (Caddy + Nginx examples), SQS background jobs, Redis rate limiting, splitting the ingester, observability pointers, upgrades, troubleshooting section that covers stuck-in-queued, OAuth loops, redis-in-middleware, M-chip arm64 builds, and detail-page-404 schema drift.
- **`docs/ingester-deploy.md` (rewrite)** — drop namuh.co/ECS-cluster/`scripts/deploy.sh` references; keep the operational shape (SQS, EventBridge or HTTP scans, SNS cutover, replay procedure, pre-cutover checklist) so any container platform can use it.
- **`README.md`** — Self-Hosting section trimmed from ~160 lines to ~50; the deep dive lives in `docs/self-hosting.md` now. Removed the team-prod `bash scripts/deploy.sh` block and the migrate-tip team-prod blurb.
- **`CLAUDE.md` / `AGENTS.md`** — see commit 1.

## How to Test
- [x] `grep` confirms no remaining `namuh.co | namuh-alb | scripts/deploy.sh | App Runner | team prod | resend-clone` references in any of these files (the only `namuh.co` left is the legitimate Opensend Cloud product URL in the README's "Two ways to use Opensend" comparison table).
- [x] All Markdown links in the new doc point at files that exist (`self-hosting.md`, `ingester-deploy.md`, `observability.md`).
- [x] Pre-push guardrails (`bun run check`) pass.

## Notes
- Internal-only deploy runbooks (cluster names, secret IDs, scripts/deploy.sh contract) now live in private notes / runner config, not in the public repo.
- The `docs/self-hosting.md` troubleshooting section folds in the prod gotchas that were previously on CLAUDE.md, framed for self-hosters rather than team operators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)