### PR TITLE
Improve Playwright E2E standards and tenant fixtures

### DIFF
--- a/agent_docs/learnings/active/2026-05-08-issue-229-e2e-tenant-fixtures.md
+++ b/agent_docs/learnings/active/2026-05-08-issue-229-e2e-tenant-fixtures.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-08
+issue: "#229"
+type: pattern
+promoted_to: null
+---
+
+## Tenant-isolation E2E specs should create real users plus API keys
+
+**What:** Issue #229 adds shared Playwright helpers that create deterministic Better Auth users/sessions, full-access API keys, and cleanup by `E2E_RUN_ID`/test title. The canonical tenant-isolation proof uses real app routes and Postgres rows instead of route mocks.
+**Why:** API-key tenant ownership depends on the `api_keys.user_id` resolved by `validateApiKey`; a signed dashboard cookie alone does not prove public API isolation.
+**Fix:** For future cross-tenant API regressions, create two tenants with `createE2ETenant`, call app routes via `APIRequestContext`, assert list exclusion plus 404/deny on detail and mutation, then call `cleanupE2ERun` in `finally`.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,8 +1,37 @@
-# E2E testing standards
+# Playwright E2E testing standards
 
-## Authenticated dashboard tests
+Issue #229 sets the E2E bar for future agent work: prove behavior through the
+real app boundary whenever possible, and label narrower smoke/mocked tests so
+reviewers do not mistake them for full end-to-end coverage.
 
-Use the real Better Auth fixture instead of mocking `/api/auth/get-session`:
+## Decision tree
+
+1. **Vitest unit tests** — use for pure functions, schema validation, DTO
+   mapping, repository/service branching with injected dependencies, and fast
+   edge-case matrices. Do not use Vitest alone to claim a browser, auth, route,
+   or database workflow works end-to-end.
+2. **Playwright API request tests** — use when the product contract is an app
+   route or public API. These tests should call `request`/`APIRequestContext`
+   against the running Next app and use real Postgres rows for auth, tenants,
+   API keys, and seeded data. This is the default for tenant isolation and route
+   authorization regressions.
+3. **Playwright browser UI tests** — use when the claim includes rendered UI,
+   navigation, forms, server components, cookies, or browser-visible behavior.
+   Use the real Better Auth session fixture for authenticated dashboard pages.
+4. **Mocked smoke/integration tests** — allowed only for UI component flows that
+   would otherwise require external providers or unfinished backend contracts.
+   Keep route mocks local to the spec, state that the test is mocked/smoke in
+   the title or classification table below, and do not cite it as proof of real
+   API/database behavior.
+
+Do not make every UI test hit SES, Stripe, Cloudflare, S3, or other real
+external services. Prefer sandbox/dev stubs at the app boundary and reserve real
+external-provider coverage for explicitly scoped scenarios.
+
+## Shared fixtures and helpers
+
+Import from `./fixtures/auth` for tests that need real auth, tenants, API keys,
+or deterministic cleanup:
 
 ```ts
 import { expect, test } from "./fixtures/auth";
@@ -10,21 +39,90 @@ import { expect, test } from "./fixtures/auth";
 test("dashboard flow", async ({ authenticatedPage, e2eUser, e2eDb }) => {
   await authenticatedPage.goto("/domains");
   await expect(authenticatedPage.getByRole("heading", { name: "Domains" })).toBeVisible();
+
+  const { rows } = await e2eDb.query("select id from domains where user_id = $1", [
+    e2eUser.id,
+  ]);
+  expect(rows).toBeDefined();
+});
+
+test("API route flow", async ({ e2eApiRequest }) => {
+  const response = await e2eApiRequest.get("/api/contacts");
+  expect(response.status()).toBe(200);
 });
 ```
 
-The fixture creates a real Postgres `user` + `session`, signs the
-`better-auth.session_token` cookie the same way Better Auth expects, adds it to
-the browser context, and removes the auth rows after the test.
+The fixture provides:
 
