### PR TITLE
fix(build): exclude services/ from Next.js typecheck

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,5 +29,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "packages"]
+  "exclude": ["node_modules", "packages", "services"]
 }


### PR DESCRIPTION
## Summary

- Adds `services` to the root `tsconfig.json` exclude list so `next build` no longer tries to typecheck files outside the Next.js app
- Unblocks Deploy on `main` (failing since #263 introduced `@opensend/mcp`)

## Root cause

`next build` was failing with:

```
./services/api/src/index.ts:1:38
Type error: Cannot find module '@opensend/mcp' or its corresponding type declarations.
```

The Dockerfile's `deps` stage runs `bun install`, which creates `services/api/node_modules/@opensend/mcp` (bun's per-workspace hoisting for deps not depended on by root). The `builder` stage then copies **only** `/app/node_modules` from the deps layer:

```dockerfile
COPY --from=deps /app/node_modules ./node_modules
```

`services/api/node_modules/` is silently dropped. When `next build` typechecks `services/api/src/index.ts` (matched by the root tsconfig `**/*.ts` glob), TypeScript can't resolve `@opensend/mcp` because the symlink isn't there.

CI's `tsc --noEmit` keeps passing because it runs against the full workspace install (no Docker copy step).

`services/` isn't part of the Next.js app — it's a separate Hono runtime with its own `bun build`. The root tsconfig already excludes `packages/` for the same reason; `services/` was just missed when it was added to the workspace.

## Why this is the right fix

- Matches existing treatment of `packages/`
- Doesn't change runtime behavior — Next.js never shipped or imported services/ code
- Smallest possible change: one line

## Follow-up (not in this PR)

`services/api` will no longer be typechecked by the root `tsc --noEmit`. It still has its own `bun build` step, but to keep strict typecheck coverage we should add `services/api/tsconfig.json` and a CI step (`bunx tsc -p services/api`). Filing as a separate task.

## Test plan

- [x] Local `bunx tsc --noEmit --pretty false` passes
- [ ] CI `Typecheck (full project)` passes
- [ ] Deploy workflow advances past the typecheck step on the merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)