### PR TITLE
Enforce API key sending scopes

### DIFF
--- a/agent_docs/learnings/active/2026-05-07-issue-247-api-key-scope-helper.md
+++ b/agent_docs/learnings/active/2026-05-07-issue-247-api-key-scope-helper.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-07
+issue: "#247"
+type: decision
+promoted_to: null
+---
+
+## Centralize API key permission gates at route auth boundaries
+
+Issue #247 adds `src/lib/api-key-permissions.ts` as the narrow permission/domain gate instead of scattering string comparisons. Public non-send API routes should call the full-access helper immediately after API-key/dashboard auth; send routes should call the domain helper after payload validation and before suppression/quota/queue work.
+
+Dashboard-capable routes must use the dashboard-aware helper so session callers continue to work while `sending_access` API-key callers receive the stable 403 error envelope.

--- a/packages/core/src/services/apiKeys.ts
+++ b/packages/core/src/services/apiKeys.ts
@@ -9,12 +9,12 @@ export type ApiKeyPermission = "full_access" | "sending_access";
 
 export type ApiKeyServiceListItem = Pick<
   ApiKeyRow,
-  "id" | "name" | "createdAt" | "lastUsedAt"
+  "id" | "name" | "permission" | "domain" | "createdAt" | "lastUsedAt"
 >;
 
 export type ApiKeyDetail = Pick<
   ApiKeyRow,
-  "id" | "name" | "createdAt" | "lastUsedAt"
+  "id" | "name" | "permission" | "domain" | "createdAt" | "lastUsedAt"
 >;
 
 export type ApiKeyListResult = {
@@ -110,6 +110,8 @@ export function createApiKeyService({
           name: key.name,
           createdAt: key.createdAt,
           lastUsedAt: key.lastUsedAt,
+          permission: key.permission,
+          domain: key.domain,
         })),
         hasMore: result.hasMore,
       };
@@ -159,6 +161,8 @@ export function createApiKeyService({
         name: key.name,
         createdAt: key.createdAt,
         lastUsedAt: key.lastUsedAt,
+        permission: key.permission,
+        domain: key.domain,
       };
     },
 

