### PR TITLE
feat(automations): contact_delete action backend semantics (#287)

### DIFF
--- a/packages/core/src/dto/automations.ts
+++ b/packages/core/src/dto/automations.ts
@@ -9,6 +9,7 @@ export type AutomationStepType =
   | "condition"
   | "wait_for_event"
   | "contact_update"
+  | "contact_delete"
   | "add_to_segment";
 
 export type AutomationRunStatus =
@@ -95,6 +96,8 @@ export interface ContactUpdateStepConfig {
   properties?: Record<string, ContactUpdateValue>;
 }
 
+export type ContactDeleteStepConfig = Record<string, never>;
+
 export type AutomationStepConfig =
   | TriggerStepConfig
   | DelayStepConfig
@@ -102,7 +105,8 @@ export type AutomationStepConfig =
   | EndStepConfig
   | ConditionStepConfig
   | WaitForEventStepConfig
-  | ContactUpdateStepConfig;
+  | ContactUpdateStepConfig
+  | ContactDeleteStepConfig;
 
 export interface AutomationStepInput {
   key: string;
@@ -588,6 +592,18 @@ export function normalizeContactUpdateConfig(
   return config;
 }
 
+export function normalizeContactDeleteConfig(
+  raw: Record<string, unknown>,
+): ContactDeleteStepConfig {
+  if (raw && Object.keys(raw).length > 0) {
+    throw new AutomationValidationError(
+      "contact_delete config must be empty",
+      "contact_delete_config_invalid",
+    );
+  }
+  return {} as ContactDeleteStepConfig;
+}
+
 export function normalizeStepConfig(
   type: AutomationStepType,
   config: Record<string, unknown>,
@@ -617,6 +633,11 @@ export function normalizeStepConfig(
       >;
     case "contact_update":
       return normalizeContactUpdateConfig(config) as unknown as Record<
+        string,
+        unknown
+      >;
+    case "contact_delete":
+      return normalizeContactDeleteConfig(config) as unknown as Record<
         string,
         unknown
       >;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -71,7 +71,8 @@ export interface AutomationStepPayload {
     | "end"
     | "condition"
     | "wait_for_event"
-    | "contact_update";
+    | "contact_update"
+    | "contact_delete";
   config?: Record<string, unknown>;
   position?: number;
 }

--- a/src/lib/validation/automations.ts
+++ b/src/lib/validation/automations.ts
@@ -10,6 +10,7 @@ export const automationStepTypeSchema = z.enum([
   "condition",
   "wait_for_event",
   "contact_update",
+  "contact_delete",
 ]);
 
 const conditionComparableValueSchema = z.union([
@@ -117,6 +118,8 @@ const contactUpdateStepConfigSchema = z
     }
   });
 
+const contactDeleteStepConfigSchema = z.object({}).strict();
+
 const waitForEventStepConfigSchema = z.object({
   event_name: z
     .string()
@@ -174,6 +177,18 @@ export const automationStepSchema = z
 
     if (step.type === "contact_update") {
       const parsed = contactUpdateStepConfigSchema.safeParse(step.config);
+      if (!parsed.success) {
+        for (const issue of parsed.error.issues) {
+          ctx.addIssue({
+            ...issue,
+            path: ["config", ...issue.path],
+          });
+        }
+      }
+    }
+
+    if (step.type === "contact_delete") {
+      const parsed = contactDeleteStepConfigSchema.safeParse(step.config ?? {});
       if (!parsed.success) {
         for (const issue of parsed.error.issues) {
           ctx.addIssue({

--- a/src/lib/workers/automation-runner.ts
+++ b/src/lib/workers/automation-runner.ts
@@ -17,6 +17,7 @@ import {
   automationRunRepo,
   emailService,
   normalizeConditionConfig,
+  normalizeContactDeleteConfig,
   normalizeContactUpdateConfig,
   normalizeWaitForEventConfig,
   parseDurationToCappedSeconds,
@@ -56,6 +57,7 @@ export interface AutomationRunnerDeps {
     id: string,
     data: Partial<typeof contacts.$inferInsert>,
   ) => Promise<Contact | null>;
+  deleteContact: (id: string) => Promise<{ id: string } | null>;
   listWaitingRunsByContact: (input: {
     contactId: string;
     userId?: string | null;
@@ -119,6 +121,13 @@ const defaultDeps: AutomationRunnerDeps = {
       .where(eq(contacts.id, id))
       .returning();
     return updated ?? null;
+  },
+  async deleteContact(id) {
+    const [deleted] = await db
+      .delete(contacts)
+      .where(eq(contacts.id, id))
+      .returning({ id: contacts.id });
+    return deleted ?? null;
   },
   async listWaitingRunsByContact(input) {
     return await automationRunRepo.listWaitingByContact(input);
@@ -788,6 +797,72 @@ async function processContactUpdateStep(
   });
 }
 
+async function processContactDeleteStep(
+  deps: AutomationRunnerDeps,
+  run: AutomationRun,
+  step: AutomationStep,
+  states: StepStates,
+  now: Date,
+) {
+  normalizeContactDeleteConfig(step.config ?? {});
+
+  if (!run.contactId) {
+    const skippedStates = setStepState(states, step.key, {
+      status: "skipped",
+      startedAt: states[step.key]?.startedAt ?? iso(now),
+      completedAt: iso(now),
+      output: { reason: "contact_already_deleted" },
+    });
+    return await deps.updateRun(run.id, {
+      status: "completed",
+      currentStepKey: null,
+      stepStates: skippedStates,
+      completedAt: now,
+      nextStepAt: null,
+      failureReason: null,
+    });
+  }
+
+  const contact = await deps.getContact(run.contactId);
+  if (!contact) {
+    return await failRun(
+      deps,
+      run,
+      step.key,
+      states,
+      now,
+      "contact_delete contact not found",
+    );
+  }
+
+  const deleted = await deps.deleteContact(contact.id);
+  if (!deleted) {
+    return await failRun(
+      deps,
+      run,
+      step.key,
+      states,
+      now,
+      "contact_delete contact not found",
+    );
+  }
+
+  const completedStates = setStepState(states, step.key, {
+    status: "completed",
+    completedAt: iso(now),
+    output: { deleted_contact_id: deleted.id },
+  });
+  return await deps.updateRun(run.id, {
+    status: "completed",
+    currentStepKey: null,
+    stepStates: completedStates,
+    completedAt: now,
+    nextStepAt: null,
+    failureReason: null,
+    contactId: null,
+  });
+}
+
 async function processSendEmailStep(
   deps: AutomationRunnerDeps,
   run: AutomationRun,
@@ -1030,6 +1105,10 @@ export async function processAutomationRunStep(
         states,
         now,
       );
+    }
+
+    if (step.type === "contact_delete") {
+      return await processContactDeleteStep(deps, run, step, states, now);
     }
 
     if (step.type === "send_email") {

--- a/tests/api-automations-events.test.ts
+++ b/tests/api-automations-events.test.ts
@@ -418,6 +418,77 @@ describe("automation API routes", () => {
     );
   });
 
+  it("creates an automation with a valid contact_delete step", async () => {
+    mockAutomationCreate.mockResolvedValue({
+      automation,
+      steps: [
+        triggerStep,
+        {
+          ...triggerStep,
+          id: "step_delete",
+          key: "delete",
+          type: "contact_delete",
+          config: {},
+          position: 1,
+        },
+      ],
+    });
+    const { POST } = await import("@/app/api/automations/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/automations", {
+        name: "Delete contact",
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.deleted" },
+          },
+          { key: "delete", type: "contact_delete", config: {} },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockAutomationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        steps: expect.arrayContaining([
+          expect.objectContaining({
+            type: "contact_delete",
+            config: {},
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it("rejects contact_delete configs with extra keys", async () => {
+    const { POST } = await import("@/app/api/automations/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/automations", {
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.deleted" },
+          },
+          {
+            key: "delete",
+            type: "contact_delete",
+            config: { reason: "spam" },
+          },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(422);
+    const json = await response.json();
+    expect(json.details.fieldErrors.steps).toEqual(
+      expect.arrayContaining([expect.stringContaining("reason")]),
+    );
+  });
+
   it("rejects invalid contact_update config with field-level errors", async () => {
     const { POST } = await import("@/app/api/automations/route");
 

--- a/tests/automation-runner.test.ts
+++ b/tests/automation-runner.test.ts
@@ -158,6 +158,7 @@ function deps(overrides: Partial<AutomationRunnerDeps> = {}) {
     getTemplate: vi.fn().mockResolvedValue(template),
     sendEmail,
     updateContact: vi.fn().mockResolvedValue(contact),
+    deleteContact: vi.fn().mockResolvedValue({ id: contact.id }),
     listWaitingRunsByContact: vi.fn().mockResolvedValue([]),
     updateRun: vi.fn(async (_id, data) => {
       updates.push(data as Partial<AutomationRun>);
@@ -825,6 +826,186 @@ describe("automation runner", () => {
     expect(setup.updates[0]?.stepStates?.send).toMatchObject({
       status: "failed",
       error: "send_email template is missing or unpublished",
+    });
+  });
+
+  it("deletes the current contact and terminates the run with minimal output", async () => {
+    const deleteAutomation: Automation = {
+      ...automation,
+      connections: [
+        { from: "trigger", to: "delete" },
+        { from: "delete", to: "send" },
+      ],
+    };
+    const deleteStep: AutomationStep = {
+      ...steps[1],
+      key: "delete",
+      type: "contact_delete",
+      config: {},
+      position: 1,
+    };
+    const setup = deps({
+      getAutomation: vi.fn().mockResolvedValue(deleteAutomation),
+      listSteps: vi.fn().mockResolvedValue([steps[0], deleteStep, steps[2]]),
+    });
+
+    await processAutomationRunStep(
+      run({ currentStepKey: "delete" }),
+      setup.deps,
+    );
+
+    expect(setup.deps.deleteContact).toHaveBeenCalledWith(contact.id);
+    expect(setup.sendEmail).not.toHaveBeenCalled();
+    expect(setup.updates[0]).toMatchObject({
+      status: "completed",
+      currentStepKey: null,
+      contactId: null,
+    });
+    expect(setup.updates[0]?.stepStates?.delete).toMatchObject({
+      status: "completed",
+      output: { deleted_contact_id: contact.id },
+    });
+  });
+
+  it("does not run downstream contact-dependent steps after a successful delete", async () => {
+    const deleteAutomation: Automation = {
+      ...automation,
+      connections: [
+        { from: "delete", to: "send" },
+        { from: "send", to: "end" },
+      ],
+    };
+    const deleteStep: AutomationStep = {
+      ...steps[1],
+      key: "delete",
+      type: "contact_delete",
+      config: {},
+      position: 0,
+    };
+    const setup = deps({
+      getAutomation: vi.fn().mockResolvedValue(deleteAutomation),
+      listSteps: vi.fn().mockResolvedValue([deleteStep, steps[2], steps[3]]),
+    });
+
+    const completed = await processAutomationRunStep(
+      run({ currentStepKey: "delete" }),
+      setup.deps,
+    );
+
+    // Run is terminal — no further dispatch happens. Simulate the scheduler
+    // re-loading this run and confirm the runner does not attempt downstream work.
+    expect(completed?.status).toBe("completed");
+    expect(completed?.currentStepKey).toBeNull();
+    expect(setup.sendEmail).not.toHaveBeenCalled();
+    expect(setup.deps.updateContact).not.toHaveBeenCalled();
+  });
+
+  it("fails contact_delete deterministically when the contact is missing", async () => {
+    const deleteStep: AutomationStep = {
+      ...steps[1],
+      key: "delete",
+      type: "contact_delete",
+      config: {},
+      position: 0,
+    };
+    const setup = deps({
+      listSteps: vi.fn().mockResolvedValue([deleteStep]),
+      getContact: vi.fn().mockResolvedValue(null),
+    });
+
+    await processAutomationRunStep(
+      run({ currentStepKey: "delete" }),
+      setup.deps,
+    );
+
+    expect(setup.deps.deleteContact).not.toHaveBeenCalled();
+    expect(setup.updates[0]).toMatchObject({
+      status: "failed",
+      currentStepKey: "delete",
+      failureReason: "contact_delete contact not found",
+    });
+    expect(setup.updates[0]?.stepStates?.delete).toMatchObject({
+      status: "failed",
+      error: "contact_delete contact not found",
+    });
+  });
+
+  it("fails contact_delete when delete returns no rows (idempotent storage race)", async () => {
+    const deleteStep: AutomationStep = {
+      ...steps[1],
+      key: "delete",
+      type: "contact_delete",
+      config: {},
+      position: 0,
+    };
+    const setup = deps({
+      listSteps: vi.fn().mockResolvedValue([deleteStep]),
+      deleteContact: vi.fn().mockResolvedValue(null),
+    });
+
+    await processAutomationRunStep(
+      run({ currentStepKey: "delete" }),
+      setup.deps,
+    );
+
+    expect(setup.updates[0]).toMatchObject({
+      status: "failed",
+      currentStepKey: "delete",
+      failureReason: "contact_delete contact not found",
+    });
+  });
+
+  it("skips repeated contact_delete steps when the run already lost its contact", async () => {
+    const deleteStep: AutomationStep = {
+      ...steps[1],
+      key: "delete_again",
+      type: "contact_delete",
+      config: {},
+      position: 0,
+    };
+    const setup = deps({
+      listSteps: vi.fn().mockResolvedValue([deleteStep]),
+    });
+
+    await processAutomationRunStep(
+      run({ currentStepKey: "delete_again", contactId: null }),
+      setup.deps,
+    );
+
+    expect(setup.deps.getContact).not.toHaveBeenCalled();
+    expect(setup.deps.deleteContact).not.toHaveBeenCalled();
+    expect(setup.updates[0]).toMatchObject({
+      status: "completed",
+      currentStepKey: null,
+    });
+    expect(setup.updates[0]?.stepStates?.delete_again).toMatchObject({
+      status: "skipped",
+      output: { reason: "contact_already_deleted" },
+    });
+  });
+
+  it("fails contact_delete steps with non-empty config persisted on disk", async () => {
+    const deleteStep: AutomationStep = {
+      ...steps[1],
+      key: "delete",
+      type: "contact_delete",
+      config: { foo: "bar" },
+      position: 0,
+    };
+    const setup = deps({
+      listSteps: vi.fn().mockResolvedValue([deleteStep]),
+    });
+
+    await processAutomationRunStep(
+      run({ currentStepKey: "delete" }),
+      setup.deps,
+    );
+
+    expect(setup.deps.deleteContact).not.toHaveBeenCalled();
+    expect(setup.updates[0]).toMatchObject({
+      status: "failed",
+      currentStepKey: "delete",
+      failureReason: "contact_delete config must be empty",
     });
   });
 

--- a/tests/core-automation-repo.test.ts
+++ b/tests/core-automation-repo.test.ts
@@ -368,6 +368,49 @@ describe("automationRepo.create", () => {
     ).rejects.toMatchObject({ code: "contact_update_field_invalid" });
   });
 
+  it("accepts contact_delete steps with empty config and minimal connections", async () => {
+    const { automationRepo } = await import(
+      "../packages/core/src/db/repositories/automationRepo"
+    );
+
+    await expect(
+      automationRepo.create({
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.deleted" },
+          },
+          { key: "delete", type: "contact_delete", config: {} },
+        ],
+        connections: [{ from: "trigger", to: "delete" }],
+      }),
+    ).resolves.toMatchObject({ automation: { id: "auto_1" } });
+  });
+
+  it("rejects contact_delete configs with extra keys", async () => {
+    const { automationRepo } = await import(
+      "../packages/core/src/db/repositories/automationRepo"
+    );
+
+    await expect(
+      automationRepo.create({
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "user.deleted" },
+          },
+          {
+            key: "delete",
+            type: "contact_delete",
+            config: { reason: "spam" },
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "contact_delete_config_invalid" });
+  });
+
   it("rejects condition branch labels from non-condition steps", async () => {
     const { automationRepo } = await import(
       "../packages/core/src/db/repositories/automationRepo"


### PR DESCRIPTION
## Summary
- Adds the `contact_delete` automation action across DTO, validation, SDK, and runner surfaces as a bounded post-MVP slice of #120.
- Reuses existing contact storage (`db.delete(contacts).where(eq(contacts.id, ...))`) via a new `deleteContact` runner dependency so we don't fork a parallel delete path.
- After a successful delete the runner sets `run.contactId = null` and marks the run `completed` immediately — downstream contact-dependent steps (send_email, contact_update, wait_for_event, repeat contact_delete) cannot execute in the same run.
- Step output is the audit-safe minimum: `{ deleted_contact_id }` only.
- Missing contact at runtime → deterministic step-level failure (`contact_delete contact not found`).
- Re-entry without a contact (idempotent / replay) → terminal `skipped` with `{ reason: "contact_already_deleted" }`.
- Empty config is required; extra keys produce a `contact_delete_config_invalid` validation error consistently from API and repository surfaces.

## Files changed
- `packages/core/src/dto/automations.ts` — type union, `ContactDeleteStepConfig`, `normalizeContactDeleteConfig`, `normalizeStepConfig` wiring.
- `src/lib/validation/automations.ts` — `automationStepTypeSchema` enum + strict `contactDeleteStepConfigSchema` superRefine.
- `src/lib/workers/automation-runner.ts` — `deleteContact` dep + default impl, `processContactDeleteStep`, dispatcher.
- `packages/sdk/src/index.ts` — public `AutomationStepPayload.type` union.
- `tests/automation-runner.test.ts` — successful delete, downstream-block, missing contact, delete-race (no rows), idempotent re-entry, invalid config.
- `tests/api-automations-events.test.ts` — API accepts valid config, rejects extra keys.
- `tests/core-automation-repo.test.ts` — repo accepts empty config, rejects extra keys.

## Validation
- `node_modules/.bin/vitest run tests/automation-runner.test.ts tests/api-automations-events.test.ts tests/core-automation-repo.test.ts tests/automations-schema.test.ts` → 65 passed.
- `make check` → typecheck + Biome clean.

## Test plan
- [x] Vitest: valid config → automation creates with empty `contact_delete` config
- [x] Vitest: invalid config (extra keys) → 422 from API and repo error code `contact_delete_config_invalid`
- [x] Vitest: successful delete → `deleteContact` invoked, run completed, output `{ deleted_contact_id }`, `contactId` nulled
- [x] Vitest: missing contact at runtime → step-level failure with `contact_delete contact not found`
- [x] Vitest: downstream step never reached after delete (run terminal `completed`)
- [x] Vitest: repeated/idempotent delete with already-null contact → run completes with `skipped` reason
- [x] Vitest: storage delete returns no rows (race) → deterministic step-level failure
- [x] `make check` (typecheck + Biome)

## Not in this slice
- No dashboard/canvas/editor UI (per issue Not Doing).
- No `add_to_segment` or broader contact mutation refactor.
- No soft-delete / audit model redesign — uses existing hard-delete storage semantics.

## Residual risk
- Hard delete cascades depend on existing `contacts` FK semantics (e.g., `automation_runs.contactId`); current schema sets `contactId` nullable so a deleted contact's other waiting/queued runs will keep referencing the deleted id. This slice nulls `contactId` on the deleting run only — separate cleanup of unrelated waiting runs for the same contact is out of scope and would be a follow-up.
- Destructive action without UI confirmation copy by design — issue calls this out.

Closes #287