-## Rules
+- `e2eDb` — a real `pg` client connected through `DATABASE_URL`.
+- `e2eRunId` — a deterministic marker derived from the Playwright test title,
+  worker, retry, and parallel index, or from `E2E_RUN_ID` when provided.
+- `createE2EUser(client, runId, suffix)` — inserts a Better Auth `user` and
+  `session` row.
+- `authenticatedPage` — adds a signed `better-auth.session_token` cookie for a
+  real session; this is the canonical dashboard auth path. Client-side mocks of
+  `/api/auth/get-session` do **not** authenticate server components or app
+  routes that call `getServerSession()`.
+- `createE2EApiKey(client, runId, userId, suffix)` — inserts a full-access API
+  key with a deterministic raw token and hash.
+- `createE2ETenant(client, runId, suffix)` — creates a user plus API key for
+  multi-tenant API-route tests.
+- `e2eTenant` and `e2eApiRequest` — a default tenant and API request context
+  with the tenant's bearer token.
+- `cleanupE2ERun(client, runId)` — deletes rows owned by the deterministic test
+  users/API keys and contact rows marked with the run id. Call it in `finally`
+  when a spec creates extra tenants or app data.
 
-- Server-rendered dashboard pages must use `authenticatedPage`; client route
-  mocks do not authenticate `getServerSession()`.
-- Keep auth backed by real `DATABASE_URL` rows and real browser cookies.
-- Do not route-mock `/api/auth/get-session` for tests that need dashboard page
-  or app-route authorization.
-- Tests that create tenant-owned app rows should delete those rows in their own
-  `finally` block using `e2eUser.id`.
-- For SES-touching scenarios, run with a HOME that does not contain AWS
-  credentials so local development uses the SES dev stub.
+## Database and cleanup rules
+
+- Every DB-backed E2E test must skip with a clear reason when `DATABASE_URL` is
+  missing.
+- Use deterministic emails like `name@${e2eRunId}.e2e.opensend.test` and store
+  `{ test_run_id: e2eRunId }` in `document`/properties when the table supports
+  it.
+- Clean before and after by `e2eRunId`. Avoid data-dependent no-op assertions;
+  assert exact IDs or exact status codes.
+- Avoid brittle sleeps. Prefer URL assertions, locator assertions, route/API
+  responses, or DB polling tied to a concrete condition.
+- For SES-touching scenarios, run with an isolated `HOME` that has no AWS
+  credentials so local development uses the SES dev stub instead of creating
+  real SES identities.
+
+## Current E2E classification audit
+
+| Spec | Classification | Notes |
+| --- | --- | --- |
+| `tenant-isolation.spec.ts` | Real Playwright API E2E | Canonical issue #229 proof: real app routes, API keys, Postgres users/contacts, cross-tenant list/detail/mutation/delete denial. |
+| `domain-create-auth.spec.ts` | Real browser E2E | Uses `authenticatedPage`, real Better Auth rows, dashboard UI, and Postgres domain assertion. |
+| `domains-page.spec.ts` | Real browser E2E | Uses `authenticatedPage`; mostly page rendering/navigation over current DB state. |
+| `landing-page.spec.ts` | Real browser E2E | Public landing page plus signed-in redirect through real auth fixture. |
+| `logs-search.spec.ts` | Real browser/API-backed E2E | Requires `DATABASE_URL`; seeds dashboard log data. |
+| `unsubscribe.spec.ts` | Real public route E2E | Uses real Postgres contact row for success path; invalid-token path is public-route smoke. |
+| `emails-alias.spec.ts`, `openapi.spec.ts` | Real API smoke | Calls real app routes, but negative/static assertions only; not a full domain workflow proof. |
+| `billing-checkout.spec.ts`, `billing-page.spec.ts` | Mixed smoke/mocked integration | Negative API assertions are real route smoke; checkout UI uses route mocks for Stripe-dependent flow. |
+| `automations-dashboard.spec.ts`, `sidebar-logout.spec.ts` | Mocked browser integration | Route-mocks auth/API responses; useful UI coverage but not server auth or DB proof. |
+| Broadcast/template editor/list specs | API-assisted UI smoke | Create data through page request and exercise UI, but currently depend on legacy request auth assumptions; treat as smoke until migrated to shared fixtures. |
+| Remaining component/page specs | Browser smoke | Primarily render/navigation/interaction checks; use them for UI regressions, not tenant/auth/data-isolation proof. |
+
+When adding or changing a spec, update this table if its proof level changes.
+
+## Running E2E tests
+
+`make test-e2e` runs `bun run test:e2e`, which starts `bun run dev` on port
+`3015` through `playwright.config.ts` unless a server already exists.
+
+Prerequisites for DB/auth-backed specs:
+
+1. Install dependencies with Bun.
+2. Start or provide Postgres and set `DATABASE_URL`.
+3. Apply migrations: `bun run db:migrate` (or use `docker compose up -d`, whose
+   migrator service applies migrations for the compose database).
+4. Set `BETTER_AUTH_SECRET` consistently when overriding the local default.
+5. Optional: set `E2E_RUN_ID=<short-id>` to group cleanup for a local run.
+
+Targeted examples:
+
+```bash
+bunx playwright test tests/e2e/tenant-isolation.spec.ts
+bunx playwright test tests/e2e/domain-create-auth.spec.ts
+```

