### PR TITLE
fix(domains): adopt existing SES identity on AlreadyExistsException

### DIFF
--- a/agent_docs/learnings/active/2026-05-07-issue-262-ses-domain-create-iam-and-adopt.md
+++ b/agent_docs/learnings/active/2026-05-07-issue-262-ses-domain-create-iam-and-adopt.md
@@ -1,0 +1,89 @@
+---
+date: 2026-05-07
+issue: 262
+type: decision
+promoted_to: null
+---
+
+# Dashboard "Add domain" failures: IAM root cause + SES adopt-existing behavior
+
+## Symptom
+
+After PR #238 restored dashboard auth on `POST /api/domains`, the dashboard
+"Add domain" still 500'd in production. Two distinct errors surfaced in
+sequence:
+
+1. `AccessDeniedException ... is not authorized to perform: ses:CreateEmailIdentity`
+2. `AlreadyExistsException: Email identity foreverbrowsing.com already exist.`
+
+## Root causes
+
+### (1) ECS task had no SES permissions
+
+The `opensend-app:5` task definition reused `ecsTaskExecutionRole` for both
+`executionRoleArn` and `taskRoleArn`. That role only had:
+
+- `AmazonECSTaskExecutionRolePolicy`, `AmazonSSMReadOnlyAccess`, `SecretsManagerReadWrite`
+- inline `cloudwatch`, `KMS_DECRYPTION`
+
+No `ses:*`. Every `CreateEmailIdentity` call was denied at the IAM layer.
+
+### (2) Identity already existed in the AWS account
+
+`foreverbrowsing.com` was already registered as an SES identity in account
+`699486076867` (verified, DKIM `SUCCESS`) from a prior run. The opensend DB
+had no matching row, so the dashboard treated it as never added — but SES
+correctly refused to create a duplicate identity.
+
+## Fixes applied
+
+### Dedicated task role
+
+Created IAM role `opensend-app-task` (trust: `ecs-tasks.amazonaws.com`) with
+inline policy `opensend-app-runtime`:
+
+- `ses:CreateEmailIdentity`, `ses:GetEmailIdentity`, `ses:DeleteEmailIdentity`
+  on `arn:aws:ses:us-east-1:699486076867:identity/*`
+- `ses:SendEmail` on identity + configuration-set ARNs
+- `s3:GetObject`/`PutObject`/`DeleteObject` on
+  `arn:aws:s3:::rc-storage-e469a71830a5/*`
+
+Registered task definition `opensend-app:6` with `taskRoleArn` pointed at
+the new role. `executionRoleArn` left unchanged. Service rolled cleanly.
+
+This split (execution role for boot-time agent actions, task role for
+SDK calls) is the AWS-recommended pattern and limits blast radius — the
+running container now has SES + S3 only, never `SecretsManagerReadWrite`.
+
+### Idempotent `createDomainIdentity` (PR #259)
+
+`src/lib/ses.ts` now catches `AlreadyExistsException` and falls back to
+`GetEmailIdentity`, returning the existing DKIM tokens. The new dashboard
+row is created from those tokens, so DNS that's already in place keeps
+working — no re-verify needed.
+
+## Important caveat (recorded against #262)
+
+The adopt-existing branch is only safe under opensend's current deploy
+posture: **one AWS account = one opensend tenant** (the self-hostable
+docker-compose default). Under that assumption, "identity already exists
+in this AWS account" implies "this tenant owns it."
+
+If opensend is ever run multi-tenant on a shared AWS account, the adopt
+branch would hand the dashboard caller live DKIM tokens for a domain
+they may not control. Issue #262 tracks the proper long-term fix:
+**migrate to BYO-DKIM (Easy DKIM with `SigningAttributesOrigin:
+EXTERNAL`)** — generate a per-tenant RSA keypair, publish the public
+key as a TXT at a per-tenant selector, sign outbound mail with the
+private key. This is the same model Resend uses, and it removes the
+`AlreadyExistsException` collision entirely while restoring explicit
+per-tenant ownership proof.
+
+## Patterns
+
+- **Always set `taskRoleArn` distinct from `executionRoleArn`.** The
+  default of "reuse execution role" silently bloats the running
+  container's permissions and breaks least-privilege.
+- **Treat `AlreadyExistsException` from SES as a recoverable state for
+  account-scoped identities, not a hard error** — but only when the
+  surrounding tenancy model guarantees ownership.

--- a/src/lib/ses.ts
+++ b/src/lib/ses.ts
@@ -154,16 +154,37 @@ export async function createDomainIdentity(
     };
   }
 
-  const command = new CreateEmailIdentityCommand({
-    EmailIdentity: domain,
-  });
+  try {
+    const response = await ses.send(
+      new CreateEmailIdentityCommand({ EmailIdentity: domain }),
+    );
+    return {
+      dkimTokens: response.DkimAttributes?.Tokens ?? [],
+      status: response.DkimAttributes?.Status ?? "PENDING",
+    };
+  } catch (error) {
+    // SES is account-scoped while opensend rows are tenant-scoped, so an
+    // identity may already exist (prior install, manual setup, or an earlier
+    // create where the DB write failed). Adopt it instead of failing so DNS
+    // already in place keeps working.
+    if (!isAlreadyExistsError(error)) throw error;
+    const response = await ses.send(
+      new GetEmailIdentityCommand({ EmailIdentity: domain }),
+    );
+    return {
+      dkimTokens: response.DkimAttributes?.Tokens ?? [],
+      status: response.DkimAttributes?.Status ?? "PENDING",
+    };
+  }
+}
 
