### PR TITLE
Add MCP parity slice for agent clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ ralph_to_ralph_archive/
 
 # Local clawhip repo metadata (single-machine only)
 .clawhip/
+.scratch/

--- a/agent_docs/learnings/active/2026-05-08-issue-260-mcp-http-adapter.md
+++ b/agent_docs/learnings/active/2026-05-08-issue-260-mcp-http-adapter.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-08
+issue: "#260"
+type: decision
+promoted_to: null
+---
+
+## MCP first slice uses a local package plus control-plane `/mcp`
+
+Issue #260's first parity slice keeps MCP transport/tool registration in a private workspace package (`@opensend/mcp`) and mounts HTTP mode from `services/api` at `/mcp`. Tool execution forwards to existing stable public API routes with the caller's Bearer API key instead of reusing dashboard cookies or duplicating repository logic.
+
+Why: the control-plane service is already the deployable non-dashboard boundary, while the current public API remains in Next.js. Forwarding preserves existing auth, tenant scoping, validation, quota, SES, and webhook behavior until follow-up thin adapters move more route logic into reusable core services.
+
+Deferred intentionally: public `npx` packaging ownership, received emails, broadcasts, segments, topics, contact properties, and API-key management tools.

--- a/bun.lock
+++ b/bun.lock
@@ -63,6 +63,13 @@
       "name": "@opensend/ingester",
       "version": "0.1.0",
     },
+    "packages/mcp": {
+      "name": "@opensend/mcp",
+      "version": "0.1.0",
+      "bin": {
+        "opensend-mcp": "src/stdio.ts",
+      },
+    },
     "packages/sdk": {
       "name": "opensend",
       "version": "1.0.0",
@@ -74,6 +81,7 @@
       "name": "@opensend/api",
       "version": "0.1.0",
       "dependencies": {
+        "@opensend/mcp": "workspace:*",
         "hono": "^4.12.15",
       },
     },
@@ -426,6 +434,8 @@
     "@opensend/core": ["@opensend/core@workspace:packages/core"],
 
     "@opensend/ingester": ["@opensend/ingester@workspace:packages/ingester"],
