### PR TITLE
Enforce Resend-compatible email tag limits

### DIFF
--- a/agent_docs/learnings/active/2026-05-07-issue-243-email-tag-validation-paths.md
+++ b/agent_docs/learnings/active/2026-05-07-issue-243-email-tag-validation-paths.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-07
+issue: "#243"
+type: pattern
+promoted_to: null
+---
+
+## Preserve public validation envelopes while adding nested field paths
+
+**What:** Issue #243 keeps the existing `validation_error` envelope and top-level Zod `fieldErrors`, but augments validation details with dotted nested paths such as `tags.0.name` and `1.tags.0.value` for array item failures.
+
+**Why:** Single and batch send clients need stable tag-specific paths without breaking existing consumers that already inspect top-level keys like `to`, `subject`, `scheduled_at`, or `tags`.
+
+**Pattern:** Add nested issue paths only when the Zod issue path has at least two segments; otherwise keep `flattenError` output authoritative to avoid duplicate top-level messages.

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -60,8 +60,17 @@ export function zodValidationDetails(error: ZodError): {
   fieldErrors: Record<string, string[]>;
 } {
   const flattened = flattenError(error);
+  const fieldErrors: Record<string, string[]> = { ...flattened.fieldErrors };
+
+  for (const issue of error.issues) {
+    if (issue.path.length < 2) continue;
+
+    const fieldPath = issue.path.join(".");
+    fieldErrors[fieldPath] = [...(fieldErrors[fieldPath] ?? []), issue.message];
+  }
+
   return {
     formErrors: flattened.formErrors,
-    fieldErrors: flattened.fieldErrors,
+    fieldErrors,
   };
 }

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -2,6 +2,7 @@ type JsonSchema = {
   type?: "array" | "boolean" | "integer" | "number" | "object" | "string";
   format?: string;
   description?: string;
+  pattern?: string;
   enum?: readonly string[];
   items?: JsonSchema | ReferenceObject;
   properties?: Record<string, JsonSchema | ReferenceObject>;
@@ -427,8 +428,16 @@ export const openApiDocument = {
       EmailTag: {
         type: "object",
         properties: {
-          name: { type: "string" },
-          value: { type: "string" },
+          name: {
+            type: "string",
+            maxLength: 256,
+            pattern: "^[A-Za-z0-9_-]+$",
+          },
+          value: {
+            type: "string",
+            maxLength: 256,
+            pattern: "^[A-Za-z0-9_-]*$",
+          },
         },
         required: ["name", "value"],
       },
@@ -459,6 +468,7 @@ export const openApiDocument = {
           },
           tags: {
             type: "array",
+            maxItems: 75,
             items: { $ref: "#/components/schemas/EmailTag" },
           },
           scheduled_at: {

--- a/src/lib/validation/emails.ts
+++ b/src/lib/validation/emails.ts
@@ -9,9 +9,22 @@ export const emailRecipientSchema = z.union([
   z.array(emailAddressSchema),
 ]);
 
+const EMAIL_TAG_PATTERN = /^[A-Za-z0-9_-]*$/;
+const EMAIL_TAG_PATTERN_MESSAGE =
+  "Tag names and values may only contain ASCII letters, numbers, underscores, or dashes.";
+const EMAIL_TAG_LENGTH_MESSAGE =
+  "Tag names and values must be no more than 256 characters.";
+
 export const tagSchema = z.object({
-  name: z.string().min(1).max(255),
-  value: z.string().max(1024),
+  name: z
+    .string()
+    .min(1)
+    .max(256, EMAIL_TAG_LENGTH_MESSAGE)
+    .regex(EMAIL_TAG_PATTERN, EMAIL_TAG_PATTERN_MESSAGE),
+  value: z
+    .string()
+    .max(256, EMAIL_TAG_LENGTH_MESSAGE)
+    .regex(EMAIL_TAG_PATTERN, EMAIL_TAG_PATTERN_MESSAGE),
 });
 
 export const attachmentSchema = z.object({
@@ -121,7 +134,7 @@ export const sendEmailSchema = z
     reply_to: emailRecipientSchema.optional(),
     headers: z.record(z.string(), z.string()).optional(),
     attachments: z.array(attachmentSchema).optional(),
-    tags: z.array(tagSchema).optional(),
+    tags: z.array(tagSchema).max(75).optional(),
     scheduled_at: scheduledAtSchema.optional(),
     topic_id: z.string().uuid().optional(),
     template: z

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -589,6 +589,149 @@ describe("POST /api/emails", () => {
     expect(mockPublishBackgroundJob).toHaveBeenCalledOnce();
   });
 
+  it("persists valid Resend-compatible tags unchanged", async () => {
+    const valuesMock = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: "email-tags-uuid" }]),
+    });
+    mockDb.insert = vi.fn().mockReturnValue({ values: valuesMock });
+
+    const tags = [
+      { name: "campaign_id", value: "spring-2026" },
+      { name: "tenant-1", value: "A_B-123" },
+    ];
+
+    const { POST } = await import("@/app/api/emails/route");
+    const req = makeRequest(
+      "POST",
+      {
+        from: "sender@domain.com",
+        to: "tagged@test.com",
+        subject: "Tagged",
+        html: "<p>Hi</p>",
+        tags,
+      },
+      { Authorization: "Bearer re_test123" },
+    );
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags,
+      }),
+    );
+  });
+
+  it("rejects tag names and values with non-Resend characters before insert", async () => {
+    const { POST } = await import("@/app/api/emails/route");
+    const req = makeRequest(
+      "POST",
+      {
+        from: "sender@domain.com",
+        to: "tagged@test.com",
+        subject: "Bad tags",
+        html: "<p>Hi</p>",
+        tags: [{ name: "campaign.id", value: "spring 2026" }],
+      },
+      { Authorization: "Bearer re_test123" },
+    );
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "validation_error",
+      details: {
+        fieldErrors: {
+          "tags.0.name": [
+            expect.stringContaining("ASCII letters, numbers, underscores"),
+          ],
+          "tags.0.value": [
+            expect.stringContaining("ASCII letters, numbers, underscores"),
+          ],
+        },
+      },
+    });
+    expect(mockReserveEmailQuota).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
+  });
+
+  it("rejects overlong tag names and values before insert", async () => {
+    const { POST } = await import("@/app/api/emails/route");
+    const basePayload = {
+      from: "sender@domain.com",
+      to: "tagged@test.com",
+      subject: "Long tags",
+      html: "<p>Hi</p>",
+    };
+
+    for (const tags of [
+      [{ name: "n".repeat(257), value: "ok" }],
+      [{ name: "name", value: "v".repeat(257) }],
+    ]) {
+      const res = await POST(
+        makeRequest(
+          "POST",
+          { ...basePayload, tags },
+          {
+            Authorization: "Bearer re_test123",
+          },
+        ),
+      );
+
+      expect(res.status).toBe(422);
+      await expect(res.json()).resolves.toMatchObject({
+        name: "validation_error",
+        details: {
+          fieldErrors: expect.objectContaining({
+            [tags[0]?.name === "name" ? "tags.0.value" : "tags.0.name"]: [
+              expect.stringContaining("no more than 256 characters"),
+            ],
+          }),
+        },
+      });
+    }
+
+    expect(mockReserveEmailQuota).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
+  });
+
+  it("rejects more than 75 tags on a single email before insert", async () => {
+    const { POST } = await import("@/app/api/emails/route");
+    const req = makeRequest(
+      "POST",
+      {
+        from: "sender@domain.com",
+        to: "tagged@test.com",
+        subject: "Too many tags",
+        html: "<p>Hi</p>",
+        tags: Array.from({ length: 76 }, (_, index) => ({
+          name: `tag_${index}`,
+          value: "ok",
+        })),
+      },
+      { Authorization: "Bearer re_test123" },
+    );
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "validation_error",
+      details: {
+        fieldErrors: {
+          tags: [expect.stringContaining("75")],
+        },
+      },
+    });
+    expect(mockReserveEmailQuota).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
+  });
+
   it("injects one-click unsubscribe headers and replaces the managed URL placeholder for known contact sends", async () => {
     process.env.UNSUBSCRIBE_SECRET = "test-unsubscribe-secret";
     Object.assign(mockDb.query, {
@@ -1179,6 +1322,86 @@ describe("POST /api/emails/batch", () => {
     expect(mockSendEmail).not.toHaveBeenCalled();
     expect(mockPublishBackgroundJob).toHaveBeenCalledTimes(2);
   });
+
+  it("rejects invalid tags on the specific batch item before any rows", async () => {
+    const { POST } = await import("@/app/api/emails/batch/route");
+    const res = await POST(
+      makeRequest(
+        "POST",
+        [
+          {
+            from: "sender@domain.com",
+            to: ["ok@test.com"],
+            subject: "OK",
+            html: "<p>OK</p>",
+            tags: [{ name: "valid_name", value: "valid-value" }],
+          },
+          {
+            from: "sender@domain.com",
+            to: ["bad@test.com"],
+            subject: "Bad",
+            html: "<p>Bad</p>",
+            tags: [{ name: "bad.name", value: "bad value" }],
+          },
+        ],
+        { Authorization: "Bearer re_test123" },
+      ),
+    );
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "validation_error",
+      details: {
+        fieldErrors: {
+          "1.tags.0.name": [
+            expect.stringContaining("ASCII letters, numbers, underscores"),
+          ],
+          "1.tags.0.value": [
+            expect.stringContaining("ASCII letters, numbers, underscores"),
+          ],
+        },
+      },
+    });
+    expect(mockReserveEmailQuota).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
+  });
+
+  it("rejects a batch item with more than 75 tags before any rows", async () => {
+    const { POST } = await import("@/app/api/emails/batch/route");
+    const res = await POST(
+      makeRequest(
+        "POST",
+        [
+          {
+            from: "sender@domain.com",
+            to: ["bad@test.com"],
+            subject: "Too many batch tags",
+            html: "<p>Bad</p>",
+            tags: Array.from({ length: 76 }, (_, index) => ({
+              name: `tag_${index}`,
+              value: "ok",
+            })),
+          },
+        ],
+        { Authorization: "Bearer re_test123" },
+      ),
+    );
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "validation_error",
+      details: {
+        fieldErrors: {
+          "0.tags": [expect.stringContaining("75")],
+        },
+      },
+    });
+    expect(mockReserveEmailQuota).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
+  });
+
   it("normalizes batch ISO and natural-language scheduled_at values without queueing", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-07T00:00:00.000Z"));


### PR DESCRIPTION
## Summary
- Enforces Resend-compatible send tag limits in the shared email request schema: allowed characters, 256-character name/value cap, and max 75 tags per email.
- Preserves existing tag persistence for valid single and batch sends while rejecting invalid payloads before quota reservation or email row insertion.
- Adds nested public validation field paths such as `tags.0.name`, `1.tags.0.value`, and `0.tags` without changing the existing `validation_error` envelope.
- Documents the public OpenAPI tag constraints and records the validation-path pattern in learnings.

Issue: #243

## Changed files
- `src/lib/validation/emails.ts` — shared tag constraints for `/emails` and `/emails/batch`.
- `src/lib/api-errors.ts` — augments validation details with stable dotted nested paths.
- `src/lib/openapi.ts` — documents tag limits in public schema.
- `tests/api-emails.test.ts` — covers valid tags, invalid characters, overlong name/value, too many tags, and batch per-email tag validation.
- `agent_docs/learnings/active/2026-05-07-issue-243-email-tag-validation-paths.md` — captures the nested validation path pattern.

## Validation
- `bunx vitest run tests/api-emails.test.ts` — 40 tests passed.
- `make check` — typecheck + Biome passed.
- `make test` — 97 files / 822 tests passed.
- `git diff --check` — passed.
- Push hook also reran full-project typecheck and changed-file Biome successfully.

## Residual risks
- Did not run Playwright E2E; this API validation slice is covered by route-level Vitest and no UI behavior changed.
