### PR TITLE
[parity] Expose root contacts API and SDK CRUD

### DIFF
--- a/packages/core/src/dto/index.ts
+++ b/packages/core/src/dto/index.ts
@@ -236,6 +236,14 @@ export interface CreateContactResponse {
   id: string;
 }
 
+export type UpdateContactPayload = Partial<CreateContactPayload>;
+
+export interface DeleteContactResponse {
+  object: "contact";
+  id: string;
+  deleted: true;
+}
+
 export interface ContactTopicPreference {
   id: string;
   subscription: "opt_in" | "opt_out";
@@ -257,6 +265,9 @@ export interface ContactResponse {
 export interface ContactListItem {
   id: string;
   email: string;
+  first_name: string | null;
+  last_name: string | null;
+  unsubscribed: boolean;
   firstName: string | null;
   lastName: string | null;
   status: "subscribed" | "unsubscribed";

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -201,6 +201,12 @@ const { data } = await resend.contacts.list();
 
 // Get a contact
 await resend.contacts.get("contact-id");
+
+// Update a contact by id or email
+await resend.contacts.update("user@example.com", { unsubscribed: true });
+
+// Delete a contact by id or email
+await resend.contacts.delete("user@example.com");
 ```
 
 ## TypeScript

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -13,6 +13,7 @@ import type {
   CreateApiKeyPayload,
   CreateContactPayload,
   CreateContactResponse,
+  DeleteContactResponse,
   DomainCapability,
   DomainListItem,
   DomainListResponse,
@@ -30,6 +31,7 @@ import type {
   EmailTag,
   EmailTemplateReference,
   SendEmailResponse,
+  UpdateContactPayload,
   UpdateDomainPayload,
 } from "../../core/src/dto";
 
@@ -373,17 +375,35 @@ class Contacts {
   ): Promise<ApiResponse<CreateContactResponse>> {
     return this.http.request<CreateContactResponse>(
       "POST",
-      "/api/contacts",
+      "/contacts",
       payload,
     );
   }
 
   async list(): Promise<ApiResponse<ContactListResponse>> {
-    return this.http.request<ContactListResponse>("GET", "/api/contacts");
+    return this.http.request<ContactListResponse>("GET", "/contacts");
   }
 
   async get(id: string): Promise<ApiResponse<ContactResponse>> {
-    return this.http.request<ContactResponse>("GET", `/api/contacts/${id}`);
+    return this.http.request<ContactResponse>("GET", `/contacts/${id}`);
+  }
+
+  async update(
+    id: string,
+    payload: UpdateContactPayload,
+  ): Promise<ApiResponse<ContactResponse>> {
+    return this.http.request<ContactResponse>(
+      "PATCH",
+      `/contacts/${id}`,
+      payload,
+    );
+  }
+
+  async delete(id: string): Promise<ApiResponse<DeleteContactResponse>> {
+    return this.http.request<DeleteContactResponse>(
+      "DELETE",
+      `/contacts/${id}`,
+    );
   }
 }
 
@@ -536,6 +556,8 @@ export type {
   ApiKeyListResponse,
   CreateContactPayload,
   CreateContactResponse,
+  UpdateContactPayload,
+  DeleteContactResponse,
   ContactResponse,
   ContactTopicPreference,
   ContactListItem,

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -243,6 +243,9 @@ export async function GET(request: Request) {
     const data = dataRows.map((c) => ({
       id: c.id,
       email: c.email,
+      first_name: c.firstName,
+      last_name: c.lastName,
+      unsubscribed: c.unsubscribed,
       firstName: c.firstName,
       lastName: c.lastName,
       status: c.unsubscribed ? "unsubscribed" : "subscribed",

--- a/src/app/contacts/[contact_id]/route.ts
+++ b/src/app/contacts/[contact_id]/route.ts
@@ -1,0 +1,35 @@
+import {
+  DELETE as deleteContact,
+  GET as getContact,
+  PATCH as patchContact,
+} from "@/app/api/contacts/[id]/route";
+
+type ContactRouteContext = {
+  params: Promise<{ contact_id: string }>;
+};
+
+async function toInternalContext(context: ContactRouteContext) {
+  const { contact_id } = await context.params;
+  return { params: Promise.resolve({ id: contact_id }) };
+}
+
+export async function GET(
+  request: Request,
+  context: ContactRouteContext,
+): Promise<Response> {
+  return getContact(request, await toInternalContext(context));
+}
+
+export async function PATCH(
+  request: Request,
+  context: ContactRouteContext,
+): Promise<Response> {
+  return patchContact(request, await toInternalContext(context));
+}
+
+export async function DELETE(
+  request: Request,
+  context: ContactRouteContext,
+): Promise<Response> {
+  return deleteContact(request, await toInternalContext(context));
+}

--- a/src/app/contacts/route.ts
+++ b/src/app/contacts/route.ts
@@ -1,0 +1,1 @@
+export { GET, POST } from "@/app/api/contacts/route";

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -88,6 +88,14 @@ function isSendPostAlias(pathname: string, method: string): boolean {
   );
 }
 
+function isContactsAlias(pathname: string, method: string): boolean {
+  if (pathname === "/contacts") return ["GET", "POST"].includes(method);
+  if (pathname.startsWith("/contacts/")) {
+    return ["GET", "PATCH", "DELETE"].includes(method);
+  }
+  return false;
+}
+
 function isSendApiPost(pathname: string, method: string): boolean {
   return (
     method === "POST" &&
@@ -101,6 +109,11 @@ function isSendApiPost(pathname: string, method: string): boolean {
 function getRateLimitPathname(pathname: string, method: string): string {
   if (isSingleSendPostAlias(pathname, method)) return "/api/emails";
   if (isBatchSendPostAlias(pathname, method)) return "/api/emails/batch";
+  if (isContactsAlias(pathname, method)) {
+    return pathname === "/contacts"
+      ? "/api/contacts"
+      : pathname.replace(/^\/contacts/, "/api/contacts");
+  }
   return pathname;
 }
 
@@ -149,7 +162,8 @@ export async function middleware(request: NextRequest) {
   // Protect non-API page routes with session check. Resend-compatible send
   // aliases must bypass dashboard session redirects and use public API auth.
   const isSendAlias = isSendPostAlias(pathname, request.method);
-  if (!pathname.startsWith("/api/") && !isSendAlias) {
+  const isContactAlias = isContactsAlias(pathname, request.method);
+  if (!pathname.startsWith("/api/") && !isSendAlias && !isContactAlias) {
     // Allow auth page, public landing page, and static assets
     if (
       pathname === "/auth" ||

--- a/tests/contact-root-api.test.ts
+++ b/tests/contact-root-api.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockContactFindFirst = vi.hoisted(() => vi.fn());
+const mockSelect = vi.hoisted(() => vi.fn());
+const mockInsert = vi.hoisted(() => vi.fn());
+const mockUpdate = vi.hoisted(() => vi.fn());
+const mockDelete = vi.hoisted(() => vi.fn());
+const mockQueueEvent = vi.hoisted(() => vi.fn());
+
+function makeRequest(url: string, init?: RequestInit) {
+  const request = new Request(url, init) as Request & { nextUrl: URL };
+  request.nextUrl = new URL(url);
+  return request;
+}
+
+type Chain<T> = {
+  from: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  orderBy: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  values: ReturnType<typeof vi.fn>;
+  returning: ReturnType<typeof vi.fn>;
+  then: (resolve: (value: T[]) => unknown) => Promise<unknown>;
+};
+
+function makeChain<T>(rows: T[]): Chain<T> {
+  const chain = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    orderBy: vi.fn(() => chain),
+    limit: vi.fn(() => chain),
+    set: vi.fn(() => chain),
+    values: vi.fn(() => chain),
+    returning: vi.fn(() => Promise.resolve(rows)),
+    // biome-ignore lint/suspicious/noThenProperty: mocks Drizzle's thenable query builder
+    then: (resolve: (value: T[]) => unknown) => Promise.resolve(resolve(rows)),
+  };
+  return chain;
+}
+
+vi.mock("@/lib/api-auth", () => ({
+  authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
+  getServerSession: mockGetServerSession,
+  validateApiKey: mockValidateApiKey,
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/events", () => ({
+  queueEvent: mockQueueEvent,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      contacts: { findFirst: mockContactFindFirst },
+      segments: { findFirst: vi.fn() },
+      topics: { findFirst: vi.fn() },
+    },
+    select: mockSelect,
+    insert: mockInsert,
+    update: mockUpdate,
+    delete: mockDelete,
+  },
+}));
+
+describe("Resend-compatible root contacts API", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    const auth = {
+      apiKeyId: "key-1",
+      permission: "full_access",
+      domain: null,
+      userId: "user-1",
+    };
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue(auth);
+    mockValidateApiKey.mockResolvedValue(auth);
+    mockGetServerSession.mockResolvedValue(null);
+    mockQueueEvent.mockResolvedValue({ eventId: "event-1", deliveryIds: [] });
+  });
+
+  it("creates, lists, retrieves, updates, and deletes contacts at /contacts", async () => {
+    const createdAt = new Date("2026-05-08T00:00:00.000Z");
+    const insertedContact = {
+      id: "contact-1",
+      email: "user@example.com",
+      firstName: "User",
+      lastName: "One",
+      unsubscribed: false,
+      customProperties: { plan: "pro" },
+      segments: null,
+      topicSubscriptions: null,
+      createdAt,
+      document: null,
+      userId: "user-1",
+    };
+    const updatedContact = {
+      ...insertedContact,
+      unsubscribed: true,
+    };
+
+    mockInsert.mockReturnValueOnce(makeChain([insertedContact]));
+    mockSelect.mockReturnValueOnce(makeChain([insertedContact]));
+    mockContactFindFirst
+      .mockResolvedValueOnce(insertedContact)
+      .mockResolvedValueOnce(insertedContact)
+      .mockResolvedValueOnce(updatedContact);
+    mockUpdate.mockReturnValueOnce(makeChain([updatedContact]));
+    mockDelete.mockReturnValueOnce(
+      makeChain([{ id: "contact-1", email: "user@example.com" }]),
+    );
+
+    const collectionRoute = await import("@/app/contacts/route");
+    const detailRoute = await import("@/app/contacts/[contact_id]/route");
+
+    const createResponse = await collectionRoute.POST(
+      makeRequest("http://localhost/contacts", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer key",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          email: "USER@EXAMPLE.COM",
+          first_name: "User",
+          last_name: "One",
+          properties: { plan: "pro" },
+        }),
+      }) as never,
+    );
+    await expect(createResponse.json()).resolves.toEqual({
+      object: "contact",
+      id: "contact-1",
+    });
+    expect(createResponse.status).toBe(201);
+
+    const listResponse = await collectionRoute.GET(
+      makeRequest("http://localhost/contacts", {
+        headers: { authorization: "Bearer key" },
+      }),
+    );
+    await expect(listResponse.json()).resolves.toMatchObject({
+      object: "list",
+      has_more: false,
+      data: [
+        {
+          id: "contact-1",
+          email: "user@example.com",
+          first_name: "User",
+          last_name: "One",
+          unsubscribed: false,
+          status: "subscribed",
+        },
+      ],
+    });
+
+    const getResponse = await detailRoute.GET(
+      makeRequest("http://localhost/contacts/user@example.com", {
+        headers: { authorization: "Bearer key" },
+      }),
+      { params: Promise.resolve({ contact_id: "user@example.com" }) },
+    );
+    await expect(getResponse.json()).resolves.toMatchObject({
+      object: "contact",
+      id: "contact-1",
+      email: "user@example.com",
+    });
+
+    const updateResponse = await detailRoute.PATCH(
+      makeRequest("http://localhost/contacts/user@example.com", {
+        method: "PATCH",
+        headers: { authorization: "Bearer key" },
+        body: JSON.stringify({ unsubscribed: true }),
+      }),
+      { params: Promise.resolve({ contact_id: "user@example.com" }) },
+    );
+    await expect(updateResponse.json()).resolves.toMatchObject({
+      object: "contact",
+      id: "contact-1",
+      unsubscribed: true,
+    });
+
+    const deleteResponse = await detailRoute.DELETE(
+      makeRequest("http://localhost/contacts/contact-1", {
+        method: "DELETE",
+        headers: { authorization: "Bearer key" },
+      }),
+      { params: Promise.resolve({ contact_id: "contact-1" }) },
+    );
+    await expect(deleteResponse.json()).resolves.toEqual({
+      object: "contact",
+      id: "contact-1",
+      deleted: true,
+    });
+
+    expect(mockQueueEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "contact.created", userId: "user-1" }),
+    );
+    expect(mockQueueEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "contact.updated", userId: "user-1" }),
+    );
+    expect(mockQueueEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "contact.deleted", userId: "user-1" }),
+    );
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 404 for root email lookups outside the caller tenant", async () => {
+    mockContactFindFirst.mockResolvedValueOnce(null);
+
+    const detailRoute = await import("@/app/contacts/[contact_id]/route");
+    const response = await detailRoute.GET(
+      makeRequest("http://localhost/contacts/other@example.com", {
+        headers: { authorization: "Bearer key" },
+      }),
+      { params: Promise.resolve({ contact_id: "other@example.com" }) },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Contact not found",
+    });
+  });
+});

--- a/tests/middleware-rate-limit.test.ts
+++ b/tests/middleware-rate-limit.test.ts
@@ -124,6 +124,22 @@ describe("middleware rate limiting", () => {
     expect(response.headers.get("location")).toBe("https://example.com/auth");
   });
 
+  it("allows root contacts API aliases without requiring a dashboard session", async () => {
+    mockGetSessionCookie.mockReturnValue(null);
+    const { middleware } = await import("@/middleware");
+
+    const response = await middleware(
+      makeRequest("https://example.com/contacts/user@example.com", {
+        method: "PATCH",
+        headers: { authorization: "Bearer test-api-key" },
+      }),
+    );
+
+    expect(mockGetSessionCookie).not.toHaveBeenCalled();
+    expect(response.status).not.toBe(307);
+    expect(response.headers.get("x-ratelimit-backend")).toBe("disabled");
+  });
+
   it("enforces Redis-backed limits for API routes", async () => {
     process.env.RATE_LIMIT_BACKEND = "redis";
     mockIncrCache.mockResolvedValue(1);
@@ -194,6 +210,29 @@ describe("middleware rate limiting", () => {
     );
     expect(response.headers.get("x-middleware-rewrite")).toBe(
       "https://example.com/api/emails/batch",
+    );
+    expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
+  });
+
+  it("shares rate-limit buckets between root contacts aliases and /api/contacts", async () => {
+    process.env.RATE_LIMIT_BACKEND = "redis";
+    mockGetSessionCookie.mockReturnValue(null);
+    mockIncrCache.mockResolvedValue(1);
+
+    const { middleware } = await import("@/middleware");
+    const response = await middleware(
+      makeRequest("https://example.com/contacts/user@example.com", {
+        method: "DELETE",
+        headers: {
+          "x-forwarded-for": "203.0.113.10",
+          authorization: "Bearer test-api-key",
+        },
+      }),
+    );
+
+    expect(mockIncrCache).toHaveBeenCalledWith(
+      "ratelimit:203.0.113.10:Bearer test-api-key:/api/contacts/user@example.com",
+      60,
     );
     expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
   });

--- a/tests/sdk-client.test.tsx
+++ b/tests/sdk-client.test.tsx
@@ -4,6 +4,9 @@ import type {
   ApiError,
   ApiResponse,
   BatchEmailResponse,
+  ContactListResponse,
+  ContactResponse,
+  DeleteContactResponse,
   EmailOptions,
   EmailResponse,
   RequestOptions,
@@ -146,6 +149,20 @@ describe("Opensend SDK", () => {
       error: ApiError | null;
     }>();
     expectTypeOf<BatchEmailResponse>().toMatchTypeOf<{ data: unknown[] }>();
+    expectTypeOf<ContactListResponse>().toMatchTypeOf<{
+      object: "list";
+      data: Array<{
+        email: string;
+        first_name: string | null;
+        last_name: string | null;
+        unsubscribed: boolean;
+      }>;
+    }>();
+    expectTypeOf<ContactResponse>().toMatchTypeOf<{ object: "contact" }>();
+    expectTypeOf<DeleteContactResponse>().toMatchTypeOf<{
+      object: "contact";
+      deleted: true;
+    }>();
   });
 
   it("renders react payloads to html before sending", async () => {
@@ -196,6 +213,53 @@ describe("Opensend SDK", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.example.com/api/emails?limit=10&status=queued",
       expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("uses Resend-compatible root contacts endpoints for CRUD", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ object: "contact", id: "contact_123" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new Opensend("re_test", {
+      baseUrl: "https://api.example.com",
+    });
+
+    await client.contacts.create({ email: "user@example.com" });
+    await client.contacts.list();
+    await client.contacts.get("user@example.com");
+    await client.contacts.update("user@example.com", { unsubscribed: true });
+    await client.contacts.delete("user@example.com");
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example.com/contacts",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.example.com/contacts",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "https://api.example.com/contacts/user@example.com",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      "https://api.example.com/contacts/user@example.com",
+      expect.objectContaining({ method: "PATCH" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      5,
+      "https://api.example.com/contacts/user@example.com",
+      expect.objectContaining({ method: "DELETE" }),
     );
   });
 


### PR DESCRIPTION
Closes #256

## Summary
- Adds Resend-compatible root contact endpoints: `POST /contacts`, `GET /contacts`, and `GET`/`PATCH`/`DELETE /contacts/:contact_id`.
- Reuses the existing tenant-scoped `/api/contacts` handlers so auth, full-access API key enforcement, email/id lookup, and lifecycle webhook enqueue behavior stay aligned.
- Updates contacts list payloads/types with Resend snake_case fields while retaining legacy dashboard camelCase/status fields.
- Moves SDK contacts CRUD calls to root `/contacts` paths and adds `contacts.update(...)` / `contacts.delete(...)` typings and docs.

## Files / Scope
- API aliases: `src/app/contacts/route.ts`, `src/app/contacts/[contact_id]/route.ts`
- Middleware public API bypass/rate key normalization: `src/middleware.ts`
- Contact list response compatibility: `src/app/api/contacts/route.ts`, `packages/core/src/dto/index.ts`
- SDK surface/docs: `packages/sdk/src/index.ts`, `packages/sdk/README.md`
- Tests: `tests/contact-root-api.test.ts`, `tests/middleware-rate-limit.test.ts`, `tests/sdk-client.test.tsx`

Out of scope: deprecated audiences, dashboard audience UI, broadcasts, segments/topics, webhooks beyond existing contact lifecycle events, billing, migrations, and contact uniqueness/schema changes.

## Validation
- `bun run test tests/contact-root-api.test.ts tests/contact-tenant-isolation.test.ts tests/contacts-list.test.ts tests/middleware-rate-limit.test.ts tests/sdk-client.test.tsx` — 5 files / 46 tests passed
- `make check` — typecheck + Biome passed
- `make test` — 99 files / 845 tests passed
- `git diff --check` — passed
- Push guardrails — typecheck passed; changed-file Biome passed

## Playwright
Skipped. This slice changes API route aliases, middleware API handling, SDK calls/types, and SDK docs only; no dashboard/browser UI behavior changed. The required API-level scenario is covered by `tests/contact-root-api.test.ts`, which creates, lists, retrieves by email, updates unsubscribe state, and deletes through the public root contacts surface.