+
+    "@opensend/mcp": ["@opensend/mcp@workspace:packages/mcp"],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@opensend/mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "bin": {
+    "opensend-mcp": "src/stdio.ts"
+  },
+  "scripts": {
+    "start": "bun src/stdio.ts"
+  }
+}

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -1,0 +1,221 @@
+import type { JsonObject, JsonValue, OpensendMcpToolName } from "./schema";
+
+export type OpensendApiClientOptions = {
+  apiKey: string;
+  baseUrl?: string;
+  fetcher?: typeof fetch;
+};
+
+export type OpensendApiResult = {
+  status: number;
+  ok: boolean;
+  body: JsonValue;
+};
+
+const DEFAULT_BASE_URL = "http://localhost:3015";
+
+function normalizeBaseUrl(baseUrl: string | undefined): string {
+  return (baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toJsonValue(value: unknown): JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+
+  if (Array.isArray(value)) return value.map(toJsonValue);
+
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, toJsonValue(entry)]),
+    );
+  }
+
+  return String(value);
+}
+
+function getStringArgument(args: JsonObject, key: string): string {
+  const value = args[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Missing required string argument: ${key}`);
+  }
+  return value;
+}
+
+function getOptionalStringArgument(
+  args: JsonObject,
+  key: string,
+): string | null {
+  const value = args[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function appendPagination(search: URLSearchParams, args: JsonObject): void {
+  const limit = args.limit;
+  if (typeof limit === "number" && Number.isFinite(limit)) {
+    search.set("limit", String(Math.trunc(limit)));
+  }
+  const after = getOptionalStringArgument(args, "after");
+  if (after) search.set("after", after);
+  const before = getOptionalStringArgument(args, "before");
+  if (before) search.set("before", before);
+}
+
+function bodyFromArgs(args: JsonObject, keys: string[]): JsonObject {
+  const body: JsonObject = {};
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(args, key)) {
+      body[key] = args[key];
+    }
+  }
+  return body;
+}
+
+export class OpensendApiClient {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly fetcher: typeof fetch;
+
+  constructor(options: OpensendApiClientOptions) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = normalizeBaseUrl(options.baseUrl);
+    this.fetcher = options.fetcher ?? fetch;
+  }
+
+  async callTool(
+    name: OpensendMcpToolName,
+    args: JsonObject,
+  ): Promise<OpensendApiResult> {
+    switch (name) {
+      case "opensend_send_email":
+        return await this.request(
+          "POST",
+          "/api/emails",
+          bodyFromArgs(args, [
+            "from",
+            "to",
+            "subject",
+            "html",
+            "text",
+            "cc",
+            "bcc",
+            "reply_to",
+            "headers",
+            "tags",
+            "scheduled_at",
+            "topic_id",
+            "template",
+          ]),
+        );
+      case "opensend_list_emails":
+        return await this.list("/api/emails", args);
+      case "opensend_get_email":
+        return await this.request(
+          "GET",
+          `/api/emails/${encodeURIComponent(getStringArgument(args, "id"))}`,
+        );
+      case "opensend_create_contact":
+        return await this.request(
+          "POST",
+          "/api/contacts",
+          bodyFromArgs(args, [
+            "email",
+            "first_name",
+            "last_name",
+            "unsubscribed",
+            "properties",
+            "segments",
+            "topics",
+          ]),
+        );
+      case "opensend_list_contacts":
+        return await this.list("/api/contacts", args);
+      case "opensend_get_contact":
+        return await this.request(
+          "GET",
+          `/api/contacts/${encodeURIComponent(getStringArgument(args, "id"))}`,
+        );
+      case "opensend_create_domain":
+        return await this.request(
+          "POST",
+          "/api/domains",
+          bodyFromArgs(args, [
+            "name",
+            "region",
+            "custom_return_path",
+            "open_tracking",
+            "click_tracking",
+            "tracking_subdomain",
+            "tls",
+          ]),
+        );
+      case "opensend_list_domains":
+        return await this.list("/api/domains", args);
+      case "opensend_get_domain":
+        return await this.request(
+          "GET",
+          `/api/domains/${encodeURIComponent(getStringArgument(args, "id"))}`,
+        );
+      case "opensend_create_webhook":
+        return await this.request(
+          "POST",
+          "/api/webhooks",
+          bodyFromArgs(args, ["endpoint", "events"]),
+        );
+      case "opensend_list_webhooks":
+        return await this.list("/api/webhooks", args);
+      case "opensend_get_webhook":
+        return await this.request(
+          "GET",
+          `/api/webhooks/${encodeURIComponent(getStringArgument(args, "id"))}`,
+        );
+    }
+  }
+
+  private async list(
+    path: string,
+    args: JsonObject,
+  ): Promise<OpensendApiResult> {
+    const search = new URLSearchParams();
+    appendPagination(search, args);
+    const suffix = search.size > 0 ? `?${search.toString()}` : "";
+    return await this.request("GET", `${path}${suffix}`);
+  }
+
+  private async request(
+    method: "GET" | "POST",
+    path: string,
+    body?: JsonObject,
+  ): Promise<OpensendApiResult> {
+    const response = await this.fetcher(`${this.baseUrl}${path}`, {
+      method,
+      headers: {
+        authorization: `Bearer ${this.apiKey}`,
+        accept: "application/json",
+        ...(body ? { "content-type": "application/json" } : {}),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    const text = await response.text();
+    let parsed: JsonValue = null;
+    if (text) {
+      try {
+        parsed = toJsonValue(JSON.parse(text));
+      } catch {
+        parsed = text;
+      }
+    }
+
+    return { status: response.status, ok: response.ok, body: parsed };
+  }
+}

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -1,0 +1,87 @@
+import {
+  type JsonRpcResponse,
+  authenticateBearerHeader,
+  createMcpServer,
+} from "./protocol";
+
+export type McpHttpOptions = {
+  apiBaseUrl?: string;
+  fetcher?: typeof fetch;
+};
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...Object.fromEntries(new Headers(init?.headers).entries()),
+    },
+  });
+}
+
+function authError(status: number, code: string, message: string): Response {
+  return jsonResponse({ error: { code, message } }, { status });
+}
+
+async function parseJson(request: Request): Promise<unknown> {
+  const text = await request.text();
+  if (!text) return null;
+  return JSON.parse(text) as unknown;
+}
+
+export async function handleMcpHttpRequest(
+  request: Request,
+  options: McpHttpOptions = {},
+): Promise<Response> {
+  if (request.method !== "POST") {
+    return jsonResponse(
+      {
+        error: {
+          code: "method_not_allowed",
+          message: "Use POST for MCP JSON-RPC requests.",
+        },
+      },
+      {
+        status: 405,
+        headers: { allow: "POST" },
+      },
+    );
+  }
+
+  const auth = authenticateBearerHeader(request.headers.get("authorization"));
+  if (!auth.ok) return authError(401, auth.code, auth.message);
+
+  let input: unknown;
+  try {
+    input = await parseJson(request);
+  } catch {
+    return jsonResponse(
+      {
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32700, message: "Parse error." },
+      },
+      { status: 400 },
+    );
+  }
+
+  const server = createMcpServer({
+    apiKey: auth.apiKey,
+    apiBaseUrl: options.apiBaseUrl,
+    fetcher: options.fetcher,
+  });
+
+  if (Array.isArray(input)) {
+    const responses: JsonRpcResponse[] = [];
+    for (const item of input) {
+      const response = await server.handleJsonRpc(item);
+      if (response) responses.push(response);
+    }
+    return jsonResponse(responses);
+  }
+
+  const response = await server.handleJsonRpc(input);
+  return response
+    ? jsonResponse(response)
+    : new Response(null, { status: 202 });
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./client";
+export * from "./http";
+export * from "./protocol";
+export * from "./schema";

--- a/packages/mcp/src/protocol.ts
+++ b/packages/mcp/src/protocol.ts
@@ -1,0 +1,240 @@
+import { OpensendApiClient } from "./client";
+import {
+  type JsonObject,
+  type JsonValue,
+  type OpensendMcpToolName,
+  listMcpTools,
+} from "./schema";
+
+export type JsonRpcId = string | number | null;
+
+export type McpAuthResult =
+  | { ok: true; apiKey: string }
+  | {
+      ok: false;
+      code: "missing_api_key" | "malformed_api_key";
+      message: string;
+    };
+
+export type McpServerOptions = {
+  apiBaseUrl?: string;
+  apiKey?: string;
+  fetcher?: typeof fetch;
+};
+
+type JsonRpcSuccess = {
+  jsonrpc: "2.0";
+  id: JsonRpcId;
+  result: JsonValue;
+};
+
+type JsonRpcFailure = {
+  jsonrpc: "2.0";
+  id: JsonRpcId;
+  error: {
+    code: number;
+    message: string;
+    data?: JsonValue;
+  };
+};
+
+export type JsonRpcResponse = JsonRpcSuccess | JsonRpcFailure;
+
+type JsonRpcRequest = {
+  jsonrpc?: string;
+  id?: JsonRpcId;
+  method?: string;
+  params?: unknown;
+};
+
+const TOOL_NAMES = new Set<string>(listMcpTools().map((tool) => tool.name));
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toJsonValue(value: unknown): JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) return value.map(toJsonValue);
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, toJsonValue(entry)]),
+    );
+  }
+  return String(value);
+}
+
+function success(id: JsonRpcId, result: JsonValue): JsonRpcSuccess {
+  return { jsonrpc: "2.0", id, result };
+}
+
+function failure(
+  id: JsonRpcId,
+  code: number,
+  message: string,
+  data?: JsonValue,
+): JsonRpcFailure {
+  return data === undefined
+    ? { jsonrpc: "2.0", id, error: { code, message } }
+    : { jsonrpc: "2.0", id, error: { code, message, data } };
+}
+
+function requestId(input: unknown): JsonRpcId {
+  if (!isRecord(input)) return null;
+  const id = input.id;
+  return typeof id === "string" || typeof id === "number" || id === null
+    ? id
+    : null;
+}
+
+function parseRequest(input: unknown): JsonRpcRequest | null {
+  if (!isRecord(input)) return null;
+  const id = input.id;
+  const method = input.method;
+  if (
+    id !== undefined &&
+    typeof id !== "string" &&
+    typeof id !== "number" &&
+    id !== null
+  )
+    return null;
+  if (typeof method !== "string") return null;
+  return {
+    jsonrpc: typeof input.jsonrpc === "string" ? input.jsonrpc : undefined,
+    id: id as JsonRpcId | undefined,
+    method,
+    params: input.params,
+  };
+}
+
+function paramsObject(params: unknown): JsonObject {
+  return isRecord(params) ? (toJsonValue(params) as JsonObject) : {};
+}
+
+function getCallParams(
+  params: unknown,
+): { name: OpensendMcpToolName; arguments: JsonObject } | null {
+  if (
+    !isRecord(params) ||
+    typeof params.name !== "string" ||
+    !TOOL_NAMES.has(params.name)
+  ) {
+    return null;
+  }
+  return {
+    name: params.name as OpensendMcpToolName,
+    arguments: paramsObject(params.arguments),
+  };
+}
+
+export function authenticateBearerHeader(
+  authHeader: string | null | undefined,
+): McpAuthResult {
+  if (!authHeader) {
+    return {
+      ok: false,
+      code: "missing_api_key",
+      message:
+        "Missing API key. Provide an Authorization: Bearer <api_key> header.",
+    };
+  }
+
+  const parts = authHeader.split(" ");
+  if (parts.length !== 2 || parts[0] !== "Bearer" || !parts[1]) {
+    return {
+      ok: false,
+      code: "malformed_api_key",
+      message:
+        "Malformed API key. Use the Authorization: Bearer <api_key> header format.",
+    };
+  }
+
+  return { ok: true, apiKey: parts[1] };
+}
+
+export function createMcpServer(options: McpServerOptions = {}) {
+  async function handleJsonRpc(
+    input: unknown,
+  ): Promise<JsonRpcResponse | null> {
+    const id = requestId(input);
+    const request = parseRequest(input);
+    if (!request) return failure(id, -32600, "Invalid JSON-RPC request.");
+
+    if (request.id === undefined) return null;
+
+    switch (request.method) {
+      case "initialize":
+        return success(request.id, {
+          protocolVersion: "2024-11-05",
+          capabilities: { tools: {} },
+          serverInfo: { name: "opensend-mcp", version: "0.1.0" },
+        });
+      case "tools/list":
+        return success(request.id, { tools: listMcpTools() });
+      case "tools/call": {
+        const call = getCallParams(request.params);
+        if (!call)
+          return failure(request.id, -32602, "Unknown or invalid tool call.");
+
+        const apiKey = options.apiKey;
+        if (!apiKey) {
+          return failure(
+            request.id,
+            -32001,
+            "OpenSend API key is required for tool calls.",
+            {
+              code: "missing_api_key",
+            },
+          );
+        }
+
+        try {
+          const client = new OpensendApiClient({
+            apiKey,
+            baseUrl: options.apiBaseUrl,
+            fetcher: options.fetcher,
+          });
+          const apiResult = await client.callTool(call.name, call.arguments);
+          return success(request.id, {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(
+                  {
+                    status: apiResult.status,
+                    ok: apiResult.ok,
+                    body: apiResult.body,
+                  },
+                  null,
+                  2,
+                ),
+              },
+            ],
+            isError: !apiResult.ok,
+          });
+        } catch (error) {
+          return failure(
+            request.id,
+            -32000,
+            error instanceof Error ? error.message : "Tool execution failed.",
+          );
+        }
+      }
+      default:
+        return failure(
+          request.id,
+          -32601,
+          `Unsupported MCP method: ${request.method}`,
+        );
+    }
+  }
+
+  return { handleJsonRpc };
+}

--- a/packages/mcp/src/schema.ts
+++ b/packages/mcp/src/schema.ts
@@ -1,0 +1,249 @@
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export type JsonObject = { [key: string]: JsonValue };
+
+export type JsonSchema = {
+  type: "object";
+  properties: Record<string, JsonValue>;
+  required?: string[];
+  additionalProperties: boolean;
+};
+
+export type McpTool = {
+  name: string;
+  description: string;
+  inputSchema: JsonSchema;
+};
+
+const paginationProperties = {
+  limit: {
+    type: "integer",
+    minimum: 1,
+    maximum: 100,
+    description: "Maximum number of records to return.",
+  },
+  after: {
+    type: "string",
+    description: "Opaque cursor/id for fetching the next page when supported.",
+  },
+} satisfies Record<string, JsonValue>;
+
+const idProperties = {
+  id: { type: "string", description: "OpenSend resource id." },
+} satisfies Record<string, JsonValue>;
+
+export const OPENSEND_MCP_TOOLS = [
+  {
+    name: "opensend_send_email",
+    description:
+      "Send or schedule one email through the existing OpenSend POST /api/emails API.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["from", "to", "subject"],
+      properties: {
+        from: { type: "string", description: "Sender email address." },
+        to: {
+          oneOf: [
+            { type: "string" },
+            { type: "array", items: { type: "string" } },
+          ],
+          description: "Recipient email address or addresses.",
+        },
+        subject: { type: "string" },
+        html: { type: "string" },
+        text: { type: "string" },
+        cc: {
+          oneOf: [
+            { type: "string" },
+            { type: "array", items: { type: "string" } },
+          ],
+        },
+        bcc: {
+          oneOf: [
+            { type: "string" },
+            { type: "array", items: { type: "string" } },
+          ],
+        },
+        reply_to: {
+          oneOf: [
+            { type: "string" },
+            { type: "array", items: { type: "string" } },
+          ],
+        },
+        headers: { type: "object", additionalProperties: { type: "string" } },
+        tags: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: { name: { type: "string" }, value: { type: "string" } },
+            required: ["name", "value"],
+            additionalProperties: false,
+          },
+        },
+        scheduled_at: {
+          type: "string",
+          description: "ISO-8601 scheduled send timestamp.",
+        },
+        topic_id: { type: "string" },
+        template: {
+          type: "object",
+          properties: { id: { type: "string" }, variables: { type: "object" } },
+          required: ["id"],
+          additionalProperties: false,
+        },
+      },
+    },
+  },
+  {
+    name: "opensend_list_emails",
+    description: "List sent/scheduled email records through GET /api/emails.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        ...paginationProperties,
+        before: {
+          type: "string",
+          description:
+            "Cursor/id for fetching records before this id when supported.",
+        },
+      },
+    },
+  },
+  {
+    name: "opensend_get_email",
+    description: "Fetch one email record through GET /api/emails/{id}.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id"],
+      properties: idProperties,
+    },
+  },
+  {
+    name: "opensend_create_contact",
+    description: "Create one contact through POST /api/contacts.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["email"],
+      properties: {
+        email: { type: "string" },
+        first_name: { type: "string" },
+        last_name: { type: "string" },
+        unsubscribed: { type: "boolean" },
+        properties: {
+          type: "object",
+          additionalProperties: { type: "string" },
+        },
+        segments: { type: "array", items: { type: "string" } },
+        topics: {
+          type: "array",
+          items: { oneOf: [{ type: "string" }, { type: "object" }] },
+        },
+      },
+    },
+  },
+  {
+    name: "opensend_list_contacts",
+    description: "List contacts through GET /api/contacts.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: paginationProperties,
+    },
+  },
+  {
+    name: "opensend_get_contact",
+    description: "Fetch one contact through GET /api/contacts/{id}.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id"],
+      properties: idProperties,
+    },
+  },
+  {
+    name: "opensend_create_domain",
+    description: "Create one sending domain through POST /api/domains.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["name"],
+      properties: {
+        name: { type: "string" },
+        region: {
+          type: "string",
+          enum: ["us-east-1", "eu-west-1", "sa-east-1", "ap-northeast-1"],
+        },
+        custom_return_path: { type: "string" },
+        open_tracking: { type: "boolean" },
+        click_tracking: { type: "boolean" },
+        tracking_subdomain: { type: "string" },
+        tls: { type: "string", enum: ["opportunistic", "enforced"] },
+      },
+    },
+  },
+  {
+    name: "opensend_list_domains",
+    description: "List domains through GET /api/domains.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: paginationProperties,
+    },
+  },
+  {
+    name: "opensend_get_domain",
+    description: "Fetch one domain through GET /api/domains/{id}.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id"],
+      properties: idProperties,
+    },
+  },
+  {
+    name: "opensend_create_webhook",
+    description: "Create one webhook endpoint through POST /api/webhooks.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["endpoint", "events"],
+      properties: {
+        endpoint: { type: "string", description: "Webhook destination URL." },
+        events: { type: "array", items: { type: "string" }, minItems: 1 },
+      },
+    },
+  },
+  {
+    name: "opensend_list_webhooks",
+    description: "List webhooks through GET /api/webhooks.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: paginationProperties,
+    },
+  },
+  {
+    name: "opensend_get_webhook",
+    description: "Fetch one webhook through GET /api/webhooks/{id}.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id"],
+      properties: idProperties,
+    },
+  },
+] as const satisfies readonly McpTool[];
+
+export type OpensendMcpToolName = (typeof OPENSEND_MCP_TOOLS)[number]["name"];
+
+export function listMcpTools(): McpTool[] {
+  return OPENSEND_MCP_TOOLS.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+  }));
+}

--- a/packages/mcp/src/stdio.ts
+++ b/packages/mcp/src/stdio.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env bun
+import { createMcpServer } from "./protocol";
+
+const apiKey = process.env.OPENSEND_API_KEY;
+const apiBaseUrl = process.env.OPENSEND_API_BASE_URL;
+const server = createMcpServer({ apiKey, apiBaseUrl });
+let buffer = "";
+
+async function handleLine(line: string): Promise<void> {
+  if (!line.trim()) return;
+  let input: unknown;
+  try {
+    input = JSON.parse(line) as unknown;
+  } catch {
+    process.stdout.write(
+      `${JSON.stringify({ jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error." } })}\n`,
+    );
+    return;
+  }
+
+  const response = await server.handleJsonRpc(input);
+  if (response) process.stdout.write(`${JSON.stringify(response)}\n`);
+}
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk: string) => {
+  buffer += chunk;
+  const lines = buffer.split("\n");
+  buffer = lines.pop() ?? "";
+  for (const line of lines) {
+    void handleLine(line);
+  }
+});
+process.stdin.on("end", () => {
+  if (buffer.trim()) void handleLine(buffer);
+});

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -13,6 +13,7 @@ Current endpoints:
 
 - `GET /healthz` — service/version health metadata
 - `GET /readyz` — static readiness response that does not require AWS, database, queue, or other external credentials
