### PR TITLE
Restore dashboard domain creation

### DIFF
--- a/agent_docs/learnings/active/2026-05-07-domain-dashboard-create-auth.md
+++ b/agent_docs/learnings/active/2026-05-07-domain-dashboard-create-auth.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-07
+issue: "domain-create"
+type: mistake
+promoted_to: null
+---
+
+## Dashboard create routes must accept dashboard session auth
+
+The domains dashboard page posted to `/api/domains` with same-origin session cookies, but `POST /api/domains` only accepted API-key auth while `GET/PATCH/DELETE/verify/auto-configure` accepted dashboard-or-API-key auth. The UI failed to add domains because the route returned 401 for dashboard users.
+
+When a dashboard component calls an app API route without an Authorization header, the route must use the dashboard session authorization path (`authorizeDashboardOrApiKey` + `getServerSession`) and stamp the resulting session `user.id` on tenant-owned rows.

--- a/agent_docs/learnings/active/2026-05-07-e2e-better-auth-fixture.md
+++ b/agent_docs/learnings/active/2026-05-07-e2e-better-auth-fixture.md
@@ -1,0 +1,19 @@
+---
+date: 2026-05-07
+issue: "#229"
+type: decision
+promoted_to: null
+---
+
+## Dashboard E2E auth must be real Better Auth rows plus a signed cookie
+
+Playwright route mocks for `/api/auth/get-session` only affect browser fetches;
+they do not authenticate server components or app routes that call
+`getServerSession()`. Dashboard E2E specs should use the shared auth fixture in
+`tests/e2e/fixtures/auth.ts`, which inserts a real Better Auth `user` and
+`session`, signs `better-auth.session_token` with the Better Auth secret, and
+adds that cookie to the browser context before navigation.
+
+When an E2E path can call SES, run with an isolated HOME that has no AWS
+credentials so local development uses the SES stub instead of creating real SES
+identities.

--- a/src/app/api/domains/route.ts
+++ b/src/app/api/domains/route.ts
@@ -2,7 +2,6 @@ import {
   authorizeDashboardOrApiKey,
   getServerSession,
   unauthorizedResponse,
-  validateApiKey,
 } from "@/lib/api-auth";
 import { checkDomainQuota, quotaExceededResponse } from "@/lib/billing/quota";
 import { invalidateDomainCaches } from "@/lib/domain-cache";
@@ -52,9 +51,14 @@ function mapDomainError(error: unknown, fallback: string): Response {
 }
 
 export async function POST(request: Request): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
   if (!auth) return unauthorizedResponse();
