### PR TITLE
feat(landing): redesign landing + add pricing page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,293 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --bg: #0a0a0c;
+  --bg-2: #111114;
+  --bg-3: #16161a;
+  --line: rgba(255, 255, 255, 0.07);
+  --line-2: rgba(255, 255, 255, 0.12);
+  --fg: #f4f4f5;
+  --fg-2: #b6b6bb;
+  --fg-3: #76767c;
+  --fg-4: #4a4a50;
+  --accent: #c4ff5a;
+  --accent-2: #a3e635;
+  --accent-ink: #0a0a0c;
+  --violet: #b18cff;
+  --pink: #ff9ec7;
+  --warn: #ffb86b;
+  --landing-sans: var(
+    --font-sans,
+    "Geist",
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    sans-serif
+  );
+  --landing-mono: var(
+    --font-mono,
+    "Geist Mono",
+    "JetBrains Mono",
+    ui-monospace,
+    Menlo,
+    monospace
+  );
+  --landing-serif: var(
+    --font-serif,
+    "Instrument Serif",
+    "Times New Roman",
+    serif
+  );
+}
+
+.landing-root {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--landing-sans);
+  font-feature-settings: "ss01", "ss02", "cv11";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+  position: relative;
+  min-height: 100vh;
+}
+
+.landing-root ::selection {
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+
+.landing-root a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.landing-root button {
+  font-family: inherit;
+}
+
+.landing-root .mono {
+  font-family: var(--landing-mono);
+  font-feature-settings: "ss02", "ss03";
+}
+
+.landing-root .serif {
+  font-family: var(--landing-serif);
+  font-style: italic;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+}
+
+.landing-root .wrap {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+@media (max-width: 720px) {
+  .landing-root .wrap {
+    padding: 0 20px;
+  }
+}
+
+.landing-root .grain {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.5'/></svg>");
+  opacity: 0.035;
+  mix-blend-mode: screen;
+}
+
+.landing-root .ambient {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 0;
+}
+
+.landing-root .ambient::before {
+  content: "";
+  position: absolute;
+  top: -400px;
+  left: 50%;
+  width: 1100px;
+  height: 700px;
+  transform: translateX(-50%);
+  background: radial-gradient(
+    ellipse at center,
+    color-mix(in oklch, var(--accent) 22%, transparent) 0%,
+    transparent 60%
+  );
+  filter: blur(60px);
+}
+
+.landing-root .pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 11px 5px 8px;
+  border: 1px solid var(--line-2);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.02);
+  font-size: 12px;
+  color: var(--fg-2);
+  font-family: var(--landing-mono);
+  letter-spacing: 0.01em;
+  width: fit-content;
+}
+
+.landing-root .pill .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 99px;
+  background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+}
+
+.landing-root .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 40px;
+  padding: 0 16px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 100ms ease, background 150ms ease, border-color 150ms
+    ease, color 150ms ease;
+  white-space: nowrap;
+}
+
+.landing-root .btn:active {
+  transform: translateY(1px);
+}
+
+.landing-root .btn-primary {
+  background: var(--accent);
+  color: var(--accent-ink);
+  box-shadow: 0 0 0 1px rgba(196, 255, 90, 0.25), 0 8px 28px -10px
+    rgba(196, 255, 90, 0.5);
+}
+
+.landing-root .btn-primary:hover {
+  background: var(--accent-2);
+}
+
+.landing-root .btn-ghost {
+  background: rgba(255, 255, 255, 0.02);
+  border-color: var(--line-2);
+  color: var(--fg);
+}
+
+.landing-root .btn-ghost:hover {
+  border-color: rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.landing-root .btn-link {
+  color: var(--fg-2);
+  padding: 0 4px;
+  height: auto;
+  background: transparent;
+  border: none;
+}
+
+.landing-root .btn-link:hover {
+  color: var(--fg);
+}
+
+.landing-root .kicker {
+  font-family: var(--landing-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--fg-3);
+}
+
+.landing-root .title-xl {
+  font-size: clamp(44px, 7vw, 88px);
+  line-height: 0.96;
+  letter-spacing: -0.035em;
+  font-weight: 500;
+  margin: 0;
+}
+
+.landing-root .title-l {
+  font-size: clamp(32px, 4.4vw, 56px);
+  line-height: 1;
+  letter-spacing: -0.03em;
+  font-weight: 500;
+  margin: 0;
+}
+
+.landing-root .title-m {
+  font-size: 22px;
+  line-height: 1.15;
+  letter-spacing: -0.015em;
+  font-weight: 500;
+  margin: 0;
+}
+
+.landing-root .body {
+  color: var(--fg-2);
+  font-size: 16px;
+  line-height: 1.55;
+}
+
+.landing-root .body-s {
+  color: var(--fg-2);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.landing-root hr.line {
+  border: none;
+  border-top: 1px solid var(--line);
+  margin: 0;
+}
+
+.landing-root .landing-content {
+  position: relative;
+  z-index: 2;
+}
+
+@keyframes landing-blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+@media (max-width: 900px) {
+  .landing-root .hero-grid,
+  .landing-root .sh-grid {
+    grid-template-columns: 1fr !important;
+  }
+  .landing-root .feat-grid {
+    grid-template-columns: repeat(6, 1fr) !important;
+  }
+  .landing-root .feat-grid > div {
+    grid-column: span 6 !important;
+  }
+  .landing-root .stats-grid {
+    grid-template-columns: repeat(2, 1fr) !important;
+  }
+  .landing-root .road-grid {
+    grid-template-columns: 1fr !important;
+  }
+  .landing-root .footer-grid {
+    grid-template-columns: 1fr 1fr !important;
+  }
+  .landing-root .nav-links-desktop {
+    display: none !important;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,28 @@
 import type { Metadata } from "next";
+import { Geist, Geist_Mono, Instrument_Serif } from "next/font/google";
 import "./globals.css";
+
+const geistSans = Geist({
+  subsets: ["latin"],
+  variable: "--font-sans",
+  weight: ["300", "400", "500", "600", "700"],
+  display: "swap",
+});
+
+const geistMono = Geist_Mono({
+  subsets: ["latin"],
+  variable: "--font-mono",
+  weight: ["400", "500"],
+  display: "swap",
+});
+
+const instrumentSerif = Instrument_Serif({
+  subsets: ["latin"],
+  variable: "--font-serif",
+  weight: ["400"],
+  style: ["italic", "normal"],
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "Opensend",
@@ -12,7 +35,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="dark">
+    <html
+      lang="en"
+      className={`dark ${geistSans.variable} ${geistMono.variable} ${instrumentSerif.variable}`}
+    >
       <body className="bg-black text-gray-100 min-h-screen antialiased">
         {children}
       </body>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,29 @@
+import { PricingPage } from "@/components/landing/pricing-page";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Pricing — OpenSend",
+  description:
+    "Pay for sending, not for licenses. OpenSend is open-source under ELv2 — self-host free forever on your own AWS SES, or use the hosted version with usage-based pricing.",
+  openGraph: {
+    title: "Pricing — OpenSend",
+    description:
+      "Self-host free forever under ELv2, or use OpenSend's hosted plans. Usage-based pricing, no per-seat fees, no vendor lock-in.",
+    type: "website",
+    url: "https://opensend.namuh.co/pricing",
+    siteName: "OpenSend",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Pricing — OpenSend",
+    description:
+      "Self-host free forever under ELv2, or use OpenSend's hosted plans.",
+  },
+  alternates: {
+    canonical: "https://opensend.namuh.co/pricing",
+  },
+};
+
+export default function PricingRoute() {
+  return <PricingPage />;
+}

--- a/src/components/landing/landing-page.tsx
+++ b/src/components/landing/landing-page.tsx
@@ -1,507 +1,1909 @@
-import Image from "next/image";
+"use client";
+
 import Link from "next/link";
+import type { CSSProperties } from "react";
+import { useEffect, useState } from "react";
 
 const GITHUB_URL = "https://github.com/namuh-eng/opensend";
 const DOCS_URL = "/docs";
 const HOSTED_SIGNIN_URL = "/auth";
 const SELF_HOST_URL = `${GITHUB_URL}#self-host`;
 
-const FEATURES: Array<{ title: string; body: string }> = [
-  {
-    title: "Resend-compatible API",
-    body: "Drop-in REST API for transactional and broadcast email. Move existing integrations over without rewriting payloads.",
-  },
-  {
-    title: "TypeScript SDK",
-    body: "Use the `opensend` package with typed request payloads, idempotency keys, and familiar developer ergonomics.",
-  },
-  {
-    title: "Domain verification",
-    body: "DKIM, SPF, and DMARC are auto-configured through Cloudflare. Verify domains in minutes, not hours.",
-  },
-  {
-    title: "Contacts, segments, broadcasts",
-    body: "Manage your audience, segment by properties or topics, and send broadcasts from a real dashboard.",
-  },
-  {
-    title: "Webhooks with HMAC signing",
-    body: "Svix-compatible webhook headers with HMAC signatures for delivery, opens, clicks, bounces, and complaints.",
-  },
-  {
-    title: "Runs on your AWS SES quota",
-    body: "Bring your own SES account. Your sending reputation, your data, your cost — no vendor lock-in.",
-  },
-];
-
-const COMPARISON_ROWS: Array<{
-  feature: string;
-  opensend: string;
-  resend: string;
-  postmark: string;
-}> = [
-  {
-    feature: "Deployment model",
-    opensend: "Self-host or hosted",
-    resend: "Hosted",
-    postmark: "Hosted",
-  },
-  {
-    feature: "Source availability",
-    opensend: "Open source under ELv2",
-    resend: "Closed source service",
-    postmark: "Closed source service",
-  },
-  {
-    feature: "Sending infrastructure",
-    opensend: "Your AWS SES account or hosted OpenSend",
-    resend: "Vendor-managed sending",
-    postmark: "Vendor-managed sending",
-  },
-  {
-    feature: "API and SDK",
-    opensend: "Resend-compatible REST API + TypeScript SDK",
-    resend: "REST API + SDKs",
-    postmark: "REST API + SDKs",
-  },
-  {
-    feature: "Self-host price floor",
-    opensend: "App is self-hostable; pay your infrastructure and SES costs",
-    resend: "Hosted subscription and usage pricing",
-    postmark: "Hosted subscription and usage pricing",
-  },
-];
-
-const PRICING_CARDS: Array<{ title: string; price: string; body: string }> = [
-  {
-    title: "Self-host",
-    price: "Your infra + SES",
-    body: "Run Docker Compose with your Postgres, S3, Cloudflare, and AWS SES credentials.",
-  },
-  {
-    title: "Hosted",
-    price: "Managed OpenSend",
-    body: "Use the same API without operating the stack yourself. Sign in to get started.",
-  },
-];
-
-const FAQS: Array<{ question: string; answer: string }> = [
-  {
-    question: "What does the Elastic License 2.0 allow?",
-    answer:
-      "OpenSend source is available under ELv2 so teams can inspect, modify, and run it for their own use. Review the license before offering it as a competing hosted service.",
-  },
-  {
-    question: "Do I need AWS SES to self-host?",
-    answer:
-      "Yes. The self-hosted path is designed around your AWS SES quota, plus Postgres for data, S3 for attachments, and optional Cloudflare DNS automation.",
-  },
-  {
-    question: "Should I self-host or use hosted OpenSend?",
-    answer:
-      "Self-host when you want infrastructure control and your own SES reputation. Use hosted OpenSend when you want the API and dashboard without operating the stack.",
-  },
-  {
-    question: "Can I migrate from Resend-style payloads?",
-    answer:
-      "OpenSend keeps a Resend-compatible surface for core send flows, so many integrations can move over by changing the base URL and API key.",
-  },
-];
-
-const SDK_SAMPLE = `import { OpenSend } from "opensend";
-
-const opensend = new OpenSend({
-  apiKey: process.env.OPENSEND_API_KEY,
-  baseUrl: "https://email.your-domain.com",
-});
-
-await opensend.emails.send({
-  from: "Acme <hello@acme.com>",
-  to: ["dev@example.com"],
-  subject: "Welcome to OpenSend",
-  html: "<strong>Your self-hosted email API is ready.</strong>",
-});`;
-
-export function LandingPage() {
+function LogoMark({
+  size = 26,
+  glow = true,
+}: { size?: number; glow?: boolean }) {
   return (
-    <div className="min-h-screen bg-black text-[#F0F0F0]">
-      <header className="border-b border-[rgba(176,199,217,0.145)]">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-          <Link
-            href="/"
-            className="flex items-center gap-2 text-[14px] font-semibold tracking-tight"
-          >
-            <span className="flex h-7 w-7 items-center justify-center rounded-md bg-purple-600 text-[13px] font-semibold text-white">
-              o
-            </span>
-            OpenSend
-          </Link>
-          <nav className="flex items-center gap-5 text-[13px] text-[#A1A4A5]">
-            <Link
-              href={DOCS_URL}
-              className="transition-colors hover:text-[#F0F0F0]"
-            >
-              Docs
-            </Link>
-            <a
-              href={GITHUB_URL}
-              className="transition-colors hover:text-[#F0F0F0]"
-              rel="noreferrer noopener"
-              target="_blank"
-            >
-              GitHub
-            </a>
-            <Link
-              href={HOSTED_SIGNIN_URL}
-              data-testid="nav-sign-in"
-              className="rounded-md bg-white px-3 py-1.5 text-[13px] font-medium text-black transition-colors hover:bg-gray-200"
-            >
-              Sign in
-            </Link>
-          </nav>
-        </div>
-      </header>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      style={{
+        display: "block",
+        filter: glow
+          ? "drop-shadow(0 0 12px color-mix(in oklch, var(--accent) 40%, transparent))"
+          : "none",
+      }}
+      role="img"
+      aria-label="opensend"
+    >
+      <title>opensend</title>
+      <rect
+        x="0.5"
+        y="0.5"
+        width="31"
+        height="31"
+        rx="7.4"
+        fill="var(--accent)"
+      />
+      <path
+        d="M6 11.2 L16 17 L26 11.2"
+        fill="none"
+        stroke="var(--accent-ink)"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6.5 21.5 L21.5 21.5"
+        fill="none"
+        stroke="var(--accent-ink)"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+      />
+      <path
+        d="M18.2 18.5 L21.8 21.5 L18.2 24.5"
+        fill="none"
+        stroke="var(--accent-ink)"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
 
-      <main>
-        <section className="mx-auto grid max-w-6xl gap-12 px-6 py-20 lg:grid-cols-[minmax(0,1fr)_440px] lg:items-center lg:py-24">
-          <div className="max-w-3xl">
-            <p className="mb-4 text-[12px] font-medium uppercase tracking-widest text-[#A1A4A5]">
-              Open source · ELv2 · Self-hostable
-            </p>
-            <h1 className="text-4xl font-semibold leading-tight tracking-tight text-[#F0F0F0] sm:text-5xl">
-              The open-source email API you can self-host.
+function Logo({
+  size = 26,
+  gap = 10,
+  fontSize = 15,
+}: {
+  size?: number;
+  gap?: number;
+  fontSize?: number;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap,
+        fontWeight: 500,
+        fontSize,
+        letterSpacing: "-0.01em",
+      }}
+    >
+      <LogoMark size={size} />
+      <span>opensend</span>
+    </div>
+  );
+}
+
+function LogoGlyphLarge({
+  size = 280,
+  color = "currentColor",
+  strokeWidth = 1,
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      aria-hidden="true"
+      focusable="false"
+      style={{ display: "block" }}
+    >
+      <title>opensend mark</title>
+      <rect
+        x="1"
+        y="1"
+        width="30"
+        height="30"
+        rx="7"
+        fill="none"
+        stroke={color}
+        strokeWidth={strokeWidth}
+      />
+      <path
+        d="M6 11.2 L16 17 L26 11.2"
+        fill="none"
+        stroke={color}
+        strokeWidth={strokeWidth * 1.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6.5 21.5 L21.5 21.5"
+        fill="none"
+        stroke={color}
+        strokeWidth={strokeWidth * 1.6}
+        strokeLinecap="round"
+      />
+      <path
+        d="M18.2 18.5 L21.8 21.5 L18.2 24.5"
+        fill="none"
+        stroke={color}
+        strokeWidth={strokeWidth * 1.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function TopNav() {
+  return (
+    <header
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 50,
+        backdropFilter: "blur(12px)",
+        WebkitBackdropFilter: "blur(12px)",
+        background: "rgba(10,10,12,0.7)",
+        borderBottom: "1px solid var(--line)",
+      }}
+    >
+      <div
+        className="wrap"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          height: 60,
+        }}
+      >
+        <Link href="/" aria-label="opensend home">
+          <Logo />
+        </Link>
+        <nav
+          className="nav-links-desktop"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 28,
+            fontSize: 13.5,
+            color: "var(--fg-2)",
+          }}
+        >
+          <Link href={DOCS_URL} style={{ cursor: "pointer" }}>
+            Docs
+          </Link>
+          <Link href={`${DOCS_URL}#api`} style={{ cursor: "pointer" }}>
+            API
+          </Link>
+          <a href={SELF_HOST_URL} rel="noreferrer noopener" target="_blank">
+            Self-host
+          </a>
+          <Link href="/pricing" style={{ cursor: "pointer" }}>
+            Pricing
+          </Link>
+          <a
+            href={GITHUB_URL}
+            rel="noreferrer noopener"
+            target="_blank"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 8,
+              height: 32,
+              padding: "0 12px",
+              borderRadius: 8,
+              border: "1px solid var(--line-2)",
+              background: "rgba(255,255,255,0.02)",
+              fontSize: 12.5,
+              color: "var(--fg-2)",
+              fontFamily: "var(--landing-mono)",
+            }}
+          >
+            <svg
+              width="13"
+              height="13"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <title>star</title>
+              <path d="M8 12.4l-4.7 2.6 1-5.3L.6 6l5.3-.7L8 .4l2.1 4.9L15.4 6l-3.7 3.7 1 5.3z" />
+            </svg>
+            <span>Star</span>
+            <span style={{ color: "var(--fg)", fontWeight: 500 }}>2.4k</span>
+          </a>
+          <Link
+            href={HOSTED_SIGNIN_URL}
+            data-testid="nav-sign-in"
+            className="btn btn-primary"
+            style={{ height: 32, fontSize: 13 }}
+          >
+            Sign in
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+type Token = { t: "k" | "s" | "a" | "p"; s: string };
+
+const TABS: Array<{ id: "curl" | "ts" | "react"; label: string }> = [
+  { id: "curl", label: "cURL" },
+  { id: "ts", label: "TypeScript" },
+  { id: "react", label: "React Email" },
+];
+
+const SNIPPETS: Record<"curl" | "ts" | "react", Token[]> = {
+  curl: [
+    { t: "k", s: "curl" },
+    { t: "p", s: " -X POST https://api.opensend.dev/emails \\" },
+    { t: "p", s: "\n  -H " },
+    { t: "s", s: '"Authorization: Bearer os_live_•••"' },
+    { t: "p", s: " \\" },
+    { t: "p", s: "\n  -H " },
+    { t: "s", s: '"Idempotency-Key: 4f9d…"' },
+    { t: "p", s: " \\" },
+    { t: "p", s: "\n  -d " },
+    {
+      t: "s",
+      s: `'{"from":"hi@acme.com","to":"jane@example.com","subject":"Welcome to Acme","html":"<h1>Hi Jane</h1>"}'`,
+    },
+  ],
+  ts: [
+    { t: "k", s: "import" },
+    { t: "p", s: " { Opensend } " },
+    { t: "k", s: "from" },
+    { t: "s", s: ' "opensend"' },
+    { t: "p", s: ";\n\n" },
+    { t: "k", s: "const" },
+    { t: "p", s: " send = " },
+    { t: "k", s: "new" },
+    { t: "p", s: " Opensend(" },
+    { t: "s", s: "process.env.OPENSEND_KEY" },
+    { t: "p", s: ");\n\n" },
+    { t: "k", s: "await" },
+    { t: "p", s: " send.emails.send({\n  " },
+    { t: "a", s: "from" },
+    { t: "p", s: ": " },
+    { t: "s", s: '"hi@acme.com"' },
+    { t: "p", s: ",\n  " },
+    { t: "a", s: "to" },
+    { t: "p", s: ":   " },
+    { t: "s", s: '"jane@example.com"' },
+    { t: "p", s: ",\n  " },
+    { t: "a", s: "subject" },
+    { t: "p", s: ": " },
+    { t: "s", s: '"Welcome to Acme"' },
+    { t: "p", s: ",\n  " },
+    { t: "a", s: "react" },
+    { t: "p", s: ": <Welcome name=" },
+    { t: "s", s: '"Jane"' },
+    { t: "p", s: " />,\n});" },
+  ],
+  react: [
+    { t: "k", s: "export default function" },
+    { t: "p", s: " Welcome({ name }) {\n  " },
+    { t: "k", s: "return" },
+    { t: "p", s: " (\n    <Email>\n      <Header logo=" },
+    { t: "s", s: '"/acme.svg"' },
+    {
+      t: "p",
+      s: " />\n      <Heading>Hi {name},</Heading>\n      <Text>Thanks for joining Acme. Your sandbox is ready.</Text>\n      <Button href=",
+    },
+    { t: "s", s: '"https://acme.com/start"' },
+    {
+      t: "p",
+      s: ">\n        Open dashboard\n      </Button>\n    </Email>\n  );\n}",
+    },
+  ],
+};
+
+const TOK_COLOR: Record<Token["t"], string> = {
+  k: "#b18cff",
+  s: "#c4ff5a",
+  a: "#ffd591",
+  p: "var(--fg-2)",
+};
+
+function CodeWindow({
+  tab,
+  setTab,
+}: {
+  tab: "curl" | "ts" | "react";
+  setTab: (id: "curl" | "ts" | "react") => void;
+}) {
+  const tokens = SNIPPETS[tab];
+  return (
+    <div
+      aria-label="TypeScript SDK code sample"
+      style={{
+        position: "relative",
+        borderRadius: 14,
+        border: "1px solid var(--line-2)",
+        background: "linear-gradient(180deg, #131318 0%, #0d0d11 100%)",
+        boxShadow:
+          "0 30px 60px -30px rgba(0,0,0,0.7), inset 0 1px 0 rgba(255,255,255,0.04)",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "10px 14px",
+          borderBottom: "1px solid var(--line)",
+          background: "rgba(255,255,255,0.015)",
+        }}
+      >
+        <div style={{ display: "flex", gap: 6 }}>
+          <span
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: 99,
+              background: "#3a3a40",
+            }}
+          />
+          <span
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: 99,
+              background: "#3a3a40",
+            }}
+          />
+          <span
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: 99,
+              background: "#3a3a40",
+            }}
+          />
+        </div>
+        <div style={{ display: "flex", gap: 4 }}>
+          {TABS.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => setTab(t.id)}
+              style={{
+                background:
+                  tab === t.id ? "rgba(255,255,255,0.06)" : "transparent",
+                color: tab === t.id ? "var(--fg)" : "var(--fg-3)",
+                border: "none",
+                fontFamily: "var(--landing-mono)",
+                fontSize: 12,
+                padding: "5px 10px",
+                borderRadius: 6,
+                cursor: "pointer",
+              }}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        <span className="mono" style={{ fontSize: 11, color: "var(--fg-4)" }}>
+          POST /emails
+        </span>
+      </div>
+      <pre
+        style={{
+          margin: 0,
+          padding: "20px 22px",
+          fontFamily: "var(--landing-mono)",
+          fontSize: 13,
+          lineHeight: 1.65,
+          color: "var(--fg)",
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+          minHeight: 260,
+        }}
+      >
+        {tokens.map((t, i) => (
+          <span
+            // biome-ignore lint/suspicious/noArrayIndexKey: stable token order
+            key={i}
+            style={{ color: TOK_COLOR[t.t] || "var(--fg)" }}
+          >
+            {t.s}
+          </span>
+        ))}
+      </pre>
+    </div>
+  );
+}
+
+const HERO_EVENTS: Array<{ t: string; ms: string; color: string }> = [
+  { t: "email.queued", ms: "0ms", color: "var(--fg-2)" },
+  { t: "email.accepted", ms: "124ms", color: "var(--violet)" },
+  { t: "email.sent", ms: "418ms", color: "#7ed1ff" },
+  { t: "email.delivered", ms: "1.4s", color: "var(--accent)" },
+  { t: "email.opened", ms: "37s", color: "var(--accent)" },
+];
+
+function EventLog({ pulse }: { pulse: number }) {
+  return (
+    <div
+      style={{
+        borderRadius: 12,
+        border: "1px solid var(--line)",
+        background: "rgba(13,13,16,0.65)",
+        padding: "14px 16px",
+        backdropFilter: "blur(6px)",
+        WebkitBackdropFilter: "blur(6px)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          fontFamily: "var(--landing-mono)",
+          fontSize: 11,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+          color: "var(--fg-3)",
+          marginBottom: 10,
+        }}
+      >
+        <span>events · jane@example.com</span>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+          <span
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: 99,
+              background: "var(--accent)",
+              boxShadow: "0 0 10px var(--accent)",
+            }}
+          />
+          live
+        </span>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {HERO_EVENTS.map((e, i) => (
+          <div
+            key={e.t}
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              fontFamily: "var(--landing-mono)",
+              fontSize: 12.5,
+              opacity: pulse >= i ? 1 : 0.25,
+              transform: pulse >= i ? "translateX(0)" : "translateX(-6px)",
+              transition: "opacity 350ms ease, transform 350ms ease",
+            }}
+          >
+            <span style={{ color: pulse >= i ? e.color : "var(--fg-4)" }}>
+              {e.t}
+            </span>
+            <span style={{ color: "var(--fg-3)" }}>{e.ms}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function HeroDemo() {
+  const [tab, setTab] = useState<"curl" | "ts" | "react">("ts");
+  const [pulse, setPulse] = useState(-1);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: tab change resets the pulse loop
+  useEffect(() => {
+    setPulse(-1);
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    for (let i = 0; i < 5; i++) {
+      timers.push(
+        setTimeout(() => setPulse((p) => Math.max(p, i)), 350 + i * 600),
+      );
+    }
+    timers.push(setTimeout(() => setPulse(-1), 5500));
+    const loop = setInterval(() => {
+      setPulse(-1);
+      for (let i = 0; i < 5; i++) {
+        timers.push(
+          setTimeout(() => setPulse((p) => Math.max(p, i)), 350 + i * 600),
+        );
+      }
+    }, 7000);
+    return () => {
+      for (const t of timers) clearTimeout(t);
+      clearInterval(loop);
+    };
+  }, [tab]);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 14,
+        position: "relative",
+      }}
+    >
+      <CodeWindow tab={tab} setTab={setTab} />
+      <EventLog pulse={pulse} />
+    </div>
+  );
+}
+
+function Hero() {
+  return (
+    <section
+      style={{
+        position: "relative",
+        paddingTop: 80,
+        paddingBottom: 80,
+        overflow: "hidden",
+      }}
+    >
+      <div className="ambient" aria-hidden />
+      <div className="wrap" style={{ position: "relative" }}>
+        <div
+          className="hero-grid"
+          style={{
+            display: "grid",
+            gap: 56,
+            gridTemplateColumns: "minmax(0, 1fr) minmax(0, 1fr)",
+            alignItems: "center",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 28,
+              maxWidth: 580,
+            }}
+          >
+            <span className="pill">
+              <span className="dot" /> v0.4 · ELv2 · self-hostable
+            </span>
+            <h1 className="title-xl">
+              Email infrastructure,
+              <br />
+              <span className="serif" style={{ color: "var(--fg-2)" }}>
+                open by default.
+              </span>
             </h1>
-            <p className="mt-6 max-w-2xl text-[16px] leading-relaxed text-[#A1A4A5]">
-              OpenSend is a Resend-compatible email platform with a REST API,
-              TypeScript SDK, broadcasts, contacts, and a full dashboard. Run it
-              on your own AWS SES quota, or use the hosted version we run for
-              you.
+            <p
+              style={{
+                maxWidth: 520,
+                fontSize: 18,
+                lineHeight: 1.5,
+                color: "var(--fg-2)",
+              }}
+            >
+              A drop-in Resend-compatible API, a typed SDK, broadcasts,
+              contacts, and a real dashboard — running on your AWS&nbsp;SES,
+              your Postgres, your domain. No per-email pricing. No vendor
+              lock-in.
             </p>
-            <div className="mt-10 flex flex-wrap items-center gap-3">
+            <div
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 12,
+                alignItems: "center",
+              }}
+            >
               <a
                 href={SELF_HOST_URL}
                 data-testid="cta-self-host"
                 rel="noreferrer noopener"
                 target="_blank"
