### PR TITLE
architecture: add Go ingester shadow skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ curl http://localhost:3026/readyz
 
 For now, the Next.js routes under `src/app/api` remain the current public API and own production request handling. The control-plane service only exposes health/readiness endpoints until follow-up thin-adapter PRs move route ownership behind this boundary.
 
+### Go ingester skeleton
+
+This repository also includes an experimental Go data-plane skeleton at [`services/ingester-go`](./services/ingester-go). It reserves local port **3027** and exposes only static `GET /health` and `GET /readyz` endpoints:
+
+```bash
+cd services/ingester-go
+go test ./...
+go run .
+```
+
+The Go ingester is shadow-only for future issue #71 parity slices. The current production ingester remains `packages/ingester` on port **3016** for SES/SNS ingestion, Stripe webhooks, scheduled jobs, and webhook dispatch.
+
 ### TypeScript SDK
 
 ```bash
@@ -228,7 +240,7 @@ docker run -p 3015:8080 --env-file .env opensend
 
 ## Architecture
 
-Opensend is a Bun workspace monorepo. The Next.js app and a standalone Hono ingester service share a typed core package.
+Opensend is a Bun workspace monorepo. The Next.js app and the production Hono ingester service share a typed core package; an experimental Go ingester skeleton lives under `services/ingester-go` for the planned data-plane migration.
 
 ```
 src/                 # Next.js app (App Router)
@@ -246,6 +258,10 @@ packages/
 │                    #   scheduled-email worker, webhook retry scan (port 3016)
 ├── sdk/             # opensend — published TypeScript SDK
 └── python-sdk/      # opensend — first-party Python SDK package
+
+services/
+├── api/             # Bun + Hono control-plane skeleton (port 3026)
+└── ingester-go/     # Experimental Go ingester skeleton (shadow-only, port 3027)
 
 tests/               # Vitest unit tests
 tests/e2e/           # Playwright E2E tests

--- a/agent_docs/learnings/active/2026-05-09-issue-280-go-ingester-shadow.md
+++ b/agent_docs/learnings/active/2026-05-09-issue-280-go-ingester-shadow.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-09
+issue: 280
+type: decision
+promoted_to: null
+---
+
+## Go ingester skeleton stays outside Compose until parity
+
+**What:** The initial `services/ingester-go` service is documented and buildable, but intentionally not wired into `docker-compose.yml` as a running service.
+**Why:** The Bun/Hono `packages/ingester` remains production on port 3016 and still owns SES/SNS, Stripe, scheduled jobs, and webhook fan-out. Adding a Compose service now could look like a supported local replacement before parity exists.
+**Pattern:** Keep shadow-only migration skeletons discoverable with their own README, tests, Dockerfile, and top-level docs, but avoid runtime wiring that implies traffic cutover until parity slices explicitly add behavior and deployment ownership.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,10 @@
 #   - postgres   : Postgres 16 with the OpenSend schema, persisted in the named volume `pgdata`.
 #   - migrate    : One-shot job that runs Drizzle migrations and exits.
 #   - app        : Next.js dashboard + REST API on http://localhost:${PORT:-3015}.
-#   - ingester   : Standalone Hono service that handles SES/SNS, Stripe, and scheduled-email
+#   - ingester   : Production Bun/Hono service that handles SES/SNS, Stripe, and scheduled-email
 #                  webhooks on http://localhost:${INGESTER_PORT:-3016}.
+#                  Experimental Go shadow skeleton lives at services/ingester-go
+#                  and defaults to 3027, but is intentionally not wired into Compose.
 #
 # Optional overrides (all read from .env):
 #   - PORT                        : host port for the app (default 3015)
@@ -91,8 +93,9 @@ services:
       retries: 3
       start_period: 10s
 
