### PR TITLE
Validate Resend-compatible scheduled_at values

### DIFF
--- a/agent_docs/learnings/active/2026-05-07-issue-240-scheduled-at-validation.md
+++ b/agent_docs/learnings/active/2026-05-07-issue-240-scheduled-at-validation.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-07
+issue: "#240"
+type: decision
+promoted_to: null
+---
+
+## Keep scheduled_at natural language intentionally narrow
+
+**What:** Issue #240 accepts `scheduled_at` as either a future ISO 8601 date-time with an explicit timezone or the narrow Resend-compatible form `in <positive integer> <minute|min|minutes|hour|hours|day|days>`, capped at 30 days.
+
+**Why:** Resend compatibility needs the common scheduled-send shorthand, but accepting broad natural language would make validation nondeterministic and expand the public API contract. A shared parser in `src/lib/validation/emails.ts` keeps single send, batch send, and reschedule behavior aligned before rows are inserted or updated.
+
+**Pattern:** Add new scheduled-send formats to the shared parser and tests first; do not parse route-local strings with `new Date(...)` directly.

--- a/packages/core/src/dto/index.ts
+++ b/packages/core/src/dto/index.ts
@@ -28,6 +28,11 @@ export interface EmailOptions {
   headers?: Record<string, string>;
   attachments?: EmailAttachment[];
   tags?: EmailTag[];
+  /**
+   * Schedule delivery with a future ISO 8601 date-time including timezone,
+   * or `in <positive integer> <minute|min|minutes|hour|hours|day|days>`
+   * within 30 days.
+   */
   scheduled_at?: string;
   topic_id?: string;
   template?: EmailTemplateReference;

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -96,6 +96,16 @@ const { data, error } = await resend.emails.sendBatch([
 `resend.emails.sendBatch()` posts to the Resend-compatible `/emails/batch`
 endpoint.
 
+## Scheduled Sends
+
+Pass `scheduled_at` as a string to defer delivery for `send` or `sendBatch`.
+The API reschedule endpoint accepts the same formats. Supported values are
+future ISO 8601 date-times with a timezone (for example `2026-05-08T00:00:00.000Z`) or the small
+Resend-compatible natural-language form `in <positive integer>
+<minute|min|minutes|hour|hours|day|days>` such as `in 1 min`. Values must be
+within 30 days; unparseable, past, or out-of-policy values return
+`validation_error`.
+
 ## Idempotency Keys
 
 Pass a per-request `idempotencyKey` option to prevent accidental duplicate

--- a/src/app/api/emails/[id]/route.ts
+++ b/src/app/api/emails/[id]/route.ts
@@ -1,6 +1,11 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { publicApiError } from "@/lib/api-errors";
 import { db } from "@/lib/db";
 import { emails } from "@/lib/db/schema";
+import {
+  parseScheduledAt,
+  scheduledAtValidationMessage,
+} from "@/lib/validation/emails";
 import { and, eq } from "drizzle-orm";
 
 export async function GET(
@@ -55,6 +60,22 @@ export async function GET(
   }
 }
 
+function scheduledAtValidationResponse(): Response {
+  return Response.json(
+    publicApiError("validation_error", "Validation failed.", 422, {
+      formErrors: [],
+      fieldErrors: {
+        scheduled_at: [scheduledAtValidationMessage],
+      },
+    }),
+    { status: 422 },
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
@@ -64,11 +85,15 @@ export async function PATCH(
 
   const { id } = await params;
 
-  let body: { scheduled_at?: string | null };
+  let body: unknown;
   try {
     body = await request.json();
   } catch {
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!isRecord(body)) {
+    return scheduledAtValidationResponse();
   }
 
   try {
@@ -88,10 +113,17 @@ export async function PATCH(
     }
 
     const updates: { scheduledAt?: Date | null } = {};
-    if (body.scheduled_at !== undefined) {
-      updates.scheduledAt = body.scheduled_at
-        ? new Date(body.scheduled_at)
-        : null;
+    if ("scheduled_at" in body) {
+      const scheduledAt = body.scheduled_at;
+      if (scheduledAt === null) {
+        updates.scheduledAt = null;
+      } else if (typeof scheduledAt === "string") {
+        const parsed = parseScheduledAt(scheduledAt);
+        if (!parsed.ok) return scheduledAtValidationResponse();
+        updates.scheduledAt = parsed.date;
+      } else {
+        return scheduledAtValidationResponse();
+      }
     }
 
     if (Object.keys(updates).length === 0) {

--- a/src/app/api/emails/batch/route.ts
+++ b/src/app/api/emails/batch/route.ts
@@ -24,7 +24,10 @@ import {
   hasUnsubscribePlaceholder,
   replaceUnsubscribePlaceholder,
 } from "@/lib/unsubscribe";
-import { batchSendEmailSchema } from "@/lib/validation/emails";
+import {
+  batchSendEmailSchema,
+  normalizeScheduledAt,
+} from "@/lib/validation/emails";
 import {
   createBackgroundJob,
   createTelemetryContext,
@@ -384,7 +387,7 @@ export async function POST(request: Request): Promise<Response> {
         const bcc = normalizeToArray(item.bcc);
         const replyTo = normalizeToArray(item.reply_to);
         const scheduledAt = item.scheduled_at
-          ? new Date(item.scheduled_at)
+          ? normalizeScheduledAt(item.scheduled_at)
           : null;
 
         const shouldQueueNow = !scheduledAt || scheduledAt <= new Date();

--- a/src/app/api/emails/route.ts
+++ b/src/app/api/emails/route.ts
@@ -25,7 +25,7 @@ import {
   hasUnsubscribePlaceholder,
   replaceUnsubscribePlaceholder,
 } from "@/lib/unsubscribe";
-import { sendEmailSchema } from "@/lib/validation/emails";
+import { normalizeScheduledAt, sendEmailSchema } from "@/lib/validation/emails";
 import {
   createBackgroundJob,
   createTelemetryContext,
@@ -337,7 +337,7 @@ export async function POST(request: Request): Promise<Response> {
   const bcc = normalizeToArray(validated.bcc);
   const replyTo = normalizeToArray(validated.reply_to);
   const scheduledAt = validated.scheduled_at
-    ? new Date(validated.scheduled_at)
+    ? normalizeScheduledAt(validated.scheduled_at)
     : null;
 
   const suppressedRecipients = await findSuppressedRecipients({

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -461,7 +461,11 @@ export const openApiDocument = {
             type: "array",
             items: { $ref: "#/components/schemas/EmailTag" },
           },
-          scheduled_at: { type: "string", format: "date-time" },
+          scheduled_at: {
+            type: "string",
+            description:
+              "Schedule delivery with a future ISO 8601 date-time including timezone, or the supported Resend-compatible natural language form `in <positive integer> <minute|min|minutes|hour|hours|day|days>`. Values must be within 30 days.",
+          },
           topic_id: { type: "string", format: "uuid" },
           template: { $ref: "#/components/schemas/TemplateReference" },
         },

--- a/src/lib/validation/emails.ts
+++ b/src/lib/validation/emails.ts
@@ -22,6 +22,91 @@ export const attachmentSchema = z.object({
   content_id: z.string().optional(),
 });
 
+// ── Scheduled send parsing ────────────────────────────────────────
+
+const MAX_SCHEDULE_DELAY_MS = 30 * 24 * 60 * 60 * 1000;
+const NATURAL_LANGUAGE_SCHEDULE_RE =
+  /^in\s+([1-9]\d*)\s+(min|minute|minutes|hour|hours|day|days)$/i;
+const ISO_8601_WITH_TIMEZONE_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+export const scheduledAtValidationMessage =
+  "scheduled_at must be a future ISO 8601 date-time or 'in <positive integer> <minute|min|minutes|hour|hours|day|days>' within 30 days.";
+
+export type ScheduledAtParseResult =
+  | { ok: true; date: Date }
+  | { ok: false; message: string };
+
+function isAllowedScheduledDate(date: Date, now: Date): boolean {
+  const time = date.getTime();
+  const nowTime = now.getTime();
+  return (
+    Number.isFinite(time) &&
+    time > nowTime &&
+    time <= nowTime + MAX_SCHEDULE_DELAY_MS
+  );
+}
+
+function parseNaturalLanguageScheduledAt(
+  value: string,
+  now: Date,
+): Date | null {
+  const match = NATURAL_LANGUAGE_SCHEDULE_RE.exec(value.trim());
+  if (!match) return null;
+
+  const amount = Number(match[1]);
+  const unit = match[2]?.toLowerCase();
+  if (!Number.isSafeInteger(amount)) return null;
+
+  const multiplier = unit?.startsWith("day")
+    ? 24 * 60 * 60 * 1000
+    : unit?.startsWith("hour")
+      ? 60 * 60 * 1000
+      : 60 * 1000;
+
+  return new Date(now.getTime() + amount * multiplier);
+}
+
+export function parseScheduledAt(
+  value: string,
+  now: Date = new Date(),
+): ScheduledAtParseResult {
+  const trimmed = value.trim();
+  const naturalDate = parseNaturalLanguageScheduledAt(trimmed, now);
+  const parsedDate = naturalDate
+    ? naturalDate
+    : ISO_8601_WITH_TIMEZONE_RE.test(trimmed)
+      ? new Date(trimmed)
+      : null;
+
+  if (!parsedDate || !isAllowedScheduledDate(parsedDate, now)) {
+    return { ok: false, message: scheduledAtValidationMessage };
+  }
+
+  return { ok: true, date: parsedDate };
+}
+
+export function normalizeScheduledAt(
+  value: string,
+  now: Date = new Date(),
+): Date {
+  const parsed = parseScheduledAt(value, now);
+  if (!parsed.ok) {
+    throw new Error(parsed.message);
+  }
+  return parsed.date;
+}
+
+const scheduledAtSchema = z.string().superRefine((value, ctx) => {
+  const parsed = parseScheduledAt(value);
+  if (!parsed.ok) {
+    ctx.addIssue({
+      code: "custom",
+      message: parsed.message,
+    });
+  }
+});
+
 // ── Email Request Schemas ──────────────────────────────────────────
 
 export const sendEmailSchema = z
@@ -37,7 +122,7 @@ export const sendEmailSchema = z
     headers: z.record(z.string(), z.string()).optional(),
     attachments: z.array(attachmentSchema).optional(),
     tags: z.array(tagSchema).optional(),
-    scheduled_at: z.string().optional(),
+    scheduled_at: scheduledAtSchema.optional(),
     topic_id: z.string().uuid().optional(),
     template: z
       .object({

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -277,6 +277,7 @@ describe("POST /api/emails", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -722,6 +723,97 @@ describe("POST /api/emails", () => {
       }),
     );
   });
+  it("normalizes future ISO and natural-language scheduled_at values without queueing", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-07T00:00:00.000Z"));
+
+    let callCount = 0;
+    const valuesMock = vi.fn().mockImplementation(() => ({
+      returning: vi.fn().mockResolvedValue([{ id: `email-${++callCount}` }]),
+    }));
+    mockDb.insert = vi.fn().mockReturnValue({ values: valuesMock });
+
+    const { POST } = await import("@/app/api/emails/route");
+
+    const isoRes = await POST(
+      makeRequest(
+        "POST",
+        {
+          from: "sender@domain.com",
+          to: ["iso@test.com"],
+          subject: "ISO",
+          html: "<p>ISO</p>",
+          scheduled_at: "2026-05-08T00:00:00.000Z",
+        },
+        { Authorization: "Bearer re_test123" },
+      ),
+    );
+    const naturalRes = await POST(
+      makeRequest(
+        "POST",
+        {
+          from: "sender@domain.com",
+          to: ["natural@test.com"],
+          subject: "Natural",
+          html: "<p>Natural</p>",
+          scheduled_at: "in 1 min",
+        },
+        { Authorization: "Bearer re_test123" },
+      ),
+    );
+
+    expect(isoRes.status).toBe(200);
+    expect(naturalRes.status).toBe(200);
+    expect(valuesMock.mock.calls[0][0]).toMatchObject({
+      status: "scheduled",
+      scheduledAt: new Date("2026-05-08T00:00:00.000Z"),
+    });
+    expect(valuesMock.mock.calls[2][0]).toMatchObject({
+      status: "scheduled",
+      scheduledAt: new Date("2026-05-07T00:01:00.000Z"),
+    });
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid, past, and out-of-policy scheduled_at values before quota or insert", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-07T00:00:00.000Z"));
+
+    const { POST } = await import("@/app/api/emails/route");
+    const payload = {
+      from: "sender@domain.com",
+      to: ["user@test.com"],
+      subject: "Bad schedule",
+      html: "<p>Bad</p>",
+    };
+
+    for (const scheduled_at of [
+      "tomorrow",
+      "2026-05-06T23:59:00.000Z",
+      "in 31 days",
+    ]) {
+      const res = await POST(
+        makeRequest(
+          "POST",
+          { ...payload, scheduled_at },
+          { Authorization: "Bearer re_test123" },
+        ),
+      );
+      expect(res.status).toBe(422);
+      await expect(res.json()).resolves.toMatchObject({
+        name: "validation_error",
+        details: {
+          fieldErrors: {
+            scheduled_at: [expect.stringContaining("future ISO 8601")],
+          },
+        },
+      });
+    }
+
+    expect(mockReserveEmailQuota).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
+  });
 });
 
 // ── POST /api/emails/batch Tests ──────────────────────────────────
@@ -759,6 +851,10 @@ describe("POST /api/emails/batch", () => {
       reason: "queue_url_missing",
     });
     mockValidateApiKey.mockResolvedValue(AUTH_RESULT);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("rejects batch exceeding 100 emails", async () => {
@@ -1083,6 +1179,85 @@ describe("POST /api/emails/batch", () => {
     expect(mockSendEmail).not.toHaveBeenCalled();
     expect(mockPublishBackgroundJob).toHaveBeenCalledTimes(2);
   });
+  it("normalizes batch ISO and natural-language scheduled_at values without queueing", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-07T00:00:00.000Z"));
+
+    let callCount = 0;
+    const valuesMock = vi.fn().mockImplementation(() => ({
+      returning: vi.fn().mockResolvedValue([{ id: `email-${++callCount}` }]),
+    }));
+    mockDb.insert = vi.fn().mockReturnValue({ values: valuesMock });
+
+    const { POST } = await import("@/app/api/emails/batch/route");
+    const res = await POST(
+      makeRequest(
+        "POST",
+        [
+          {
+            from: "sender@domain.com",
+            to: ["iso@test.com"],
+            subject: "ISO",
+            html: "<p>ISO</p>",
+            scheduled_at: "2026-05-08T00:00:00.000Z",
+          },
+          {
+            from: "sender@domain.com",
+            to: ["natural@test.com"],
+            subject: "Natural",
+            html: "<p>Natural</p>",
+            scheduled_at: "in 2 hours",
+          },
+        ],
+        { Authorization: "Bearer re_test123" },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(valuesMock.mock.calls[0][0]).toMatchObject({
+      status: "scheduled",
+      scheduledAt: new Date("2026-05-08T00:00:00.000Z"),
+    });
+    expect(valuesMock.mock.calls[1][0]).toMatchObject({
+      status: "scheduled",
+      scheduledAt: new Date("2026-05-07T02:00:00.000Z"),
+    });
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid, past, and out-of-policy batch scheduled_at before any rows", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-07T00:00:00.000Z"));
+
+    const { POST } = await import("@/app/api/emails/batch/route");
+    const base = {
+      from: "sender@domain.com",
+      to: ["user@test.com"],
+      subject: "Bad batch schedule",
+      html: "<p>Bad</p>",
+    };
+
+    for (const scheduled_at of [
+      "next Friday",
+      "2026-05-06T23:59:00.000Z",
+      "in 31 days",
+    ]) {
+      const res = await POST(
+        makeRequest("POST", [{ ...base, scheduled_at }], {
+          Authorization: "Bearer re_test123",
+        }),
+      );
+      expect(res.status).toBe(422);
+      await expect(res.json()).resolves.toMatchObject({
+        name: "validation_error",
+        code: "validation_error",
+      });
+    }
+
+    expect(mockReserveEmailQuota).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
+  });
 });
 
 // ── GET /api/emails Tests ─────────────────────────────────────────
@@ -1289,6 +1464,10 @@ describe("PATCH /api/emails/:id", () => {
     mockValidateApiKey.mockResolvedValue(AUTH_RESULT);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("scopes scheduled email updates to the authenticated user", async () => {
     const findFirst = vi.fn().mockResolvedValue({
       id: "email-uuid",
@@ -1309,7 +1488,7 @@ describe("PATCH /api/emails/:id", () => {
       new Request("http://localhost:3015/api/emails/email-uuid", {
         method: "PATCH",
         headers: { Authorization: "Bearer re_test123" },
-        body: JSON.stringify({ scheduled_at: "2026-05-06T00:00:00.000Z" }),
+        body: JSON.stringify({ scheduled_at: "2026-05-08T00:00:00.000Z" }),
       }),
       { params: Promise.resolve({ id: "email-uuid" }) },
     );
@@ -1345,6 +1524,95 @@ describe("PATCH /api/emails/:id", () => {
         ]),
       }),
     );
+  });
+
+  it("normalizes ISO and natural-language scheduled_at updates", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-07T00:00:00.000Z"));
+
+    const findFirst = vi.fn().mockResolvedValue({
+      id: "email-uuid",
+      status: "scheduled",
+    });
+    mockDb.query = {
+      emails: { findFirst },
+    } as unknown as ReturnType<typeof vi.fn>;
+
+    const returning = vi.fn().mockResolvedValue([{ id: "email-uuid" }]);
+    const where = vi.fn().mockReturnValue({ returning });
+    const set = vi.fn().mockReturnValue({ where });
+    mockDb.update = vi.fn().mockReturnValue({ set });
+
+    const { PATCH } = await import("@/app/api/emails/[id]/route");
+    const isoRes = await PATCH(
+      new Request("http://localhost:3015/api/emails/email-uuid", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer re_test123" },
+        body: JSON.stringify({ scheduled_at: "2026-05-08T00:00:00.000Z" }),
+      }),
+      { params: Promise.resolve({ id: "email-uuid" }) },
+    );
+    const naturalRes = await PATCH(
+      new Request("http://localhost:3015/api/emails/email-uuid", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer re_test123" },
+        body: JSON.stringify({ scheduled_at: "in 1 day" }),
+      }),
+      { params: Promise.resolve({ id: "email-uuid" }) },
+    );
+
+    expect(isoRes.status).toBe(200);
+    expect(naturalRes.status).toBe(200);
+    expect(set).toHaveBeenNthCalledWith(1, {
+      scheduledAt: new Date("2026-05-08T00:00:00.000Z"),
+    });
+    expect(set).toHaveBeenNthCalledWith(2, {
+      scheduledAt: new Date("2026-05-08T00:00:00.000Z"),
+    });
+  });
+
+  it("rejects invalid, past, and out-of-policy scheduled_at updates before writing", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-07T00:00:00.000Z"));
+
+    const findFirst = vi.fn().mockResolvedValue({
+      id: "email-uuid",
+      status: "scheduled",
+    });
+    mockDb.query = {
+      emails: { findFirst },
+    } as unknown as ReturnType<typeof vi.fn>;
+    const set = vi.fn();
+    mockDb.update = vi.fn().mockReturnValue({ set });
+
+    const { PATCH } = await import("@/app/api/emails/[id]/route");
+
+    for (const scheduled_at of [
+      "later today",
+      "2026-05-06T23:59:00.000Z",
+      "in 31 days",
+    ]) {
+      const res = await PATCH(
+        new Request("http://localhost:3015/api/emails/email-uuid", {
+          method: "PATCH",
+          headers: { Authorization: "Bearer re_test123" },
+          body: JSON.stringify({ scheduled_at }),
+        }),
+        { params: Promise.resolve({ id: "email-uuid" }) },
+      );
+      expect(res.status).toBe(422);
+      await expect(res.json()).resolves.toMatchObject({
+        name: "validation_error",
+        details: {
+          fieldErrors: {
+            scheduled_at: [expect.stringContaining("future ISO 8601")],
+          },
+        },
+      });
+    }
+
+    expect(mockDb.update).not.toHaveBeenCalled();
+    expect(set).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Refs #240.

Implements Resend-compatible `scheduled_at` parsing/validation for transactional send APIs:

- Added a shared parser/validator in `src/lib/validation/emails.ts` for future ISO 8601 date-times with timezone and the narrow natural-language subset `in <positive integer> <minute|min|minutes|hour|hours|day|days>`.
- Enforced validation before persistence for `POST /api/emails`, `POST /api/emails/batch`, and `PATCH /api/emails/:id`, rejecting unparseable, past, and >30-day out-of-policy values with stable `validation_error` responses.
- Normalized accepted values to `Date` before writing `emails.scheduledAt`; scheduled rows keep `status = "scheduled"`, unscheduled sends still queue immediately, and the scheduled worker is unchanged.
- Updated OpenAPI, core DTO comments, SDK README, and project learning notes to document supported formats while keeping `scheduled_at` typed as `string`.

## Changed files

- `src/lib/validation/emails.ts`
- `src/app/api/emails/route.ts`
- `src/app/api/emails/batch/route.ts`
- `src/app/api/emails/[id]/route.ts`
- `tests/api-emails.test.ts`
- `src/lib/openapi.ts`
- `packages/core/src/dto/index.ts`
- `packages/sdk/README.md`
- `agent_docs/learnings/active/2026-05-07-issue-240-scheduled-at-validation.md`

## Validation

- `bun run vitest run tests/api-emails.test.ts` — passed (34 tests)
- `make check` — passed (typecheck + Biome)
- `make test` — passed (97 test files, 816 tests)
- `git diff --check` — passed
- Push guardrails — passed (change-scoped guardrails, full-project typecheck, changed-file Biome lint)

## Residual risks

- No Playwright e2e was run; this change is API validation-focused and covered by unit tests.
- Natural-language support is intentionally narrow; broader phrases like `tomorrow` remain invalid by design.