--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -1,6 +1,6 @@
-import { createHmac } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import { test as base, expect } from "@playwright/test";
-import type { Page } from "@playwright/test";
+import type { APIRequestContext, Page, TestInfo } from "@playwright/test";
 import { Client } from "pg";
 
 export interface E2EUser {
@@ -12,9 +12,25 @@ export interface E2EUser {
   signedSessionToken: string;
 }
 
+export interface E2EApiKey {
+  id: string;
+  token: string;
+  tokenHash: string;
+  userId: string;
+  authorization: string;
+}
+
+export interface E2ETenant {
+  user: E2EUser;
+  apiKey: E2EApiKey;
+}
+
 type AuthFixtures = {
   authenticatedPage: Page;
+  e2eApiRequest: APIRequestContext;
   e2eDb: Client;
+  e2eRunId: string;
+  e2eTenant: E2ETenant;
   e2eUser: E2EUser;
 };
 
@@ -22,12 +38,38 @@ function getDatabaseUrl(): string | null {
   return process.env.DATABASE_URL ?? null;
 }
 
-function getBaseUrl(): string {
+export function getE2EBaseUrl(): string {
   return (
     process.env.E2E_BASE_URL ??
     process.env.NEXT_PUBLIC_APP_URL ??
     `http://localhost:${process.env.PORT ?? "3015"}`
   );
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+}
+
+function buildRunId(testInfo: TestInfo): string {
+  const provided = process.env.E2E_RUN_ID?.trim();
+  if (provided) return slugify(provided);
+
+  const stableTitle = slugify(testInfo.titlePath.slice(1).join("-"));
+  return [
+    "e2e",
+    stableTitle,
+    `w${testInfo.workerIndex}`,
+    `r${testInfo.retry}`,
+    `p${testInfo.parallelIndex}`,
+  ].join("-");
+}
+
+function hashApiKey(rawKey: string): string {
+  return createHash("sha256").update(rawKey).digest("hex");
 }
 
 export function signBetterAuthSessionToken(sessionToken: string): string {
@@ -39,12 +81,56 @@ export function signBetterAuthSessionToken(sessionToken: string): string {
   return `${sessionToken}.${signature}`;
 }
 
-async function insertE2EUser(client: Client, runId: string): Promise<E2EUser> {
-  const userId = `e2e-user-${runId}`;
-  const sessionToken = `e2e-session-${runId}`;
-  const sessionId = `e2e-session-id-${runId}`;
-  const email = `${userId}@example.com`;
-  const name = "OpenSend E2E User";
+export async function cleanupE2ERun(
+  client: Client,
+  runId: string,
+): Promise<void> {
+  const userPrefix = `e2e-user-${runId}`;
+  const apiKeyPrefix = `e2e-api-key-${runId}`;
+  const emailPattern = `%@${runId}.e2e.opensend.test`;
+
+  await client.query(
+    `delete from webhook_deliveries
+     where event_id in (
+       select id from email_events
+       where user_id like $1
+     )`,
+    [`${userPrefix}%`],
+  );
+  await client.query("delete from email_events where user_id like $1", [
+    `${userPrefix}%`,
+  ]);
+  await client.query(
+    "delete from contacts_to_segments where contact_id in (select id from contacts where user_id like $1 or email like $2 or document->>'test_run_id' = $3)",
+    [`${userPrefix}%`, emailPattern, runId],
+  );
+  await client.query(
+    "delete from contacts where user_id like $1 or email like $2 or document->>'test_run_id' = $3",
+    [`${userPrefix}%`, emailPattern, runId],
+  );
+  await client.query(
+    "delete from api_keys where user_id like $1 or name like $2 or document->>'test_run_id' = $3",
+    [`${userPrefix}%`, `${apiKeyPrefix}%`, runId],
+  );
+  await client.query('delete from "session" where user_id like $1', [
+    `${userPrefix}%`,
+  ]);
+  await client.query('delete from "account" where user_id like $1', [
+    `${userPrefix}%`,
+  ]);
+  await client.query('delete from "user" where id like $1', [`${userPrefix}%`]);
+}
+
+export async function createE2EUser(
+  client: Client,
+  runId: string,
+  suffix = "primary",
+): Promise<E2EUser> {
+  const userId = `e2e-user-${runId}-${suffix}`;
+  const sessionToken = `e2e-session-${runId}-${suffix}`;
+  const sessionId = `e2e-session-id-${runId}-${suffix}`;
+  const email = `${userId}@${runId}.e2e.opensend.test`;
+  const name = `OpenSend E2E ${suffix}`;
 
   await client.query(
     `insert into "user" (id, name, email, email_verified, created_at, updated_at)
@@ -69,16 +155,51 @@ async function insertE2EUser(client: Client, runId: string): Promise<E2EUser> {
   };
 }
 
-async function cleanupE2EUser(client: Client, user: E2EUser): Promise<void> {
-  await client.query('delete from "session" where token = $1 or user_id = $2', [
-    user.sessionToken,
-    user.id,
-  ]);
-  await client.query('delete from "account" where user_id = $1', [user.id]);
-  await client.query('delete from "user" where id = $1', [user.id]);
+export async function createE2EApiKey(
+  client: Client,
+  runId: string,
+  userId: string,
+  suffix = "primary",
+): Promise<E2EApiKey> {
+  const rawKey = `re_e2e_${hashApiKey(`${runId}:${suffix}:${userId}`).slice(0, 32)}`;
+  const tokenHash = hashApiKey(rawKey);
+  const { rows } = await client.query<{ id: string }>(
+    `insert into api_keys (name, token_hash, token_preview, permission, user_id, document)
+     values ($1, $2, $3, 'full_access', $4, $5::jsonb)
+     on conflict (token_hash) do update set user_id = excluded.user_id
+     returning id`,
+    [
+      `e2e-api-key-${runId}-${suffix}`,
+      tokenHash,
+      `${rawKey.slice(0, 6)}...${rawKey.slice(-4)}`,
+      userId,
+      JSON.stringify({ test_run_id: runId }),
+    ],
+  );
+
+  return {
+    id: rows[0]?.id ?? "",
+    token: rawKey,
+    tokenHash,
+    userId,
+    authorization: `Bearer ${rawKey}`,
+  };
+}
+
+export async function createE2ETenant(
+  client: Client,
+  runId: string,
+  suffix: string,
+): Promise<E2ETenant> {
+  const user = await createE2EUser(client, runId, suffix);
+  const apiKey = await createE2EApiKey(client, runId, user.id, suffix);
+  return { user, apiKey };
 }
 
 export const test = base.extend<AuthFixtures>({
+  e2eRunId: async ({ browserName: _browserName }, use, testInfo) => {
+    await use(buildRunId(testInfo));
+  },
   e2eDb: async ({ browserName: _browserName }, use, testInfo) => {
     const databaseUrl = getDatabaseUrl();
     testInfo.skip(!databaseUrl, "DATABASE_URL is required for auth-backed E2E");
@@ -92,16 +213,31 @@ export const test = base.extend<AuthFixtures>({
       await client.end();
     }
   },
-  e2eUser: async ({ e2eDb }, use, testInfo) => {
-    const runId = `${testInfo.workerIndex}-${Date.now()}-${Math.random()
-      .toString(36)
-      .slice(2)}`;
-    const user = await insertE2EUser(e2eDb, runId);
+  e2eTenant: async ({ e2eDb, e2eRunId }, use) => {
+    await cleanupE2ERun(e2eDb, e2eRunId);
+    const tenant = await createE2ETenant(e2eDb, e2eRunId, "primary");
 
     try {
-      await use(user);
+      await use(tenant);
     } finally {
-      await cleanupE2EUser(e2eDb, user);
+      await cleanupE2ERun(e2eDb, e2eRunId);
+    }
+  },
+  e2eUser: async ({ e2eTenant }, use) => {
+    await use(e2eTenant.user);
+  },
+  e2eApiRequest: async ({ playwright, e2eTenant }, use) => {
+    const request = await playwright.request.newContext({
+      baseURL: getE2EBaseUrl(),
+      extraHTTPHeaders: {
+        Authorization: e2eTenant.apiKey.authorization,
+      },
+    });
+
+    try {
+      await use(request);
+    } finally {
+      await request.dispose();
     }
   },
   authenticatedPage: async ({ context, e2eUser, page }, use) => {
@@ -109,7 +245,7 @@ export const test = base.extend<AuthFixtures>({
       {
         name: "better-auth.session_token",
         value: e2eUser.signedSessionToken,
-        url: getBaseUrl(),
+        url: getE2EBaseUrl(),
         httpOnly: true,
         sameSite: "Lax",
       },

--- a/tests/e2e/tenant-isolation.spec.ts
+++ b/tests/e2e/tenant-isolation.spec.ts
@@ -1,0 +1,98 @@
+import {
+  cleanupE2ERun,
+  createE2ETenant,
+  expect,
+  getE2EBaseUrl,
+  test,
+} from "./fixtures/auth";
+
+test("contact API routes isolate tenant-owned list, detail, mutation, and delete access", async ({
+  e2eDb,
+  e2eRunId,
+  playwright,
+}) => {
+  await cleanupE2ERun(e2eDb, e2eRunId);
+
+  const tenantA = await createE2ETenant(e2eDb, e2eRunId, "tenant-a");
+  const tenantB = await createE2ETenant(e2eDb, e2eRunId, "tenant-b");
+  const tenantARequest = await playwright.request.newContext({
+    baseURL: getE2EBaseUrl(),
+    extraHTTPHeaders: { Authorization: tenantA.apiKey.authorization },
+  });
+  const tenantBRequest = await playwright.request.newContext({
+    baseURL: getE2EBaseUrl(),
+    extraHTTPHeaders: { Authorization: tenantB.apiKey.authorization },
+  });
+
+  try {
+    const createA = await tenantARequest.post("/api/contacts", {
+      data: {
+        email: `tenant-a-contact@${e2eRunId}.e2e.opensend.test`,
+        first_name: "Tenant",
+        last_name: "A",
+        properties: { test_run_id: e2eRunId },
+      },
+    });
+    expect(createA.status()).toBe(201);
+    const createdA = (await createA.json()) as { id: string };
+    expect(createdA.id).toBeTruthy();
+
+    const createB = await tenantBRequest.post("/api/contacts", {
+      data: {
+        email: `tenant-b-contact@${e2eRunId}.e2e.opensend.test`,
+        first_name: "Tenant",
+        last_name: "B",
+        properties: { test_run_id: e2eRunId },
+      },
+    });
+    expect(createB.status()).toBe(201);
+    const createdB = (await createB.json()) as { id: string };
+    expect(createdB.id).toBeTruthy();
+
+    const listB = await tenantBRequest.get("/api/contacts", {
+      params: { search: e2eRunId, limit: "20" },
+    });
+    expect(listB.status()).toBe(200);
+    const tenantBList = (await listB.json()) as {
+      data: Array<{ id: string; email: string }>;
+    };
+    expect(tenantBList.data.map((contact) => contact.id)).toContain(
+      createdB.id,
+    );
+    expect(tenantBList.data.map((contact) => contact.id)).not.toContain(
+      createdA.id,
+    );
+
+    const crossTenantDetail = await tenantBRequest.get(
+      `/api/contacts/${createdA.id}`,
+    );
+    expect(crossTenantDetail.status()).toBe(404);
+
+    const crossTenantMutation = await tenantBRequest.patch(
+      `/api/contacts/${createdA.id}`,
+      { data: { first_name: "Compromised" } },
+    );
+    expect(crossTenantMutation.status()).toBe(404);
+
+    const { rows: afterPatchRows } = await e2eDb.query<{ first_name: string }>(
+      "select first_name from contacts where id = $1",
+      [createdA.id],
+    );
+    expect(afterPatchRows).toEqual([{ first_name: "Tenant" }]);
+
+    const crossTenantDelete = await tenantBRequest.delete(
+      `/api/contacts/${createdA.id}`,
+    );
+    expect(crossTenantDelete.status()).toBe(404);
+
+    const { rows: afterDeleteRows } = await e2eDb.query<{ id: string }>(
+      "select id from contacts where id = $1",
+      [createdA.id],
+    );
+    expect(afterDeleteRows).toEqual([{ id: createdA.id }]);
+  } finally {
+    await tenantARequest.dispose();
+    await tenantBRequest.dispose();
+    await cleanupE2ERun(e2eDb, e2eRunId);
+  }
+});


### PR DESCRIPTION
## Summary
- Adds shared Playwright fixtures for deterministic Better Auth users, API-key tenants, API request contexts, and cleanup by E2E run id.
- Adds a canonical real-route tenant-isolation spec for contacts that proves tenant B cannot list, read, patch, or delete tenant A data.
- Expands `tests/e2e/README.md` with the Vitest/API-request/browser/mocked-smoke decision tree, fixture guidance, prerequisites, and a classification audit of current E2E specs.

Closes #229

## Validation
- `make check` ✅
- Push guardrails: full-project typecheck + changed-file Biome ✅
- `bunx playwright test tests/e2e/tenant-isolation.spec.ts --workers=1` with no `DATABASE_URL` ✅ skipped with the documented fixture prerequisite
- `DATABASE_URL=postgresql://opensend:opensend@127.0.0.1:5432/opensend bunx playwright test tests/e2e/tenant-isolation.spec.ts --workers=1` ❌ environment-blocked: `connect ECONNREFUSED 127.0.0.1:5432`

## Residual risks
- Real DB-backed targeted Playwright execution could not complete in this local worktree because there is no `.env`, local Postgres is not listening on `127.0.0.1:5432`, and `timeout 10 docker info` timed out while Docker emitted a local plugin warning. The spec is written to run once `DATABASE_URL` points at a migrated Postgres database.
- Existing smoke/mocked E2E specs are classified but intentionally not migrated in this PR to keep #229 scoped.