-  # Standalone Hono service for inbound webhooks (SES bounces/complaints, Stripe billing
-  # events, scheduled-email worker). Point your SES SNS topic and Stripe webhook at:
+  # Production Bun/Hono service for inbound webhooks (SES bounces/complaints, Stripe billing
+  # events, scheduled-email worker). The Go ingester skeleton under services/ingester-go
+  # is experimental/shadow-only and must not receive production traffic yet. Point your SES SNS topic and Stripe webhook at:
   #   http://<host>:${INGESTER_PORT:-3016}/events/ses
   #   http://<host>:${INGESTER_PORT:-3016}/events/stripe
   # Set BACKGROUND_WORKER_POLL=true to enable the SQS long-poll loop in this container.

--- a/docs/ingester-deploy.md
+++ b/docs/ingester-deploy.md
@@ -1,10 +1,12 @@
 # Ingester service deployment
 
-The ingester is a standalone process that handles two things:
+The production ingester is the Bun/Hono service in `packages/ingester`. It is a standalone process that handles two things:
 
 1. SES/SNS event ingestion at `POST /events/ses`
 2. Background job execution (queued email sends, scheduled-email scans,
    webhook dispatch, webhook retry scans)
+
+A separate Go skeleton now exists at `services/ingester-go` for the planned issue #71 data-plane migration. It is experimental and shadow-only: it exposes static `GET /health` and `GET /readyz` endpoints on local port `3027` by default, but it does **not** process SES/SNS events, jobs, Stripe webhooks, or webhook fan-out. Keep production traffic on `packages/ingester` until future parity and cutover slices explicitly change this.
 
 In Docker Compose it runs side-by-side with the app. In production we strongly
 recommend running it as a **separate service** so webhook bursts and worker
@@ -25,10 +27,19 @@ Endpoints:
 - App: `http://localhost:${PORT:-3015}`
 - Ingester health: `http://localhost:${INGESTER_PORT:-3016}/health`
 - SES SNS webhook target: `http://localhost:${INGESTER_PORT:-3016}/events/ses`
+- Experimental Go ingester health, when run separately: `http://localhost:3027/health`
 
 ```bash
 docker compose ps ingester
 docker compose logs -f ingester
+```
+
+The Go ingester skeleton is not wired into Compose on purpose. Run it separately for shadow validation:
+
+```bash
+cd services/ingester-go
+go test ./...
+go run .
 ```
 
 ## Production shape
@@ -40,6 +51,7 @@ and SQS:
 | --- | --- | --- | --- |
 | App | `Dockerfile` (default target) | `app.yourdomain.com` and `api.app.yourdomain.com` | `8080` |
 | Ingester | `packages/ingester/Dockerfile` | `events.app.yourdomain.com` | `3016` |
+| Go ingester skeleton | `services/ingester-go/Dockerfile` | none; shadow-only | `3027` |
 
 If your platform has host-based routing (AWS ALB, GCP Load Balancer, Cloudflare
 Spectrum), point each hostname at its target service. The events host has to
@@ -54,6 +66,14 @@ docker buildx build --platform linux/amd64 \
 docker buildx build --platform linux/amd64 \
   -f packages/ingester/Dockerfile \
   -t yourorg/opensend-ingester:latest --push .
