### PR TITLE
fix(domains): propagate verified status to per-record badges

### DIFF
--- a/src/app/api/domains/[id]/verify/route.ts
+++ b/src/app/api/domains/[id]/verify/route.ts
@@ -47,35 +47,23 @@ export async function POST(
 
     const identity = await getCachedDomainIdentity(domain.name);
 
-    let verificationStatus:
-      | "pending"
-      | "verified"
-      | "partially_verified"
-      | "failed"
-      | "temporary_failure" = "pending";
+    type DomainRecord = {
+      type: string;
+      name: string;
+      value: string;
+      status: string;
+      ttl: string;
+      priority?: number;
+    };
+    const existingRecords = (domain.records as DomainRecord[] | null) ?? [];
+    const recordsForUpdate: DomainRecord[] = existingRecords.map((record) => ({
+      ...record,
+      status: identity.verified ? "verified" : "pending",
+    }));
 
-    if (identity.verified) {
-      verificationStatus = "verified";
-    } else {
-      const records =
-        (domain.records as Array<{
-          type: string;
-          name: string;
-          value: string;
-          status: string;
-          ttl: string;
-          priority?: number;
-        }>) ?? [];
-      const verifiedCount = records.filter(
-        (record) => record.status === "verified",
-      ).length;
-
-      if (verifiedCount > 0 && verifiedCount < records.length) {
-        verificationStatus = "partially_verified";
-      } else if (verifiedCount === 0 && records.length > 0) {
-        verificationStatus = "pending";
-      }
-    }
+    const verificationStatus: "pending" | "verified" = identity.verified
+      ? "verified"
+      : "pending";
 
     const previousStatus = domain.status;
 
@@ -83,6 +71,7 @@ export async function POST(
       .update(domains)
       .set({
         status: verificationStatus,
+        records: recordsForUpdate,
       })
       .where(and(eq(domains.id, id), eq(domains.userId, userId)))
       .returning();


### PR DESCRIPTION
## Summary
- Verify route only updated `domain.status` but never touched `domain.records[].status`, so per-row DKIM/SPF/MX/DMARC badges stayed "Pending" even after SES flipped the identity to verified.
- Map each record's status from `identity.verified` so all rows flip alongside the overall domain status.
- Removes the dead `partially_verified` branch — `verifiedCount` was always 0 because per-record statuses were never written.

## Why now
Hit on `foreverbrowsing.com` after BYO-DKIM (#266 / #267): SES reports `VerifiedForSendingStatus: true`, `DkimStatus: SUCCESS`, but the dashboard still displayed every record as "Pending".

## Test plan
- [x] `bunx vitest run tests/cache-invalidation-routes.test.ts` (8 passing, including verify-after-cache-invalidate)
- [ ] After deploy: hit POST `/api/domains/{id}/verify` for foreverbrowsing.com and confirm all four record badges flip to "Verified"

🤖 Generated with [Claude Code](https://claude.com/claude-code)