### PR TITLE
feat(automations): validate custom event schemas (#289)

### DIFF
--- a/agent_docs/learnings/active/2026-05-10-289-custom-event-schema-dialect.md
+++ b/agent_docs/learnings/active/2026-05-10-289-custom-event-schema-dialect.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-10
+issue: "#289"
+type: decision
+promoted_to: null
+---
+
+## Custom event schemas use a narrow JSON-Schema-like object dialect
+
+**What:** Stored custom event schemas are validated as root object descriptors with optional `properties` and `required` keys. Property descriptors support only `string`, `number`, `boolean`, `object`, and `array`; extra event payload fields remain allowed.
+
+**Why:** The database only stored schema JSONB without an established dialect. A small in-house contract avoids a broad JSON Schema dependency while still proving send-time payload validation and useful field-path errors.
+
+**Fix:** Extend this dialect only with focused tests and documentation, or switch to a full JSON Schema validator in a separate PR that justifies the dependency/API tradeoff.

--- a/docs/custom-event-schemas.md
+++ b/docs/custom-event-schemas.md
@@ -1,0 +1,39 @@
+# Custom event payload schemas
+
+Custom events may be created without a schema. Schema-less events, including
+unknown event names that have not been created yet, keep accepting any object
+payload and can still record deliveries or trigger matching automations.
+
+When a stored custom event has a schema, `POST /api/events/send` validates the
+payload before contact creation, delivery recording, waiting-run resume, or new
+automation-run creation. Invalid payloads return `422` with stable `details`
+entries that include field paths such as `payload.plan`.
+
+## Supported schema dialect
+
+The first backend slice intentionally supports a narrow JSON-Schema-like object
+descriptor instead of adding a broad JSON Schema dependency:
+
+```json
+{
+  "type": "object",
+  "required": ["plan", "trial"],
+  "properties": {
+    "plan": { "type": "string" },
+    "seats": { "type": "number" },
+    "trial": { "type": "boolean" },
+    "metadata": {
+      "type": "object",
+      "required": ["source"],
+      "properties": {
+        "source": { "type": "string" }
+      }
+    }
+  }
+}
+```
+
+Supported property types are `string`, `number`, `boolean`, `object`, and
+`array`. Extra payload fields are allowed; the schema only constrains listed
+properties and required fields. Unsupported schema keywords are rejected when an
+event schema is created.

--- a/src/app/api/events/send/route.ts
+++ b/src/app/api/events/send/route.ts
@@ -6,13 +6,18 @@ import {
 } from "@/lib/automations";
 import { db } from "@/lib/db";
 import { contacts } from "@/lib/db/schema";
-import { sendEventSchema } from "@/lib/validation/events";
+import {
+  isRecord,
+  sendEventSchema,
+  validateEventPayloadAgainstSchema,
+} from "@/lib/validation/events";
 import { resumeWaitingRunsForEvent } from "@/lib/workers/automation-runner";
 import {
   AutomationValidationError,
   automationRepo,
   automationRunRepo,
   customEventDeliveryRepo,
+  customEventRepo,
 } from "@opensend/core";
 import { eq } from "drizzle-orm";
 
@@ -62,6 +67,45 @@ export async function POST(request: Request): Promise<Response> {
   const contactId = event.contact_id ?? event.contactId;
 
   try {
+    const customEvent = await customEventRepo.findByName(
+      event.event,
+      auth.userId,
+    );
+    const payload = event.payload ?? {};
+    if (customEvent?.schema !== null && customEvent?.schema !== undefined) {
+      if (!isRecord(customEvent.schema)) {
+        return Response.json(
+          {
+            error: "Stored event schema is invalid",
+            code: "event_schema_invalid",
+            details: [{ path: "schema", message: "schema must be an object" }],
+          },
+          { status: 422 },
+        );
+      }
+
+      const details = validateEventPayloadAgainstSchema(
+        payload,
+        customEvent.schema,
+      );
+      if (details.length > 0) {
+        const code = details.some((detail) => detail.path.startsWith("schema"))
+          ? "event_schema_invalid"
+          : "event_payload_invalid";
+        return Response.json(
+          {
+            error:
+              code === "event_schema_invalid"
+                ? "Stored event schema is invalid"
+                : "Event payload does not match schema",
+            code,
+            details,
+          },
+          { status: 422 },
+        );
+      }
+    }
+
     const resolvedContactId = await resolveContactId({
       contactId,
       email: event.email,
@@ -69,7 +113,7 @@ export async function POST(request: Request): Promise<Response> {
     });
     const delivery = await customEventDeliveryRepo.record({
       eventName: event.event,
-      payload: event.payload ?? {},
+      payload,
       contactId: resolvedContactId,
       email: event.email?.toLowerCase().trim() ?? null,
       userId: auth.userId,

--- a/src/lib/validation/events.ts
+++ b/src/lib/validation/events.ts
@@ -4,10 +4,187 @@ const eventNameSchema = z.string().min(1).max(255);
 const uuidSchema = z.string().uuid();
 const emailSchema = z.string().email().min(3).max(512);
 const jsonObjectSchema = z.record(z.string(), z.unknown());
+const supportedEventSchemaTypes = [
+  "string",
+  "number",
+  "boolean",
+  "object",
+  "array",
+] as const;
+
+type EventSchemaType = (typeof supportedEventSchemaTypes)[number];
+
+export interface EventSchemaIssue {
+  path: string;
+  message: string;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSupportedEventSchemaType(value: unknown): value is EventSchemaType {
+  return (
+    typeof value === "string" &&
+    supportedEventSchemaTypes.includes(value as EventSchemaType)
+  );
+}
+
+function pushIssue(
+  issues: EventSchemaIssue[],
+  path: string[],
+  message: string,
+) {
+  issues.push({ path: path.join("."), message });
+}
+
+function validateRequiredList(
+  value: unknown,
+  path: string[],
+  issues: EventSchemaIssue[],
+) {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    pushIssue(issues, path, `${path.join(".")} must be an array of strings`);
+    return;
+  }
+
+  value.forEach((entry, index) => {
+    if (typeof entry !== "string" || entry.trim().length === 0) {
+      pushIssue(
+        issues,
+        [...path, String(index)],
+        `${[...path, String(index)].join(".")} must be a non-empty string`,
+      );
+    }
+  });
+}
+
+function validatePropertiesObject(
+  value: unknown,
+  path: string[],
+  issues: EventSchemaIssue[],
+) {
+  if (value === undefined) return;
+  if (!isRecord(value)) {
+    pushIssue(issues, path, `${path.join(".")} must be an object`);
+    return;
+  }
+
+  for (const [propertyName, descriptor] of Object.entries(value)) {
+    if (propertyName.trim().length === 0) {
+      pushIssue(
+        issues,
+        [...path, propertyName],
+        `${path.join(".")} keys must be non-empty strings`,
+      );
+      continue;
+    }
+    validatePropertyDescriptor(descriptor, [...path, propertyName], issues);
+  }
+}
+
+function validateAllowedKeys(
+  value: Record<string, unknown>,
+  path: string[],
+  allowedKeys: ReadonlySet<string>,
+  issues: EventSchemaIssue[],
+) {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      pushIssue(
+        issues,
+        [...path, key],
+        `${[...path, key].join(".")} is not a supported schema keyword`,
+      );
+    }
+  }
+}
+
+function validatePropertyDescriptor(
+  value: unknown,
+  path: string[],
+  issues: EventSchemaIssue[],
+) {
+  if (!isRecord(value)) {
+    pushIssue(issues, path, `${path.join(".")} must be an object descriptor`);
+    return;
+  }
+
+  validateAllowedKeys(
+    value,
+    path,
+    new Set(["type", "properties", "required"]),
+    issues,
+  );
+
+  if (!isSupportedEventSchemaType(value.type)) {
+    pushIssue(
+      issues,
+      [...path, "type"],
+      `${[...path, "type"].join(".")} must be one of: ${supportedEventSchemaTypes.join(", ")}`,
+    );
+    return;
+  }
+
+  if (value.type !== "object") {
+    if (value.properties !== undefined) {
+      pushIssue(
+        issues,
+        [...path, "properties"],
+        `${[...path, "properties"].join(".")} is only supported when type is "object"`,
+      );
+    }
+    if (value.required !== undefined) {
+      pushIssue(
+        issues,
+        [...path, "required"],
+        `${[...path, "required"].join(".")} is only supported when type is "object"`,
+      );
+    }
+    return;
+  }
+
+  validatePropertiesObject(value.properties, [...path, "properties"], issues);
+  validateRequiredList(value.required, [...path, "required"], issues);
+}
+
+export function validateCustomEventSchemaDefinition(
+  schema: Record<string, unknown>,
+): EventSchemaIssue[] {
+  const issues: EventSchemaIssue[] = [];
+  validateAllowedKeys(
+    schema,
+    ["schema"],
+    new Set(["type", "properties", "required"]),
+    issues,
+  );
+
+  if (schema.type !== "object") {
+    pushIssue(issues, ["schema", "type"], 'schema.type must be "object"');
+    return issues;
+  }
+
+  validatePropertiesObject(schema.properties, ["schema", "properties"], issues);
+  validateRequiredList(schema.required, ["schema", "required"], issues);
+  return issues;
+}
+
+const eventSchemaDefinitionSchema = jsonObjectSchema.superRefine(
+  (schema, ctx) => {
+    for (const issue of validateCustomEventSchemaDefinition(schema)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: issue.path.split(".").slice(1),
+        message: issue.message,
+      });
+    }
+  },
+);
 
 export const createCustomEventSchema = z.object({
   name: eventNameSchema,
-  schema: jsonObjectSchema.optional(),
+  schema: eventSchemaDefinitionSchema.optional(),
 });
 
 export const listEventsQuerySchema = z.object({
@@ -50,6 +227,83 @@ export const sendEventSchema = z
       });
     }
   });
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function valueMatchesType(value: unknown, type: EventSchemaType): boolean {
+  switch (type) {
+    case "string":
+      return typeof value === "string";
+    case "number":
+      return typeof value === "number" && Number.isFinite(value);
+    case "boolean":
+      return typeof value === "boolean";
+    case "object":
+      return isRecord(value);
+    case "array":
+      return Array.isArray(value);
+  }
+}
+
+function validateObjectPayload(
+  payload: Record<string, unknown>,
+  schema: Record<string, unknown>,
+  path: string[],
+  issues: EventSchemaIssue[],
+) {
+  const required = Array.isArray(schema.required)
+    ? schema.required.filter(
+        (entry): entry is string => typeof entry === "string",
+      )
+    : [];
+
+  for (const field of required) {
+    if (!hasOwn(payload, field)) {
+      pushIssue(
+        issues,
+        [...path, field],
+        `Missing required field ${[...path, field].join(".")}`,
+      );
+    }
+  }
+
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+  for (const [field, descriptor] of Object.entries(properties)) {
+    if (!hasOwn(payload, field)) continue;
+    if (!isRecord(descriptor) || !isSupportedEventSchemaType(descriptor.type)) {
+      continue;
+    }
+
+    const value = payload[field];
+    const fieldPath = [...path, field];
+    if (!valueMatchesType(value, descriptor.type)) {
+      pushIssue(
+        issues,
+        fieldPath,
+        `Expected ${fieldPath.join(".")} to be "${descriptor.type}"`,
+      );
+      continue;
+    }
+
+    if (descriptor.type === "object" && isRecord(value)) {
+      validateObjectPayload(value, descriptor, fieldPath, issues);
+    }
+  }
+}
+
+export function validateEventPayloadAgainstSchema(
+  payload: Record<string, unknown>,
+  schema: Record<string, unknown>,
+): EventSchemaIssue[] {
+  const schemaIssues = validateCustomEventSchemaDefinition(schema);
+  if (schemaIssues.length > 0) return schemaIssues;
+
+  const issues: EventSchemaIssue[] = [];
+  validateObjectPayload(payload, schema, ["payload"], issues);
+  return issues;
+}
 
 export type CreateCustomEventRequest = z.infer<typeof createCustomEventSchema>;
 export type SendEventRequest = z.infer<typeof sendEventSchema>;

