### PR TITLE
Sync landing GitHub stars with live repo count

### DIFF
--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -1,4 +1,5 @@
 import { LandingPage } from "@/components/landing/landing-page";
+import { getOpenSendGithubStars } from "@/lib/github-stars";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -24,6 +25,8 @@ export const metadata: Metadata = {
   },
 };
 
-export default function LandingRoute() {
-  return <LandingPage />;
+export default async function LandingRoute() {
+  const githubStars = await getOpenSendGithubStars();
+
+  return <LandingPage githubStars={githubStars} />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { LandingPage } from "@/components/landing/landing-page";
 import { getServerSession } from "@/lib/api-auth";
+import { getOpenSendGithubStars } from "@/lib/github-stars";
 import { shouldRedirectRootToDashboard } from "@/lib/root-route";
 import { redirect } from "next/navigation";
 import { metadata } from "./landing/page";
@@ -13,5 +14,7 @@ export default async function Home() {
     redirect("/emails");
   }
 
-  return <LandingPage />;
+  const githubStars = await getOpenSendGithubStars();
+
+  return <LandingPage githubStars={githubStars} />;
 }

--- a/src/components/landing/landing-page.tsx
+++ b/src/components/landing/landing-page.tsx
@@ -1,7 +1,9 @@
+import { type GithubStars, OPENSEND_GITHUB_REPO_URL } from "@/lib/github-stars";
 import Image from "next/image";
 import Link from "next/link";
 
-const GITHUB_URL = "https://github.com/namuh-eng/opensend";
+const GITHUB_URL = OPENSEND_GITHUB_REPO_URL;
+const GITHUB_CTA_LABEL = "Star on GitHub";
 const DOCS_URL = "/docs";
 const HOSTED_SIGNIN_URL = "/auth";
 const SELF_HOST_URL = `${GITHUB_URL}#self-host`;
@@ -121,7 +123,11 @@ await opensend.emails.send({
   html: "<strong>Your self-hosted email API is ready.</strong>",
 });`;
 
-export function LandingPage() {
+type LandingPageProps = {
+  githubStars?: GithubStars | null;
+};
+
+export function LandingPage({ githubStars = null }: LandingPageProps) {
   return (
     <div className="min-h-screen bg-black text-[#F0F0F0]">
       <header className="border-b border-[rgba(176,199,217,0.145)]">
@@ -144,11 +150,17 @@ export function LandingPage() {
             </Link>
             <a
               href={GITHUB_URL}
-              className="transition-colors hover:text-[#F0F0F0]"
+              className="inline-flex items-center gap-1.5 transition-colors hover:text-[#F0F0F0]"
+              data-testid="nav-github"
               rel="noreferrer noopener"
               target="_blank"
             >
-              GitHub
+              <span>{GITHUB_CTA_LABEL}</span>
+              {githubStars ? (
+                <span className="rounded-full border border-[rgba(176,199,217,0.145)] px-1.5 py-0.5 text-[11px] leading-none text-[#F0F0F0]">
+                  {githubStars.formattedCount} stars
+                </span>
+              ) : null}
             </a>
             <Link
               href={HOSTED_SIGNIN_URL}
@@ -200,7 +212,7 @@ export function LandingPage() {
                 target="_blank"
                 className="inline-flex items-center gap-2 rounded-md px-4 py-2.5 text-[14px] font-medium text-[#A1A4A5] transition-colors hover:text-[#F0F0F0]"
               >
-                Star on GitHub →
+                {GITHUB_CTA_LABEL} →
               </a>
             </div>
           </div>

--- a/src/lib/github-stars.ts
+++ b/src/lib/github-stars.ts
@@ -1,0 +1,80 @@
+export const OPENSEND_GITHUB_REPO_URL = "https://github.com/namuh-eng/opensend";
+
+const OPENSEND_GITHUB_REPO_API_URL =
+  "https://api.github.com/repos/namuh-eng/opensend";
+const GITHUB_STARS_REVALIDATE_SECONDS = 60 * 30;
+
+export type GithubStars = {
+  count: number;
+  formattedCount: string;
+};
+
+function formatCompactCount(count: number, divisor: number, suffix: string) {
+  const value = count / divisor;
+  const rounded = value < 100 ? Math.round(value * 10) / 10 : Math.round(value);
+
+  return `${String(rounded).replace(/\.0$/, "")}${suffix}`;
+}
+
+export function formatGithubStarCount(rawCount: number) {
+  const count = Math.max(0, Math.floor(rawCount));
+
+  if (count < 1_000) {
+    return String(count);
+  }
+
+  if (count >= 999_500) {
+    return formatCompactCount(count, 1_000_000, "M");
+  }
+
+  return formatCompactCount(count, 1_000, "k");
+}
+
+function parseGithubStarCount(payload: unknown) {
+  if (typeof payload !== "object" || payload === null) {
+    return null;
+  }
+
+  const { stargazers_count: starCount } = payload as {
+    stargazers_count?: unknown;
+  };
+
+  if (
+    typeof starCount !== "number" ||
+    !Number.isFinite(starCount) ||
+    starCount < 0
+  ) {
+    return null;
+  }
+
+  return Math.floor(starCount);
+}
+
+export async function getOpenSendGithubStars(): Promise<GithubStars | null> {
+  try {
+    const response = await fetch(OPENSEND_GITHUB_REPO_API_URL, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "opensend-landing-page",
+      },
+      next: { revalidate: GITHUB_STARS_REVALIDATE_SECONDS },
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const starCount = parseGithubStarCount(await response.json());
+
+    if (starCount === null) {
+      return null;
+    }
+
+    return {
+      count: starCount,
+      formattedCount: formatGithubStarCount(starCount),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/tests/github-stars.test.ts
+++ b/tests/github-stars.test.ts
@@ -1,0 +1,69 @@
+import {
+  formatGithubStarCount,
+  getOpenSendGithubStars,
+} from "@/lib/github-stars";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("formatGithubStarCount", () => {
+  it("keeps raw counts readable below one thousand", () => {
+    expect(formatGithubStarCount(0)).toBe("0");
+    expect(formatGithubStarCount(123)).toBe("123");
+    expect(formatGithubStarCount(999)).toBe("999");
+  });
+
+  it("formats thousands and millions compactly", () => {
+    expect(formatGithubStarCount(1_000)).toBe("1k");
+    expect(formatGithubStarCount(1_249)).toBe("1.2k");
+    expect(formatGithubStarCount(1_250)).toBe("1.3k");
+    expect(formatGithubStarCount(12_345)).toBe("12.3k");
+    expect(formatGithubStarCount(123_456)).toBe("123k");
+    expect(formatGithubStarCount(1_234_567)).toBe("1.2M");
+  });
+
+  it("normalizes fractional and negative raw counts", () => {
+    expect(formatGithubStarCount(42.9)).toBe("42");
+    expect(formatGithubStarCount(-4)).toBe("0");
+  });
+});
+
+describe("getOpenSendGithubStars", () => {
+  it("returns a formatted star summary from the GitHub repository payload", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      Response.json({ stargazers_count: 1_234 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getOpenSendGithubStars()).resolves.toEqual({
+      count: 1_234,
+      formattedCount: "1.2k",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/repos/namuh-eng/opensend",
+      expect.objectContaining({
+        next: { revalidate: 1_800 },
+      }),
+    );
+  });
+
+  it("falls back to null when GitHub cannot return a usable count", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      Response.json({ message: "rate limited" }, { status: 403 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getOpenSendGithubStars()).resolves.toBeNull();
+  });
+
+  it("falls back to null when the fetch fails", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      throw new Error("network unavailable");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getOpenSendGithubStars()).resolves.toBeNull();
+  });
+});

--- a/tests/landing-page.test.tsx
+++ b/tests/landing-page.test.tsx
@@ -73,18 +73,30 @@ describe("Landing page route", () => {
   });
 
   it("links to docs and GitHub from header navigation", () => {
-    render(<LandingPage />);
+    render(
+      <LandingPage githubStars={{ count: 1_234, formattedCount: "1.2k" }} />,
+    );
     const docsLinks = screen.getAllByRole("link", { name: "Docs" });
     expect(docsLinks.some((el) => el.getAttribute("href") === "/docs")).toBe(
       true,
     );
 
-    const githubLinks = screen.getAllByRole("link", { name: "GitHub" });
-    expect(
-      githubLinks.some((el) =>
-        (el.getAttribute("href") ?? "").includes("github.com"),
-      ),
-    ).toBe(true);
+    const githubLink = screen.getByTestId("nav-github");
+    expect(githubLink.textContent).toContain("Star on GitHub");
+    expect(githubLink.textContent).toContain("1.2k stars");
+    expect(githubLink.getAttribute("href")).toContain(
+      "github.com/namuh-eng/opensend",
+    );
+  });
+
+  it("keeps the GitHub nav render safe when the live star count is unavailable", () => {
+    render(<LandingPage githubStars={null} />);
+
+    const githubLink = screen.getByTestId("nav-github");
+    expect(githubLink.textContent).toBe("Star on GitHub");
+    expect(githubLink.getAttribute("href")).toContain(
+      "github.com/namuh-eng/opensend",
+    );
   });
 
   it("renders the dev-focused landing sections", () => {


### PR DESCRIPTION
## Summary
- Add a cached server-side GitHub repository star fetcher for `namuh-eng/opensend` with safe null fallback.
- Format star counts compactly (`123`, `1.2k`, `1.2M`) and feed the same GitHub CTA label into navbar + hero copy.
- Render the navbar star badge only when live GitHub data is usable so landing render survives fetch/API failures.

## Test Plan
- `bunx vitest run tests/github-stars.test.ts tests/landing-page.test.tsx`
- `make check`
- `make test`
- Live helper smoke: `bunx tsx -e 'import { getOpenSendGithubStars } from "./src/lib/github-stars"; async function main(){ const stars = await getOpenSendGithubStars(); console.log(JSON.stringify(stars)); if (!stars || stars.count <= 0) process.exit(1); } main();'` → `{"count":28,"formattedCount":"28"}`

Closes #293