+- `POST /mcp` — Streamable HTTP-compatible JSON-RPC MCP endpoint for agent clients. Requires `Authorization: Bearer <opensend_api_key>` and forwards tool calls to the existing public OpenSend API (`OPENSEND_API_BASE_URL`, default `http://localhost:3015`).
 
 This service is intentionally a skeleton. The existing Next.js route handlers under `src/app/api` remain the current public API until follow-up route-move/thin-adapter PRs move route ownership behind this boundary.
 
@@ -25,3 +26,54 @@ The API keys route family is the first narrow thin-adapter pilot for issue #71:
 - The service accepts explicit dependencies, so behavior can be unit-tested without a Next.js request object and later reused by the Hono control-plane runtime.
 
 Follow-up route moves should preserve this split before adding Hono handlers: keep public API shape stable, move business logic into core or a service layer, then let each runtime provide only an adapter.
+
+
+## MCP server slice
+
+This workspace includes a private local `@opensend/mcp` package used by the control-plane service and by stdio clients. It intentionally exposes only the first parity slice backed by stable public API routes: send/list/get emails, create/list/get contacts, create/list/get domains, and create/list/get webhooks. Tool calls preserve the existing public API response or error body inside MCP `content[0].text` with `{ status, ok, body }`.
+
+### Codex stdio setup
+
+```bash
+codex mcp add opensend \
+  --env OPENSEND_API_KEY=os_... \
+  --env OPENSEND_API_BASE_URL=http://localhost:3015 \
+  -- bun /path/to/opensend/packages/mcp/src/stdio.ts
+```
+
+### JSON-config stdio setup
+
+```json
+{
+  "mcpServers": {
+    "opensend": {
+      "command": "bun",
+      "args": ["/path/to/opensend/packages/mcp/src/stdio.ts"],
+      "env": {
+        "OPENSEND_API_KEY": "os_...",
+        "OPENSEND_API_BASE_URL": "http://localhost:3015"
+      }
+    }
+  }
+}
+```
+
+### Streamable HTTP setup
+
+Run the control-plane API and point clients at `/mcp`:
+
+```bash
+OPENSEND_API_BASE_URL=http://localhost:3015 bun run dev:api
+```
+
+HTTP MCP clients must send their OpenSend API key per request:
+
+```http
+POST http://localhost:3026/mcp
+Authorization: Bearer os_...
+Content-Type: application/json
+
+{"jsonrpc":"2.0","id":"tools","method":"tools/list"}
+```
+
+Deferred from this slice: received emails, broadcasts, segments, topics, contact properties, API-key management, and packaging/publishing ownership for a public `npx` command.

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -11,6 +11,7 @@
     "build": "bun build ./src/server.ts --target bun --outfile ./dist/server.js"
   },
   "dependencies": {
-    "hono": "^4.12.15"
+    "hono": "^4.12.15",
+    "@opensend/mcp": "workspace:*"
   }
 }

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -1,3 +1,4 @@
+import { handleMcpHttpRequest } from "@opensend/mcp";
 import { Hono } from "hono";
 
 export const CONTROL_PLANE_API_SERVICE = "control-plane-api";