-                className="inline-flex items-center gap-2 rounded-md bg-white px-4 py-2.5 text-[14px] font-medium text-black transition-colors hover:bg-gray-200"
+                className="btn btn-primary"
               >
-                Self-host with Docker
+                <span>$ docker compose up</span>
+                <span style={{ opacity: 0.6 }}>↗</span>
               </a>
-              <Link
-                href={HOSTED_SIGNIN_URL}
-                data-testid="cta-hosted"
-                className="inline-flex items-center gap-2 rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] px-4 py-2.5 text-[14px] font-medium text-[#F0F0F0] transition-colors hover:border-[rgba(176,199,217,0.3)]"
-              >
-                Use the hosted version
+              <Link href={DOCS_URL} className="btn btn-ghost">
+                Read the docs
               </Link>
               <a
                 href={GITHUB_URL}
                 data-testid="cta-github"
                 rel="noreferrer noopener"
                 target="_blank"
-                className="inline-flex items-center gap-2 rounded-md px-4 py-2.5 text-[14px] font-medium text-[#A1A4A5] transition-colors hover:text-[#F0F0F0]"
+                className="btn btn-link mono"
+                style={{ fontSize: 13 }}
               >
-                Star on GitHub →
+                ★ 2.4k on github →
               </a>
             </div>
