### PR TITLE
feat(domains): add Verify DNS Records button

### DIFF
--- a/src/components/domain-detail.tsx
+++ b/src/components/domain-detail.tsx
@@ -179,9 +179,27 @@ export function DomainDetail({ domain }: DomainDetailProps) {
   );
   const [actionsOpen, setActionsOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [verifying, setVerifying] = useState(false);
+  const [verifyError, setVerifyError] = useState<string | null>(null);
 
   const regionFriendly = REGION_DISPLAY[domain.region] || domain.region;
   const isVerified = domain.status === "verified";
+
+  const handleVerify = useCallback(async () => {
+    if (verifying) return;
+    setVerifying(true);
+    setVerifyError(null);
+    try {
+      await apiRequest(`/api/domains/${domain.id}/verify`, { method: "POST" });
+      router.refresh();
+    } catch (err) {
+      setVerifyError(
+        err instanceof Error ? err.message : "Failed to verify domain",
+      );
+    } finally {
+      setVerifying(false);
+    }
+  }, [domain.id, verifying, router]);
 
   const handleDelete = useCallback(async () => {
     if (deleting) return;
@@ -249,6 +267,21 @@ export function DomainDetail({ domain }: DomainDetailProps) {
         </div>
 
         <div className="flex items-center gap-2">
+          {!isVerified && (
+            <button
+              type="button"
+              onClick={handleVerify}
+              disabled={verifying}
+              className="px-3 py-2 rounded-md border border-[rgba(176,199,217,0.145)] text-[13px] font-medium text-[#F0F0F0] hover:bg-[rgba(24,25,28,0.5)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {verifying ? "Verifying…" : "Verify DNS Records"}
+            </button>
+          )}
+          {verifyError && (
+            <span className="text-[12px] text-red-400" role="alert">
+              {verifyError}
+            </span>
+          )}
           <button
             type="button"
             aria-label="API drawer"

--- a/tests/domain-detail-verify-button.test.tsx
+++ b/tests/domain-detail-verify-button.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const refresh = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh }),
+}));
+
+import { DomainDetail } from "@/components/domain-detail";
+import type { DomainDetailData } from "@/components/domain-detail";
+
+const baseDomain: DomainDetailData = {
+  id: "d1",
+  name: "foreverbrowsing.com",
+  status: "not_started",
+  region: "us-east-1",
+  createdAt: new Date().toISOString(),
+  clickTracking: false,
+  openTracking: false,
+  tls: "opportunistic",
+  sendingEnabled: true,
+  receivingEnabled: false,
+  records: [],
+  events: [{ type: "domain_added", timestamp: new Date().toISOString() }],
+};
+
+afterEach(cleanup);
+
+describe("Domain detail – Verify button", () => {
+  beforeEach(() => {
+    refresh.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not render Verify button when domain is verified", () => {
+    render(<DomainDetail domain={{ ...baseDomain, status: "verified" }} />);
+    expect(screen.queryByText("Verify DNS Records")).toBeNull();
+  });
+
+  it("renders Verify button for unverified domain and POSTs to /verify on click", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<DomainDetail domain={baseDomain} />);
+    const button = screen.getByText("Verify DNS Records");
+    fireEvent.click(button);
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/domains/d1/verify",
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(refresh).toHaveBeenCalled();
+    });
+  });
+
+  it("shows error message when verify request fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "Domain not found" }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<DomainDetail domain={baseDomain} />);
+    fireEvent.click(screen.getByText("Verify DNS Records"));
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toContain(
+        "Domain not found",
+      );
+    });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a "Verify DNS Records" button to the domain detail header that POSTs to `/api/domains/{id}/verify`, calling the reconciler shipped in #275.
- Hidden once status is `verified`. Shows inline error if the request fails.
- Adds 3 unit tests covering: hidden-when-verified, click → POST + refresh, and error rendering.

## Why
The reconciler from #275 is live, but had no UI affordance — there was no way for a user to trigger re-check, and the cron isn't scheduled yet. SES already shows e.g. `foreverbrowsing.com` as `VerificationStatus: SUCCESS`, but the dashboard still shows "Not Started" because nothing has called the reconciler for that domain. This button closes that gap.

## Test plan
- [x] `make check`
- [x] `make test` — full Vitest suite green
- [ ] Manual: open a domain whose status is "Not Started" / "Pending" with SES already verified → click Verify → status + per-record badges flip to Verified