@@ -16,7 +17,12 @@ export type ReadinessResponse = HealthResponse & {
   };
 };
 
-export function createApp() {
+export type ControlPlaneAppOptions = {
+  mcpApiBaseUrl?: string;
+  fetcher?: typeof fetch;
+};
+
+export function createApp(options: ControlPlaneAppOptions = {}) {
   const app = new Hono();
 
   app.get("/healthz", (c) =>
@@ -25,6 +31,18 @@ export function createApp() {
       service: CONTROL_PLANE_API_SERVICE,
       version: CONTROL_PLANE_API_VERSION,
     } satisfies HealthResponse),
+  );
+
+  app.all(
+    "/mcp",
+    async (c) =>
+      await handleMcpHttpRequest(c.req.raw, {
+        apiBaseUrl:
+          options.mcpApiBaseUrl ??
+          process.env.OPENSEND_API_BASE_URL ??
+          process.env.NEXT_PUBLIC_APP_URL,
+        fetcher: options.fetcher,
+      }),
   );
 
   app.get("/readyz", (c) =>

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -384,6 +384,41 @@ export default function DocsPage() {
               .
             </p>
           </div>
+
+          <div className="mt-5 rounded-lg border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.5)] p-4 space-y-3">
+            <h2 className="text-[15px] font-semibold text-[#F0F0F0]">
+              MCP server for agent clients
+            </h2>
+            <p className="text-[13px] text-[#A1A4A5]">
+              OpenSend includes an initial MCP parity slice for Codex and other
+              MCP clients. HTTP mode is served by the control-plane API at{" "}
+              <code className="font-mono text-[#F0F0F0]">/mcp</code> and uses{" "}
+              <code className="font-mono text-[#F0F0F0]">
+                Authorization: Bearer
+              </code>{" "}
+              API-key auth, not dashboard cookies. The first tools cover
+              send/list/get emails, create/list/get contacts, create/list/get
+              domains, and create/list/get webhooks.
+            </p>
+            <pre className="text-[12px] text-[#A1A4A5] font-mono bg-[rgba(24,25,28,0.88)] border border-[rgba(176,199,217,0.145)] rounded-lg p-4 overflow-x-auto whitespace-pre-wrap">
+              {`# Codex stdio
+codex mcp add opensend \
+  --env OPENSEND_API_KEY=os_... \
+  --env OPENSEND_API_BASE_URL=https://api.opensend.com \
+  -- bun /path/to/opensend/packages/mcp/src/stdio.ts
+
+# Streamable HTTP /mcp
+POST https://api.opensend.com/mcp
+Authorization: Bearer os_...
+Content-Type: application/json
+
+{"jsonrpc":"2.0","id":"tools","method":"tools/list"}`}
+            </pre>
+            <p className="text-[12px] text-[#A1A4A5]">
+              Deferred tools: received emails, broadcasts, segments, topics,
+              contact properties, API-key management, and public npx packaging.
+            </p>
+          </div>
         </div>
 
         {/* Groups */}

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  authenticateBearerHeader,
+  createMcpServer,
+  handleMcpHttpRequest,
+  listMcpTools,
+} from "../packages/mcp/src/index";
+import { createApp } from "../services/api/src/index";
+
+describe("OpenSend MCP tool registry", () => {
+  it("registers deterministic initial parity tools with schemas", () => {
+    const tools = listMcpTools();
+
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "opensend_send_email",
+      "opensend_list_emails",
+      "opensend_get_email",
+      "opensend_create_contact",
+      "opensend_list_contacts",
+      "opensend_get_contact",
+      "opensend_create_domain",
+      "opensend_list_domains",
+      "opensend_get_domain",
+      "opensend_create_webhook",
+      "opensend_list_webhooks",
+      "opensend_get_webhook",
+    ]);
+
+    for (const tool of tools) {
+      expect(tool.description.length).toBeGreaterThan(20);
+      expect(tool.inputSchema.type).toBe("object");
+      expect(tool.inputSchema.additionalProperties).toBe(false);
+    }
+  });
+});
+
+describe("OpenSend MCP JSON-RPC protocol", () => {
+  it("lists tools through the MCP tools/list method", async () => {
+    const server = createMcpServer({ apiKey: "os_test_key" });
+
+    const response = await server.handleJsonRpc({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+    });
+
+    expect(response).toMatchObject({ jsonrpc: "2.0", id: 1 });
+    expect(JSON.stringify(response)).toContain("opensend_send_email");
+  });
+
+  it("returns a deterministic error for unknown tools", async () => {
+    const server = createMcpServer({ apiKey: "os_test_key" });
+
+    const response = await server.handleJsonRpc({
+      jsonrpc: "2.0",
+      id: "call-1",
+      method: "tools/call",
+      params: { name: "opensend_fake_tool", arguments: {} },
+    });
+
+    expect(response).toEqual({
+      jsonrpc: "2.0",
+      id: "call-1",
+      error: { code: -32602, message: "Unknown or invalid tool call." },
+    });
+  });
+
+  it("maps tool calls to stable OpenSend public API paths", async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ object: "list", data: [], has_more: false }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    );
+    const server = createMcpServer({
+      apiKey: "os_test_key",
+      apiBaseUrl: "https://opensend.example",
+      fetcher,
+    });
+
+    const response = await server.handleJsonRpc({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: {
+        name: "opensend_list_contacts",
+        arguments: { limit: 10, after: "contact_123" },
+      },
+    });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://opensend.example/api/contacts?limit=10&after=contact_123",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          authorization: "Bearer os_test_key",
+        }),
+      }),
+    );
+    expect(JSON.stringify(response)).toContain('\\"ok\\": true');
+  });
+});
+
+describe("OpenSend MCP HTTP auth and transport", () => {
+  it("requires Bearer authorization for /mcp", async () => {
+    expect(authenticateBearerHeader(null)).toEqual({
+      ok: false,
+      code: "missing_api_key",
+      message:
+        "Missing API key. Provide an Authorization: Bearer <api_key> header.",
+    });
+    expect(authenticateBearerHeader("Basic abc")).toEqual({
+      ok: false,
+      code: "malformed_api_key",
+      message:
+        "Malformed API key. Use the Authorization: Bearer <api_key> header format.",
+    });
+
+    const response = await handleMcpHttpRequest(
+      new Request("https://api.example/mcp", {
+        method: "POST",
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "missing_api_key",
+        message:
+          "Missing API key. Provide an Authorization: Bearer <api_key> header.",
+      },
+    });
+  });
+
+  it("serves /mcp from the Hono control-plane app", async () => {
+    const app = createApp();
+    const response = await app.request("/mcp", {
+      method: "POST",
+      headers: { authorization: "Bearer os_test_key" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "tools",
+        method: "tools/list",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.result.tools[0].name).toBe("opensend_send_email");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,10 @@ export default defineConfig({
         find: "@opensend/core",
         replacement: path.resolve(__dirname, "./packages/core/src/index.ts"),
       },
+      {
+        find: "@opensend/mcp",
+        replacement: path.resolve(__dirname, "./packages/mcp/src/index.ts"),
+      },
       { find: "@", replacement: path.resolve(__dirname, "./src") },
     ],
   },


### PR DESCRIPTION
## Summary

Closes #260 for the first scoped MCP parity slice.

- Adds private workspace package `@opensend/mcp` with deterministic tool registry, JSON-RPC protocol handling, stdio entrypoint, and HTTP request adapter.
- Mounts API-key-only `POST /mcp` in `services/api`, forwarding tool calls to existing stable OpenSend public API routes instead of dashboard cookie/session auth.
- Documents Codex stdio, JSON-config stdio, and Streamable HTTP `/mcp` setup examples.
- Covers schema/tool registration, auth/error behavior, tool-call path mapping, and Hono `/mcp` transport with focused tests.

## Changed files

- `.gitignore`
- `agent_docs/learnings/active/2026-05-08-issue-260-mcp-http-adapter.md`
- `bun.lock`
- `packages/mcp/package.json`
- `packages/mcp/src/client.ts`
- `packages/mcp/src/http.ts`
- `packages/mcp/src/index.ts`
- `packages/mcp/src/protocol.ts`
- `packages/mcp/src/schema.ts`
- `packages/mcp/src/stdio.ts`
- `services/api/README.md`
- `services/api/package.json`
- `services/api/src/index.ts`
- `src/app/docs/page.tsx`
- `tests/mcp-server.test.ts`
- `vitest.config.ts`

## Validation

- `bunx vitest run tests/mcp-server.test.ts` — passed, 6 tests.
- `bun run typecheck` — passed.
- `bun run lint` — passed.
- `bun run build:api` — passed, bundled `services/api`.
- `.scratch/mcp-tools-list.sh` — passed, listed 12 MCP tools through HTTP adapter.
- `bunx tsc --noEmit --strict --skipLibCheck --moduleResolution bundler --module esnext --target es2022 --lib dom,dom.iterable,esnext packages/mcp/src/*.ts services/api/src/*.ts` — passed for the new package/service slice.
- `make check` — passed.
- `make test` — passed, 100 files / 851 tests.
- Push guardrails: typecheck and changed-file Biome passed.

## Intentionally deferred tools / risks

- Deferred from this first slice: received emails, broadcasts, segments, topics, contact properties, API-key management, and public `npx` packaging/release ownership.
- HTTP `/mcp` validates Bearer header shape at the MCP boundary; tool calls are then authorized by the existing public API using the same key, preserving current tenant scoping and error envelopes.
- Live production MCP client verification with a real API key was not run locally.