+            <div
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 18,
+                alignItems: "center",
+                paddingTop: 12,
+                color: "var(--fg-3)",
+                fontSize: 12.5,
+                fontFamily: "var(--landing-mono)",
+              }}
+            >
+              {["Resend-compatible", "HMAC webhooks", "React Email"].map(
+                (label) => (
+                  <span
+                    key={label}
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 8,
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 14,
+                        height: 14,
+                        borderRadius: 99,
+                        border: "1px solid var(--accent)",
+                        display: "inline-flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        color: "var(--accent)",
+                        fontSize: 9,
+                      }}
+                    >
+                      ✓
+                    </span>
+                    {label}
+                  </span>
+                ),
+              )}
+            </div>
+          </div>
+          <HeroDemo />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function StatsBar() {
+  const stats: Array<[string, string]> = [
+    ["10k+", "sends/mo · free tier"],
+    ["<1.4s", "p50 send → delivered"],
+    ["Resend", "API parity"],
+    ["ELv2", "free to self-host"],
+  ];
+  return (
+    <section
+      style={{
+        padding: "40px 0",
+        borderTop: "1px solid var(--line)",
+        borderBottom: "1px solid var(--line)",
+      }}
+    >
+      <div
+        className="wrap stats-grid"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(4, 1fr)",
+          gap: 0,
+        }}
+      >
+        {stats.map(([n, label], i) => (
+          <div
+            key={label}
+            style={{
+              padding: "16px 24px",
+              borderLeft: i ? "1px solid var(--line)" : "none",
+              display: "flex",
+              flexDirection: "column",
+              gap: 4,
+            }}
+          >
+            <div
+              className="serif"
+              style={{ fontSize: 40, lineHeight: 1, letterSpacing: "-0.02em" }}
+            >
+              {n}
+            </div>
+            <div
+              className="mono"
+              style={{
+                fontSize: 11.5,
+                color: "var(--fg-3)",
+                textTransform: "uppercase",
+                letterSpacing: "0.1em",
+              }}
+            >
+              {label}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+type GlyphKind =
+  | "rest"
+  | "idem"
+  | "dns"
+  | "broadcast"
+  | "hook"
+  | "ses"
+  | "team";
+
+function Glyph({ kind }: { kind: GlyphKind }) {
+  const common = {
+    width: 22,
+    height: 22,
+    fill: "none" as const,
+    stroke: "currentColor",
+    strokeWidth: 1.5,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    "aria-hidden": "true" as const,
+    focusable: "false" as const,
+    viewBox: "0 0 22 22",
+  };
+  switch (kind) {
+    case "rest":
+      return (
+        <svg {...common}>
+          <title>{kind}</title>
+          <path d="M3 11h7M3 7h13M3 15h10" />
+          <path d="M14 8l4 3-4 3" />
+        </svg>
+      );
+    case "idem":
+      return (
+        <svg {...common}>
+          <title>{kind}</title>
+          <circle cx="11" cy="11" r="6" />
+          <path d="M11 8v3l2 2" />
+        </svg>
+      );
+    case "dns":
+      return (
+        <svg {...common}>
+          <title>{kind}</title>
+          <circle cx="11" cy="11" r="7" />
+          <path d="M4 11h14M11 4c2.5 2 2.5 12 0 14M11 4c-2.5 2-2.5 12 0 14" />
+        </svg>
+      );
+    case "broadcast":
+      return (
+        <svg {...common}>
+          <title>{kind}</title>
+          <path d="M5 8l11-3v12L5 14V8z" />
+          <path d="M5 8v6" />
+          <circle cx="5" cy="11" r="1.5" fill="currentColor" />
+        </svg>
+      );
+    case "hook":
+      return (
+        <svg {...common}>
+          <title>{kind}</title>
+          <path d="M7 5v6a4 4 0 008 0V8" />
+          <circle cx="15" cy="6" r="2" />
+          <circle cx="7" cy="17" r="2" />
+        </svg>
+      );
+    case "ses":
+      return (
+        <svg {...common}>
+          <title>{kind}</title>
+          <rect x="3" y="6" width="16" height="11" rx="2" />
+          <path d="M3 8l8 5 8-5" />
+        </svg>
+      );
+    case "team":
+      return (
+        <svg {...common}>
+          <title>{kind}</title>
+          <circle cx="8" cy="9" r="3" />
+          <circle cx="15" cy="10" r="2.5" />
+          <path d="M3 18c0-3 2.5-5 5-5s5 2 5 5M13 18c0-2.5 2-4 4-4s2 .5 2 .5" />
+        </svg>
+      );
+  }
+}
+
+type Feature = {
+  span: number;
+  title: string;
+  body: string;
+  glyph: GlyphKind;
+  extra: GlyphKind;
+};
+
+const FEATURES: Feature[] = [
+  {
+    span: 5,
+    title: "Resend-compatible REST",
+    body: "Same payloads, same headers, same SDK shape. Migrate by changing a base URL — not your code.",
+    glyph: "rest",
+    extra: "rest",
+  },
+  {
+    span: 7,
+    title: "Typed SDK + idempotency",
+    body: "Opt-in Idempotency-Key on send and per-row keys on batch sends, so retries collapse safely on the server.",
+    glyph: "idem",
+    extra: "idem",
+  },
+  {
+    span: 4,
+    title: "Domain verification",
+    body: "DKIM, SPF, DMARC and click-tracking subdomains written straight to Cloudflare DNS.",
+    glyph: "dns",
+    extra: "dns",
+  },
+  {
+    span: 4,
+    title: "Broadcasts & audiences",
+    body: "Block editor with slash commands. Segments, topics, custom properties, CSV import.",
+    glyph: "broadcast",
+    extra: "broadcast",
+  },
+  {
+    span: 4,
+    title: "Webhooks, signed",
+    body: "Svix-compatible HMAC headers across delivered, opened, clicked, bounced, complained.",
+    glyph: "hook",
+    extra: "hook",
+  },
+  {
+    span: 6,
+    title: "Runs on your SES quota",
+    body: "Bring your own AWS account. Your sending reputation, your data, your bill — caps only at the SES limit.",
+    glyph: "ses",
+    extra: "ses",
+  },
+  {
+    span: 6,
+    title: "Multi-tenant by design",
+    body: "Better Auth with Google OAuth, organization invites, per-tenant suppression list, scoped API keys.",
+    glyph: "team",
+    extra: "team",
+  },
+];
+
+function Extra({ kind }: { kind: GlyphKind }) {
+  if (kind === "rest") {
+    return (
+      <div
+        className="mono"
+        style={{
+          marginTop: "auto",
+          fontSize: 12,
+          border: "1px solid var(--line)",
+          borderRadius: 8,
+          padding: "10px 12px",
+          background: "rgba(255,255,255,0.015)",
+          color: "var(--fg-2)",
+          display: "flex",
+          flexDirection: "column",
+          gap: 4,
+        }}
+      >
+        <div>
+          <span style={{ color: "var(--violet)" }}>POST</span> /v1/emails
+        </div>
+        <div>
+          <span style={{ color: "var(--violet)" }}>POST</span> /v1/emails/batch
+        </div>
+        <div>
+          <span style={{ color: "#7ed1ff" }}>GET</span> /v1/domains
+        </div>
+        <div style={{ color: "var(--fg-3)" }}>+ 24 more</div>
+      </div>
+    );
+  }
+  if (kind === "idem") {
+    return (
+      <div
+        style={{
+          marginTop: "auto",
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: 10,
+        }}
+      >
+        {[1, 2, 3].map((n) => (
+          <div
+            key={n}
+            className="mono"
+            style={{
+              fontSize: 11,
+              padding: "8px 10px",
+              border: "1px solid var(--line)",
+              borderRadius: 8,
+              background: "rgba(255,255,255,0.015)",
+              color: n === 1 ? "var(--accent)" : "var(--fg-3)",
+              display: "flex",
+              justifyContent: "space-between",
+            }}
+          >
+            <span>retry #{n}</span>
+            <span>{n === 1 ? "202 sent" : "collapsed"}</span>
+          </div>
+        ))}
+        <div
+          className="mono"
+          style={{
+            fontSize: 11,
+            padding: "8px 10px",
+            border: "1px solid var(--line)",
+            borderRadius: 8,
+            background: "rgba(255,255,255,0.015)",
+            color: "var(--fg-3)",
+            display: "flex",
+            justifyContent: "space-between",
+          }}
+        >
+          <span>key</span>
+          <span>4f9d…</span>
+        </div>
+      </div>
+    );
+  }
+  if (kind === "dns") {
+    const rows: Array<[string, string, string, string]> = [
+      ["DKIM", "TXT", "os._domainkey", "v=DKIM1; p=…"],
+      ["SPF", "TXT", "@", "v=spf1 include:…"],
+      ["DMARC", "TXT", "_dmarc", "v=DMARC1; p=…"],
+    ];
+    return (
+      <div
+        className="mono"
+        style={{
+          marginTop: "auto",
+          fontSize: 11,
+          border: "1px solid var(--line)",
+          borderRadius: 8,
+          background: "rgba(255,255,255,0.015)",
+          overflow: "hidden",
+        }}
+      >
+        {rows.map((r, i) => (
+          <div
+            key={r[0]}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "auto auto 1fr auto",
+              gap: 10,
+              padding: "7px 10px",
+              borderTop: i ? "1px solid var(--line)" : "none",
+              color: "var(--fg-2)",
+            }}
+          >
+            <span style={{ color: "var(--accent)" }}>✓</span>
+            <span style={{ color: "var(--fg-3)" }}>{r[1]}</span>
+            <span>{r[2]}</span>
+            <span style={{ color: "var(--fg-4)" }}>set</span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+  if (kind === "broadcast") {
+    return (
+      <div
+        style={{
+          marginTop: "auto",
+          display: "flex",
+          flexDirection: "column",
+          gap: 6,
+        }}
+      >
+        <div className="mono" style={{ fontSize: 11, color: "var(--fg-3)" }}>
+          audience: paid · 12,847
+        </div>
+        <div
+          style={{
+            height: 6,
+            borderRadius: 99,
+            background: "var(--bg-3)",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              width: "72%",
+              height: "100%",
+              background: "var(--accent)",
+            }}
+          />
+        </div>
+        <div
+          className="mono"
+          style={{
+            fontSize: 11,
+            color: "var(--fg-2)",
+            display: "flex",
+            justifyContent: "space-between",
+          }}
+        >
+          <span>72% delivered</span>
+          <span>9,250 / 12,847</span>
+        </div>
+      </div>
+    );
+  }
+  if (kind === "hook") {
+    return (
+      <div
+        className="mono"
+        style={{
+          marginTop: "auto",
+          fontSize: 11.5,
+          display: "flex",
+          flexDirection: "column",
+          gap: 4,
+        }}
+      >
+        <div style={{ color: "var(--fg-3)" }}>svix-id: msg_2x9b…</div>
+        <div style={{ color: "var(--fg-3)" }}>svix-timestamp: 1730…</div>
+        <div style={{ color: "var(--accent)" }}>svix-signature: v1,Az9…</div>
+      </div>
+    );
+  }
+  if (kind === "ses") {
+    const heights = [20, 32, 28, 44, 38, 52, 46, 60, 54, 68, 62, 76];
+    return (
+      <div
+        style={{
+          marginTop: "auto",
+          display: "flex",
+          alignItems: "flex-end",
+          gap: 4,
+          height: 56,
+        }}
+      >
+        {heights.map((h, i) => (
+          <div
+            // biome-ignore lint/suspicious/noArrayIndexKey: chart index
+            key={i}
+            style={{
+              flex: 1,
+              height: `${h}%`,
+              background:
+                i === heights.length - 1
+                  ? "var(--accent)"
+                  : "rgba(255,255,255,0.12)",
+              borderRadius: 2,
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
+  if (kind === "team") {
+    const initials = ["JH", "AH", "MK", "+"];
+    const bg = [
+      "rgba(177,140,255,0.15)",
+      "rgba(196,255,90,0.15)",
+      "rgba(255,158,199,0.15)",
+      "transparent",
+    ];
+    return (
+      <div
+        style={{
+          marginTop: "auto",
+          display: "flex",
+          gap: 8,
+          alignItems: "center",
+        }}
+      >
+        {initials.map((c, i) => (
+          <span
+            key={c}
+            className="mono"
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: 99,
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              border: "1px solid var(--line-2)",
+              background: bg[i],
+              color: i === 3 ? "var(--fg-3)" : "var(--fg)",
+              fontSize: 11,
+              fontWeight: 500,
+            }}
+          >
+            {c}
+          </span>
+        ))}
+        <span
+          className="mono"
+          style={{ fontSize: 12, color: "var(--fg-3)", marginLeft: 4 }}
+        >
+          4 admins · 12 senders
+        </span>
+      </div>
+    );
+  }
+  return null;
+}
+
+function FeatureCell({ f }: { f: Feature }) {
+  return (
+    <div
+      style={{
+        background: "var(--bg)",
+        padding: "28px 28px 32px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 14,
+        minHeight: 220,
+        position: "relative",
+        gridColumn: `span ${f.span}`,
+      }}
+    >
+      <span
+        style={{
+          width: 44,
+          height: 44,
+          borderRadius: 10,
+          border: "1px solid var(--line-2)",
+          background: "rgba(255,255,255,0.025)",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "var(--accent)",
+        }}
+      >
+        <Glyph kind={f.glyph} />
+      </span>
+      <div style={{ fontSize: 17, fontWeight: 500, letterSpacing: "-0.01em" }}>
+        {f.title}
+      </div>
+      <div style={{ fontSize: 13.5, lineHeight: 1.55, color: "var(--fg-2)" }}>
+        {f.body}
+      </div>
+      <Extra kind={f.extra} />
+    </div>
+  );
+}
+
+function FeaturesSection() {
+  return (
+    <section style={{ padding: "120px 0 60px", position: "relative" }}>
+      <div className="wrap">
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 14,
+            maxWidth: 720,
+            marginBottom: 56,
+          }}
+        >
+          <span className="kicker">{"// in the box"}</span>
+          <h2 className="title-l">
+            Everything Resend has.
+            <br />
+            <span className="serif" style={{ color: "var(--fg-2)" }}>
+              None of the lock-in.
+            </span>
+          </h2>
+        </div>
+        <div
+          className="feat-grid"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(12, 1fr)",
+            gap: 1,
+            background: "var(--line-2)",
+            border: "1px solid var(--line-2)",
+            borderRadius: 16,
+            overflow: "hidden",
+          }}
+        >
+          {FEATURES.map((f) => (
+            <FeatureCell key={f.title} f={f} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CompareSection() {
+  const rows: Array<[string, string, string]> = [
+    ["Where it runs", "Managed at opensend.dev", "Your infrastructure"],
+    ["Setup", "Sign in with Google", "docker compose up -d"],
+    ["Pricing", "Free 10k/mo, $19+ paid", "You pay AWS SES only"],
+    ["Data residency", "us-east-1 / eu-west-1", "Wherever you run it"],
+    ["SES quota", "Shared, soft caps", "Your own account"],
+    ["Best for", "Teams that want zero ops", "Teams that want full control"],
+  ];
+  return (
+    <section style={{ padding: "60px 0 100px" }} id="pricing">
+      <div className="wrap">
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 14,
+            maxWidth: 720,
+            marginBottom: 32,
+          }}
+        >
+          <span className="kicker">{"// two ways to run it"}</span>
+          <h2 className="title-l">Cloud, or yours.</h2>
+        </div>
+        <div
+          style={{
+            border: "1px solid var(--line-2)",
+            borderRadius: 16,
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1.2fr 1fr 1fr",
+              background: "rgba(255,255,255,0.025)",
+              borderBottom: "1px solid var(--line-2)",
+            }}
+          >
+            <div style={{ padding: "18px 22px" }} />
+            <div
+              style={{
+                padding: "18px 22px",
+                borderLeft: "1px solid var(--line-2)",
+              }}
+            >
+              <div
+                className="mono"
+                style={{
+                  fontSize: 11,
+                  color: "var(--fg-3)",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.12em",
+                }}
+              >
+                option A
+              </div>
+              <div style={{ fontSize: 17, fontWeight: 500, marginTop: 4 }}>
+                opensend Cloud
+              </div>
+            </div>
+            <div
+              style={{
+                padding: "18px 22px",
+                borderLeft: "1px solid var(--line-2)",
+                position: "relative",
+              }}
+            >
+              <div
+                className="mono"
+                style={{
+                  fontSize: 11,
+                  color: "var(--accent)",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.12em",
+                }}
+              >
+                option B · default
+              </div>
+              <div style={{ fontSize: 17, fontWeight: 500, marginTop: 4 }}>
+                Self-host
+              </div>
+              <span
+                style={{
+                  position: "absolute",
+                  top: 12,
+                  right: 14,
+                  width: 6,
+                  height: 6,
+                  borderRadius: 99,
+                  background: "var(--accent)",
+                  boxShadow: "0 0 10px var(--accent)",
+                }}
+              />
+            </div>
+          </div>
+          {rows.map((r, i) => (
+            <div
+              key={r[0]}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1.2fr 1fr 1fr",
+                borderTop: i ? "1px solid var(--line)" : "none",
+              }}
+            >
+              <div
+                style={{
+                  padding: "14px 22px",
+                  fontFamily: "var(--landing-mono)",
+                  fontSize: 12,
+                  color: "var(--fg-3)",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.1em",
+                }}
+              >
+                {r[0]}
+              </div>
+              <div
+                style={{
+                  padding: "14px 22px",
+                  borderLeft: "1px solid var(--line)",
+                  fontSize: 14,
+                  color: "var(--fg-2)",
+                }}
+              >
+                {r[1]}
+              </div>
+              <div
+                style={{
+                  padding: "14px 22px",
+                  borderLeft: "1px solid var(--line)",
+                  fontSize: 14,
+                  color: "var(--fg)",
+                }}
+              >
+                {r[2]}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SelfHostSection() {
+  const [step, setStep] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setStep((s) => (s + 1) % 5), 1400);
+    return () => clearInterval(id);
+  }, []);
+  const lines: Array<{ p: string; s: string; c?: string }> = [
+    { p: "$", s: "git clone github.com/namuh-eng/opensend" },
+    { p: "$", s: "cd opensend && cp .env.example .env" },
+    { p: "$", s: "docker compose up -d" },
+    { p: "✓", s: "app  ready on :3015", c: "var(--accent)" },
+    { p: "✓", s: "ingester  on :3016", c: "var(--accent)" },
+  ];
+  return (
+    <section style={{ padding: "60px 0", position: "relative" }}>
+      <div
+        className="wrap sh-grid"
+        style={{
+          display: "grid",
+          gap: 56,
+          gridTemplateColumns: "minmax(0,1fr) minmax(0,1fr)",
+          alignItems: "center",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 22,
+            maxWidth: 520,
+          }}
+        >
+          <span className="kicker">{"// self-host"}</span>
+          <h2 className="title-l">
+            Four lines.
+            <br />
+            <span className="serif" style={{ color: "var(--fg-2)" }}>
+              Then you own it.
+            </span>
+          </h2>
+          <p className="body">
+            A multi-stage Dockerfile and a docker-compose.yml with
+            auto-migration. Bring your own AWS SES credentials and Postgres —
+            your data stays on your infrastructure, on your network, behind your
+            perimeter.
+          </p>
+          <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+            <a
+              href={SELF_HOST_URL}
+              rel="noreferrer noopener"
+              target="_blank"
+              className="btn btn-ghost"
+            >
+              Self-host guide ↗
+            </a>
+            <a
+              href={`${GITHUB_URL}/blob/main/Dockerfile`}
+              rel="noreferrer noopener"
+              target="_blank"
+              className="btn btn-link mono"
+              style={{ fontSize: 13 }}
+            >
+              ./Dockerfile →
+            </a>
           </div>
           <div
-            aria-label="TypeScript SDK code sample"
-            className="rounded-xl border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] p-4 shadow-2xl shadow-purple-950/20"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(3, 1fr)",
+              gap: 1,
+              background: "var(--line)",
+              border: "1px solid var(--line)",
+              borderRadius: 12,
+              overflow: "hidden",
+              marginTop: 8,
+            }}
           >
-            <div className="mb-3 flex items-center justify-between text-[12px] text-[#A1A4A5]">
-              <span>send-email.ts</span>
-              <span>opensend</span>
-            </div>
-            <pre className="overflow-x-auto rounded-lg bg-black p-4 font-mono text-[12px] leading-relaxed text-[#F0F0F0]">
-              <code>{SDK_SAMPLE}</code>
-            </pre>
+            {[
+              ["ELv2", "free + modify + self-host"],
+              ["Bun + Next 16", "turbopack monorepo"],
+              ["Postgres", "drizzle + migrations"],
+            ].map(([k, v]) => (
+              <div
+                key={k}
+                style={{ padding: "14px 16px", background: "var(--bg)" }}
+              >
+                <div
+                  className="mono"
+                  style={{
+                    fontSize: 11,
+                    color: "var(--fg-3)",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.1em",
+                  }}
+                >
+                  {k}
+                </div>
+                <div
+                  style={{ fontSize: 13, color: "var(--fg-2)", marginTop: 4 }}
+                >
+                  {v}
+                </div>
+              </div>
+            ))}
           </div>
-        </section>
-
-        <section
-          aria-labelledby="features-heading"
-          className="border-t border-[rgba(176,199,217,0.145)]"
+        </div>
+        <div
+          style={{
+            borderRadius: 14,
+            border: "1px solid var(--line-2)",
+            background: "linear-gradient(180deg, #0f0f13 0%, #0a0a0c 100%)",
+            boxShadow: "0 30px 60px -30px rgba(0,0,0,0.7)",
+            overflow: "hidden",
+          }}
         >
-          <div className="mx-auto max-w-6xl px-6 py-20">
-            <h2
-              id="features-heading"
-              className="text-[11px] font-medium uppercase tracking-widest text-[#A1A4A5]"
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              padding: "10px 14px",
+              borderBottom: "1px solid var(--line)",
+              background: "rgba(255,255,255,0.015)",
+            }}
+          >
+            <div style={{ display: "flex", gap: 6 }}>
+              <span
+                style={{
+                  width: 10,
+                  height: 10,
+                  borderRadius: 99,
+                  background: "#3a3a40",
+                }}
+              />
+              <span
+                style={{
+                  width: 10,
+                  height: 10,
+                  borderRadius: 99,
+                  background: "#3a3a40",
+                }}
+              />
+              <span
+                style={{
+                  width: 10,
+                  height: 10,
+                  borderRadius: 99,
+                  background: "#3a3a40",
+                }}
+              />
+            </div>
+            <span
+              className="mono"
+              style={{ fontSize: 11, color: "var(--fg-4)" }}
             >
-              What's in the box
-            </h2>
-            <p className="mt-3 max-w-2xl text-2xl font-semibold tracking-tight text-[#F0F0F0]">
-              Everything you need to send production email — without the vendor
-              lock-in.
-            </p>
-            <ul className="mt-12 grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-[rgba(176,199,217,0.145)] bg-[rgba(176,199,217,0.145)] sm:grid-cols-2 lg:grid-cols-3">
-              {FEATURES.map((feature) => (
-                <li key={feature.title} className="bg-black p-6">
-                  <h3 className="text-[14px] font-semibold text-[#F0F0F0]">
-                    {feature.title}
-                  </h3>
-                  <p className="mt-2 text-[13px] leading-relaxed text-[#A1A4A5]">
-                    {feature.body}
-                  </p>
+              ~/opensend
+            </span>
+            <span />
+          </div>
+          <div
+            style={{
+              padding: "18px 22px",
+              minHeight: 220,
+              fontFamily: "var(--landing-mono)",
+              fontSize: 13,
+              lineHeight: 1.7,
+            }}
+          >
+            {lines.map((l, i) => (
+              <div
+                key={l.s}
+                style={{
+                  display: "flex",
+                  gap: 12,
+                  opacity: step >= i ? 1 : 0.18,
+                  color: step >= i ? l.c || "var(--fg)" : "var(--fg-4)",
+                  transition: "opacity 250ms ease",
+                }}
+              >
+                <span style={{ color: l.c || "var(--fg-3)", width: 14 }}>
+                  {l.p}
+                </span>
+                <span>
+                  {l.s}
+                  {step === i && i < 3 && (
+                    <span
+                      style={{
+                        display: "inline-block",
+                        width: 7,
+                        height: 14,
+                        background: "var(--accent)",
+                        marginLeft: 4,
+                        verticalAlign: "middle",
+                        animation: "landing-blink 1s steps(1) infinite",
+                      }}
+                    />
+                  )}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function RoadmapSection() {
+  const items: Array<{ done: boolean; t: string; s: string }> = [
+    { done: true, t: "HMAC-signed webhooks", s: "Svix-compatible headers" },
+    { done: true, t: "Email scheduling", s: "EventBridge → SQS workers" },
+    { done: true, t: "Multi-tenant teams", s: "Org invites + scoped keys" },
+    { done: true, t: "Built-in analytics", s: "No external dependency" },
+    { done: false, t: "SMTP relay", s: "Send without AWS SES" },
+    { done: false, t: "Inbound parsing", s: "Reply threading + parsing" },
+  ];
+  return (
+    <section style={{ padding: "100px 0" }}>
+      <div className="wrap">
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 14,
+            marginBottom: 40,
+          }}
+        >
+          <span className="kicker">{"// roadmap"}</span>
+          <h2 className="title-l">Shipping in public.</h2>
+        </div>
+        <div
+          className="road-grid"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(3, 1fr)",
+            gap: 1,
+            background: "var(--line)",
+            border: "1px solid var(--line)",
+            borderRadius: 12,
+            overflow: "hidden",
+          }}
+        >
+          {items.map((it) => (
+            <div
+              key={it.t}
+              style={{
+                background: "var(--bg)",
+                padding: "20px 22px",
+                display: "flex",
+                flexDirection: "column",
+                gap: 8,
+                minHeight: 110,
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                <span
+                  style={{
+                    width: 16,
+                    height: 16,
+                    borderRadius: 99,
+                    display: "inline-flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    background: it.done ? "var(--accent)" : "transparent",
+                    border: it.done ? "none" : "1px dashed var(--fg-4)",
+                    color: "var(--accent-ink)",
+                    fontSize: 10,
+                    fontWeight: 700,
+                  }}
+                >
+                  {it.done ? "✓" : ""}
+                </span>
+                <span
+                  className="mono"
+                  style={{
+                    fontSize: 11,
+                    color: it.done ? "var(--accent)" : "var(--fg-3)",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.1em",
+                  }}
+                >
+                  {it.done ? "shipped" : "next"}
+                </span>
+              </div>
+              <div
+                style={{
+                  fontSize: 16,
+                  fontWeight: 500,
+                  letterSpacing: "-0.01em",
+                }}
+              >
+                {it.t}
+              </div>
+              <div style={{ fontSize: 13, color: "var(--fg-2)" }}>{it.s}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function BigCTA() {
+  const cornerStyle: CSSProperties = {
+    position: "absolute",
+    top: 16,
+    fontSize: 11,
+    color: "var(--fg-4)",
+    letterSpacing: "0.12em",
+    textTransform: "uppercase",
+  };
+  return (
+    <section style={{ padding: "80px 0 100px", position: "relative" }}>
+      <div className="wrap">
+        <div
+          style={{
+            position: "relative",
+            borderRadius: 20,
+            border: "1px solid var(--line-2)",
+            background:
+              "radial-gradient(900px 400px at 50% 120%, color-mix(in oklch, var(--accent) 20%, transparent) 0%, transparent 60%), linear-gradient(180deg, #0e0e12 0%, #0a0a0c 100%)",
+            padding: "80px 32px",
+            textAlign: "center",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            aria-hidden
+            style={{
+              position: "absolute",
+              right: -40,
+              bottom: -40,
+              opacity: 0.06,
+              color: "var(--accent)",
+              pointerEvents: "none",
+            }}
+          >
+            <LogoGlyphLarge size={320} />
+          </div>
+          <div className="mono" style={{ ...cornerStyle, left: 18 }}>
+            opensend / 0.4.0
+          </div>
+          <div className="mono" style={{ ...cornerStyle, right: 18 }}>
+            send.email()
+          </div>
+          <h2 className="title-l" style={{ maxWidth: 760, margin: "0 auto" }}>
+            Stop renting your
+            <br />
+            <span className="serif" style={{ color: "var(--accent)" }}>
+              email infrastructure.
+            </span>
+          </h2>
+          <p className="body" style={{ maxWidth: 540, margin: "18px auto 0" }}>
+            Clone the repo, set your SES keys, run docker compose. The same
+            developer experience you already love — on your servers.
+          </p>
+          <div
+            style={{
+              display: "flex",
+              gap: 12,
+              justifyContent: "center",
+              marginTop: 32,
+              flexWrap: "wrap",
+            }}
+          >
+            <a
+              href={SELF_HOST_URL}
+              rel="noreferrer noopener"
+              target="_blank"
+              className="btn btn-primary"
+            >
+              $ docker compose up
+            </a>
+            <Link
+              href={HOSTED_SIGNIN_URL}
+              data-testid="cta-hosted"
+              className="btn btn-ghost"
+            >
+              Try Cloud free
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SiteFooter() {
+  const cols: Array<[string, string[]]> = [
+    [
+      "Product",
+      ["REST API", "TypeScript SDK", "React Email", "Broadcasts", "Webhooks"],
+    ],
+    [
+      "Self-host",
+      [
+        "Docker compose",
+        "Architecture",
+        "Migrations",
+        "Observability",
+        "Ingester",
+      ],
+    ],
+    [
+      "Resources",
+      ["Docs", "API reference", "Changelog", "Contributing", "License (ELv2)"],
+    ],
+    ["Community", ["GitHub", "Discussions", "Issues", "X / Twitter", "Status"]],
+  ];
+  return (
+    <footer
+      style={{ borderTop: "1px solid var(--line)", padding: "60px 0 40px" }}
+    >
+      <div
+        className="wrap footer-grid"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1.4fr repeat(4, 1fr)",
+          gap: 40,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+            maxWidth: 280,
+          }}
+        >
+          <Logo size={24} gap={10} fontSize={15} />
+          <p className="body-s" style={{ color: "var(--fg-3)" }}>
+            Open-source email infrastructure for developers. Built by
+            <span style={{ color: "var(--fg-2)" }}> Jaeyun Ha</span> and
+            <span style={{ color: "var(--fg-2)" }}> Ashley Ha</span>.
+          </p>
+          <div
+            className="mono"
+            style={{
+              fontSize: 11,
+              color: "var(--fg-4)",
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+            }}
+          >
+            ELv2 · {new Date().getFullYear()}
+          </div>
+        </div>
+        {cols.map(([h, items]) => (
+          <div
+            key={h}
+            style={{ display: "flex", flexDirection: "column", gap: 12 }}
+          >
+            <div
+              className="mono"
+              style={{
+                fontSize: 11,
+                color: "var(--fg-3)",
+                letterSpacing: "0.12em",
+                textTransform: "uppercase",
+              }}
+            >
+              {h}
+            </div>
+            <ul
+              style={{
+                listStyle: "none",
+                padding: 0,
+                margin: 0,
+                display: "flex",
+                flexDirection: "column",
+                gap: 9,
+              }}
+            >
+              {items.map((i) => (
+                <li key={i}>
+                  <span
+                    style={{
+                      fontSize: 13.5,
+                      color: "var(--fg-2)",
+                      cursor: "pointer",
+                    }}
+                  >
+                    {i}
+                  </span>
                 </li>
               ))}
             </ul>
           </div>
-        </section>
-
-        <section
-          aria-labelledby="dashboard-heading"
-          className="border-t border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.35)]"
-        >
-          <div className="mx-auto max-w-6xl px-6 py-20">
-            <div className="max-w-2xl">
-              <h2
-                id="dashboard-heading"
-                className="text-2xl font-semibold tracking-tight text-[#F0F0F0]"
-              >
-                A full dashboard for production email
-              </h2>
-              <p className="mt-4 text-[14px] leading-relaxed text-[#A1A4A5]">
-                Inspect messages, manage API keys, verify domains, and track
-                delivery health from the same app that serves your API.
-              </p>
-            </div>
-            <div className="mt-10 overflow-hidden rounded-xl border border-[rgba(176,199,217,0.145)] bg-black">
-              <Image
-                src="/landing/screenshot-dashboard.png"
-                alt="OpenSend dashboard showing email sending activity"
-                width={3456}
-                height={2184}
-                priority
-                sizes="(min-width: 1152px) 1104px, calc(100vw - 48px)"
-                className="h-auto w-full"
-              />
-            </div>
-          </div>
-        </section>
-
-        <section
-          aria-labelledby="comparison-heading"
-          className="border-t border-[rgba(176,199,217,0.145)]"
-        >
-          <div className="mx-auto max-w-6xl px-6 py-20">
-            <h2
-              id="comparison-heading"
-              className="text-2xl font-semibold tracking-tight text-[#F0F0F0]"
-            >
-              OpenSend vs hosted email APIs
-            </h2>
-            <p className="mt-4 max-w-2xl text-[14px] leading-relaxed text-[#A1A4A5]">
-              Use OpenSend when source access, self-hosting, and SES ownership
-              matter. Hosted providers remain strong choices when you want a
-              fully managed third-party sender.
-            </p>
-            <div className="mt-10 overflow-x-auto rounded-lg border border-[rgba(176,199,217,0.145)]">
-              <table className="min-w-full border-collapse text-left text-[13px]">
-                <caption className="sr-only">
-                  Comparison of OpenSend, Resend, and Postmark
-                </caption>
-                <thead className="bg-[rgba(24,25,28,0.88)] text-[#F0F0F0]">
-                  <tr>
-                    <th scope="col" className="px-5 py-4 font-semibold">
-                      Feature
-                    </th>
-                    <th scope="col" className="px-5 py-4 font-semibold">
-                      OpenSend
-                    </th>
-                    <th scope="col" className="px-5 py-4 font-semibold">
-                      Resend
-                    </th>
-                    <th scope="col" className="px-5 py-4 font-semibold">
-                      Postmark
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-[rgba(176,199,217,0.145)]">
-                  {COMPARISON_ROWS.map((row) => (
-                    <tr key={row.feature}>
-                      <th
-                        scope="row"
-                        className="px-5 py-4 font-medium text-[#F0F0F0]"
-                      >
-                        {row.feature}
-                      </th>
-                      <td className="px-5 py-4 text-[#A1A4A5]">
-                        {row.opensend}
-                      </td>
-                      <td className="px-5 py-4 text-[#A1A4A5]">{row.resend}</td>
-                      <td className="px-5 py-4 text-[#A1A4A5]">
-                        {row.postmark}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </section>
-
-        <section
-          aria-labelledby="pricing-heading"
-          className="border-t border-[rgba(176,199,217,0.145)]"
-        >
-          <div className="mx-auto max-w-6xl px-6 py-20">
-            <h2
-              id="pricing-heading"
-              className="text-2xl font-semibold tracking-tight text-[#F0F0F0]"
-            >
-              Pricing that matches how you want to operate
-            </h2>
-            <p className="mt-4 max-w-2xl text-[14px] leading-relaxed text-[#A1A4A5]">
-              Keep costs close to AWS SES when you self-host, or choose the
-              hosted path when managed operations are worth more than running
-              infrastructure yourself.
-            </p>
-            <div className="mt-10 grid gap-4 sm:grid-cols-2">
-              {PRICING_CARDS.map((card) => (
-                <article
-                  key={card.title}
-                  className="rounded-lg border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] p-6"
-                >
-                  <h3 className="text-[15px] font-semibold text-[#F0F0F0]">
-                    {card.title}
-                  </h3>
-                  <p className="mt-3 text-2xl font-semibold tracking-tight text-[#F0F0F0]">
-                    {card.price}
-                  </p>
-                  <p className="mt-3 text-[13px] leading-relaxed text-[#A1A4A5]">
-                    {card.body}
-                  </p>
-                </article>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section
-          aria-labelledby="self-host-heading"
-          className="border-t border-[rgba(176,199,217,0.145)]"
-        >
-          <div className="mx-auto grid max-w-6xl gap-10 px-6 py-20 lg:grid-cols-2 lg:gap-16">
-            <div>
-              <h2
-                id="self-host-heading"
-                className="text-2xl font-semibold tracking-tight text-[#F0F0F0]"
-              >
-                Self-host in one command
-              </h2>
-              <p className="mt-4 text-[14px] leading-relaxed text-[#A1A4A5]">
-                OpenSend ships as a multi-stage Dockerfile and{" "}
-                <code className="rounded bg-[rgba(24,25,28,0.88)] px-1.5 py-0.5 font-mono text-[13px] text-[#F0F0F0]">
-                  docker-compose.yml
-                </code>{" "}
-                with auto-migration. Bring your own AWS SES credentials and
-                Postgres — your data stays on your infrastructure.
-              </p>
-              <div className="mt-6 flex flex-wrap gap-3">
-                <a
-                  href={SELF_HOST_URL}
-                  rel="noreferrer noopener"
-                  target="_blank"
-                  className="inline-flex items-center gap-2 rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] px-4 py-2.5 text-[14px] font-medium text-[#F0F0F0] transition-colors hover:border-[rgba(176,199,217,0.3)]"
-                >
-                  Self-host instructions
-                </a>
-                <Link
-                  href={DOCS_URL}
-                  className="inline-flex items-center gap-2 rounded-md px-4 py-2.5 text-[14px] font-medium text-[#A1A4A5] transition-colors hover:text-[#F0F0F0]"
-                >
-                  Read the API docs →
-                </Link>
-              </div>
-            </div>
-            <pre className="overflow-x-auto rounded-lg border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] p-5 font-mono text-[13px] leading-relaxed text-[#F0F0F0]">
-              <code>{`git clone https://github.com/namuh-eng/opensend
-cd opensend
-cp .env.example .env
-docker compose up -d`}</code>
-            </pre>
-          </div>
-        </section>
-
-        <section
-          aria-labelledby="faq-heading"
-          className="border-t border-[rgba(176,199,217,0.145)]"
-        >
-          <div className="mx-auto max-w-4xl px-6 py-20">
-            <h2
-              id="faq-heading"
-              className="text-2xl font-semibold tracking-tight text-[#F0F0F0]"
-            >
-              Frequently asked questions
-            </h2>
-            <div className="mt-8 divide-y divide-[rgba(176,199,217,0.145)] rounded-lg border border-[rgba(176,199,217,0.145)]">
-              {FAQS.map((faq) => (
-                <details key={faq.question} className="group p-5" open>
-                  <summary className="cursor-pointer list-none text-[14px] font-semibold text-[#F0F0F0]">
-                    {faq.question}
-                  </summary>
-                  <p className="mt-3 text-[13px] leading-relaxed text-[#A1A4A5]">
-                    {faq.answer}
-                  </p>
-                </details>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section
-          aria-labelledby="hosted-heading"
-          className="border-t border-[rgba(176,199,217,0.145)]"
-        >
-          <div className="mx-auto flex max-w-6xl flex-col items-start gap-6 px-6 py-20 lg:flex-row lg:items-center lg:justify-between">
-            <div className="max-w-xl">
-              <h2
-                id="hosted-heading"
-                className="text-2xl font-semibold tracking-tight text-[#F0F0F0]"
-              >
-                Don't want to run it yourself?
-              </h2>
-              <p className="mt-3 text-[14px] leading-relaxed text-[#A1A4A5]">
-                Use the hosted version of OpenSend. We handle the SES
-                deliverability, monitoring, and upgrades — you keep the same
-                API.
-              </p>
-            </div>
-            <Link
-              href={HOSTED_SIGNIN_URL}
-              data-testid="cta-hosted-bottom"
-              className="inline-flex items-center gap-2 rounded-md bg-white px-4 py-2.5 text-[14px] font-medium text-black transition-colors hover:bg-gray-200"
-            >
-              Get started with hosted
-            </Link>
-          </div>
-        </section>
-      </main>
-
-      <footer className="border-t border-[rgba(176,199,217,0.145)]">
-        <div className="mx-auto flex max-w-6xl flex-col items-start justify-between gap-4 px-6 py-8 sm:flex-row sm:items-center">
-          <p className="text-[12px] text-[#A1A4A5]">
-            © {new Date().getFullYear()} OpenSend · Licensed under Elastic
-            License 2.0
-          </p>
-          <div className="flex flex-wrap items-center gap-5 text-[13px] text-[#A1A4A5]">
-            <Link href={DOCS_URL} className="hover:text-[#F0F0F0]">
-              Docs
-            </Link>
-            <a
-              href={GITHUB_URL}
-              rel="noreferrer noopener"
-              target="_blank"
-              className="hover:text-[#F0F0F0]"
-            >
-              GitHub
-            </a>
-            <Link href={HOSTED_SIGNIN_URL} className="hover:text-[#F0F0F0]">
-              Sign in
-            </Link>
-          </div>
+        ))}
+      </div>
+      <div
+        className="wrap"
+        style={{
+          marginTop: 40,
+          paddingTop: 20,
+          borderTop: "1px solid var(--line)",
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          flexWrap: "wrap",
+          gap: 12,
+        }}
+      >
+        <div className="mono" style={{ fontSize: 11.5, color: "var(--fg-4)" }}>
+          curl -X POST opensend.dev/emails — one API for everywhere you ship
         </div>
-      </footer>
+        <div
+          className="mono"
+          style={{
+            fontSize: 11.5,
+            color: "var(--fg-4)",
+            display: "flex",
+            gap: 16,
+          }}
+        >
+          <span>status: all systems normal</span>
+          <span>·</span>
+          <span>build: 06d5384</span>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+export function LandingPage() {
+  return (
+    <div className="landing-root">
+      <div className="grain" aria-hidden />
+      <div className="landing-content">
+        <TopNav />
+        <Hero />
+        <hr className="line" />
+        <StatsBar />
+        <FeaturesSection />
+        <CompareSection />
+        <SelfHostSection />
+        <RoadmapSection />
+        <BigCTA />
+        <SiteFooter />
+      </div>
     </div>
   );
 }

--- a/src/components/landing/pricing-page.tsx
+++ b/src/components/landing/pricing-page.tsx
@@ -1,0 +1,1042 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+const GITHUB_URL = "https://github.com/namuh-eng/opensend";
+const DOCS_URL = "/docs";
+const HOSTED_SIGNIN_URL = "/auth";
+const SELF_HOST_URL = `${GITHUB_URL}#self-host`;
+const CONTACT_URL = "mailto:hello@opensend.namuh.co";
+
+type Plan = {
+  slug: string;
+  name: string;
+  blurb: string;
+  monthly: number | string;
+  yearly: number | string;
+  quota: string;
+  domains: string;
+  keys: string;
+  cta: string;
+  ctaStyle: "primary" | "ghost";
+  ctaHref: string;
+  featured?: boolean;
+  perks: string[];
+};
+
+const PLANS: Plan[] = [
+  {
+    slug: "free",
+    name: "Free",
+    blurb: "For tinkering and side projects.",
+    monthly: 0,
+    yearly: 0,
+    quota: "10,000 emails/mo",
+    domains: "1 verified domain",
+    keys: "2 API keys",
+    cta: "Get started",
+    ctaStyle: "ghost",
+    ctaHref: HOSTED_SIGNIN_URL,
+    perks: [
+      "Resend-compatible REST API",
+      "TypeScript SDK + React Email",
+      "HMAC-signed webhooks",
+      "Open/click analytics",
+      "Community support",
+    ],
+  },
+  {
+    slug: "starter",
+    name: "Starter",
+    blurb: "For small teams shipping production email.",
+    monthly: 19,
+    yearly: 15,
+    quota: "50,000 emails/mo",
+    domains: "5 verified domains",
+    keys: "10 API keys",
+    cta: "Start Starter",
+    ctaStyle: "ghost",
+    ctaHref: HOSTED_SIGNIN_URL,
+    perks: [
+      "Everything in Free",
+      "Higher SES quota allocation",
+      "Broadcast & audience segments",
+      "Email automations",
+      "Email support · 48h",
+    ],
+  },
+  {
+    slug: "growth",
+    name: "Growth",
+    blurb: "For teams scaling to millions.",
+    monthly: 79,
+    yearly: 65,
+    quota: "500,000 emails/mo",
+    domains: "25 verified domains",
+    keys: "50 API keys",
+    cta: "Start Growth",
+    ctaStyle: "primary",
+    ctaHref: HOSTED_SIGNIN_URL,
+    featured: true,
+    perks: [
+      "Everything in Starter",
+      "Dedicated IPs (add-on)",
+      "Custom Return-Path domains",
+      "Audit log & SSO (Google)",
+      "Priority support · 12h",
+    ],
+  },
+  {
+    slug: "scale",
+    name: "Scale",
+    blurb: "High-volume, regulated, custom needs.",
+    monthly: "Custom",
+    yearly: "Custom",
+    quota: "Unlimited (your SES)",
+    domains: "Unlimited",
+    keys: "Unlimited",
+    cta: "Talk to us",
+    ctaStyle: "ghost",
+    ctaHref: CONTACT_URL,
+    perks: [
+      "Everything in Growth",
+      "BYO AWS account",
+      "Dedicated infra & VPC peering",
+      "BAA / SOC 2 assistance",
+      "Slack channel · 1h SLA",
+    ],
+  },
+];
+
+const FAQ: Array<[string, string]> = [
+  [
+    "What happens if I exceed my quota?",
+    "You get a soft warning at 80% and a notification at 100%. Sends are not blocked — overage is billed at $0.40 per 1,000 emails until you upgrade.",
+  ],
+  [
+    "Do I have to use AWS SES?",
+    "On Cloud, no — we manage the SES side for you. On Self-host, yes (for now). SMTP relay is on the roadmap.",
+  ],
+  [
+    "Can I switch between Cloud and Self-host?",
+    "Yes. Self-host is always free under the Elastic License 2.0 — you only pay AWS. You can also export your data and migrate at any time.",
+  ],
+  [
+    "What does ELv2 mean for me?",
+    "You can use, modify, and self-host opensend for free, including for commercial purposes. The only restriction is offering opensend itself as a hosted service to third parties.",
+  ],
+  [
+    "Is there a yearly discount?",
+    "Yes — paying yearly saves roughly 20% on Starter and Growth. Toggle the switch above the plans.",
+  ],
+  [
+    "How do I cancel?",
+    "From Settings → Billing. There's no contract — you can cancel anytime and keep your current period.",
+  ],
+];
+
+const COMPARE_ROWS: string[][] = [
+  ["Monthly emails", "10k", "50k", "500k", "Unlimited"],
+  ["Verified domains", "1", "5", "25", "Unlimited"],
+  ["API keys", "2", "10", "50", "Unlimited"],
+  ["Webhooks", "✓", "✓", "✓", "✓"],
+  ["Broadcasts", "—", "✓", "✓", "✓"],
+  ["Automations", "—", "✓", "✓", "✓"],
+  ["Dedicated IP", "—", "—", "Add-on", "Included"],
+  ["SSO (Google)", "—", "—", "✓", "✓"],
+  ["Audit log", "—", "—", "90 days", "Unlimited"],
+  ["SLA", "—", "99.9%", "99.95%", "99.99%"],
+  ["Support", "Community", "48h email", "12h email", "1h Slack"],
+];
+
+function LogoMark({ size = 24 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      style={{
+        display: "block",
+        filter:
+          "drop-shadow(0 0 12px color-mix(in oklch, var(--accent) 40%, transparent))",
+      }}
+      role="img"
+      aria-label="opensend"
+    >
+      <title>opensend</title>
+      <rect
+        x="0.5"
+        y="0.5"
+        width="31"
+        height="31"
+        rx="7.4"
+        fill="var(--accent)"
+      />
+      <path
+        d="M6 11.2 L16 17 L26 11.2"
+        fill="none"
+        stroke="var(--accent-ink)"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6.5 21.5 L21.5 21.5"
+        fill="none"
+        stroke="var(--accent-ink)"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+      />
+      <path
+        d="M18.2 18.5 L21.8 21.5 L18.2 24.5"
+        fill="none"
+        stroke="var(--accent-ink)"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function TopNav() {
+  return (
+    <header
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 50,
+        backdropFilter: "blur(12px)",
+        WebkitBackdropFilter: "blur(12px)",
+        background: "rgba(10,10,12,0.7)",
+        borderBottom: "1px solid var(--line)",
+      }}
+    >
+      <div
+        className="wrap"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          height: 60,
+        }}
+      >
+        <Link
+          href="/"
+          aria-label="opensend home"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            fontWeight: 500,
+            fontSize: 15,
+            letterSpacing: "-0.01em",
+          }}
+        >
+          <LogoMark />
+          <span>opensend</span>
+        </Link>
+        <nav
+          className="nav-links-desktop"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 28,
+            fontSize: 13.5,
+            color: "var(--fg-2)",
+          }}
+        >
+          <Link href={DOCS_URL}>Docs</Link>
+          <Link href={`${DOCS_URL}#api`}>API</Link>
+          <a href={SELF_HOST_URL} rel="noreferrer noopener" target="_blank">
+            Self-host
+          </a>
+          <Link href="/pricing" style={{ color: "var(--fg)" }}>
+            Pricing
+          </Link>
+          <Link
+            href={HOSTED_SIGNIN_URL}
+            data-testid="nav-sign-in"
+            className="btn btn-primary"
+            style={{ height: 32, fontSize: 13 }}
+          >
+            Sign in
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+function CheckIcon({ accent }: { accent: boolean }) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      style={{
+        flex: "none",
+        marginTop: 3,
+        color: accent ? "var(--accent)" : "var(--fg)",
+      }}
+      aria-hidden="true"
+      focusable="false"
+    >
+      <title>included</title>
+      <path
+        d="M3 7.5l2.5 2.5L11 4"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function PlanCard({
+  plan,
+  billing,
+}: {
+  plan: Plan;
+  billing: "monthly" | "yearly";
+}) {
+  const isCustom = typeof plan.monthly === "string";
+  const eff =
+    billing === "yearly" && typeof plan.yearly === "number"
+      ? plan.yearly
+      : plan.monthly;
+  const showSave =
+    billing === "yearly" &&
+    typeof plan.yearly === "number" &&
+    typeof plan.monthly === "number" &&
+    plan.yearly < plan.monthly;
+
+  const ctaIsExternal =
+    plan.ctaHref.startsWith("mailto:") || plan.ctaHref.startsWith("http");
+
+  return (
+    <div
+      data-testid={`plan-${plan.slug}`}
+      style={{
+        position: "relative",
+        borderRadius: 14,
+        border: plan.featured
+          ? "1px solid color-mix(in oklch, var(--accent) 60%, transparent)"
+          : "1px solid var(--line-2)",
+        background: plan.featured
+          ? "linear-gradient(180deg, rgba(196,255,90,0.04) 0%, rgba(13,13,16,0.85) 60%)"
+          : "linear-gradient(180deg, #131318 0%, #0d0d11 100%)",
+        padding: "28px 26px 26px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 18,
+        minHeight: 480,
+        boxShadow: plan.featured
+          ? "0 30px 60px -30px rgba(196,255,90,0.25)"
+          : "0 30px 60px -40px rgba(0,0,0,0.6)",
+      }}
+    >
+      {plan.featured && (
+        <span
+          style={{
+            position: "absolute",
+            top: -12,
+            right: 20,
+            padding: "4px 10px",
+            borderRadius: 99,
+            background: "var(--accent)",
+            color: "var(--accent-ink)",
+            fontFamily: "var(--landing-mono)",
+            fontSize: 11,
+            letterSpacing: "0.06em",
+            textTransform: "uppercase",
+            boxShadow:
+              "0 0 0 1px rgba(196,255,90,0.35), 0 0 24px -4px rgba(196,255,90,0.5)",
+          }}
+        >
+          most popular
+        </span>
+      )}
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        <span
+          className="mono"
+          style={{
+            fontSize: 11,
+            letterSpacing: "0.12em",
+            textTransform: "uppercase",
+            color: plan.featured ? "var(--accent)" : "var(--fg-3)",
+          }}
+        >
+          {plan.name.toLowerCase()}
+        </span>
+        <h3
+          style={{
+            margin: 0,
+            fontSize: 22,
+            fontWeight: 500,
+            letterSpacing: "-0.015em",
+          }}
+        >
+          {plan.name}
+        </h3>
+        <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 13.5 }}>
+          {plan.blurb}
+        </p>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          gap: 8,
+          minHeight: 56,
+        }}
+      >
+        {isCustom ? (
+          <span
+            className="serif"
+            style={{ fontSize: 44, lineHeight: 1, letterSpacing: "-0.02em" }}
+          >
+            Let's talk
+          </span>
+        ) : (
+          <>
+            <span
+              style={{
+                fontSize: 12,
+                color: "var(--fg-3)",
+                fontFamily: "var(--landing-mono)",
+              }}
+            >
+              $
+            </span>
+            <span
+              style={{
+                fontSize: 44,
+                fontWeight: 500,
+                letterSpacing: "-0.025em",
+                lineHeight: 1,
+              }}
+            >
+              {eff}
+            </span>
+            <span
+              className="mono"
+              style={{ fontSize: 12, color: "var(--fg-3)" }}
+            >
+              /mo
+            </span>
+            {showSave && (
+              <span
+                style={{
+                  marginLeft: "auto",
+                  alignSelf: "center",
+                  fontFamily: "var(--landing-mono)",
+                  fontSize: 11,
+                  padding: "3px 8px",
+                  borderRadius: 6,
+                  background: "rgba(196,255,90,0.12)",
+                  color: "var(--accent)",
+                  border: "1px solid rgba(196,255,90,0.25)",
+                }}
+              >
+                billed yearly
+              </span>
+            )}
+          </>
+        )}
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr",
+          border: "1px solid var(--line)",
+          borderRadius: 10,
+          background: "rgba(255,255,255,0.015)",
+          overflow: "hidden",
+        }}
+      >
+        {[plan.quota, plan.domains, plan.keys].map((row, i) => {
+          const labels = ["quota", "domains", "keys"];
+          return (
+            <div
+              key={labels[i]}
+              className="mono"
+              style={{
+                padding: "9px 12px",
+                fontSize: 12,
+                color: "var(--fg-2)",
+                borderTop: i ? "1px solid var(--line)" : "none",
+                display: "flex",
+                justifyContent: "space-between",
+              }}
+            >
+              <span style={{ color: "var(--fg-3)" }}>{labels[i]}</span>
+              <span
+                style={{
+                  color:
+                    plan.featured && i === 0 ? "var(--accent)" : "var(--fg)",
+                }}
+              >
+                {row}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      <ul
+        style={{
+          listStyle: "none",
+          padding: 0,
+          margin: 0,
+          display: "flex",
+          flexDirection: "column",
+          gap: 9,
+        }}
+      >
+        {plan.perks.map((p) => (
+          <li
+            key={p}
+            style={{
+              display: "flex",
+              gap: 10,
+              alignItems: "flex-start",
+              fontSize: 13.5,
+              color: "var(--fg-2)",
+            }}
+          >
+            <CheckIcon accent={!!plan.featured} />
+            <span>{p}</span>
+          </li>
+        ))}
+      </ul>
+
+      <div style={{ marginTop: "auto" }}>
+        {ctaIsExternal ? (
+          <a
+            href={plan.ctaHref}
+            className={`btn btn-${plan.ctaStyle}`}
+            style={{ width: "100%" }}
+            rel={
+              plan.ctaHref.startsWith("http")
+                ? "noreferrer noopener"
+                : undefined
+            }
+            target={plan.ctaHref.startsWith("http") ? "_blank" : undefined}
+          >
+            {plan.cta}
+          </a>
+        ) : (
+          <Link
+            href={plan.ctaHref}
+            className={`btn btn-${plan.ctaStyle}`}
+            style={{ width: "100%" }}
+            data-testid={`cta-${plan.slug}`}
+          >
+            {plan.cta}
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SelfHostLane() {
+  return (
+    <div
+      className="sh-lane"
+      style={{
+        marginTop: 24,
+        borderRadius: 16,
+        border: "1px dashed var(--line-2)",
+        background:
+          "linear-gradient(180deg, rgba(177,140,255,0.04) 0%, transparent 60%)",
+        padding: "24px 28px",
+        display: "grid",
+        gridTemplateColumns: "auto 1fr auto",
+        alignItems: "center",
+        gap: 24,
+      }}
+    >
+      <div
+        style={{
+          width: 48,
+          height: 48,
+          borderRadius: 10,
+          border: "1px solid var(--line-2)",
+          background: "rgba(255,255,255,0.025)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "var(--violet)",
+        }}
+      >
+        <svg
+          width="22"
+          height="22"
+          viewBox="0 0 22 22"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <title>self-host</title>
+          <rect x="3" y="4" width="16" height="14" rx="2" />
+          <path d="M3 9h16M7 14l2 2 4-4" />
+        </svg>
+      </div>
+      <div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 4,
+            flexWrap: "wrap",
+          }}
+        >
+          <span
+            style={{ fontSize: 17, fontWeight: 500, letterSpacing: "-0.01em" }}
+          >
+            Self-host
+          </span>
+          <span
+            className="mono"
+            style={{
+              padding: "2px 8px",
+              borderRadius: 99,
+              fontSize: 11,
+              background: "rgba(177,140,255,0.12)",
+              color: "var(--violet)",
+              border: "1px solid rgba(177,140,255,0.25)",
+            }}
+          >
+            free forever · ELv2
+          </span>
+        </div>
+        <div
+          style={{
+            color: "var(--fg-2)",
+            fontSize: 13.5,
+            lineHeight: 1.5,
+            maxWidth: 640,
+          }}
+        >
+          Run opensend on your infrastructure. You only pay AWS SES — no
+          per-email fees, no seat caps. Same source. Same dashboard. Same SDK.
+        </div>
+      </div>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <a
+          href={SELF_HOST_URL}
+          rel="noreferrer noopener"
+          target="_blank"
+          className="btn btn-ghost mono"
+          style={{ fontSize: 12.5 }}
+          data-testid="cta-self-host"
+        >
+          $ docker compose up
+        </a>
+        <a
+          href={SELF_HOST_URL}
+          rel="noreferrer noopener"
+          target="_blank"
+          className="btn btn-ghost"
+          style={{ fontSize: 13 }}
+        >
+          Self-host docs ↗
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function CompareTable() {
+  const headers = ["Free", "Starter", "Growth", "Scale"];
+  return (
+    <section style={{ padding: "80px 0" }}>
+      <div className="wrap">
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 14,
+            marginBottom: 32,
+            maxWidth: 720,
+          }}
+        >
+          <span className="kicker">{"// compare plans"}</span>
+          <h2 className="title-l">All the details.</h2>
+        </div>
+        <div
+          style={{
+            border: "1px solid var(--line-2)",
+            borderRadius: 16,
+            overflow: "hidden",
+          }}
+        >
+          <div
+            className="cmp-grid"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1.4fr repeat(4, 1fr)",
+              background: "rgba(255,255,255,0.025)",
+              borderBottom: "1px solid var(--line-2)",
+            }}
+          >
+            <div style={{ padding: "18px 22px" }} />
+            {headers.map((n, i) => (
+              <div
+                key={n}
+                style={{
+                  padding: "18px 22px",
+                  borderLeft: "1px solid var(--line-2)",
+                  position: "relative",
+                }}
+              >
+                <div
+                  className="mono"
+                  style={{
+                    fontSize: 11,
+                    color: i === 2 ? "var(--accent)" : "var(--fg-3)",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.12em",
+                  }}
+                >
+                  {i === 2 ? "most popular" : "plan"}
+                </div>
+                <div style={{ fontSize: 16, fontWeight: 500, marginTop: 4 }}>
+                  {n}
+                </div>
+                {i === 2 && (
+                  <span
+                    style={{
+                      position: "absolute",
+                      top: 14,
+                      right: 16,
+                      width: 6,
+                      height: 6,
+                      borderRadius: 99,
+                      background: "var(--accent)",
+                      boxShadow: "0 0 10px var(--accent)",
+                    }}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+          {COMPARE_ROWS.map((r, i) => (
+            <div
+              key={r[0]}
+              className="cmp-grid"
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1.4fr repeat(4, 1fr)",
+                borderTop: i ? "1px solid var(--line)" : "none",
+              }}
+            >
+              <div
+                style={{
+                  padding: "13px 22px",
+                  fontFamily: "var(--landing-mono)",
+                  fontSize: 12,
+                  color: "var(--fg-3)",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                }}
+              >
+                {r[0]}
+              </div>
+              {r.slice(1).map((cell, j) => (
+                <div
+                  // biome-ignore lint/suspicious/noArrayIndexKey: cells are positional
+                  key={j}
+                  style={{
+                    padding: "13px 22px",
+                    borderLeft: "1px solid var(--line)",
+                    fontSize: 13.5,
+                    color:
+                      cell === "—"
+                        ? "var(--fg-4)"
+                        : j === 2
+                          ? "var(--fg)"
+                          : "var(--fg-2)",
+                    fontFamily:
+                      cell === "✓" || cell === "—"
+                        ? "var(--landing-mono)"
+                        : "inherit",
+                  }}
+                >
+                  {cell}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FAQSection() {
+  const [open, setOpen] = useState(0);
+  return (
+    <section style={{ padding: "40px 0 100px" }}>
+      <div className="wrap">
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 14,
+            marginBottom: 32,
+            maxWidth: 720,
+          }}
+        >
+          <span className="kicker">{"// questions"}</span>
+          <h2 className="title-l">Things people ask.</h2>
+        </div>
+        <div
+          style={{
+            border: "1px solid var(--line-2)",
+            borderRadius: 14,
+            overflow: "hidden",
+          }}
+        >
+          {FAQ.map(([q, a], i) => {
+            const isOpen = open === i;
+            return (
+              <div
+                key={q}
+                style={{ borderTop: i ? "1px solid var(--line)" : "none" }}
+              >
+                <button
+                  type="button"
+                  onClick={() => setOpen(isOpen ? -1 : i)}
+                  aria-expanded={isOpen}
+                  style={{
+                    width: "100%",
+                    textAlign: "left",
+                    cursor: "pointer",
+                    padding: "18px 22px",
+                    background: isOpen
+                      ? "rgba(255,255,255,0.02)"
+                      : "transparent",
+                    border: "none",
+                    color: "var(--fg)",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    fontSize: 15,
+                    fontWeight: 500,
+                    letterSpacing: "-0.005em",
+                  }}
+                >
+                  <span>{q}</span>
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      transition: "transform 200ms ease",
+                      transform: isOpen ? "rotate(45deg)" : "rotate(0)",
+                      color: "var(--fg-3)",
+                      fontSize: 18,
+                    }}
+                  >
+                    +
+                  </span>
+                </button>
+                <div
+                  style={{
+                    maxHeight: isOpen ? 240 : 0,
+                    overflow: "hidden",
+                    transition: "max-height 250ms ease",
+                  }}
+                >
+                  <div
+                    style={{
+                      padding: "0 22px 20px",
+                      color: "var(--fg-2)",
+                      fontSize: 14,
+                      lineHeight: 1.6,
+                      maxWidth: 720,
+                    }}
+                  >
+                    {a}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function MiniFooter() {
+  return (
+    <footer style={{ borderTop: "1px solid var(--line)", padding: "32px 0" }}>
+      <div
+        className="wrap"
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          flexWrap: "wrap",
+          gap: 12,
+        }}
+      >
+        <div className="mono" style={{ fontSize: 11.5, color: "var(--fg-4)" }}>
+          ELv2 · {new Date().getFullYear()} · opensend
+        </div>
+        <div
+          style={{
+            display: "flex",
+            gap: 22,
+            fontSize: 13,
+            color: "var(--fg-3)",
+          }}
+        >
+          <Link href="/">← Back to home</Link>
+          <Link href={DOCS_URL}>Docs</Link>
+          <a href={GITHUB_URL} rel="noreferrer noopener" target="_blank">
+            GitHub
+          </a>
+          <span>Status</span>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+export function PricingPage() {
+  const [billing, setBilling] = useState<"monthly" | "yearly">("monthly");
+
+  return (
+    <div className="landing-root">
+      <div className="grain" aria-hidden="true" />
+      <div className="landing-content">
+        <TopNav />
+
+        <section style={{ padding: "80px 0 30px", position: "relative" }}>
+          <div
+            aria-hidden="true"
+            style={{
+              position: "absolute",
+              top: -200,
+              left: "50%",
+              transform: "translateX(-50%)",
+              width: 1100,
+              height: 600,
+              background:
+                "radial-gradient(ellipse at center, color-mix(in oklch, var(--accent) 18%, transparent) 0%, transparent 60%)",
+              filter: "blur(60px)",
+              pointerEvents: "none",
+            }}
+          />
+          <div
+            className="wrap"
+            style={{
+              position: "relative",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              textAlign: "center",
+              gap: 22,
+            }}
+          >
+            <span className="pill">
+              <span className="dot" /> simple pricing · cancel anytime
+            </span>
+            <h1 className="title-l" style={{ maxWidth: 820 }}>
+              Pay for sending,
+              <br />
+              <span className="serif" style={{ color: "var(--fg-2)" }}>
+                not for licenses.
+              </span>
+            </h1>
+            <p className="body" style={{ maxWidth: 580 }}>
+              Start free. Upgrade when your volume grows. Or self-host the same
+              source for free forever — opensend is ELv2 either way.
+            </p>
+
+            <fieldset
+              aria-label="Billing period"
+              style={{
+                display: "inline-flex",
+                padding: 4,
+                borderRadius: 999,
+                border: "1px solid var(--line-2)",
+                background: "rgba(255,255,255,0.02)",
+                marginTop: 8,
+                marginInline: 0,
+                minWidth: 0,
+              }}
+            >
+              {(
+                [
+                  ["monthly", "Monthly"],
+                  ["yearly", "Yearly · save 20%"],
+                ] as const
+              ).map(([k, label]) => {
+                const active = billing === k;
+                return (
+                  <button
+                    key={k}
+                    type="button"
+                    onClick={() => setBilling(k)}
+                    aria-pressed={active}
+                    data-testid={`billing-${k}`}
+                    style={{
+                      padding: "7px 16px",
+                      borderRadius: 999,
+                      cursor: "pointer",
+                      border: "none",
+                      background: active ? "var(--fg)" : "transparent",
+                      color: active ? "var(--bg)" : "var(--fg-2)",
+                      fontSize: 13,
+                      fontWeight: 500,
+                      transition: "background 150ms ease, color 150ms ease",
+                    }}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </fieldset>
+          </div>
+        </section>
+
+        <section style={{ padding: "40px 0" }}>
+          <div className="wrap">
+            <div
+              className="plan-grid"
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(4, 1fr)",
+                gap: 18,
+              }}
+            >
+              {PLANS.map((p) => (
+                <PlanCard key={p.slug} plan={p} billing={billing} />
+              ))}
+            </div>
+            <SelfHostLane />
+          </div>
+        </section>
+
+        <CompareTable />
+        <hr className="line" />
+        <FAQSection />
+        <MiniFooter />
+      </div>
+    </div>
+  );
+}

--- a/tests/e2e/landing-page.spec.ts
+++ b/tests/e2e/landing-page.spec.ts
@@ -12,44 +12,35 @@ for (const route of ["/", "/landing"] as const) {
       await expect(
         page.getByRole("heading", {
           level: 1,
-          name: /open-source email API/i,
+          name: /email infrastructure/i,
         }),
       ).toBeVisible();
       await expect(
-        page.getByRole("heading", { name: /What's in the box/i }),
+        page.getByRole("heading", { name: /none of the lock-in/i }),
       ).toBeVisible();
       await expect(page.getByTestId("cta-self-host")).toBeVisible();
       await expect(page.getByTestId("cta-hosted")).toBeVisible();
     });
 
-    test("renders the developer code sample, comparison table, dashboard screenshot, and FAQ", async ({
+    test("renders the developer code sample, comparison, self-host quickstart, and roadmap", async ({
       page,
     }) => {
       await page.goto(route);
 
       await expect(page.getByLabel("TypeScript SDK code sample")).toContainText(
-        "opensend.emails.send",
+        "send.emails.send",
       );
       await expect(
-        page.getByRole("table", {
-          name: /comparison of opensend, resend, and postmark/i,
-        }),
+        page.getByRole("heading", { name: /cloud, or yours/i }),
+      ).toBeVisible();
+      await expect(page.getByText(/option B · default/i)).toBeVisible();
+      await expect(page.getByText("docker compose up -d")).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: /shipping in public/i }),
       ).toBeVisible();
       await expect(
-        page.getByRole("columnheader", { name: "Postmark" }),
+        page.getByRole("heading", { name: /stop renting your/i }),
       ).toBeVisible();
-      await expect(
-        page.getByRole("img", { name: /opensend dashboard/i }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole("heading", { name: /frequently asked questions/i }),
-      ).toBeVisible();
-      await expect(
-        page.getByText(/What does the Elastic License 2\.0 allow/i),
-      ).toBeVisible();
-      await expect(page.getByText(/Do I need AWS SES/i)).toBeVisible();
-      await expect(page.getByText(/self-host or use hosted/i)).toBeVisible();
-      await expect(page.getByText(/migrate from Resend-style/i)).toBeVisible();
     });
   });
 }

--- a/tests/landing-page.test.tsx
+++ b/tests/landing-page.test.tsx
@@ -54,22 +54,24 @@ describe("Landing page route", () => {
   it("renders the hero headline", () => {
     render(<LandingPage />);
     const heading = screen.getByRole("heading", { level: 1 });
-    expect(heading.textContent).toMatch(/open-source email API/i);
+    expect(heading.textContent).toMatch(/email infrastructure/i);
+    expect(heading.textContent).toMatch(/open by default/i);
   });
 
   it("renders all required marketing CTAs", () => {
     render(<LandingPage />);
 
-    const selfHost = screen
-      .getAllByText(/self-host/i)
-      .find((el) => el.getAttribute("data-testid") === "cta-self-host");
-    expect(selfHost?.getAttribute("href")).toMatch(/github\.com/);
+    const selfHost = screen.getByTestId("cta-self-host");
+    expect(selfHost.getAttribute("href")).toMatch(/github\.com/);
 
     const hosted = screen.getByTestId("cta-hosted");
     expect(hosted.getAttribute("href")).toBe("/auth");
 
     const github = screen.getByTestId("cta-github");
     expect(github.getAttribute("href")).toMatch(/github\.com/);
+
+    const navSignIn = screen.getByTestId("nav-sign-in");
+    expect(navSignIn.getAttribute("href")).toBe("/auth");
   });
 
   it("links to docs and GitHub from header navigation", () => {
@@ -79,42 +81,37 @@ describe("Landing page route", () => {
       true,
     );
 
-    const githubLinks = screen.getAllByRole("link", { name: "GitHub" });
-    expect(
-      githubLinks.some((el) =>
-        (el.getAttribute("href") ?? "").includes("github.com"),
-      ),
-    ).toBe(true);
+    const githubLink = screen.getByTestId("cta-github");
+    expect(githubLink.getAttribute("href")).toMatch(/github\.com/);
   });
 
   it("renders the dev-focused landing sections", () => {
     render(<LandingPage />);
 
-    expect(screen.getByText(/opensend\.emails\.send/i)).toBeDefined();
+    expect(screen.getByLabelText(/TypeScript SDK code sample/i)).toBeDefined();
     expect(
-      screen.getByRole("table", {
-        name: /comparison of opensend, resend, and postmark/i,
-      }),
+      screen.getByRole("heading", { name: /none of the lock-in/i }),
     ).toBeDefined();
     expect(
-      screen.getByRole("heading", { name: /pricing that matches/i }),
+      screen.getByRole("heading", { name: /cloud, or yours/i }),
     ).toBeDefined();
     expect(
-      screen.getByRole("heading", { name: /frequently asked questions/i }),
+      screen.getByRole("heading", { name: /shipping in public/i }),
     ).toBeDefined();
-    expect(screen.getAllByText(/\?/).length).toBeGreaterThanOrEqual(4);
-    expect(screen.getByAltText(/OpenSend dashboard/i)).toBeDefined();
+    expect(
+      screen.getByRole("heading", { name: /stop renting your/i }),
+    ).toBeDefined();
   });
 
-  it("renders a footer with copyright and license attribution", () => {
+  it("renders a footer with license attribution", () => {
     render(<LandingPage />);
-    expect(screen.getAllByText(/Elastic License 2\.0/i).length).toBeGreaterThan(
-      0,
-    );
+    expect(screen.getAllByText(/ELv2/i).length).toBeGreaterThan(0);
   });
 
   it("includes a self-host quickstart code block", () => {
     render(<LandingPage />);
-    expect(screen.getByText(/docker compose up -d/i)).toBeDefined();
+    expect(screen.getAllByText(/docker compose up -d/i).length).toBeGreaterThan(
+      0,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Port the Claude Design handoff to the Next.js landing page — lime accent (`#c4ff5a`), dark theme, Geist + Instrument Serif fonts, animated hero code window, event log, self-host terminal, compare/roadmap sections.
- Add a new `/pricing` route (`src/app/pricing/page.tsx`) backed by `PricingPage` component: 4 plans (Free/Starter/Growth/Scale), monthly/yearly billing toggle, self-host lane, 11-row compare table, FAQ accordion.
- Wire `next/font/google` for Geist, Geist Mono, and Instrument Serif as CSS variables; scope new design tokens under `.landing-root` in `globals.css` to avoid clashes with the dashboard theme.
- Update unit + e2e tests to match the new copy and the TypeScript SDK code window.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (855 tests pass)
- [ ] Manual: visit `/` and `/pricing`, confirm hero animation, billing toggle, FAQ accordion, and nav `Pricing → /pricing` work.
- [ ] `make test-e2e` against running dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)