--- a/tests/api-automations-events.test.ts
+++ b/tests/api-automations-events.test.ts
@@ -7,6 +7,7 @@ const mockAutomationValidate = vi.hoisted(() => vi.fn());
 const mockAutomationDelete = vi.hoisted(() => vi.fn());
 const mockFindEnabledByTriggerEventName = vi.hoisted(() => vi.fn());
 const mockCustomEventCreate = vi.hoisted(() => vi.fn());
+const mockCustomEventFindByName = vi.hoisted(() => vi.fn());
 const mockCustomEventList = vi.hoisted(() => vi.fn());
 const mockDeliveryRecord = vi.hoisted(() => vi.fn());
 const mockRunCreateFromTrigger = vi.hoisted(() => vi.fn());
@@ -87,6 +88,7 @@ vi.mock("@opensend/core", () => ({
   },
   customEventRepo: {
     create: mockCustomEventCreate,
+    findByName: mockCustomEventFindByName,
     list: mockCustomEventList,
   },
   customEventDeliveryRepo: {
@@ -606,6 +608,7 @@ describe("events API routes", () => {
     vi.resetModules();
     vi.clearAllMocks();
     mockValidateApiKey.mockResolvedValue(auth);
+    mockCustomEventFindByName.mockResolvedValue(null);
     mockResumeWaitingRunsForEvent.mockResolvedValue([]);
   });
 
@@ -648,6 +651,35 @@ describe("events API routes", () => {
     await expect(response.json()).resolves.toMatchObject({
       code: "event_name_reserved",
     });
+  });
+
+  it("rejects invalid custom event schema definitions with 422 details", async () => {
+    const { POST } = await import("@/app/api/events/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/events", {
+        name: "user.signed_up",
+        schema: {
+          type: "object",
+          properties: {
+            plan: { type: "text" },
+          },
+        },
+      }),
+    );
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Validation failed",
+      details: {
+        fieldErrors: {
+          schema: expect.arrayContaining([
+            "schema.properties.plan.type must be one of: string, number, boolean, object, array",
+          ]),
+        },
+      },
+    });
+    expect(mockCustomEventCreate).not.toHaveBeenCalled();
   });
 
   it("requires exactly one contact identifier when sending events", async () => {
@@ -735,6 +767,180 @@ describe("events API routes", () => {
       expect.objectContaining({ id: "delivery_1" }),
     );
     expect(mockRunCreateFromTrigger).toHaveBeenCalledTimes(2);
+  });
+
+  it("validates a payload against a stored custom event schema before recording delivery", async () => {
+    mockCustomEventFindByName.mockResolvedValue({
+      ...customEvent,
+      schema: {
+        type: "object",
+        required: ["plan", "trial"],
+        properties: {
+          plan: { type: "string" },
+          seats: { type: "number" },
+          trial: { type: "boolean" },
+        },
+      },
+    });
+    mockContactFindFirst.mockResolvedValue({ id: "contact_1" });
+    mockDeliveryRecord.mockResolvedValue({
+      id: "delivery_1",
+      eventName: "user.signed_up",
+      contactId: "contact_1",
+      email: "user@example.com",
+      payload: { plan: "pro", seats: 3, trial: false },
+      receivedAt: now,
+    });
+    mockFindEnabledByTriggerEventName.mockResolvedValue([
+      { ...automation, id: "auto_1" },
+    ]);
+    mockRunCreateFromTrigger.mockResolvedValue({
+      id: "run_1",
+      automationId: "auto_1",
+      status: "queued",
+      triggerEventId: "delivery_1",
+      contactId: "contact_1",
+      stepStates: {},
+      startedAt: null,
+      completedAt: null,
+      currentStepKey: "trigger",
+      failureReason: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const { POST } = await import("@/app/api/events/send/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/events/send", {
+        event: "user.signed_up",
+        email: "user@example.com",
+        payload: { plan: "pro", seats: 3, trial: false },
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(mockCustomEventFindByName).toHaveBeenCalledWith(
+      "user.signed_up",
+      "user_1",
+    );
+    expect(mockDeliveryRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { plan: "pro", seats: 3, trial: false },
+      }),
+    );
+    expect(mockRunCreateFromTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 422 path details and creates no delivery or runs when schema validation fails", async () => {
+    mockCustomEventFindByName.mockResolvedValue({
+      ...customEvent,
+      schema: {
+        type: "object",
+        required: ["plan", "trial"],
+        properties: {
+          plan: { type: "string" },
+          trial: { type: "boolean" },
+        },
+      },
+    });
+    const { POST } = await import("@/app/api/events/send/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/events/send", {
+        event: "user.signed_up",
+        email: "user@example.com",
+        payload: { plan: 42 },
+      }),
+    );
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "event_payload_invalid",
+      details: expect.arrayContaining([
+        {
+          path: "payload.plan",
+          message: 'Expected payload.plan to be "string"',
+        },
+        {
+          path: "payload.trial",
+          message: "Missing required field payload.trial",
+        },
+      ]),
+    });
+    expect(mockContactFindFirst).not.toHaveBeenCalled();
+    expect(mockDbInsert).not.toHaveBeenCalled();
+    expect(mockDeliveryRecord).not.toHaveBeenCalled();
+    expect(mockResumeWaitingRunsForEvent).not.toHaveBeenCalled();
+    expect(mockFindEnabledByTriggerEventName).not.toHaveBeenCalled();
+    expect(mockRunCreateFromTrigger).not.toHaveBeenCalled();
+  });
+
+  it("keeps schema-less custom events accepting arbitrary object payloads", async () => {
+    mockCustomEventFindByName.mockResolvedValue({
+      ...customEvent,
+      schema: null,
+    });
+    mockContactFindFirst.mockResolvedValue({ id: "contact_1" });
+    mockDeliveryRecord.mockResolvedValue({
+      id: "delivery_1",
+      eventName: "user.signed_up",
+      contactId: "contact_1",
+      email: "user@example.com",
+      payload: { nested: { ok: true }, extra: ["anything"] },
+      receivedAt: now,
+    });
+    mockFindEnabledByTriggerEventName.mockResolvedValue([]);
+    const { POST } = await import("@/app/api/events/send/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/events/send", {
+        event: "user.signed_up",
+        email: "user@example.com",
+        payload: { nested: { ok: true }, extra: ["anything"] },
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(mockDeliveryRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { nested: { ok: true }, extra: ["anything"] },
+      }),
+    );
+  });
+
+  it("documents current-compatible unknown event names as schema-less sends", async () => {
+    mockCustomEventFindByName.mockResolvedValue(null);
+    mockContactFindFirst.mockResolvedValue({ id: "contact_1" });
+    mockDeliveryRecord.mockResolvedValue({
+      id: "delivery_unknown",
+      eventName: "unknown.event",
+      contactId: "contact_1",
+      email: "user@example.com",
+      payload: { arbitrary: true },
+      receivedAt: now,
+    });
+    mockFindEnabledByTriggerEventName.mockResolvedValue([]);
+    const { POST } = await import("@/app/api/events/send/route");
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/events/send", {
+        event: "unknown.event",
+        email: "user@example.com",
+        payload: { arbitrary: true },
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(mockCustomEventFindByName).toHaveBeenCalledWith(
+      "unknown.event",
+      "user_1",
+    );
+    expect(mockDeliveryRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventName: "unknown.event",
+        payload: { arbitrary: true },
+      }),
+    );
   });
 
   it("includes wait_for_event resumed runs when sending a matching event", async () => {


### PR DESCRIPTION
## Summary
- Add a narrow JSON-Schema-like validator for stored custom event schemas: root `type: "object"`, optional `required`, optional `properties`, and property types `string | number | boolean | object | array`.
- Enforce stored custom event schemas in `POST /api/events/send` before contact creation, delivery recording, waiting-run resume, or automation-run creation.
- Preserve schema-less custom events and unknown event names as current-compatible schema-less sends.

## Changed files
- `src/lib/validation/events.ts` — schema definition validation and send-time payload validation helpers.
- `src/app/api/events/send/route.ts` — tenant/name lookup and pre-side-effect payload enforcement.
- `tests/api-automations-events.test.ts` — focused route coverage for valid/invalid/schema-less/unknown/no-side-effect cases.
- `docs/custom-event-schemas.md` — supported dialect and unknown-event behavior documentation.
- `agent_docs/learnings/active/2026-05-10-289-custom-event-schema-dialect.md` — durable dialect decision note.

## Test evidence
- `bun run test tests/api-automations-events.test.ts` — 22 tests passed.
- `make check` — typecheck + Biome passed.
- `make test` — 102 files / 880 tests passed.
- Push guardrail also reran typecheck and changed-file Biome successfully.

## Unknown-event behavior decision
Unknown event names keep the existing public behavior: they are treated as schema-less sends, accept arbitrary object payloads, record deliveries, and can trigger any matching automation behavior. This avoids silently breaking callers because there was no existing evidence that unknown custom event names were rejected.

## Residual risk
- The schema dialect is intentionally narrow; full JSON Schema features such as enums, formats, numeric bounds, `additionalProperties`, and arrays item schemas are not supported in this slice.
- No Playwright E2E was run because this is a backend API validation slice with focused Vitest and full unit-suite coverage.

Closes #289
