### PR TITLE
fix(domains): insert empty dkim_tokens for BYO-DKIM rows (#262)

### DIFF
--- a/packages/core/src/services/domain.ts
+++ b/packages/core/src/services/domain.ts
@@ -253,7 +253,9 @@ export function createDomainService({
         name: domainName,
         region,
         status: "not_started",
-        dkimTokens: identity.dkimTokens ?? null,
+        // Production schema has NOT NULL on dkim_tokens; EXTERNAL rows
+        // legitimately have no SES-managed tokens, so insert an empty array.
+        dkimTokens: identity.dkimTokens ?? [],
         records,
         customReturnPath: input.customReturnPath ?? null,
         trackOpens: input.openTracking ?? false,


### PR DESCRIPTION
## Summary
Hotfix — production schema enforces NOT NULL on `dkim_tokens` from the legacy AWS_SES managed-DKIM era. EXTERNAL rows insert `null`, which the DB rejects.

## Symptom
`Failed to create domain: insert into "domains" ... null value in column "dkim_tokens" of relation "domains" violates not-null constraint`

The SES call + keypair generation are working — only the DB write fails.

## Fix
Insert `[]` instead of null for EXTERNAL rows. Empty array is the right semantic for "no SES-managed tokens" and satisfies the NOT NULL constraint without a migration.

Closes the immediate prod regression from #266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)