### PR TITLE
feat(domains): periodic verification reconciler

### DIFF
--- a/packages/core/src/db/repositories/domainRepo.ts
+++ b/packages/core/src/db/repositories/domainRepo.ts
@@ -1,6 +1,8 @@
-import { and, desc, eq, lt } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, lt } from "drizzle-orm";
 import { db } from "../client";
 import { domains } from "../schema";
+
+const PENDING_VERIFICATION_STATUSES = ["not_started", "pending"] as const;
 
 export const domainRepo = {
   async findById(id: string) {
@@ -32,6 +34,16 @@ export const domainRepo = {
       .delete(domains)
       .where(eq(domains.id, id))
       .returning({ id: domains.id });
+  },
+
+  async listPendingVerification(options: { limit?: number } = {}) {
+    const { limit = 100 } = options;
+    return await db
+      .select()
+      .from(domains)
+      .where(inArray(domains.status, [...PENDING_VERIFICATION_STATUSES]))
+      .orderBy(asc(domains.createdAt))
+      .limit(limit);
   },
 
   async list(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export * from "./webhook-signing";
 export * from "./webhook-events";
 export * from "./services/dns";
 export * from "./services/domain";
+export * from "./services/domain-events";
 export * from "./services/webhook";
 export * from "./services/apiKeys";
 export * from "./services/email";

--- a/packages/core/src/services/domain-events.ts
+++ b/packages/core/src/services/domain-events.ts
@@ -1,0 +1,83 @@
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "../db/client";
+import { emailEvents, webhookDeliveries, webhooks } from "../db/schema";
+import {
+  type SupportedWebhookEventType,
+  isSupportedWebhookEventType,
+} from "../webhook-events";
+
+export type DomainEventPayload = {
+  id: string;
+  name: string;
+  status: string;
+  previous_status: string;
+  records: unknown[];
+  capabilities: unknown[];
+};
+
+export type EnqueueDomainEventInput = {
+  type: SupportedWebhookEventType;
+  userId: string;
+  payload: DomainEventPayload;
+};
+
+export type EnqueueDomainEventResult = {
+  eventId: string;
+  deliveryIds: string[];
+};
+
+export async function enqueueDomainEvent(
+  input: EnqueueDomainEventInput,
+): Promise<EnqueueDomainEventResult> {
+  const { type, payload, userId } = input;
+
+  if (!isSupportedWebhookEventType(type)) {
+    throw new Error(`Unsupported webhook event type: ${type}`);
+  }
+
+  return await db.transaction(async (tx) => {
+    const [event] = await tx
+      .insert(emailEvents)
+      .values({
+        emailId: null,
+        sourceId: null,
+        type,
+        payload,
+        userId,
+      })
+      .returning({ id: emailEvents.id });
+
+    const matchingWebhooks = await tx
+      .select({ id: webhooks.id })
+      .from(webhooks)
+      .where(
+        and(
+          eq(webhooks.userId, userId),
+          eq(webhooks.status, "active"),
+          sql`${webhooks.eventTypes} ? ${type}`,
+        ),
+      );
+
+    if (matchingWebhooks.length === 0) {
+      return { eventId: event.id, deliveryIds: [] };
+    }
+
+    const deliveries = await tx
+      .insert(webhookDeliveries)
+      .values(
+        matchingWebhooks.map((webhook) => ({
+          webhookId: webhook.id,
+          eventId: event.id,
+          status: "pending",
+          attempt: 0,
+          nextRetryAt: null,
+        })),
+      )
+      .returning({ id: webhookDeliveries.id });
+
+    return {
+      eventId: event.id,
+      deliveryIds: deliveries.map((delivery) => delivery.id),
+    };
+  });
+}

--- a/packages/core/src/services/domain.ts
+++ b/packages/core/src/services/domain.ts
@@ -86,10 +86,39 @@ export type DomainRepository = {
     data: DomainRow[];
     hasMore: boolean;
   }>;
+  listPendingVerification(options?: { limit?: number }): Promise<DomainRow[]>;
   create(data: DomainInsert): Promise<DomainRow[]>;
   findById(id: string): Promise<DomainRow | undefined>;
   update(id: string, data: Partial<DomainInsert>): Promise<DomainRow[]>;
   delete(id: string): Promise<Array<{ id: string }>>;
+};
+
+export type DomainReconcileResult =
+  | { status: "not_found" }
+  | {
+      status: "unchanged";
+      domain: DomainRow;
+    }
+  | {
+      status: "updated";
+      domain: DomainRow;
+      previousStatus: string;
+    };
+
+export type DomainReconcileBatchResult = {
+  scanned: number;
+  updated: number;
+  unchanged: number;
+  failed: number;
+  changes: Array<{
+    domainId: string;
+    domainName: string;
+    userId: string | null;
+    previousStatus: string;
+    nextStatus: string;
+    records: NonNullable<DomainRow["records"]>;
+    capabilities: NonNullable<DomainRow["capabilities"]>;
+  }>;
 };
 
 export type DomainServiceDependencies = {
@@ -276,16 +305,106 @@ export function createDomainService({
       return toDomainDetail(row);
     },
 
-    async verify(id: string) {
+    async reconcileVerification(id: string): Promise<DomainReconcileResult> {
       const domain = await repository.findById(id);
-      if (!domain) throw new Error("Domain not found");
+      if (!domain) return { status: "not_found" };
 
       const identity = await getDomainIdentity(domain.name);
-      const status: "pending" | "verified" | "failed" = identity.verified
+      const nextStatus: "pending" | "verified" = identity.verified
         ? "verified"
         : "pending";
 
-      return await repository.update(id, { status });
+      const existingRecords = (domain.records ?? []) as DomainRecord[];
+      const recordsForUpdate: DomainRecord[] = existingRecords.map(
+        (record) => ({
+          ...record,
+          status: identity.verified ? "verified" : "pending",
+        }),
+      );
+
+      const recordsChanged =
+        existingRecords.length !== recordsForUpdate.length ||
+        existingRecords.some(
+          (record, idx) => record.status !== recordsForUpdate[idx].status,
+        );
+      const statusChanged = domain.status !== nextStatus;
+
+      if (!statusChanged && !recordsChanged) {
+        return { status: "unchanged", domain };
+      }
+
+      const previousStatus = domain.status;
+      const [updated] = await repository.update(id, {
+        status: nextStatus,
+        records: recordsForUpdate,
+      });
+
+      if (!updated) {
+        await invalidateDomainCaches({ id, name: domain.name });
+        return { status: "not_found" };
+      }
+
+      await invalidateDomainCaches({ id: updated.id, name: updated.name });
+
+      if (!statusChanged) {
+        return { status: "unchanged", domain: updated };
+      }
+
+      return {
+        status: "updated",
+        domain: updated,
+        previousStatus,
+      };
+    },
+
+    async verify(id: string) {
+      const result = await this.reconcileVerification(id);
+      if (result.status === "not_found") {
+        throw new Error("Domain not found");
+      }
+      return [result.domain];
+    },
+
+    async reconcileAllPendingVerifications(
+      options: { limit?: number } = {},
+    ): Promise<DomainReconcileBatchResult> {
+      const pending = await repository.listPendingVerification({
+        limit: options.limit,
+      });
+
+      const result: DomainReconcileBatchResult = {
+        scanned: pending.length,
+        updated: 0,
+        unchanged: 0,
+        failed: 0,
+        changes: [],
+      };
+
+      for (const domain of pending) {
+        try {
+          const reconciled = await this.reconcileVerification(domain.id);
+          if (reconciled.status === "updated") {
+            result.updated++;
+            result.changes.push({
+              domainId: reconciled.domain.id,
+              domainName: reconciled.domain.name,
+              userId: reconciled.domain.userId ?? null,
+              previousStatus: reconciled.previousStatus,
+              nextStatus: reconciled.domain.status,
+              records: reconciled.domain.records ?? [],
+              capabilities: reconciled.domain.capabilities ?? [],
+            });
+          } else if (reconciled.status === "unchanged") {
+            result.unchanged++;
+          } else {
+            result.failed++;
+          }
+        } catch {
+          result.failed++;
+        }
+      }
+
+      return result;
     },
 
     async delete(id: string) {

--- a/packages/ingester/src/index.ts
+++ b/packages/ingester/src/index.ts
@@ -1,9 +1,11 @@
 import {
   createBackgroundJob,
   createTelemetryContext,
+  domainService,
   emailEventRepo,
   emailService,
   emitCloudWatchMetric,
+  enqueueDomainEvent,
   getTelemetryCarrier,
   logTelemetry,
   publishBackgroundJob,
@@ -119,6 +121,76 @@ app.post("/jobs/webhooks", async (c) =>
     c,
     async () => await webhookDispatcher.dispatchPendingDeliveries(),
   ),
+);
+
+app.post("/jobs/domain-verify", async (c) =>
+  runJobEndpoint(c, async () => {
+    const telemetry = createTelemetryContext({
+      service: "ingester",
+      operation: "POST /jobs/domain-verify",
+    });
+
+    let result: Awaited<
+      ReturnType<typeof domainService.reconcileAllPendingVerifications>
+    >;
+    try {
+      result = await domainService.reconcileAllPendingVerifications();
+    } catch (error) {
+      recordTelemetryError(telemetry, "domain.verify.reconcile_failed", error);
+      throw error;
+    }
+
+    for (const change of result.changes) {
+      if (!change.userId) continue;
+      try {
+        await enqueueDomainEvent({
+          type: "domain.updated",
+          userId: change.userId,
+          payload: {
+            id: change.domainId,
+            name: change.domainName,
+            status: change.nextStatus,
+            previous_status: change.previousStatus,
+            records: change.records,
+            capabilities: change.capabilities,
+          },
+        });
+      } catch (error) {
+        recordTelemetryError(
+          telemetry,
+          "domain.verify.event_enqueue_failed",
+          error,
+          { domain_id: change.domainId },
+        );
+      }
+    }
+
+    logTelemetry("info", "domain.verify.reconcile_completed", telemetry, {
+      scanned: result.scanned,
+      updated: result.updated,
+      unchanged: result.unchanged,
+      failed: result.failed,
+    });
+
+    emitCloudWatchMetric(telemetry, {
+      metrics: [
+        { name: "DomainVerifyScanned", value: result.scanned, unit: "Count" },
+        { name: "DomainVerifyUpdated", value: result.updated, unit: "Count" },
+        { name: "DomainVerifyFailed", value: result.failed, unit: "Count" },
+      ],
+      dimensions: {
+        Service: "ingester",
+        Operation: "domain.verify.reconcile",
+      },
+    });
+
+    return {
+      scanned: result.scanned,
+      updated: result.updated,
+      unchanged: result.unchanged,
+      failed: result.failed,
+    };
+  }),
 );
 
 app.post("/webhooks/stripe", async (c) => {

--- a/src/app/api/domains/[id]/verify/route.ts
+++ b/src/app/api/domains/[id]/verify/route.ts
@@ -4,17 +4,13 @@ import {
   unauthorizedResponse,
 } from "@/lib/api-auth";
 import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { domains } from "@/lib/db/schema";
 import {
   getCachedDomainById,
-  getCachedDomainIdentity,
   invalidateDomainCaches,
 } from "@/lib/domain-cache";
 import { queueEvent } from "@/lib/events";
 import { verifyDomainParamsSchema } from "@/lib/validation/domains";
-import { getEffectiveReturnPathLabel } from "@opensend/core";
-import { and, eq } from "drizzle-orm";
+import { domainService, getEffectiveReturnPathLabel } from "@opensend/core";
 
 export async function POST(
   request: Request,
@@ -48,68 +44,40 @@ export async function POST(
       return Response.json({ error: "Domain not found" }, { status: 404 });
     }
 
-    const identity = await getCachedDomainIdentity(domain.name);
+    const result = await domainService.reconcileVerification(id);
 
-    type DomainRecord = {
-      type: string;
-      name: string;
-      value: string;
-      status: string;
-      ttl: string;
-      priority?: number;
-    };
-    const existingRecords = (domain.records as DomainRecord[] | null) ?? [];
-    const recordsForUpdate: DomainRecord[] = existingRecords.map((record) => ({
-      ...record,
-      status: identity.verified ? "verified" : "pending",
-    }));
-
-    const verificationStatus: "pending" | "verified" = identity.verified
-      ? "verified"
-      : "pending";
-
-    const previousStatus = domain.status;
-
-    const [updated] = await db
-      .update(domains)
-      .set({
-        status: verificationStatus,
-        records: recordsForUpdate,
-      })
-      .where(and(eq(domains.id, id), eq(domains.userId, userId)))
-      .returning();
-
-    if (!updated) {
+    if (result.status === "not_found") {
       await invalidateDomainCaches({ id, name: domain.name });
       return Response.json({ error: "Domain not found" }, { status: 404 });
     }
 
-    await invalidateDomainCaches({ id: updated.id, name: updated.name });
+    const reconciled = result.domain;
+    await invalidateDomainCaches({ id: reconciled.id, name: reconciled.name });
 
-    if (updated.status !== previousStatus) {
+    if (result.status === "updated") {
       await queueEvent({
         type: "domain.updated",
         userId,
         payload: {
-          id: updated.id,
-          name: updated.name,
-          status: updated.status,
-          previous_status: previousStatus,
-          records: updated.records || [],
-          capabilities: updated.capabilities || [],
+          id: reconciled.id,
+          name: reconciled.name,
+          status: reconciled.status,
+          previous_status: result.previousStatus,
+          records: reconciled.records || [],
+          capabilities: reconciled.capabilities || [],
         },
       });
     }
 
     return Response.json({
       object: "domain",
-      id: updated.id,
-      name: updated.name,
-      status: updated.status,
-      records: updated.records || [],
-      custom_return_path: updated.customReturnPath,
-      return_path: getEffectiveReturnPathLabel(updated.customReturnPath),
-      created_at: updated.createdAt,
+      id: reconciled.id,
+      name: reconciled.name,
+      status: reconciled.status,
+      records: reconciled.records || [],
+      custom_return_path: reconciled.customReturnPath,
+      return_path: getEffectiveReturnPathLabel(reconciled.customReturnPath),
+      created_at: reconciled.createdAt,
     });
   } catch (err) {
     const message =

--- a/tests/api-domains.test.ts
+++ b/tests/api-domains.test.ts
@@ -10,6 +10,7 @@ const mockGetDomainIdentity = vi.hoisted(() => vi.fn());
 const mockCreateDomainIdentity = vi.hoisted(() => vi.fn());
 const mockCheckDomainQuota = vi.hoisted(() => vi.fn());
 const mockCreateDomain = vi.hoisted(() => vi.fn());
+const mockReconcileVerification = vi.hoisted(() => vi.fn());
 const mockDb = vi.hoisted(() => ({
   insert: vi.fn(),
   update: vi.fn(),
@@ -47,6 +48,9 @@ vi.mock("@opensend/core", () => ({
     createDomain: mockCreateDomain,
     listDomains: vi.fn(),
   }),
+  domainService: {
+    reconcileVerification: mockReconcileVerification,
+  },
   getEffectiveReturnPathLabel: (value: string | null | undefined) =>
     value?.trim() || "send",
 }));
@@ -106,6 +110,7 @@ describe("Domain API validation", () => {
     mockDeleteDomainIdentity.mockReset();
     mockGetDomainIdentity.mockReset();
     mockCreateDomainIdentity.mockReset();
+    mockReconcileVerification.mockReset();
     mockCheckDomainQuota.mockResolvedValue({
       ok: true,
       info: { limit: 10, used: 0 },
@@ -391,17 +396,25 @@ describe("Domain API validation", () => {
     const updated = {
       ...domain,
       status: "verified",
+      records: [
+        {
+          type: "TXT",
+          name: "_dmarc.example.com",
+          value: "v=DMARC1; p=none;",
+          status: "verified",
+          ttl: "Auto",
+        },
+      ],
+      capabilities: [],
+      customReturnPath: null,
       createdAt: new Date("2024-01-01T00:00:00.000Z"),
     };
 
     mockDb.query.domains.findFirst.mockResolvedValue(domain);
-    mockGetDomainIdentity.mockResolvedValue({ verified: true });
-    mockDb.update.mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([updated]),
-        }),
-      }),
+    mockReconcileVerification.mockResolvedValue({
+      status: "updated",
+      domain: updated,
+      previousStatus: "pending",
     });
 
     const { POST } = await import("@/app/api/domains/[id]/verify/route");
@@ -421,10 +434,10 @@ describe("Domain API validation", () => {
       type: "TXT",
       name: "_dmarc.example.com",
       value: "v=DMARC1; p=none;",
-      status: "pending",
+      status: "verified",
       ttl: "Auto",
     });
-    expect(mockDb.query.domains.findFirst).toHaveBeenCalledTimes(1);
+    expect(mockReconcileVerification).toHaveBeenCalledWith(VALID_DOMAIN_ID);
     expect(mockQueueEvent).toHaveBeenCalledWith({
       type: "domain.updated",
       userId: "user-1",
@@ -457,8 +470,7 @@ describe("Domain API validation", () => {
     });
 
     expect(res.status).toBe(404);
-    expect(mockGetDomainIdentity).not.toHaveBeenCalled();
-    expect(mockDb.update).not.toHaveBeenCalled();
+    expect(mockReconcileVerification).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/cache-invalidation-routes.test.ts
+++ b/tests/cache-invalidation-routes.test.ts
@@ -14,6 +14,7 @@ const mockDeleteDomainIdentity = vi.hoisted(() => vi.fn());
 const mockListDNSRecords = vi.hoisted(() => vi.fn());
 const mockDeleteDNSRecord = vi.hoisted(() => vi.fn());
 const mockQueueEvent = vi.hoisted(() => vi.fn());
+const mockReconcileVerification = vi.hoisted(() => vi.fn());
 
 const VALID_DOMAIN_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -35,6 +36,9 @@ vi.mock("@opensend/core", () => ({
   createDomainService: () => ({
     createDomain: mockCreateDomain,
   }),
+  domainService: {
+    reconcileVerification: mockReconcileVerification,
+  },
   DMARC_RECORD_VALUE: "v=DMARC1; p=none;",
   buildDmarcRecordName: (domainName: string) => `_dmarc.${domainName}`,
   getEffectiveReturnPathLabel: (customReturnPath: string | null | undefined) =>
@@ -257,25 +261,18 @@ describe("cache invalidation routes", () => {
       status: "pending",
       records: [],
     });
-    mockGetCachedDomainIdentity.mockResolvedValue({
-      verified: true,
-      dkimStatus: "SUCCESS",
-      dkimTokens: ["a"],
-    });
-    mockDb.update.mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([
-            {
-              id: VALID_DOMAIN_ID,
-              name: "example.com",
-              status: "verified",
-              records: [],
-              createdAt: new Date("2026-04-28T00:00:00.000Z"),
-            },
-          ]),
-        }),
-      }),
+    mockReconcileVerification.mockResolvedValue({
+      status: "updated",
+      domain: {
+        id: VALID_DOMAIN_ID,
+        name: "example.com",
+        status: "verified",
+        records: [],
+        capabilities: [],
+        customReturnPath: null,
+        createdAt: new Date("2026-04-28T00:00:00.000Z"),
+      },
+      previousStatus: "pending",
     });
 
     const route = await import("@/app/api/domains/[id]/verify/route");

--- a/tests/domain-service.test.ts
+++ b/tests/domain-service.test.ts
@@ -38,6 +38,9 @@ function createRepository(overrides: Partial<DomainRepository> = {}) {
     async list() {
       return { data: [], hasMore: false };
     },
+    async listPendingVerification() {
+      return [];
+    },
     async create(data: DomainInsert) {
       return [domainRow({ ...data, id: "created-domain" })];
     },
@@ -216,6 +219,157 @@ describe("domain service", () => {
         ttl: "Auto",
       },
     ]);
+  });
+
+  it("reconciles verification: maps records[].status from identity.verified", async () => {
+    const updates: Array<{ id: string; data: Partial<DomainInsert> }> = [];
+    const existingDomain = domainRow({
+      id: "dom-1",
+      name: "example.com",
+      status: "pending",
+      records: [
+        {
+          type: "TXT",
+          name: "_dmarc.example.com",
+          value: "v=DMARC1; p=none;",
+          status: "pending",
+          ttl: "Auto",
+        },
+        {
+          type: "TXT",
+          name: "send.example.com",
+          value: "v=spf1 include:amazonses.com ~all",
+          status: "pending",
+          ttl: "Auto",
+        },
+      ],
+    });
+    const repository = createRepository({
+      async findById() {
+        return existingDomain;
+      },
+      async update(id, data) {
+        updates.push({ id, data });
+        return [domainRow({ ...existingDomain, ...data })];
+      },
+    });
+
+    const service = createDomainService({
+      repository,
+      getDomainIdentity: async () => ({ verified: true }),
+    });
+
+    const result = await service.reconcileVerification("dom-1");
+
+    expect(result.status).toBe("updated");
+    expect(updates).toHaveLength(1);
+    expect(updates[0].data.status).toBe("verified");
+    expect(updates[0].data.records).toEqual([
+      expect.objectContaining({
+        name: "_dmarc.example.com",
+        status: "verified",
+      }),
+      expect.objectContaining({
+        name: "send.example.com",
+        status: "verified",
+      }),
+    ]);
+    if (result.status === "updated") {
+      expect(result.previousStatus).toBe("pending");
+      expect(result.domain.status).toBe("verified");
+    }
+  });
+
+  it("reconciles verification: returns unchanged when status and records are stable", async () => {
+    const updates: Array<{ id: string; data: Partial<DomainInsert> }> = [];
+    const existingDomain = domainRow({
+      id: "dom-2",
+      status: "pending",
+      records: [
+        {
+          type: "TXT",
+          name: "_dmarc.example.com",
+          value: "v=DMARC1; p=none;",
+          status: "pending",
+          ttl: "Auto",
+        },
+      ],
+    });
+    const repository = createRepository({
+      async findById() {
+        return existingDomain;
+      },
+      async update(id, data) {
+        updates.push({ id, data });
+        return [domainRow({ ...existingDomain, ...data })];
+      },
+    });
+
+    const service = createDomainService({
+      repository,
+      getDomainIdentity: async () => ({ verified: false }),
+    });
+
+    const result = await service.reconcileVerification("dom-2");
+
+    expect(result.status).toBe("unchanged");
+    expect(updates).toHaveLength(0);
+  });
+
+  it("reconcileAllPendingVerifications: tolerates per-domain failures", async () => {
+    const pendingA = domainRow({
+      id: "dom-a",
+      name: "a.example",
+      status: "not_started",
+      userId: "user-a",
+      records: [],
+    });
+    const pendingB = domainRow({
+      id: "dom-b",
+      name: "b.example",
+      status: "pending",
+      userId: "user-b",
+      records: [],
+    });
+
+    const repository = createRepository({
+      async listPendingVerification() {
+        return [pendingA, pendingB];
+      },
+      async findById(id) {
+        return id === "dom-a" ? pendingA : pendingB;
+      },
+      async update(id, data) {
+        return [
+          domainRow({
+            ...(id === "dom-a" ? pendingA : pendingB),
+            ...data,
+          }),
+        ];
+      },
+    });
+
+    const service = createDomainService({
+      repository,
+      getDomainIdentity: async (name) => {
+        if (name === "a.example") return { verified: true };
+        throw new Error("ses unavailable");
+      },
+    });
+
+    const result = await service.reconcileAllPendingVerifications();
+
+    expect(result.scanned).toBe(2);
+    expect(result.updated).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]).toMatchObject({
+      domainId: "dom-a",
+      domainName: "a.example",
+      userId: "user-a",
+      previousStatus: "not_started",
+      nextStatus: "verified",
+    });
   });
 
   it("lists with normalized pagination and maps public list fields", async () => {


### PR DESCRIPTION
## Summary
- Domain status was stuck at `not_started`/`pending` in the dashboard because nothing automatically calls verify. The fix in #272 only propagates record badges *when* `/api/domains/:id/verify` is hit, and that endpoint isn't wired into the UI.
- Adds a server-side reconciler (`domainService.reconcileAllPendingVerifications`) that polls SES `GetEmailIdentity` for every domain in `not_started`/`pending` and writes both `domain.status` and `records[].status` back. Exposed as `POST /jobs/domain-verify` on the ingester, mirroring the existing `/jobs/scheduled-emails` and `/jobs/webhooks` cron pattern.
- Emits `domain.updated` webhooks for every status flip the cron detects, so API-only users get notified even if no one opens the dashboard.
- Refactors `/api/domains/:id/verify` to share `domainService.reconcileVerification` with the cron — manual and automatic paths now produce identical results.

## Deploy
Add a cron entry that POSTs to `https://<ingester>/jobs/domain-verify` every few minutes (uses the same `INGESTER_JOB_TOKEN` as the other job endpoints).

## Test plan
- [x] `make check`
- [x] `make test` (824/824)
- [x] Added `tests/domain-service.test.ts` cases: status flip updates `records[].status`, unchanged path skips writes, batch tolerates per-domain failures
- [x] Updated `tests/api-domains.test.ts` and `tests/cache-invalidation-routes.test.ts` to use the shared `domainService.reconcileVerification`
- [ ] After deploy: hit `/jobs/domain-verify` once, confirm `foreverbrowsing.com` flips to `verified` and per-row badges update without a manual API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)