+```
+
+Optional shadow-only Go ingester image build:
+
+```bash
+docker buildx build --platform linux/amd64 \
+  -f services/ingester-go/Dockerfile \
+  -t yourorg/opensend-ingester-go:shadow --push .
 ```
 
 Run a one-shot migrator container against the production `DATABASE_URL`

--- a/services/ingester-go/Dockerfile
+++ b/services/ingester-go/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.23-alpine AS build
+WORKDIR /src
+COPY services/ingester-go/go.mod ./
+RUN go mod download
+COPY services/ingester-go/ ./
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/ingester-go .
+
+FROM alpine:3.21
+RUN addgroup -S opensend && adduser -S opensend -G opensend
+USER opensend
+COPY --from=build /out/ingester-go /usr/local/bin/ingester-go
+ENV HOST=0.0.0.0 PORT=3027
+EXPOSE 3027
+ENTRYPOINT ["/usr/local/bin/ingester-go"]

--- a/services/ingester-go/README.md
+++ b/services/ingester-go/README.md
@@ -1,0 +1,35 @@
+# Go ingester service (experimental)
+
+`services/ingester-go` is a standard-library Go skeleton for the planned OpenSend data-plane migration tracked by issue #71.
+
+Current status: **experimental / shadow-only**. The production ingester remains the Bun/Hono service in `packages/ingester` on port `3016`. Do not point SES SNS topics, Stripe webhooks, scheduled jobs, or production traffic at this Go service yet.
+
+## Local defaults
+
+- `HOST` defaults to `0.0.0.0`
+- `PORT` defaults to `3027`, matching the #71 local port plan for the future Go ingester cutover
+
+## Endpoints
+
+- `GET /health` returns static service health JSON
+- `GET /readyz` returns static readiness JSON and does not check Postgres, AWS, SQS, SES, SNS, or webhook dispatcher dependencies
+
+## Development
+
+```bash
+cd services/ingester-go
+go test ./...
+go run .
+```
+
+The service listens on `http://localhost:3027` by default when run locally with the default host/port.
+
+## Container build
+
+From the repository root:
+
+```bash
+docker build -f services/ingester-go/Dockerfile -t opensend-ingester-go:dev .
+```
+
+This image is for local/shadow validation only. Future parity slices must explicitly port SES/SNS parsing, queue polling, scheduled-email processing, and webhook fan-out before any production cutover.

--- a/services/ingester-go/go.mod
+++ b/services/ingester-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/namuh-eng/opensend/services/ingester-go
+
+go 1.23

--- a/services/ingester-go/internal/config/config.go
+++ b/services/ingester-go/internal/config/config.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+const (
+	DefaultHost = "0.0.0.0"
+	DefaultPort = 3027
+)
+
+type Config struct {
+	Host string
+	Port int
+}
+
+func (c Config) Addr() string {
+	return fmt.Sprintf("%s:%d", c.Host, c.Port)
+}
+
+type Getenv func(string) string
+
+func Load(getenv Getenv) Config {
+	host := getenv("HOST")
+	if host == "" {
+		host = DefaultHost
+	}
+
+	port := DefaultPort
+	if rawPort := getenv("PORT"); rawPort != "" {
+		if parsed, err := strconv.Atoi(rawPort); err == nil && parsed > 0 && parsed <= 65535 {
+			port = parsed
+		}
+	}
+
+	return Config{Host: host, Port: port}
+}

--- a/services/ingester-go/internal/config/config_test.go
+++ b/services/ingester-go/internal/config/config_test.go
@@ -1,0 +1,52 @@
+package config
+
+import "testing"
+
+func TestLoadDefaults(t *testing.T) {
+	cfg := Load(func(string) string { return "" })
+
+	if cfg.Host != DefaultHost {
+		t.Fatalf("expected default host %q, got %q", DefaultHost, cfg.Host)
+	}
+	if cfg.Port != DefaultPort {
+		t.Fatalf("expected default port %d, got %d", DefaultPort, cfg.Port)
+	}
+	if cfg.Addr() != "0.0.0.0:3027" {
+		t.Fatalf("expected default addr 0.0.0.0:3027, got %q", cfg.Addr())
+	}
+}
+
+func TestLoadHostAndPortFromEnv(t *testing.T) {
+	env := map[string]string{
+		"HOST": "127.0.0.1",
+		"PORT": "4027",
+	}
+
+	cfg := Load(func(key string) string { return env[key] })
+
+	if cfg.Host != "127.0.0.1" {
+		t.Fatalf("expected host from env, got %q", cfg.Host)
+	}
+	if cfg.Port != 4027 {
+		t.Fatalf("expected port from env, got %d", cfg.Port)
+	}
+}
+
+func TestLoadFallsBackForInvalidPorts(t *testing.T) {
+	tests := []string{"not-a-number", "0", "-1", "65536"}
+
+	for _, rawPort := range tests {
+		t.Run(rawPort, func(t *testing.T) {
+			cfg := Load(func(key string) string {
+				if key == "PORT" {
+					return rawPort
+				}
+				return ""
+			})
+
+			if cfg.Port != DefaultPort {
+				t.Fatalf("expected invalid port %q to fall back to %d, got %d", rawPort, DefaultPort, cfg.Port)
+			}
+		})
+	}
+}

