### PR TITLE
Fix Resend-compatible attachment delivery

### DIFF
--- a/agent_docs/learnings/active/2026-05-07-issue-250-queue-provider-boundary.md
+++ b/agent_docs/learnings/active/2026-05-07-issue-250-queue-provider-boundary.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-07
+issue: "#250"
+type: pattern
+promoted_to: null
+---
+
+## Queued email delivery uses the core provider, not the app SES helper
+
+OpenSend's public send routes persist email rows and enqueue `email.send`; the ingester worker then calls `emailProvider` from `@opensend/core`. Attachment MIME changes that only touch `src/lib/ses.ts` cover app-domain SES helpers and tests, but queued production delivery also needs matching support in `packages/core/src/services/emailProvider.ts` plus worker-side normalization/resolution in `packages/ingester/src/queue-worker.ts`.
+
+When changing send-provider behavior, verify both the app helper and the core provider/worker path so accepted API payloads are actually delivered after queueing.

--- a/packages/core/src/services/emailProvider.ts
+++ b/packages/core/src/services/emailProvider.ts
@@ -6,6 +6,15 @@ import {
   SendEmailCommand,
 } from "@aws-sdk/client-sesv2";
 
+type EmailAttachment = {
+  filename: string;
+  content: string;
+  contentType?: string;
+  contentId?: string;
+  content_type?: string;
+  content_id?: string;
+};
+
 export class EmailProviderService {
   private client: SESv2Client | null = null;
 
@@ -27,26 +36,41 @@ export class EmailProviderService {
     bcc?: string[];
     replyTo?: string[];
     headers?: Record<string, string>;
-    attachments?: Array<{ filename: string; content: string }>;
+    attachments?: EmailAttachment[];
   }) {
-    const command = new SendEmailCommand({
-      FromEmailAddress: params.from,
-      Destination: {
-        ToAddresses: params.to,
-        CcAddresses: params.cc,
-        BccAddresses: params.bcc,
-      },
-      Content: {
-        Simple: {
-          Subject: { Data: params.subject },
-          Body: {
-            Html: params.html ? { Data: params.html } : undefined,
-            Text: params.text ? { Data: params.text } : undefined,
-          },
-        },
-      },
-      ReplyToAddresses: params.replyTo,
-    });
+    const command =
+      params.attachments && params.attachments.length > 0
+        ? new SendEmailCommand({
+            FromEmailAddress: params.from,
+            Destination: {
+              ToAddresses: params.to,
+              CcAddresses: params.cc,
+              BccAddresses: params.bcc,
+            },
+            Content: {
+              Raw: {
+                Data: new TextEncoder().encode(buildMimeMessage(params)),
+              },
+            },
+          })
+        : new SendEmailCommand({
+            FromEmailAddress: params.from,
+            Destination: {
+              ToAddresses: params.to,
+              CcAddresses: params.cc,
+              BccAddresses: params.bcc,
+            },
+            Content: {
+              Simple: {
+                Subject: { Data: params.subject },
+                Body: {
+                  Html: params.html ? { Data: params.html } : undefined,
+                  Text: params.text ? { Data: params.text } : undefined,
+                },
+              },
+            },
+            ReplyToAddresses: params.replyTo,
+          });
 
     if (!process.env.AWS_ACCESS_KEY_ID) {
       console.log(
@@ -89,3 +113,107 @@ export class EmailProviderService {
 }
 
 export const emailProvider = new EmailProviderService();
+
+function buildMimeMessage(params: {
+  from: string;
+  to: string[];
+  subject: string;
+  html?: string;
+  text?: string;
+  cc?: string[];
+  bcc?: string[];
+  replyTo?: string[];
+  headers?: Record<string, string>;
+  attachments?: EmailAttachment[];
+}): string {
+  const boundary = `----=_Part_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+  const lines: string[] = [];
+
+  lines.push(`From: ${params.from}`);
+  lines.push(`To: ${params.to.join(", ")}`);
+  if (params.cc?.length) lines.push(`Cc: ${params.cc.join(", ")}`);
+  if (params.bcc?.length) lines.push(`Bcc: ${params.bcc.join(", ")}`);
+  lines.push(`Subject: ${params.subject}`);
+  if (params.replyTo?.length)
+    lines.push(`Reply-To: ${params.replyTo.join(", ")}`);
+  if (params.headers) {
+    for (const [key, value] of Object.entries(params.headers)) {
+      lines.push(`${key}: ${value}`);
+    }
+  }
+  lines.push("MIME-Version: 1.0");
+  lines.push(`Content-Type: multipart/mixed; boundary="${boundary}"`);
+  lines.push("");
+
+  lines.push(`--${boundary}`);
+  if (params.html) {
+    lines.push("Content-Type: text/html; charset=UTF-8");
+    lines.push("Content-Transfer-Encoding: 7bit");
+    lines.push("");
+    lines.push(params.html);
+  } else if (params.text) {
+    lines.push("Content-Type: text/plain; charset=UTF-8");
+    lines.push("Content-Transfer-Encoding: 7bit");
+    lines.push("");
+    lines.push(params.text);
+  }
+
+  for (const attachment of params.attachments ?? []) {
+    const contentType =
+      attachment.contentType ??
+      attachment.content_type ??
+      inferContentType(attachment.filename);
+    const contentId = attachment.contentId ?? attachment.content_id;
+
+    lines.push(`--${boundary}`);
+    lines.push(`Content-Type: ${contentType}; name="${attachment.filename}"`);
+    lines.push("Content-Transfer-Encoding: base64");
+    if (contentId) {
+      lines.push(`Content-ID: ${formatContentId(contentId)}`);
+    }
+    lines.push(
+      `Content-Disposition: ${contentId ? "inline" : "attachment"}; filename="${attachment.filename}"`,
+    );
+    lines.push("");
+    lines.push(attachment.content);
+  }
+
+  lines.push(`--${boundary}--`);
+  return lines.join("\r\n");
+}
+
+function inferContentType(filename: string): string {
+  const extension = filename.toLowerCase().split(".").pop();
+  switch (extension) {
+    case "txt":
+      return "text/plain";
+    case "html":
+    case "htm":
+      return "text/html";
+    case "json":
+      return "application/json";
+    case "csv":
+      return "text/csv";
+    case "pdf":
+      return "application/pdf";
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "png":
+      return "image/png";
+    case "gif":
+      return "image/gif";
+    case "svg":
+      return "image/svg+xml";
+    case "webp":
+      return "image/webp";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+function formatContentId(contentId: string): string {
+  const trimmed = contentId.trim();
+  if (trimmed.startsWith("<") && trimmed.endsWith(">")) return trimmed;
+  return `<${trimmed}>`;
+}

--- a/packages/ingester/src/queue-worker.ts
+++ b/packages/ingester/src/queue-worker.ts
@@ -30,6 +30,11 @@ const DEFAULT_VISIBILITY_TIMEOUT_SECONDS = 60;
 const DEFAULT_IDLE_SLEEP_MS = 1_000;
 const MAX_SQS_DELAY_SECONDS = 900;
 const DEFAULT_PROVIDER_MAX_ATTEMPTS = 3;
+const MAX_EMAIL_ATTACHMENT_BASE64_BYTES = 40 * 1024 * 1024;
+const MAX_EMAIL_ATTACHMENT_RAW_BYTES = Math.floor(
+  (MAX_EMAIL_ATTACHMENT_BASE64_BYTES / 4) * 3,
+);
+const ATTACHMENT_FETCH_TIMEOUT_MS = 10_000;
 
 type QueueWorkerOptions = {
   queueUrl?: string | null;
@@ -54,6 +59,16 @@ type ProviderErrorSummary = {
 type StoredAttachment = {
   filename?: unknown;
   content?: unknown;
+  path?: unknown;
+  content_type?: unknown;
+  content_id?: unknown;
+};
+
+type ProviderAttachment = {
+  filename: string;
+  content: string;
+  content_type?: string;
+  content_id?: string;
 };
 
 type PollResult = {
@@ -402,7 +417,7 @@ export class QueueWorker {
         bcc: email.bcc ?? undefined,
         replyTo: email.replyTo ?? undefined,
         headers: email.headers ?? undefined,
-        attachments: normalizeAttachmentsForSend(email.attachments),
+        attachments: await normalizeAttachmentsForSend(email.attachments),
       });
       const sendDurationMs = finishTelemetrySpan(sesSpan, { status: "ok" });
 
@@ -551,22 +566,125 @@ function getReceiveCount(
   return Math.floor(receiveCount);
 }
 
-function normalizeAttachmentsForSend(
+async function normalizeAttachmentsForSend(
   attachments: StoredAttachment[] | null | undefined,
-): Array<{ filename: string; content: string }> | undefined {
+): Promise<ProviderAttachment[] | undefined> {
   if (!attachments) return undefined;
 
-  const sendable = attachments.flatMap((attachment) => {
-    if (
-      typeof attachment.filename === "string" &&
-      typeof attachment.content === "string"
-    ) {
-      return [{ filename: attachment.filename, content: attachment.content }];
+  const sendable: ProviderAttachment[] = [];
+  let totalEncodedBytes = 0;
+
+  for (const attachment of attachments) {
+    if (typeof attachment.filename !== "string") continue;
+
+    const contentType =
+      typeof attachment.content_type === "string"
+        ? attachment.content_type
+        : undefined;
+    const contentId =
+      typeof attachment.content_id === "string"
+        ? attachment.content_id
+        : undefined;
+    const metadata = {
+      filename: attachment.filename,
+      ...(contentType ? { content_type: contentType } : {}),
+      ...(contentId ? { content_id: contentId } : {}),
+    };
+
+    if (typeof attachment.content === "string") {
+      totalEncodedBytes += attachment.content.replace(/\s/g, "").length;
+      assertAttachmentSize(totalEncodedBytes);
+      sendable.push({ ...metadata, content: attachment.content });
+      continue;
     }
-    return [];
-  });
+
+    if (typeof attachment.path === "string") {
+      const content = await fetchAttachmentContent(attachment.path);
+      totalEncodedBytes += getBase64EncodedSize(content.byteLength);
+      assertAttachmentSize(totalEncodedBytes);
+      sendable.push({
+        ...metadata,
+        content: Buffer.from(content).toString("base64"),
+      });
+    }
+  }
 
   return sendable.length > 0 ? sendable : undefined;
+}
+
+async function fetchAttachmentContent(path: string): Promise<Uint8Array> {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    ATTACHMENT_FETCH_TIMEOUT_MS,
+  );
+
+  try {
+    const response = await fetch(path, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(
+        `Attachment fetch failed for ${path}: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const contentLength = response.headers.get("content-length");
+    if (
+      contentLength &&
+      Number.isFinite(Number(contentLength)) &&
+      Number(contentLength) > MAX_EMAIL_ATTACHMENT_RAW_BYTES
+    ) {
+      throw new Error(
+        "Attachments exceed 40MB per email after Base64 encoding",
+      );
+    }
+
+    if (!response.body) {
+      const buffer = new Uint8Array(await response.arrayBuffer());
+      if (buffer.byteLength > MAX_EMAIL_ATTACHMENT_RAW_BYTES) {
+        throw new Error(
+          "Attachments exceed 40MB per email after Base64 encoding",
+        );
+      }
+      return buffer;
+    }
+
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+
+    while (true) {
+      const result = await reader.read();
+      if (result.done) break;
+
+      totalBytes += result.value.byteLength;
+      if (totalBytes > MAX_EMAIL_ATTACHMENT_RAW_BYTES) {
+        throw new Error(
+          "Attachments exceed 40MB per email after Base64 encoding",
+        );
+      }
+      chunks.push(result.value);
+    }
+
+    const content = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      content.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return content;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function getBase64EncodedSize(byteLength: number): number {
+  return Math.ceil(byteLength / 3) * 4;
+}
+
+function assertAttachmentSize(encodedBytes: number): void {
+  if (encodedBytes > MAX_EMAIL_ATTACHMENT_BASE64_BYTES) {
+    throw new Error("Attachments exceed 40MB per email after Base64 encoding");
+  }
 }
 
 function getRetryDelaySeconds(

--- a/src/lib/email-attachments.ts
+++ b/src/lib/email-attachments.ts
@@ -15,13 +15,25 @@ export type StoredEmailAttachment = {
 
 export function normalizeAttachmentsForSend(
   attachments: SendEmailRequest["attachments"],
-): Array<{ filename: string; content: string }> | undefined {
+):
+  | Array<{
+      filename: string;
+      content: string;
+      content_type?: string;
+      content_id?: string;
+    }>
+  | undefined {
   const sendableAttachments = attachments
     ?.filter(
       (attachment): attachment is RequestAttachment & { content: string } =>
         typeof attachment.content === "string",
     )
-    .map(({ filename, content }) => ({ filename, content }));
+    .map(({ filename, content, content_type, content_id }) => ({
+      filename,
+      content,
+      content_type,
+      content_id,
+    }));
 
   return sendableAttachments && sendableAttachments.length > 0
     ? sendableAttachments

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -416,12 +416,26 @@ export const openApiDocument = {
       },
       EmailAttachment: {
         type: "object",
+        description:
+          "Resend-compatible attachment. Provide content or an http(s) path. Total attachments are limited to 40MB per email after Base64 encoding.",
         properties: {
           filename: { type: "string" },
           content: { type: "string", description: "Base64-encoded content." },
-          path: { type: "string", format: "uri" },
-          content_type: { type: "string" },
-          content_id: { type: "string" },
+          path: {
+            type: "string",
+            format: "uri",
+            description: "HTTP(S) URL where the attachment file is hosted.",
+          },
+          content_type: {
+            type: "string",
+            description:
+              "MIME content type to emit for the attachment. Falls back to filename-derived/default type.",
+          },
+          content_id: {
+            type: "string",
+            description:
+              "Content-ID for inline CID references such as cid:logo.",
+          },
         },
         required: ["filename"],
       },
@@ -464,6 +478,8 @@ export const openApiDocument = {
           headers: { type: "object", additionalProperties: { type: "string" } },
           attachments: {
             type: "array",
+            description:
+              "Maximum total size is 40MB per email after Base64 encoding.",
             items: { $ref: "#/components/schemas/EmailAttachment" },
           },
           tags: {

--- a/src/lib/ses.ts
+++ b/src/lib/ses.ts
@@ -38,7 +38,14 @@ export interface SendEmailInput {
   text?: string;
   replyTo?: string[];
   headers?: Record<string, string>;
-  attachments?: Array<{ filename: string; content: string }>;
+  attachments?: Array<{
+    filename: string;
+    content: string;
+    contentType?: string;
+    contentId?: string;
+    content_type?: string;
+    content_id?: string;
+  }>;
 }
 
 export interface SendEmailResult {
@@ -241,13 +248,19 @@ function buildMimeMessage(input: SendEmailInput): string {
 
   // Attachments
   for (const attachment of input.attachments ?? []) {
+    const contentType =
+      attachment.contentType ??
+      attachment.content_type ??
+      inferContentType(attachment.filename);
+    const contentId = attachment.contentId ?? attachment.content_id;
     lines.push(`--${boundary}`);
-    lines.push(
-      `Content-Type: application/octet-stream; name="${attachment.filename}"`,
-    );
+    lines.push(`Content-Type: ${contentType}; name="${attachment.filename}"`);
     lines.push("Content-Transfer-Encoding: base64");
+    if (contentId) {
+      lines.push(`Content-ID: ${formatContentId(contentId)}`);
+    }
     lines.push(
-      `Content-Disposition: attachment; filename="${attachment.filename}"`,
+      `Content-Disposition: ${contentId ? "inline" : "attachment"}; filename="${attachment.filename}"`,
     );
     lines.push("");
     lines.push(attachment.content);
@@ -255,4 +268,40 @@ function buildMimeMessage(input: SendEmailInput): string {
 
   lines.push(`--${boundary}--`);
   return lines.join("\r\n");
+}
+
+function inferContentType(filename: string): string {
+  const extension = filename.toLowerCase().split(".").pop();
+  switch (extension) {
+    case "txt":
+      return "text/plain";
+    case "html":
+    case "htm":
+      return "text/html";
+    case "json":
+      return "application/json";
+    case "csv":
+      return "text/csv";
+    case "pdf":
+      return "application/pdf";
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "png":
+      return "image/png";
+    case "gif":
+      return "image/gif";
+    case "svg":
+      return "image/svg+xml";
+    case "webp":
+      return "image/webp";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+function formatContentId(contentId: string): string {
+  const trimmed = contentId.trim();
+  if (trimmed.startsWith("<") && trimmed.endsWith(">")) return trimmed;
+  return `<${trimmed}>`;
 }

--- a/src/lib/validation/emails.ts
+++ b/src/lib/validation/emails.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 
 // ── Common Fragments ──────────────────────────────────────────────
 
+export const MAX_EMAIL_ATTACHMENT_BASE64_BYTES = 40 * 1024 * 1024;
+
 export const emailAddressSchema = z.string().email().min(3).max(512);
 
 export const emailRecipientSchema = z.union([
@@ -27,13 +29,68 @@ export const tagSchema = z.object({
     .regex(EMAIL_TAG_PATTERN, EMAIL_TAG_PATTERN_MESSAGE),
 });
 
-export const attachmentSchema = z.object({
-  filename: z.string().min(1).max(255),
-  content: z.string().optional(),
-  path: z.string().url().optional(),
-  content_type: z.string().optional(),
-  content_id: z.string().optional(),
-});
+function hasAllowedAttachmentUrlScheme(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function getBase64EncodedSize(byteLength: number): number {
+  return Math.ceil(byteLength / 3) * 4;
+}
+
+function getInlineAttachmentEncodedSize(content: string): number {
+  const normalized = content.replace(/\s/g, "");
+  return normalized.length;
+}
+
+function getTotalInlineAttachmentEncodedSize(
+  attachments: Array<{ content?: string }> | undefined,
+): number {
+  return (
+    attachments?.reduce(
+      (total, attachment) =>
+        total +
+        (typeof attachment.content === "string"
+          ? getInlineAttachmentEncodedSize(attachment.content)
+          : 0),
+      0,
+    ) ?? 0
+  );
+}
+
+export function getAttachmentBase64EncodedSize(byteLength: number): number {
+  return getBase64EncodedSize(byteLength);
+}
+
+export const attachmentSchema = z
+  .object({
+    filename: z.string().min(1).max(255),
+    content: z.string().optional(),
+    path: z.string().url().optional(),
+    content_type: z.string().min(1).optional(),
+    content_id: z.string().min(1).optional(),
+  })
+  .superRefine((attachment, ctx) => {
+    if (!attachment.content && !attachment.path) {
+      ctx.addIssue({
+        code: "custom",
+        message: "attachment requires content or path",
+        path: ["content"],
+      });
+    }
+
+    if (attachment.path && !hasAllowedAttachmentUrlScheme(attachment.path)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "attachment path must use http or https",
+        path: ["path"],
+      });
+    }
+  });
 
 // ── Scheduled send parsing ────────────────────────────────────────
 
@@ -147,7 +204,17 @@ export const sendEmailSchema = z
   .refine((data) => data.html || data.text || data.template, {
     message: "html, text, or template is required",
     path: ["html"],
-  });
+  })
+  .refine(
+    (data) =>
+      getTotalInlineAttachmentEncodedSize(data.attachments) <=
+      MAX_EMAIL_ATTACHMENT_BASE64_BYTES,
+    {
+      message:
+        "attachments must be no more than 40MB per email after Base64 encoding",
+      path: ["attachments"],
+    },
+  );
 
 export const batchSendEmailSchema = z.array(sendEmailSchema).max(100);
 

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -843,7 +843,12 @@ describe("POST /api/emails", () => {
         html: "<p>Hi</p>",
         attachments: [
           { filename: "inline.txt", content: "aGVsbG8=" },
-          { filename: "remote.txt", path: "https://example.com/file.txt" },
+          {
+            filename: "remote.png",
+            path: "https://example.com/file.png",
+            content_type: "image/png",
+            content_id: "hero",
+          },
         ],
       },
       { Authorization: "Bearer re_test123" },
@@ -864,12 +869,81 @@ describe("POST /api/emails", () => {
           }),
           expect.objectContaining({
             id: expect.any(String),
-            filename: "remote.txt",
-            path: "https://example.com/file.txt",
+            filename: "remote.png",
+            path: "https://example.com/file.png",
+            content_type: "image/png",
+            content_id: "hero",
           }),
         ],
       }),
     );
+  });
+
+  it("rejects attachments without content or path before quota, persistence, or queueing", async () => {
+    const { POST } = await import("@/app/api/emails/route");
+    const res = await POST(
+      makeRequest(
+        "POST",
+        {
+          from: "sender@domain.com",
+          to: ["single@test.com"],
+          subject: "Test",
+          html: "<p>Hi</p>",
+          attachments: [{ filename: "missing.txt" }],
+        },
+        { Authorization: "Bearer re_test123" },
+      ),
+    );
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "validation_error",
+      details: {
+        fieldErrors: {
+          "attachments.0.content": ["attachment requires content or path"],
+        },
+      },
+    });
+    expect(mockReserveEmailQuota).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
+  });
+
+  it("rejects inline attachments above 40MB encoded before queueing", async () => {
+    const { POST } = await import("@/app/api/emails/route");
+    const res = await POST(
+      makeRequest(
+        "POST",
+        {
+          from: "sender@domain.com",
+          to: ["single@test.com"],
+          subject: "Test",
+          html: "<p>Hi</p>",
+          attachments: [
+            {
+              filename: "large.txt",
+              content: "a".repeat(40 * 1024 * 1024 + 1),
+            },
+          ],
+        },
+        { Authorization: "Bearer re_test123" },
+      ),
+    );
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "validation_error",
+      details: {
+        fieldErrors: {
+          attachments: [
+            "attachments must be no more than 40MB per email after Base64 encoding",
+          ],
+        },
+      },
+    });
+    expect(mockReserveEmailQuota).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
   });
   it("normalizes future ISO and natural-language scheduled_at values without queueing", async () => {
     vi.useFakeTimers();
@@ -1102,6 +1176,14 @@ describe("POST /api/emails/batch", () => {
         to: ["user1@test.com"],
         subject: "Test 1",
         html: "<p>1</p>",
+        attachments: [
+          {
+            filename: "batch-remote.png",
+            path: "https://example.com/batch-remote.png",
+            content_type: "image/png",
+            content_id: "batch-remote",
+          },
+        ],
       },
       {
         from: "sender@domain.com",

--- a/tests/core-email-provider.test.ts
+++ b/tests/core-email-provider.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSend } = vi.hoisted(() => ({
+  mockSend: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-sesv2", () => ({
+  SESv2Client: vi.fn().mockImplementation(() => ({
+    send: mockSend,
+  })),
+  SendEmailCommand: vi.fn().mockImplementation((input) => ({
+    ...input,
+    _type: "SendEmailCommand",
+  })),
+  CreateEmailIdentityCommand: vi.fn().mockImplementation((input) => ({
+    ...input,
+    _type: "CreateEmailIdentityCommand",
+  })),
+  GetEmailIdentityCommand: vi.fn().mockImplementation((input) => ({
+    ...input,
+    _type: "GetEmailIdentityCommand",
+  })),
+  DeleteEmailIdentityCommand: vi.fn().mockImplementation((input) => ({
+    ...input,
+    _type: "DeleteEmailIdentityCommand",
+  })),
+}));
+
+describe("EmailProviderService", () => {
+  const previousAccessKey = process.env.AWS_ACCESS_KEY_ID;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockSend.mockReset();
+    process.env.AWS_ACCESS_KEY_ID = "test-key";
+  });
+
+  afterEach(() => {
+    if (previousAccessKey === undefined) {
+      process.env.AWS_ACCESS_KEY_ID = undefined;
+    } else {
+      process.env.AWS_ACCESS_KEY_ID = previousAccessKey;
+    }
+  });
+
+  it("uses raw MIME for attachments with content type and Content-ID", async () => {
+    mockSend.mockResolvedValueOnce({ MessageId: "ses-core-cid" });
+    const { EmailProviderService } = await import(
+      "../packages/core/src/services/emailProvider"
+    );
+    const provider = new EmailProviderService();
+
+    await expect(
+      provider.sendEmail({
+        from: "hello@example.com",
+        to: ["user@example.com"],
+        subject: "CID",
+        html: '<img src="cid:logo" />',
+        attachments: [
+          {
+            filename: "logo.bin",
+            content: "aW1hZ2U=",
+            content_type: "image/png",
+            content_id: "logo",
+          },
+        ],
+      }),
+    ).resolves.toEqual({ id: "ses-core-cid" });
+
+    const command = mockSend.mock.calls[0]?.[0] as {
+      Content?: { Raw?: { Data?: Uint8Array }; Simple?: unknown };
+    };
+    expect(command.Content?.Simple).toBeUndefined();
+    const raw = new TextDecoder().decode(command.Content?.Raw?.Data);
+    expect(raw).toContain('Content-Type: image/png; name="logo.bin"');
+    expect(raw).toContain("Content-ID: <logo>");
+    expect(raw).toContain('Content-Disposition: inline; filename="logo.bin"');
+    expect(raw).toContain("aW1hZ2U=");
+  });
+});

--- a/tests/queue-worker.test.ts
+++ b/tests/queue-worker.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFindById = vi.hoisted(() => vi.fn());
 const mockFindDueScheduled = vi.hoisted(() => vi.fn());
@@ -81,6 +81,10 @@ describe("QueueWorker", () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("sends queued email jobs through the worker and marks status transitions", async () => {
     mockFindById.mockResolvedValue({
       id: "email-1",
@@ -127,6 +131,138 @@ describe("QueueWorker", () => {
       status: "sent",
       sentAt: expect.any(Date),
       providerNextRetryAt: null,
+      providerDeadLetteredAt: null,
+    });
+  });
+
+  it("resolves URL path attachments and preserves content_type and content_id", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("remote file", {
+          status: 200,
+          headers: { "content-length": "11" },
+        }),
+      ),
+    );
+    mockFindById.mockResolvedValue({
+      id: "email-path",
+      from: "sender@example.com",
+      to: ["user@example.com"],
+      cc: [],
+      bcc: [],
+      replyTo: [],
+      subject: "Hello",
+      html: '<img src="cid:remote-logo" />',
+      text: "",
+      headers: {},
+      attachments: [
+        {
+          filename: "remote-logo.png",
+          path: "https://cdn.example.com/remote-logo.png",
+          content_type: "image/png",
+          content_id: "remote-logo",
+        },
+      ],
+      status: "queued",
+      scheduledAt: null,
+    });
+
+    const { QueueWorker } = await import(
+      "../packages/ingester/src/queue-worker"
+    );
+    const worker = new QueueWorker({ queueUrl: null });
+
+    await expect(
+      worker.processJob({
+        id: "email.send:email-path",
+        type: "email.send",
+        source: "api",
+        requestedAt: "2026-04-28T00:00:00.000Z",
+        emailId: "email-path",
+      }),
+    ).resolves.toEqual({ status: "sent" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://cdn.example.com/remote-logo.png",
+      {
+        signal: expect.any(AbortSignal),
+      },
+    );
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [
+          {
+            filename: "remote-logo.png",
+            content: "cmVtb3RlIGZpbGU=",
+            content_type: "image/png",
+            content_id: "remote-logo",
+          },
+        ],
+      }),
+    );
+  });
+
+  it("fails queued delivery explicitly when fetched attachments exceed 40MB encoded", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("", {
+          status: 200,
+          headers: { "content-length": String(30 * 1024 * 1024 + 1) },
+        }),
+      ),
+    );
+    mockFindById.mockResolvedValue({
+      id: "email-large-path",
+      from: "sender@example.com",
+      to: ["user@example.com"],
+      cc: [],
+      bcc: [],
+      replyTo: [],
+      subject: "Hello",
+      html: "<p>Hello</p>",
+      text: "",
+      headers: {},
+      attachments: [
+        {
+          filename: "huge.bin",
+          path: "https://cdn.example.com/huge.bin",
+        },
+      ],
+      status: "queued",
+      scheduledAt: null,
+      userId: "user-1",
+    });
+
+    const { QueueWorker } = await import(
+      "../packages/ingester/src/queue-worker"
+    );
+    const worker = new QueueWorker({ queueUrl: null });
+
+    await expect(
+      worker.processJob(
+        {
+          id: "email.send:email-large-path",
+          type: "email.send",
+          source: "api",
+          requestedAt: "2026-04-28T00:00:00.000Z",
+          emailId: "email-large-path",
+        },
+        undefined,
+        { receiveCount: 1, retryDelaySeconds: null },
+      ),
+    ).rejects.toThrow("Attachments exceed 40MB");
+
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(mockUpdateEmail).toHaveBeenNthCalledWith(2, "email-large-path", {
+      status: "queued",
+      providerRetryCount: 1,
+      providerLastAttemptedAt: expect.any(Date),
+      providerNextRetryAt: null,
+      providerLastErrorCode: "Error",
+      providerLastErrorMessage:
+        "Attachments exceed 40MB per email after Base64 encoding",
       providerDeadLetteredAt: null,
     });
   });