-  if (!auth.userId) return unauthorizedResponse();
+
+  const session = "dashboard" in auth ? await getServerSession() : null;
+  const userId = "userId" in auth ? auth.userId : session?.user?.id;
+  if (!userId) return unauthorizedResponse();
 
   let body: unknown;
   try {
@@ -72,7 +76,7 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   try {
-    const quota = await checkDomainQuota(auth.userId);
+    const quota = await checkDomainQuota(userId);
     if (!quota.ok) {
       return quotaExceededResponse(quota.info);
     }
@@ -87,12 +91,12 @@ export async function POST(request: Request): Promise<Response> {
       trackingSubdomain: validated.tracking_subdomain,
       tls: validated.tls,
       capabilities: validated.capabilities,
-      userId: auth.userId,
+      userId,
     });
 
     await queueEvent({
       type: "domain.created",
-      userId: auth.userId,
+      userId,
       payload: toDomainWebhookPayload({
         id: row.id,
         name: row.name,

--- a/tests/api-domains.test.ts
+++ b/tests/api-domains.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockDeleteDNSRecord = vi.hoisted(() => vi.fn());
 const mockListDNSRecords = vi.hoisted(() => vi.fn());
 const mockAutoConfigureDomain = vi.hoisted(() => vi.fn());
@@ -29,6 +30,7 @@ vi.mock("@/lib/db", () => ({
 vi.mock("@/lib/api-auth", () => ({
   validateApiKey: mockValidateApiKey,
   authorizeDashboardOrApiKey: mockValidateApiKey,
+  getServerSession: mockGetServerSession,
   unauthorizedResponse: () =>
     Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
 }));
@@ -99,6 +101,7 @@ describe("Domain API validation", () => {
   beforeEach(() => {
     vi.resetModules();
     mockValidateApiKey.mockResolvedValue(AUTH_RESULT);
+    mockGetServerSession.mockReset();
     mockDeleteDNSRecord.mockReset();
     mockListDNSRecords.mockReset();
     mockAutoConfigureDomain.mockReset();
@@ -165,6 +168,51 @@ describe("Domain API validation", () => {
         capabilities: expect.any(Array),
       }),
     });
+  });
+
+  it("creates a domain from an authenticated dashboard session", async () => {
+    const createdAt = new Date("2026-05-06T00:00:00.000Z");
+    mockValidateApiKey.mockResolvedValueOnce({ dashboard: true });
+    mockGetServerSession.mockResolvedValueOnce({
+      user: { id: "dashboard-user-1" },
+    });
+    mockCreateDomain.mockResolvedValueOnce({
+      id: VALID_DOMAIN_ID,
+      name: "dashboard.example.com",
+      status: "not_started",
+      region: "us-east-1",
+      records: [],
+      customReturnPath: null,
+      trackOpens: false,
+      trackClicks: false,
+      trackingSubdomain: null,
+      tls: "opportunistic",
+      capabilities: [{ name: "sending", enabled: true }],
+      createdAt,
+    });
+
+    const { POST } = await import("@/app/api/domains/route");
+    const res = await POST(
+      new Request("http://localhost:3015/api/domains", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Dashboard.Example.com" }),
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockCreateDomain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Dashboard.Example.com",
+        userId: "dashboard-user-1",
+      }),
+    );
+    expect(mockQueueEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "domain.created",
+        userId: "dashboard-user-1",
+      }),
+    );
   });
 
   it("updates a domain and enqueues domain.updated for the caller tenant", async () => {

--- a/tests/cache-invalidation-routes.test.ts
+++ b/tests/cache-invalidation-routes.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockInvalidateApiKeyAuthCache = vi.hoisted(() => vi.fn());
 const mockCreateApiKey = vi.hoisted(() => vi.fn());
 const mockDeleteApiKey = vi.hoisted(() => vi.fn());
@@ -43,6 +44,7 @@ vi.mock("@opensend/core", () => ({
 
 vi.mock("@/lib/api-auth", () => ({
   authorizeDashboardOrApiKey: mockValidateApiKey,
+  getServerSession: mockGetServerSession,
   invalidateApiKeyAuthCache: mockInvalidateApiKeyAuthCache,
   unauthorizedResponse: () =>
     Response.json({ error: "Missing or invalid API key" }, { status: 401 }),

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,30 @@
+# E2E testing standards
+
+## Authenticated dashboard tests
+
+Use the real Better Auth fixture instead of mocking `/api/auth/get-session`:
+
+```ts
+import { expect, test } from "./fixtures/auth";
+
+test("dashboard flow", async ({ authenticatedPage, e2eUser, e2eDb }) => {
+  await authenticatedPage.goto("/domains");
+  await expect(authenticatedPage.getByRole("heading", { name: "Domains" })).toBeVisible();
+});
+```
+
+The fixture creates a real Postgres `user` + `session`, signs the
+`better-auth.session_token` cookie the same way Better Auth expects, adds it to
+the browser context, and removes the auth rows after the test.
+
+## Rules
+
+- Server-rendered dashboard pages must use `authenticatedPage`; client route
+  mocks do not authenticate `getServerSession()`.
+- Keep auth backed by real `DATABASE_URL` rows and real browser cookies.
+- Do not route-mock `/api/auth/get-session` for tests that need dashboard page
+  or app-route authorization.
+- Tests that create tenant-owned app rows should delete those rows in their own
+  `finally` block using `e2eUser.id`.
+- For SES-touching scenarios, run with a HOME that does not contain AWS
+  credentials so local development uses the SES dev stub.

--- a/tests/e2e/domain-create-auth.spec.ts
+++ b/tests/e2e/domain-create-auth.spec.ts
@@ -1,0 +1,84 @@
+import { createHmac } from "node:crypto";
+import { expect, test } from "@playwright/test";
+import { Client } from "pg";
+
+function requireDatabaseUrl(): string {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required for domain create E2E");
+  }
+  return databaseUrl;
+}
+
+function signBetterAuthSessionToken(sessionToken: string): string {
+  const secret =
+    process.env.BETTER_AUTH_SECRET ?? "better-auth-secret-12345678901234567890";
+  const signature = createHmac("sha256", secret)
+    .update(sessionToken)
+    .digest("base64");
+  return `${sessionToken}.${signature}`;
+}
+
+test("dashboard user can add a domain with session auth", async ({
+  context,
+  page,
+}) => {
+  test.skip(!process.env.DATABASE_URL, "DATABASE_URL is required");
+
+  const runId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const userId = `domain-create-e2e-user-${runId}`;
+  const sessionToken = `domain-create-e2e-session-${runId}`;
+  const sessionId = `domain-create-e2e-session-id-${runId}`;
+  const domainName = `domain-create-${runId}.example.com`;
+  const client = new Client({ connectionString: requireDatabaseUrl() });
+
+  await client.connect();
+  try {
+    await client.query(
+      `insert into "user" (id, name, email, email_verified, created_at, updated_at)
+       values ($1, $2, $3, true, now(), now())
+       on conflict (id) do update set updated_at = now()`,
+      [userId, "Domain Create E2E", `${userId}@example.com`],
+    );
+    await client.query(
+      `insert into "session" (id, token, user_id, expires_at, created_at, updated_at)
+       values ($1, $2, $3, now() + interval '1 hour', now(), now())
+       on conflict (token) do update set expires_at = excluded.expires_at`,
+      [sessionId, sessionToken, userId],
+    );
+
+    await context.addCookies([
+      {
+        name: "better-auth.session_token",
+        value: signBetterAuthSessionToken(sessionToken),
+        domain: "localhost",
+        path: "/",
+        httpOnly: true,
+        sameSite: "Lax",
+      },
+    ]);
+
+    await page.goto("/domains");
+    await expect(page.getByRole("heading", { name: "Domains" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Add domain" }).click();
+    await page.getByPlaceholder("yourdomain.com").fill(domainName);
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+
+    await expect(page).toHaveURL(/\/domains\//, { timeout: 15_000 });
+    await expect(page.getByRole("heading", { name: domainName })).toBeVisible();
+
+    const { rows } = await client.query<{ user_id: string }>(
+      "select user_id from domains where name = $1",
+      [domainName],
+    );
+    expect(rows).toEqual([{ user_id: userId }]);
+  } finally {
+    await client.query("delete from domains where name = $1", [domainName]);
+    await client.query('delete from "session" where token = $1', [
+      sessionToken,
+    ]);
+    await client.query('delete from "user" where id = $1', [userId]);
+    await client.end();
+  }
+});

--- a/tests/e2e/domain-create-auth.spec.ts
+++ b/tests/e2e/domain-create-auth.spec.ts
@@ -1,84 +1,38 @@
-import { createHmac } from "node:crypto";
-import { expect, test } from "@playwright/test";
-import { Client } from "pg";
-
-function requireDatabaseUrl(): string {
-  const databaseUrl = process.env.DATABASE_URL;
-  if (!databaseUrl) {
-    throw new Error("DATABASE_URL is required for domain create E2E");
-  }
-  return databaseUrl;
-}
-
-function signBetterAuthSessionToken(sessionToken: string): string {
-  const secret =
-    process.env.BETTER_AUTH_SECRET ?? "better-auth-secret-12345678901234567890";
-  const signature = createHmac("sha256", secret)
-    .update(sessionToken)
-    .digest("base64");
-  return `${sessionToken}.${signature}`;
-}
+import { expect, test } from "./fixtures/auth";
 
 test("dashboard user can add a domain with session auth", async ({
-  context,
-  page,
+  authenticatedPage,
+  e2eDb,
+  e2eUser,
 }) => {
-  test.skip(!process.env.DATABASE_URL, "DATABASE_URL is required");
-
   const runId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const userId = `domain-create-e2e-user-${runId}`;
-  const sessionToken = `domain-create-e2e-session-${runId}`;
-  const sessionId = `domain-create-e2e-session-id-${runId}`;
   const domainName = `domain-create-${runId}.example.com`;
-  const client = new Client({ connectionString: requireDatabaseUrl() });
 
-  await client.connect();
   try {
-    await client.query(
-      `insert into "user" (id, name, email, email_verified, created_at, updated_at)
-       values ($1, $2, $3, true, now(), now())
-       on conflict (id) do update set updated_at = now()`,
-      [userId, "Domain Create E2E", `${userId}@example.com`],
-    );
-    await client.query(
-      `insert into "session" (id, token, user_id, expires_at, created_at, updated_at)
-       values ($1, $2, $3, now() + interval '1 hour', now(), now())
-       on conflict (token) do update set expires_at = excluded.expires_at`,
-      [sessionId, sessionToken, userId],
-    );
+    await authenticatedPage.goto("/domains");
+    await expect(
+      authenticatedPage.getByRole("heading", { name: "Domains" }),
+    ).toBeVisible();
 
-    await context.addCookies([
-      {
-        name: "better-auth.session_token",
-        value: signBetterAuthSessionToken(sessionToken),
-        domain: "localhost",
-        path: "/",
-        httpOnly: true,
-        sameSite: "Lax",
-      },
-    ]);
+    await authenticatedPage.getByRole("button", { name: "Add domain" }).click();
+    await authenticatedPage.getByPlaceholder("yourdomain.com").fill(domainName);
+    await authenticatedPage
+      .getByRole("button", { name: "Add", exact: true })
+      .click();
 
-    await page.goto("/domains");
-    await expect(page.getByRole("heading", { name: "Domains" })).toBeVisible();
+    await expect(authenticatedPage).toHaveURL(/\/domains\//, {
+      timeout: 15_000,
+    });
+    await expect(
+      authenticatedPage.getByRole("heading", { name: domainName }),
+    ).toBeVisible();
 
-    await page.getByRole("button", { name: "Add domain" }).click();
-    await page.getByPlaceholder("yourdomain.com").fill(domainName);
-    await page.getByRole("button", { name: "Add", exact: true }).click();
-
-    await expect(page).toHaveURL(/\/domains\//, { timeout: 15_000 });
-    await expect(page.getByRole("heading", { name: domainName })).toBeVisible();
-
-    const { rows } = await client.query<{ user_id: string }>(
+    const { rows } = await e2eDb.query<{ user_id: string }>(
       "select user_id from domains where name = $1",
       [domainName],
     );
-    expect(rows).toEqual([{ user_id: userId }]);
+    expect(rows).toEqual([{ user_id: e2eUser.id }]);
   } finally {
-    await client.query("delete from domains where name = $1", [domainName]);
-    await client.query('delete from "session" where token = $1', [
-      sessionToken,
-    ]);
-    await client.query('delete from "user" where id = $1', [userId]);
-    await client.end();
+    await e2eDb.query("delete from domains where name = $1", [domainName]);
   }
 });

--- a/tests/e2e/domains-page.spec.ts
+++ b/tests/e2e/domains-page.spec.ts
@@ -1,24 +1,30 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures/auth";
 
 test.describe("Domains Page", () => {
-  test("renders domains page with title and filter bar", async ({ page }) => {
-    await page.goto("/domains");
-    await expect(page.getByRole("heading", { name: "Domains" })).toBeVisible();
-    await expect(page.getByPlaceholder("Search...")).toBeVisible();
-    await expect(page.getByText("All Statuses")).toBeVisible();
-    await expect(page.getByText("All Regions")).toBeVisible();
-    await expect(page.getByText("Add domain")).toBeVisible();
+  test("renders domains page with title and filter bar", async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto("/domains");
+    await expect(
+      authenticatedPage.getByRole("heading", { name: "Domains" }),
+    ).toBeVisible();
+    await expect(authenticatedPage.getByPlaceholder("Search...")).toBeVisible();
+    await expect(authenticatedPage.getByText("All Statuses")).toBeVisible();
+    await expect(authenticatedPage.getByText("All Regions")).toBeVisible();
+    await expect(authenticatedPage.getByText("Add domain")).toBeVisible();
   });
 
-  test("click domain name navigates to detail page", async ({ page }) => {
-    await page.goto("/domains");
-    const domainLink = page.locator("table a").first();
+  test("click domain name navigates to detail page", async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto("/domains");
+    const domainLink = authenticatedPage.locator("table a").first();
     const count = await domainLink.count();
     if (count > 0) {
       const href = await domainLink.getAttribute("href");
       expect(href).toBeTruthy();
       await domainLink.click();
-      await expect(page).toHaveURL(href as string);
+      await expect(authenticatedPage).toHaveURL(href as string);
     }
   });
 });

--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -1,0 +1,122 @@
+import { createHmac } from "node:crypto";
+import { test as base, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { Client } from "pg";
+
+export interface E2EUser {
+  id: string;
+  email: string;
+  name: string;
+  sessionId: string;
+  sessionToken: string;
+  signedSessionToken: string;
+}
+
+type AuthFixtures = {
+  authenticatedPage: Page;
+  e2eDb: Client;
+  e2eUser: E2EUser;
+};
+
+function getDatabaseUrl(): string | null {
+  return process.env.DATABASE_URL ?? null;
+}
+
+function getBaseUrl(): string {
+  return (
+    process.env.E2E_BASE_URL ??
+    process.env.NEXT_PUBLIC_APP_URL ??
+    `http://localhost:${process.env.PORT ?? "3015"}`
+  );
+}
+
+export function signBetterAuthSessionToken(sessionToken: string): string {
+  const secret =
+    process.env.BETTER_AUTH_SECRET ?? "better-auth-secret-12345678901234567890";
+  const signature = createHmac("sha256", secret)
+    .update(sessionToken)
+    .digest("base64");
+  return `${sessionToken}.${signature}`;
+}
+
+async function insertE2EUser(client: Client, runId: string): Promise<E2EUser> {
+  const userId = `e2e-user-${runId}`;
+  const sessionToken = `e2e-session-${runId}`;
+  const sessionId = `e2e-session-id-${runId}`;
+  const email = `${userId}@example.com`;
+  const name = "OpenSend E2E User";
+
+  await client.query(
+    `insert into "user" (id, name, email, email_verified, created_at, updated_at)
+     values ($1, $2, $3, true, now(), now())
+     on conflict (id) do update set updated_at = now()`,
+    [userId, name, email],
+  );
+  await client.query(
+    `insert into "session" (id, token, user_id, expires_at, created_at, updated_at)
+     values ($1, $2, $3, now() + interval '1 hour', now(), now())
+     on conflict (token) do update set expires_at = excluded.expires_at`,
+    [sessionId, sessionToken, userId],
+  );
+
+  return {
+    id: userId,
+    email,
+    name,
+    sessionId,
+    sessionToken,
+    signedSessionToken: signBetterAuthSessionToken(sessionToken),
+  };
+}
+
+async function cleanupE2EUser(client: Client, user: E2EUser): Promise<void> {
+  await client.query('delete from "session" where token = $1 or user_id = $2', [
+    user.sessionToken,
+    user.id,
+  ]);
+  await client.query('delete from "account" where user_id = $1', [user.id]);
+  await client.query('delete from "user" where id = $1', [user.id]);
+}
+
+export const test = base.extend<AuthFixtures>({
+  e2eDb: async ({ browserName: _browserName }, use, testInfo) => {
+    const databaseUrl = getDatabaseUrl();
+    testInfo.skip(!databaseUrl, "DATABASE_URL is required for auth-backed E2E");
+    if (!databaseUrl) return;
+
+    const client = new Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+      await use(client);
+    } finally {
+      await client.end();
+    }
+  },
+  e2eUser: async ({ e2eDb }, use, testInfo) => {
+    const runId = `${testInfo.workerIndex}-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2)}`;
+    const user = await insertE2EUser(e2eDb, runId);
+
+    try {
+      await use(user);
+    } finally {
+      await cleanupE2EUser(e2eDb, user);
+    }
+  },
+  authenticatedPage: async ({ context, e2eUser, page }, use) => {
+    await context.addCookies([
+      {
+        name: "better-auth.session_token",
+        value: e2eUser.signedSessionToken,
+        url: getBaseUrl(),
+        httpOnly: true,
+        sameSite: "Lax",
+      },
+    ]);
+
+    await use(page);
+  },
+});
+
+export { expect };

--- a/tests/quota-routes.test.ts
+++ b/tests/quota-routes.test.ts
@@ -15,6 +15,8 @@ const mockDb = vi.hoisted(() => ({
 
 vi.mock("@/lib/db", () => ({ db: mockDb }));
 vi.mock("@/lib/api-auth", () => ({
+  authorizeDashboardOrApiKey: mockValidateApiKey,
+  getServerSession: vi.fn(),
   validateApiKey: mockValidateApiKey,
   getApiKeyAuthHeaderError: () => null,
   unauthorizedResponse: () =>


### PR DESCRIPTION
## What changed
- Allow `POST /api/domains` to authenticate with either an API key or the dashboard Better Auth session.
- Resolve a concrete `userId` from the API-key owner or dashboard session user before quota checks, domain creation, and `domain.created` events.
- Add focused route coverage for creating a domain through dashboard session auth.
- Add a reusable Playwright auth fixture: `tests/e2e/fixtures/auth.ts`.
  - Seeds a real Better Auth `user` + `session` in Postgres.
  - Signs `better-auth.session_token` the same way Better Auth expects.
  - Exposes `authenticatedPage`, `e2eUser`, and `e2eDb` for future dashboard E2E specs.
- Convert the domain-create and domains-page E2E specs to use the shared fixture.
- Document E2E auth standards in `tests/e2e/README.md` and record the learning for #229.

## Why
The dashboard Add domain modal posts to `/api/domains` as a same-origin browser request with session cookies, not an Authorization header. The route only accepted API-key auth, so dashboard users could view domains but could not add one.

E2E was also missing a reusable way to authenticate server-rendered dashboard pages. Mocking `/api/auth/get-session` only affects browser fetches; it does not authenticate server components or app routes that call `getServerSession()`.

## Root cause
Domain GET/PATCH/DELETE/verify/auto-configure already used the dashboard-or-API-key auth pattern, but domain POST still used `validateApiKey` directly.

For E2E, existing dashboard specs either had no auth or route-mocked client session calls, so protected pages redirected to `/auth` in a real browser run.

## Validation
- `make check`
- `bun run test tests/api-domains.test.ts tests/cache-invalidation-routes.test.ts tests/quota-routes.test.ts`
- `TZ=UTC make test` — 97 files / 807 tests passed
- Focused E2E passed in safe local env with real Postgres + SES dev stub: `bunx playwright test tests/e2e/domain-create-auth.spec.ts tests/e2e/domains-page.spec.ts --reporter=line`
- Push guardrail: full-project typecheck + changed-file Biome

## E2E baseline note
- Full Playwright suite is still known-red from the earlier baseline: 22 passed, 58 failed, 4 skipped in the safe local env.
- Failures are pre-existing fixture/selector gaps, mostly unauthenticated dashboard tests redirecting to `/auth`, and are tracked by #229 for better E2E standards/fixtures.
- Local `drizzle-kit migrate` is also not suitable for a fresh throwaway DB because old migration history creates duplicate tables; focused E2E used `drizzle-kit push --force` to apply current schema to a throwaway DB.