--- a/services/ingester-go/internal/httpapi/handlers.go
+++ b/services/ingester-go/internal/httpapi/handlers.go
@@ -1,0 +1,32 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type StatusResponse struct {
+	Status  string `json:"status"`
+	Service string `json:"service"`
+}
+
+func NewHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", healthHandler)
+	mux.HandleFunc("GET /readyz", readyzHandler)
+	return mux
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	writeStatus(w, StatusResponse{Status: "ok", Service: "ingester-go"})
+}
+
+func readyzHandler(w http.ResponseWriter, r *http.Request) {
+	writeStatus(w, StatusResponse{Status: "ready", Service: "ingester-go"})
+}
+
+func writeStatus(w http.ResponseWriter, response StatusResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(response)
+}

--- a/services/ingester-go/internal/httpapi/handlers_test.go
+++ b/services/ingester-go/internal/httpapi/handlers_test.go
@@ -1,0 +1,40 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthHandler(t *testing.T) {
+	assertStatusEndpoint(t, "/health", StatusResponse{Status: "ok", Service: "ingester-go"})
+}
+
+func TestReadyzHandler(t *testing.T) {
+	assertStatusEndpoint(t, "/readyz", StatusResponse{Status: "ready", Service: "ingester-go"})
+}
+
+func assertStatusEndpoint(t *testing.T, path string, expected StatusResponse) {
+	t.Helper()
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, path, nil)
+
+	NewHandler().ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, recorder.Code)
+	}
+	if contentType := recorder.Header().Get("Content-Type"); contentType != "application/json" {
+		t.Fatalf("expected JSON content type, got %q", contentType)
+	}
+
+	var actual StatusResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&actual); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if actual != expected {
+		t.Fatalf("expected response %#v, got %#v", expected, actual)
+	}
+}

--- a/services/ingester-go/main.go
+++ b/services/ingester-go/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/namuh-eng/opensend/services/ingester-go/internal/config"
+	"github.com/namuh-eng/opensend/services/ingester-go/internal/httpapi"
+)
+
+func main() {
+	cfg := config.Load(os.Getenv)
+	server := &http.Server{
+		Addr:              cfg.Addr(),
+		Handler:           httpapi.NewHandler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			slog.Error("ingester-go shutdown failed", "error", err)
+		}
+	}()
+
+	slog.Info("ingester-go listening", "addr", cfg.Addr(), "mode", "experimental-shadow")
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		slog.Error("ingester-go failed", "error", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `services/ingester-go` as a standard-library Go ingester skeleton with `go.mod`, config parsing, HTTP server, tests, README, and Dockerfile.
- Exposes static `GET /health` and `GET /readyz` endpoints with `HOST`/`PORT` defaults of `0.0.0.0:3027` per the #71 port plan.
- Documents that the Bun/Hono `packages/ingester` remains production on port `3016`; the Go service is experimental/shadow-only and is not wired into Compose or production traffic.

Closes #280

## Validation
- `cd services/ingester-go && go test ./...`
- `cd services/ingester-go && go build ./...`
- `make check` after installing dependencies in the worktree
- Push guardrails: `scripts/check-changed-files.mjs` reported no changed JS/TS files to typecheck; Biome changed-file lint passed

## Residual risks / not tested
- Docker image build was not completed locally because Docker daemon commands hung on socket access; the Dockerfile is included and documented for follow-up environment validation.
- No SES/SNS parsing, Stripe webhook handling, scheduled jobs, queue polling, webhook dispatch, ECS/ALB changes, or production traffic cutover are included in this slice.