-  const response = await ses.send(command);
-
-  return {
-    dkimTokens: response.DkimAttributes?.Tokens ?? [],
-    status: response.DkimAttributes?.Status ?? "PENDING",
-  };
+function isAlreadyExistsError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error as { name: string }).name === "AlreadyExistsException"
+  );
 }
 
 export async function getDomainIdentity(

--- a/src/lib/ses.ts
+++ b/src/lib/ses.ts
@@ -163,10 +163,18 @@ export async function createDomainIdentity(
       status: response.DkimAttributes?.Status ?? "PENDING",
     };
   } catch (error) {
-    // SES is account-scoped while opensend rows are tenant-scoped, so an
-    // identity may already exist (prior install, manual setup, or an earlier
-    // create where the DB write failed). Adopt it instead of failing so DNS
-    // already in place keeps working.
+    // Adopt-existing fallback. SES is account+region scoped while opensend
+    // rows are tenant-scoped, so an identity may already exist from a prior
+    // install, manual `aws sesv2 create-email-identity`, or an earlier add
+    // where the DB write rolled back.
+    //
+    // SAFETY: this assumes a single opensend tenant per AWS account — the
+    // self-hostable deploy posture. Under that assumption, "identity exists
+    // in this AWS account" implies "this tenant owns it." If opensend is
+    // ever run multi-tenant on a shared AWS account, this branch hands the
+    // dashboard caller live DKIM tokens for a domain they may not own —
+    // do not enable shared-AWS multi-tenant without first migrating to
+    // BYO-DKIM (per-tenant keypair + selector). Tracked separately.
     if (!isAlreadyExistsError(error)) throw error;
     const response = await ses.send(
       new GetEmailIdentityCommand({ EmailIdentity: domain }),

--- a/tests/ses.test.ts
+++ b/tests/ses.test.ts
@@ -229,6 +229,38 @@ describe("SES Client", () => {
       );
       expect(mockSend).not.toHaveBeenCalled();
     });
+
+    it("adopts an existing SES identity when AlreadyExistsException is thrown", async () => {
+      const alreadyExists = Object.assign(new Error("identity exists"), {
+        name: "AlreadyExistsException",
+      });
+      mockSend.mockRejectedValueOnce(alreadyExists);
+      mockSend.mockResolvedValueOnce({
+        VerifiedForSendingStatus: true,
+        DkimAttributes: {
+          Tokens: ["existing1", "existing2", "existing3"],
+          Status: "SUCCESS",
+        },
+      });
+
+      const result = await createDomainIdentity("foreverbrowsing.com");
+
+      expect(result).toEqual({
+        dkimTokens: ["existing1", "existing2", "existing3"],
+        status: "SUCCESS",
+      });
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it("rethrows non-AlreadyExists SES errors", async () => {
+      mockSend.mockRejectedValueOnce(
+        Object.assign(new Error("denied"), { name: "AccessDeniedException" }),
+      );
+      await expect(createDomainIdentity("example.com")).rejects.toThrow(
+        "denied",
+      );
+      expect(mockSend).toHaveBeenCalledOnce();
+    });
   });
 
   describe("getDomainIdentity", () => {


### PR DESCRIPTION
## Summary
- `POST /api/domains` 500'd for any name already registered as an SES identity (logged today as `AlreadyExistsException: Email identity foreverbrowsing.com already exist.`)
- Made `createDomainIdentity` idempotent: on `AlreadyExistsException`, fall back to `GetEmailIdentity` and return the live DKIM tokens. DNS already in place keeps working; the new dashboard row holds the same tokens.
- Added two Vitest cases covering the adopt-existing branch and a non-AlreadyExists rethrow.
- Added a `SAFETY` comment spelling out the assumption (single opensend tenant per AWS account).
- Added a learning doc capturing today's IAM root cause + adopt fallback.

## Why
SES is account-scoped while opensend rows are tenant-scoped, so a name can legitimately exist in SES from a prior install / manual setup / earlier add where the DB write didn't land. Treating it as a hard error blocks legitimate adds.

## Long-term direction (#262)
This adopt-existing branch is only safe under "one AWS account = one tenant" — opensend's current self-hostable posture. The proper long-term fix is **BYO-DKIM** (per-tenant RSA keypair + selector, `SigningAttributesOrigin: EXTERNAL`), which removes the SES `AlreadyExists` collision entirely and restores per-tenant ownership proof. Tracked in #262.

## Validation
- `bun run test tests/ses.test.ts` — 18/18 pass (16 prior + 2 new for adopt branch)
- `make check` — typecheck + Biome clean

## Test plan
- [ ] After deploy, retry adding `foreverbrowsing.com` from the dashboard — expect 201 with the existing 3 DKIM tokens
- [ ] List shows the domain; verify status stays `verified` since DNS is already live