--- a/src/app/api/api-keys/[id]/route.ts
+++ b/src/app/api/api-keys/[id]/route.ts
@@ -1,8 +1,10 @@
 import {
+  authorizeDashboardOrApiKey,
+  getServerSession,
   invalidateApiKeyAuthCache,
   unauthorizedResponse,
-  validateApiKey,
 } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { ApiKeyServiceError, createApiKeyService } from "@opensend/core";
 
 function apiKeyService() {
@@ -24,14 +26,22 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth?.userId || auth.permission !== "full_access") {
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
+  if (!auth) {
     return unauthorizedResponse();
   }
+  const permissionError =
+    "apiKeyId" in auth ? requireFullAccessApiKey(auth) : null;
+  if (permissionError) return permissionError;
+  const session = "dashboard" in auth ? await getServerSession() : null;
+  const userId = "userId" in auth ? auth.userId : session?.user?.id;
+  if (!userId) return unauthorizedResponse();
 
   const { id } = await params;
   try {
-    const key = await apiKeyService().getApiKey(id, auth.userId);
+    const key = await apiKeyService().getApiKey(id, userId);
 
     return Response.json({
       object: "api_key",
@@ -39,6 +49,8 @@ export async function GET(
       name: key.name,
       created_at: key.createdAt,
       last_used_at: key.lastUsedAt,
+      permission: key.permission,
+      domain: key.domain,
     });
   } catch (err) {
     return mapServiceError(err, "Failed to get API key");
@@ -49,14 +61,22 @@ export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth?.userId || auth.permission !== "full_access") {
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
+  if (!auth) {
     return unauthorizedResponse();
   }
+  const permissionError =
+    "apiKeyId" in auth ? requireFullAccessApiKey(auth) : null;
+  if (permissionError) return permissionError;
+  const session = "dashboard" in auth ? await getServerSession() : null;
+  const userId = "userId" in auth ? auth.userId : session?.user?.id;
+  if (!userId) return unauthorizedResponse();
 
   const { id } = await params;
   try {
-    await apiKeyService().deleteApiKey(id, auth.userId);
+    await apiKeyService().deleteApiKey(id, userId);
 
     return new Response(null, { status: 200 });
   } catch (err) {

--- a/src/app/api/api-keys/route.ts
+++ b/src/app/api/api-keys/route.ts
@@ -1,8 +1,10 @@
 import {
+  authorizeDashboardOrApiKey,
+  getServerSession,
   invalidateApiKeyAuthCache,
   unauthorizedResponse,
-  validateApiKey,
 } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { checkApiKeyQuota, quotaExceededResponse } from "@/lib/billing/quota";
 import {
   type ApiKeyPermission,
@@ -47,10 +49,18 @@ function parseCreateApiKeyBody(body: unknown): {
 }
 
 export async function GET(request: Request): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth?.userId || auth.permission !== "full_access") {
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
+  if (!auth) {
     return unauthorizedResponse();
   }
+  const permissionError =
+    "apiKeyId" in auth ? requireFullAccessApiKey(auth) : null;
+  if (permissionError) return permissionError;
+  const session = "dashboard" in auth ? await getServerSession() : null;
+  const userId = "userId" in auth ? auth.userId : session?.user?.id;
+  if (!userId) return unauthorizedResponse();
 
   const url = new URL(request.url);
   const limit = Number(url.searchParams.get("limit")) || 20;
@@ -58,7 +68,7 @@ export async function GET(request: Request): Promise<Response> {
 
   try {
     const result = await apiKeyService().listApiKeys({
-      userId: auth.userId,
+      userId,
       limit,
       after,
     });
@@ -70,6 +80,8 @@ export async function GET(request: Request): Promise<Response> {
         name: key.name,
         created_at: key.createdAt,
         last_used_at: key.lastUsedAt,
+        permission: key.permission,
+        domain: key.domain,
       })),
       has_more: result.hasMore,
     });
@@ -79,10 +91,18 @@ export async function GET(request: Request): Promise<Response> {
 }
 
 export async function POST(request: Request): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth?.userId || auth.permission !== "full_access") {
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
+  if (!auth) {
     return unauthorizedResponse();
   }
+  const permissionError =
+    "apiKeyId" in auth ? requireFullAccessApiKey(auth) : null;
+  if (permissionError) return permissionError;
+  const session = "dashboard" in auth ? await getServerSession() : null;
+  const userId = "userId" in auth ? auth.userId : session?.user?.id;
+  if (!userId) return unauthorizedResponse();
 
   let body: unknown;
   try {
@@ -92,14 +112,14 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   try {
-    const quota = await checkApiKeyQuota(auth.userId);
+    const quota = await checkApiKeyQuota(userId);
     if (!quota.ok) {
       return quotaExceededResponse(quota.info);
     }
 
     const created = await apiKeyService().createApiKey({
       ...parseCreateApiKeyBody(body),
-      userId: auth.userId,
+      userId,
     });
 
     return Response.json(

--- a/src/app/api/automations/[id]/route.ts
+++ b/src/app/api/automations/[id]/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { formatAutomation } from "@/lib/automations";
 import { db } from "@/lib/db";
 import { automationSteps, automations } from "@/lib/db/schema";
@@ -49,6 +50,8 @@ export async function GET(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const { id } = await params;
   try {
@@ -70,6 +73,8 @@ export async function PATCH(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   let body: unknown;
   try {
@@ -194,6 +199,8 @@ export async function DELETE(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const { id } = await params;
   try {

--- a/src/app/api/automations/[id]/runs/[runId]/route.ts
+++ b/src/app/api/automations/[id]/runs/[runId]/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { formatRunDetail } from "@/lib/automations";
 import { db } from "@/lib/db";
 import { automationRuns, automations } from "@/lib/db/schema";
@@ -10,6 +11,8 @@ export async function GET(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const { id, runId } = await params;
   try {

--- a/src/app/api/automations/[id]/runs/route.ts
+++ b/src/app/api/automations/[id]/runs/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { formatRunListItem, parseRunStatusFilter } from "@/lib/automations";
 import { db } from "@/lib/db";
 import { automationRuns, automations } from "@/lib/db/schema";
@@ -11,6 +12,8 @@ export async function GET(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const url = new URL(request.url);
   const parsed = listRunsQuerySchema.safeParse({

--- a/src/app/api/automations/route.ts
+++ b/src/app/api/automations/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { formatAutomation, formatAutomationListItem } from "@/lib/automations";
 import { db } from "@/lib/db";
 import { automationRuns, automationSteps } from "@/lib/db/schema";
@@ -30,6 +31,8 @@ function toStepInputs(
 export async function POST(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   let body: unknown;
   try {
@@ -77,6 +80,8 @@ export async function POST(request: Request): Promise<Response> {
 export async function GET(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const url = new URL(request.url);
   const parsed = listAutomationsQuerySchema.safeParse({

--- a/src/app/api/contacts/[id]/route.ts
+++ b/src/app/api/contacts/[id]/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { contacts } from "@/lib/db/schema";
 import { queueEvent } from "@/lib/events";
@@ -46,6 +47,8 @@ export async function GET(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
   if (!auth.userId) return unauthorizedResponse();
   const userId = auth.userId;
 
@@ -95,6 +98,8 @@ export async function PATCH(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
   if (!auth.userId) return unauthorizedResponse();
   const userId = auth.userId;
 
@@ -201,6 +206,8 @@ export async function DELETE(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
   if (!auth.userId) return unauthorizedResponse();
   const userId = auth.userId;
 

--- a/src/app/api/contacts/[id]/segments/[segment_id]/route.ts
+++ b/src/app/api/contacts/[id]/segments/[segment_id]/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { contacts, contactsToSegments, segments } from "@/lib/db/schema";
 import { and, eq, or } from "drizzle-orm";
@@ -26,6 +27,8 @@ export async function POST(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
   if (!auth.userId) return unauthorizedResponse();
   const userId = auth.userId;
 
@@ -86,6 +89,8 @@ export async function DELETE(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
   if (!auth.userId) return unauthorizedResponse();
   const userId = auth.userId;
 

--- a/src/app/api/contacts/[id]/segments/route.ts
+++ b/src/app/api/contacts/[id]/segments/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { contacts, segments } from "@/lib/db/schema";
 import { and, eq, or } from "drizzle-orm";
@@ -26,6 +27,8 @@ export async function GET(
 ) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
   if (!auth.userId) return unauthorizedResponse();
   const userId = auth.userId;
 

--- a/src/app/api/contacts/[id]/topics/route.ts
+++ b/src/app/api/contacts/[id]/topics/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { contacts, topics } from "@/lib/db/schema";
 import { and, eq, or } from "drizzle-orm";
@@ -38,6 +39,8 @@ export async function GET(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
   if (!auth.userId) return unauthorizedResponse();
   const userId = auth.userId;
 
@@ -88,6 +91,8 @@ export async function PATCH(
 ) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
   if (!auth.userId) return unauthorizedResponse();
   const userId = auth.userId;
 

--- a/src/app/api/contacts/bulk/route.ts
+++ b/src/app/api/contacts/bulk/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { contacts, segments, topics } from "@/lib/db/schema";
 import { and, eq, inArray } from "drizzle-orm";
@@ -7,6 +8,8 @@ import { type NextRequest, NextResponse } from "next/server";
 export async function POST(request: NextRequest) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
   if (!auth.userId) return unauthorizedResponse();
   const userId = auth.userId;
 

--- a/src/app/api/contacts/import/route.ts
+++ b/src/app/api/contacts/import/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { contacts, segments } from "@/lib/db/schema";
 import { and, eq } from "drizzle-orm";
@@ -8,6 +9,8 @@ import Papa from "papaparse";
 export async function POST(request: NextRequest) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
   if (!auth.userId) return unauthorizedResponse();
   const userId = auth.userId;
 

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -3,6 +3,7 @@ import {
   getServerSession,
   unauthorizedResponse,
 } from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { contacts, segments, topics } from "@/lib/db/schema";
 import { queueEvent } from "@/lib/events";
@@ -42,6 +43,8 @@ export async function POST(request: NextRequest) {
     request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
   const userId = await resolveUserId(auth);
   if (!userId) return unauthorizedResponse();
 
@@ -159,6 +162,8 @@ export async function GET(request: Request) {
     request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
   const userId = await resolveUserId(auth);
   if (!userId) return unauthorizedResponse();
 

--- a/src/app/api/domains/[id]/auto-configure/route.ts
+++ b/src/app/api/domains/[id]/auto-configure/route.ts
@@ -3,6 +3,7 @@ import {
   getServerSession,
   unauthorizedResponse,
 } from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
 import { autoConfigureDomain } from "@/lib/cloudflare";
 import { db } from "@/lib/db";
 import { domains } from "@/lib/db/schema";
@@ -25,6 +26,8 @@ export async function POST(
     _req.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
 
   const session = "dashboard" in auth ? await getServerSession() : null;
   const userId = "userId" in auth ? auth.userId : session?.user?.id;

--- a/src/app/api/domains/[id]/route.ts
+++ b/src/app/api/domains/[id]/route.ts
@@ -3,6 +3,7 @@ import {
   getServerSession,
   unauthorizedResponse,
 } from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
 import { deleteDNSRecord, listDNSRecords } from "@/lib/cloudflare";
 import { db } from "@/lib/db";
 import { domains } from "@/lib/db/schema";
@@ -54,6 +55,8 @@ export async function GET(
     _req.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
 
   const session = "dashboard" in auth ? await getServerSession() : null;
   const userId = "userId" in auth ? auth.userId : session?.user?.id;
@@ -108,6 +111,8 @@ export async function PATCH(
     req.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
 
   const session = "dashboard" in auth ? await getServerSession() : null;
   const userId = "userId" in auth ? auth.userId : session?.user?.id;
@@ -256,6 +261,8 @@ export async function DELETE(
     _req.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
 
   const session = "dashboard" in auth ? await getServerSession() : null;
   const userId = "userId" in auth ? auth.userId : session?.user?.id;

--- a/src/app/api/domains/[id]/verify/route.ts
+++ b/src/app/api/domains/[id]/verify/route.ts
@@ -3,6 +3,7 @@ import {
   getServerSession,
   unauthorizedResponse,
 } from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { domains } from "@/lib/db/schema";
 import {
@@ -23,6 +24,8 @@ export async function POST(
     request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
 
   const session = "dashboard" in auth ? await getServerSession() : null;
   const userId = "userId" in auth ? auth.userId : session?.user?.id;

--- a/src/app/api/domains/route.ts
+++ b/src/app/api/domains/route.ts
@@ -3,6 +3,7 @@ import {
   getServerSession,
   unauthorizedResponse,
 } from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
 import { checkDomainQuota, quotaExceededResponse } from "@/lib/billing/quota";
 import { invalidateDomainCaches } from "@/lib/domain-cache";
 import { queueEvent } from "@/lib/events";
@@ -55,6 +56,8 @@ export async function POST(request: Request): Promise<Response> {
     request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
 
   const session = "dashboard" in auth ? await getServerSession() : null;
   const userId = "userId" in auth ? auth.userId : session?.user?.id;
@@ -137,6 +140,8 @@ export async function GET(request: Request): Promise<Response> {
     request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
 
   const session = "dashboard" in auth ? await getServerSession() : null;
   const userId = "userId" in auth ? auth.userId : session?.user?.id;

--- a/src/app/api/emails/[id]/attachments/[attachmentId]/route.ts
+++ b/src/app/api/emails/[id]/attachments/[attachmentId]/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { emails } from "@/lib/db/schema";
 import { getPresignedUrl } from "@/lib/s3";
@@ -11,6 +12,8 @@ export async function GET(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth || !auth.userId) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id, attachmentId } = await params;

--- a/src/app/api/emails/[id]/attachments/route.ts
+++ b/src/app/api/emails/[id]/attachments/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { emails } from "@/lib/db/schema";
 import { and, eq } from "drizzle-orm";
@@ -10,6 +11,8 @@ export async function GET(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth || !auth.userId) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;

--- a/src/app/api/emails/[id]/cancel/route.ts
+++ b/src/app/api/emails/[id]/cancel/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { emails } from "@/lib/db/schema";
 import { and, eq } from "drizzle-orm";
@@ -10,6 +11,8 @@ export async function POST(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth || !auth.userId) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;

--- a/src/app/api/emails/[id]/events/route.ts
+++ b/src/app/api/emails/[id]/events/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { emailEvents, emails } from "@/lib/db/schema";
 import { and, asc, eq } from "drizzle-orm";
@@ -10,6 +11,8 @@ export async function GET(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth || !auth.userId) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id: emailId } = await params;

--- a/src/app/api/emails/[id]/route.ts
+++ b/src/app/api/emails/[id]/route.ts
@@ -1,5 +1,6 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { publicApiError } from "@/lib/api-errors";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { emails } from "@/lib/db/schema";
 import {
@@ -14,6 +15,8 @@ export async function GET(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth || !auth.userId) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const { id } = await params;
 
@@ -82,6 +85,8 @@ export async function PATCH(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth || !auth.userId) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const { id } = await params;
 

--- a/src/app/api/emails/batch/route.ts
+++ b/src/app/api/emails/batch/route.ts
@@ -4,6 +4,7 @@ import {
   validateApiKey,
 } from "@/lib/api-auth";
 import { publicApiError, zodValidationDetails } from "@/lib/api-errors";
+import { requireAllowedBatchSendingDomains } from "@/lib/api-key-permissions";
 import { captureApiResponseLog } from "@/lib/api-logging";
 import {
   quotaExceededResponse,
@@ -333,6 +334,24 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   const validatedItems = result.data;
+
+  const domainRestrictionError = await requireAllowedBatchSendingDomains(
+    auth,
+    validatedItems.map((item) => item.from),
+    {
+      headers: {
+        "x-correlation-id": telemetry.correlationId,
+        traceparent: telemetry.traceparent,
+      },
+    },
+  );
+  if (domainRestrictionError) {
+    recordBatchMetric(telemetry, {
+      durationMs: performance.now() - startedAt,
+      outcome: "unauthorized",
+    });
+    return await logResponse(domainRestrictionError);
+  }
   const itemRecipients = validatedItems.map(
     (item) => normalizeToArray(item.to) as string[],
   );

--- a/src/app/api/emails/receiving/[id]/attachments/[attachmentId]/route.ts
+++ b/src/app/api/emails/receiving/[id]/attachments/[attachmentId]/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { receivedEmails } from "@/lib/db/schema";
 import { getPresignedUrl } from "@/lib/s3";
@@ -11,6 +12,8 @@ export async function GET(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id, attachmentId } = await params;

--- a/src/app/api/emails/receiving/[id]/attachments/route.ts
+++ b/src/app/api/emails/receiving/[id]/attachments/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { receivedEmails } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -10,6 +11,8 @@ export async function GET(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;

--- a/src/app/api/emails/receiving/[id]/route.ts
+++ b/src/app/api/emails/receiving/[id]/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { receivedEmails } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -10,6 +11,8 @@ export async function GET(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;

--- a/src/app/api/emails/receiving/route.ts
+++ b/src/app/api/emails/receiving/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { receivedEmails } from "@/lib/db/schema";
 import { and, desc, lt, sql } from "drizzle-orm";
@@ -7,6 +8,8 @@ import { type NextRequest, NextResponse } from "next/server";
 export async function GET(request: NextRequest) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const url = request.nextUrl;
   const limit = Math.min(

--- a/src/app/api/emails/route.ts
+++ b/src/app/api/emails/route.ts
@@ -5,6 +5,10 @@ import {
   validateApiKey,
 } from "@/lib/api-auth";
 import { publicApiError, zodValidationDetails } from "@/lib/api-errors";
+import {
+  requireAllowedSendingDomain,
+  requireFullAccessApiKey,
+} from "@/lib/api-key-permissions";
 import { captureApiResponseLog } from "@/lib/api-logging";
 import {
   quotaExceededResponse,
@@ -303,6 +307,24 @@ export async function POST(request: Request): Promise<Response> {
 
   const validated = result.data;
 
+  const domainRestrictionError = await requireAllowedSendingDomain(
+    auth,
+    validated.from,
+    {
+      headers: {
+        "x-correlation-id": telemetry.correlationId,
+        traceparent: telemetry.traceparent,
+      },
+    },
+  );
+  if (domainRestrictionError) {
+    recordAcceptMetric(telemetry, {
+      durationMs: performance.now() - startedAt,
+      outcome: "unauthorized",
+    });
+    return await logResponse(domainRestrictionError);
+  }
+
   // Idempotency check
   if (idempotencyKey) {
     const existing = await db.query.emails.findFirst({
@@ -589,6 +611,8 @@ export async function POST(request: Request): Promise<Response> {
 export async function GET(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth || !auth.userId) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const url = new URL(request.url);
   const limit = Math.min(
@@ -683,6 +707,8 @@ export async function GET(request: Request): Promise<Response> {
 export async function DELETE(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth || !auth.userId) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const url = new URL(request.url);
   const id = url.searchParams.get("id");

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { formatCustomEvent } from "@/lib/automations";
 import {
   createCustomEventSchema,
@@ -18,6 +19,8 @@ function isUniqueViolation(err: unknown): boolean {
 export async function POST(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   let body: unknown;
   try {
@@ -63,6 +66,8 @@ export async function POST(request: Request): Promise<Response> {
 export async function GET(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const url = new URL(request.url);
   const parsed = listEventsQuerySchema.safeParse({

--- a/src/app/api/events/send/route.ts
+++ b/src/app/api/events/send/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import {
   formatCustomEventDelivery,
   formatRunListItem,
@@ -39,6 +40,8 @@ async function resolveContactId(input: {
 export async function POST(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   let body: unknown;
   try {

--- a/src/app/api/logs/[id]/route.ts
+++ b/src/app/api/logs/[id]/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { logs } from "@/lib/db/schema";
 import { and, eq } from "drizzle-orm";
@@ -9,6 +10,8 @@ export async function GET(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth || !auth.userId) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const { id } = await params;
 

--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { logs } from "@/lib/db/schema";
 import {
@@ -28,6 +29,8 @@ function parseDate(value: string | null, endOfDay = false): Date | null {
 export async function GET(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth || !auth.userId) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const url = new URL(request.url);
   const limit = Math.min(

--- a/src/app/api/properties/[id]/route.ts
+++ b/src/app/api/properties/[id]/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { contactProperties } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -10,6 +11,8 @@ export async function GET(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;
@@ -49,6 +52,8 @@ export async function PATCH(
 ) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;
@@ -102,6 +107,8 @@ export async function DELETE(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;

--- a/src/app/api/properties/route.ts
+++ b/src/app/api/properties/route.ts
@@ -2,6 +2,7 @@ import {
   authorizeDashboardOrApiKey,
   unauthorizedResponse,
 } from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { contactProperties } from "@/lib/db/schema";
 import { asc, count } from "drizzle-orm";
@@ -12,6 +13,8 @@ export async function GET(request: NextRequest) {
     request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
 
   try {
     const url = request.nextUrl;
@@ -67,6 +70,8 @@ export async function POST(request: NextRequest) {
     request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
 
   try {
     const body = await request.json();

--- a/src/app/api/segments/[id]/contacts/route.ts
+++ b/src/app/api/segments/[id]/contacts/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { contacts, contactsToSegments, segments } from "@/lib/db/schema";
 import { and, desc, eq, sql } from "drizzle-orm";
@@ -10,6 +11,8 @@ export async function GET(
 ) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
   if (!auth.userId) return unauthorizedResponse();
   const userId = auth.userId;
 

--- a/src/app/api/segments/[id]/route.ts
+++ b/src/app/api/segments/[id]/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { segments } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -10,6 +11,8 @@ export async function GET(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;
@@ -43,6 +46,8 @@ export async function DELETE(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;

--- a/src/app/api/segments/route.ts
+++ b/src/app/api/segments/route.ts
@@ -2,6 +2,7 @@ import {
   authorizeDashboardOrApiKey,
   unauthorizedResponse,
 } from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { segments } from "@/lib/db/schema";
 import { and, asc, count, desc, ilike, lt } from "drizzle-orm";
@@ -12,6 +13,8 @@ export async function GET(request: NextRequest) {
     request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
 
   try {
     const url = request.nextUrl;
@@ -73,6 +76,8 @@ export async function POST(request: NextRequest) {
     request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
 
   try {
     const body = await request.json();

--- a/src/app/api/suppressions/[email]/route.ts
+++ b/src/app/api/suppressions/[email]/route.ts
@@ -3,6 +3,7 @@ import {
   getServerSession,
   unauthorizedResponse,
 } from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
 import { removeSuppression } from "@/lib/suppressions";
 import { NextResponse } from "next/server";
 
@@ -14,6 +15,8 @@ export async function DELETE(
     request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
   const session = "dashboard" in auth ? await getServerSession() : null;
   const userId = "userId" in auth ? auth.userId : session?.user?.id;
   if (!userId) return unauthorizedResponse();

--- a/src/app/api/suppressions/route.ts
+++ b/src/app/api/suppressions/route.ts
@@ -3,6 +3,7 @@ import {
   getServerSession,
   unauthorizedResponse,
 } from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
 import { listSuppressions, serializeSuppression } from "@/lib/suppressions";
 import { NextResponse } from "next/server";
 
@@ -11,6 +12,8 @@ export async function GET(request: Request) {
     request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
   const session = "dashboard" in auth ? await getServerSession() : null;
   const userId = "userId" in auth ? auth.userId : session?.user?.id;
   if (!userId) return unauthorizedResponse();

--- a/src/app/api/templates/[id]/duplicate/route.ts
+++ b/src/app/api/templates/[id]/duplicate/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { templates } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -10,6 +11,8 @@ export async function POST(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;

--- a/src/app/api/templates/[id]/publish/route.ts
+++ b/src/app/api/templates/[id]/publish/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { templates } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -10,6 +11,8 @@ export async function POST(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;

--- a/src/app/api/templates/[id]/route.ts
+++ b/src/app/api/templates/[id]/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { templates } from "@/lib/db/schema";
 import { extractTemplateVariables } from "@/lib/templates/parser";
@@ -11,6 +12,8 @@ export async function GET(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;
@@ -69,6 +72,8 @@ export async function PATCH(
 ) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;
@@ -174,6 +179,8 @@ export async function DELETE(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { templates } from "@/lib/db/schema";
 import { type SQL, and, count, desc, eq, ilike } from "drizzle-orm";
@@ -22,6 +23,8 @@ const RESERVED_VARIABLE_NAMES = [
 export async function GET(request: NextRequest) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const url = request.nextUrl;
@@ -87,6 +90,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const body = await request.json();

--- a/src/app/api/topics/[id]/route.ts
+++ b/src/app/api/topics/[id]/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { topics } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -10,6 +11,8 @@ export async function GET(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;
@@ -47,6 +50,8 @@ export async function PATCH(
 ) {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;
@@ -103,6 +108,8 @@ export async function DELETE(
 ) {
   const auth = await validateApiKey(_request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   try {
     const { id } = await params;

--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -2,6 +2,7 @@ import {
   authorizeDashboardOrApiKey,
   unauthorizedResponse,
 } from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { topics } from "@/lib/db/schema";
 import { and, asc, count, desc, eq, ilike, lt } from "drizzle-orm";
@@ -12,6 +13,8 @@ export async function GET(request: NextRequest) {
     request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
 
   try {
     const url = request.nextUrl;
@@ -79,6 +82,8 @@ export async function POST(request: NextRequest) {
     request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
 
   try {
     const body = await request.json();

--- a/src/app/api/webhooks/[id]/route.ts
+++ b/src/app/api/webhooks/[id]/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { updateWebhookSchema } from "@/lib/validation/webhooks";
 import { createWebhookService } from "@opensend/core";
 
@@ -39,6 +40,8 @@ export async function GET(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth?.userId) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const { id } = await params;
 
@@ -69,6 +72,8 @@ export async function PATCH(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth?.userId) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const { id } = await params;
 
@@ -119,6 +124,8 @@ export async function DELETE(
 ): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth?.userId) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const { id } = await params;
 

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -1,4 +1,5 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { createWebhookSchema } from "@/lib/validation/webhooks";
 import { createWebhookService } from "@opensend/core";
 
@@ -14,6 +15,8 @@ function mapWebhookError(error: unknown, fallback: string): Response {
 export async function GET(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth?.userId) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   const url = new URL(request.url);
   const limit = Number(url.searchParams.get("limit")) || 20;
@@ -45,6 +48,8 @@ export async function GET(request: Request): Promise<Response> {
 export async function POST(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth?.userId) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
 
   let body: unknown;
   try {

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -7,6 +7,8 @@ export type PublicApiErrorCode =
   | "malformed_api_key"
   | "invalid_api_key"
   | "invalid_idempotency_key"
+  | "insufficient_api_key_permission"
+  | "api_key_domain_restricted"
   | "idempotency_conflict"
   | "not_found"
   | "quota_exceeded"

--- a/src/lib/api-key-permissions.ts
+++ b/src/lib/api-key-permissions.ts
@@ -1,0 +1,121 @@
+import type { AuthResult } from "@/lib/api-auth";
+import { publicApiError, publicApiErrorResponse } from "@/lib/api-errors";
+import { db } from "@/lib/db";
+import { domains } from "@/lib/db/schema";
+import { and, eq } from "drizzle-orm";
+
+export const API_KEY_PERMISSIONS = {
+  fullAccess: "full_access",
+  sendingAccess: "sending_access",
+} as const;
+
+const INSUFFICIENT_PERMISSION_MESSAGE =
+  "This API key does not have permission to access this resource.";
+const DOMAIN_RESTRICTION_MESSAGE =
+  "This API key is restricted to sending from a different domain.";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isApiKeyAuthResult(
+  auth: AuthResult | { dashboard: true },
+): auth is AuthResult {
+  return "apiKeyId" in auth;
+}
+
+export function apiKeyInsufficientPermissionResponse(init?: ResponseInit) {
+  return publicApiErrorResponse(
+    "insufficient_api_key_permission",
+    INSUFFICIENT_PERMISSION_MESSAGE,
+    403,
+    init,
+  );
+}
+
+export function requireFullAccessApiKey(auth: AuthResult): Response | null {
+  return auth.permission === API_KEY_PERMISSIONS.fullAccess
+    ? null
+    : apiKeyInsufficientPermissionResponse();
+}
+
+export function requireFullAccessForApiKeyCaller(
+  auth: AuthResult | { dashboard: true },
+): Response | null {
+  return isApiKeyAuthResult(auth) ? requireFullAccessApiKey(auth) : null;
+}
+
+export function apiKeyDomainRestrictionResponse(
+  details: { restrictedDomain: string; fromDomain: string },
+  init?: ResponseInit,
+) {
+  return publicApiErrorResponse(
+    "api_key_domain_restricted",
+    DOMAIN_RESTRICTION_MESSAGE,
+    403,
+    { ...init, details },
+  );
+}
+
+export function getEmailAddressDomain(address: string): string {
+  return address.split("@").pop()?.trim().toLowerCase() ?? "";
+}
+
+export async function resolveApiKeySendingDomainRestriction(
+  auth: AuthResult,
+): Promise<string | null> {
+  const restriction = auth.domain?.trim().toLowerCase();
+  if (!restriction) return null;
+
+  if (!auth.userId) return restriction;
+
+  const found = await db.query.domains.findFirst({
+    where: UUID_RE.test(restriction)
+      ? and(eq(domains.id, restriction), eq(domains.userId, auth.userId))
+      : and(eq(domains.name, restriction), eq(domains.userId, auth.userId)),
+  });
+
+  return found?.name.toLowerCase() ?? restriction;
+}
+
+export async function requireAllowedSendingDomain(
+  auth: AuthResult,
+  from: string,
+  init?: ResponseInit,
+): Promise<Response | null> {
+  if (auth.permission !== API_KEY_PERMISSIONS.sendingAccess) return null;
+
+  const restrictedDomain = await resolveApiKeySendingDomainRestriction(auth);
+  if (!restrictedDomain) return null;
+
+  const fromDomain = getEmailAddressDomain(from);
+  if (fromDomain === restrictedDomain) return null;
+
+  return apiKeyDomainRestrictionResponse(
+    { restrictedDomain, fromDomain },
+    init,
+  );
+}
+
+export async function requireAllowedBatchSendingDomains(
+  auth: AuthResult,
+  fromAddresses: string[],
+  init?: ResponseInit,
+): Promise<Response | null> {
+  if (auth.permission !== API_KEY_PERMISSIONS.sendingAccess) return null;
+
+  const restrictedDomain = await resolveApiKeySendingDomainRestriction(auth);
+  if (!restrictedDomain) return null;
+
+  const blockedFrom = fromAddresses.find(
+    (from) => getEmailAddressDomain(from) !== restrictedDomain,
+  );
+  if (!blockedFrom) return null;
+
+  return apiKeyDomainRestrictionResponse(
+    {
+      restrictedDomain,
+      fromDomain: getEmailAddressDomain(blockedFrom),
+    },
+    init,
+  );
+}

--- a/tests/api-domains.test.ts
+++ b/tests/api-domains.test.ts
@@ -581,3 +581,31 @@ describe("Domain API validation", () => {
     );
   });
 });
+
+describe("Domain API key permission enforcement", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockValidateApiKey.mockResolvedValue({
+      apiKeyId: "sending-key",
+      permission: "sending_access",
+      domain: null,
+      userId: "user-1",
+    });
+  });
+
+  it("rejects sending-access keys from managing domains", async () => {
+    const { POST } = await import("@/app/api/domains/route");
+    const res = await POST(
+      makeRequest("http://localhost:3015/api/domains", "POST", {
+        name: "blocked.example.com",
+      }),
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      code: "insufficient_api_key_permission",
+      statusCode: 403,
+    });
+    expect(mockCreateDomain).not.toHaveBeenCalled();
+  });
+});

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -266,6 +266,11 @@ describe("POST /api/emails", () => {
         where: vi.fn().mockResolvedValue([]),
       }),
     });
+    mockDb.select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
     mockDb.transaction.mockImplementation(
       async (callback: (tx: typeof mockDb) => unknown) => callback(mockDb),
     );
@@ -1917,5 +1922,97 @@ describe("GET /api/emails/:id/events", () => {
         ]),
       }),
     });
+  });
+});
+
+describe("API key sending permissions", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockPublishBackgroundJob.mockReset();
+    mockPublishBackgroundJob.mockResolvedValue({
+      status: "skipped",
+      reason: "queue_url_missing",
+    });
+    mockReserveEmailQuota.mockResolvedValue({ ok: true, bypassed: true });
+    mockReleaseEmailQuota.mockResolvedValue(undefined);
+    mockGetApiKeyAuthHeaderError.mockReturnValue(null);
+    Object.assign(mockDb.query, {
+      emails: { findFirst: vi.fn().mockResolvedValue(null) },
+      contacts: { findFirst: vi.fn().mockResolvedValue(null) },
+      domains: {
+        findFirst: vi.fn().mockResolvedValue({ name: "example.com" }),
+      },
+    });
+    mockDb.select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+    mockDb.transaction.mockImplementation(
+      async (callback: (tx: typeof mockDb) => unknown) => callback(mockDb),
+    );
+  });
+
+  it("allows sending-access API keys to send email", async () => {
+    mockValidateApiKey.mockResolvedValue({
+      ...AUTH_RESULT,
+      permission: "sending_access",
+      domain: null,
+    });
+    const valuesMock = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: "email-sending-key" }]),
+    });
+    mockDb.insert = vi.fn().mockReturnValue({ values: valuesMock });
+
+    const { POST } = await import("@/app/api/emails/route");
+    const res = await POST(
+      makeRequest(
+        "POST",
+        {
+          from: "sender@example.com",
+          to: ["user@test.com"],
+          subject: "Allowed",
+          html: "<p>Hello</p>",
+        },
+        { Authorization: "Bearer re_sending" },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ id: "email-sending-key" });
+  });
+
+  it("rejects domain-restricted sending keys from other from domains", async () => {
+    mockValidateApiKey.mockResolvedValue({
+      ...AUTH_RESULT,
+      permission: "sending_access",
+      domain: "example.com",
+    });
+    const insertMock = vi.fn().mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    });
+    mockDb.insert = insertMock;
+
+    const { POST } = await import("@/app/api/emails/route");
+    const res = await POST(
+      makeRequest(
+        "POST",
+        {
+          from: "sender@other.com",
+          to: ["user@test.com"],
+          subject: "Blocked",
+          html: "<p>Hello</p>",
+        },
+        { Authorization: "Bearer re_sending" },
+      ),
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      code: "api_key_domain_restricted",
+      statusCode: 403,
+      details: { restrictedDomain: "example.com", fromDomain: "other.com" },
+    });
+    expect(nonLogInsertCalls()).toHaveLength(0);
   });
 });

--- a/tests/api-key-service.test.ts
+++ b/tests/api-key-service.test.ts
@@ -139,6 +139,8 @@ describe("api key service", () => {
           name: "Secondary",
           createdAt: new Date("2026-05-02T00:00:00.000Z"),
           lastUsedAt: null,
+          permission: "full_access",
+          domain: null,
         },
       ],
       hasMore: true,

--- a/tests/webhooks-api-keys-tenant-isolation.test.ts
+++ b/tests/webhooks-api-keys-tenant-isolation.test.ts
@@ -28,6 +28,8 @@ vi.mock("@/lib/api-auth", () => ({
   unauthorizedResponse: () =>
     Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
   validateApiKey: mockValidateApiKey,
+  authorizeDashboardOrApiKey: mockValidateApiKey,
+  getServerSession: vi.fn(),
 }));
 
 vi.mock("@/lib/billing/quota", () => ({
@@ -237,5 +239,49 @@ describe("API key API tenant isolation", () => {
 
     expect(response.status).toBe(401);
     expect(mockListApiKeys).not.toHaveBeenCalled();
+  });
+});
+
+describe("API key permission enforcement", () => {
+  beforeEach(() => {
+    mockValidateApiKey.mockResolvedValue({
+      apiKeyId: "sending-key",
+      permission: "sending_access",
+      domain: null,
+      userId: "user-b",
+    });
+  });
+
+  it("rejects sending-access keys from listing API keys", async () => {
+    const route = await import("@/app/api/api-keys/route");
+    const response = await route.GET(request("http://localhost/api/api-keys"));
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "insufficient_api_key_permission",
+      statusCode: 403,
+    });
+    expect(mockListApiKeys).not.toHaveBeenCalled();
+  });
+
+  it("rejects sending-access keys from creating webhooks", async () => {
+    const route = await import("@/app/api/webhooks/route");
+    const response = await route.POST(
+      request("http://localhost/api/webhooks", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          endpoint: "https://example.com/b",
+          events: ["email.delivered"],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "insufficient_api_key_permission",
+      statusCode: 403,
+    });
+    expect(mockCreateWebhook).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Issue
- Closes #247
- Issue link: https://github.com/namuh-eng/opensend/issues/247

## Changed files / scope
- Added `src/lib/api-key-permissions.ts` to centralize API-key full-access checks, stable 403 envelopes, and sending-domain restriction checks.
- Applied full-access enforcement to non-send API routes that accept API keys, while preserving dashboard/session access on dashboard-capable routes.
- Kept `POST /api/emails` and `POST /api/emails/batch` open to both `full_access` and `sending_access`, with domain-restricted sending keys rejected before suppression/quota/queue work.
- Exposed `permission` and `domain` in API-key list/detail API responses via `packages/core/src/services/apiKeys.ts` and API-key routes.
- Added regression coverage for sending-key send behavior, non-send resource rejection, full-key resource access preservation, and domain-restricted send rejection.
- Added a learning note documenting the route-boundary helper pattern.

## Validation
- `bunx vitest run tests/api-emails.test.ts tests/webhooks-api-keys-tenant-isolation.test.ts tests/api-domains.test.ts tests/api-key-service.test.ts` — passed (70 tests).
- `make check` — passed.
- `make test` — passed (97 files, 828 tests).
- `git diff --check` — passed.
- Push guardrails: changed-file script, full-project typecheck, and changed-file Biome lint — passed.

## Playwright justification
- Not run / not added: this change is API/auth enforcement only and does not alter dashboard UI or browser auth flows. Existing dashboard API-key UI already surfaces permission/domain fields; this PR updates API responses and server enforcement, covered by Vitest route/service tests.

## Risk
- Moderate: broad non-send API-key enforcement can affect integrations that were incorrectly using `sending_access` keys for resource management. This is the intended parity behavior and returns a stable 403 JSON error.