--- a/tests/ses.test.ts
+++ b/tests/ses.test.ts
@@ -201,6 +201,47 @@ describe("SES Client", () => {
 
       expect(result).toEqual({ id: "ses-msg-attach" });
       expect(mockSend).toHaveBeenCalledOnce();
+      const command = mockSend.mock.calls[0]?.[0] as {
+        Content?: { Raw?: { Data?: Uint8Array } };
+      };
+      const raw = new TextDecoder().decode(command.Content?.Raw?.Data);
+      expect(raw).toContain('Content-Type: text/plain; name="test.txt"');
+      expect(raw).toContain(
+        'Content-Disposition: attachment; filename="test.txt"',
+      );
+      expect(raw).toContain("SGVsbG8gV29ybGQ=");
+    });
+
+    it("emits content_type and Content-ID headers for CID attachments", async () => {
+      mockSend.mockResolvedValueOnce({
+        MessageId: "ses-msg-cid",
+      });
+
+      const input: SendEmailInput = {
+        from: "hello@acme.com",
+        to: ["user@example.com"],
+        subject: "Inline image",
+        html: '<img src="cid:logo" />',
+        attachments: [
+          {
+            filename: "logo.bin",
+            content: "aW1hZ2U=",
+            content_type: "image/png",
+            content_id: "logo",
+          },
+        ],
+      };
+
+      const result = await sendEmail(input);
+
+      expect(result).toEqual({ id: "ses-msg-cid" });
+      const command = mockSend.mock.calls[0]?.[0] as {
+        Content?: { Raw?: { Data?: Uint8Array } };
+      };
+      const raw = new TextDecoder().decode(command.Content?.Raw?.Data);
+      expect(raw).toContain('Content-Type: image/png; name="logo.bin"');
+      expect(raw).toContain("Content-ID: <logo>");
+      expect(raw).toContain('Content-Disposition: inline; filename="logo.bin"');
     });
   });
 


### PR DESCRIPTION
## Summary
- Closes #250.
- Preserve Resend-compatible attachment metadata through queued delivery: `path`, `content_type`, and `content_id` now survive worker/provider handoff.
- Resolve HTTP(S) `path` attachments in the queue worker before provider send, convert them to Base64, and fail explicitly on fetch/size errors instead of silently omitting them.
- Emit MIME `Content-Type` and `Content-ID` headers for attachments, including queued production delivery through `@opensend/core`'s provider.
- Enforce the 40MB-per-email-after-Base64 cap for inline attachments at API validation and hosted attachments during worker resolution.

## Validation
- `make check`
- `make test`
- `bun run test tests/api-emails.test.ts tests/queue-worker.test.ts tests/ses.test.ts tests/core-email-provider.test.ts tests/openapi-route.test.ts`
- `git diff --check`

## Notes
- Playwright skipped: no dashboard/UI/browser flows changed.
- Non-goals preserved: no upload product surface, storage-provider change, virus/DLP scanning, pricing, quota, or dashboard changes.
