### PR TITLE
Support Resend-style template variable fallbacks

### DIFF
--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -326,7 +326,16 @@ export const templates = pgTable("templates", {
   html: text("html"),
   text: text("text"),
   variables:
-    jsonb("variables").$type<Array<{ name: string; required: boolean }>>(),
+    jsonb("variables").$type<
+      Array<{
+        name: string;
+        key?: string;
+        type?: "string" | "number";
+        required: boolean;
+        fallbackValue?: string | number | null;
+        fallback_value?: string | number | null;
+      }>
+    >(),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/src/app/api/templates/[id]/route.ts
+++ b/src/app/api/templates/[id]/route.ts
@@ -3,6 +3,11 @@ import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { templates } from "@/lib/db/schema";
 import { extractTemplateVariables } from "@/lib/templates/parser";
+import {
+  normalizeStoredTemplateVariables,
+  normalizeTemplateVariablesInput,
+  templateVariableResponse,
+} from "@/lib/templates/variables";
 import { eq } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
@@ -42,18 +47,12 @@ export async function GET(
       preview_text: template.previewText,
       html: template.html,
       text: template.text,
-      variables:
-        (
-          template.variables as Array<{ name: string; required?: boolean }>
-        )?.map((v, index) => ({
-          id: `var-${index}`,
-          key: v.name,
-          type: "string",
-          required: v.required ?? false,
-          fallback_value: null,
-          created_at: template.createdAt,
-          updated_at: template.createdAt,
-        })) || [],
+      variables: normalizeStoredTemplateVariables(template.variables).map(
+        (variable, index) =>
+          templateVariableResponse(variable, index, {
+            createdAt: template.createdAt,
+          }),
+      ),
       created_at: template.createdAt,
       updated_at: template.createdAt,
     });
@@ -98,30 +97,37 @@ export async function PATCH(
       });
 
       if (existing) {
-        const fullContent = `${body.subject ?? existing.subject ?? ""} ${body.html ?? existing.html ?? ""}`;
+        const fullContent = `${body.subject ?? existing.subject ?? ""} ${body.html ?? existing.html ?? ""} ${body.text ?? existing.text ?? ""}`;
         const extracted = extractTemplateVariables(fullContent);
 
         // Merge with existing manual variable requirements if they exist
-        const currentVars =
-          (existing.variables as Array<{ name: string; required?: boolean }>) ??
-          [];
-        const varMap = new Map(currentVars.map((v) => [v.name, v]));
+        const currentVars = normalizeStoredTemplateVariables(
+          existing.variables,
+        );
+        const varMap = new Map(
+          currentVars.map((variable) => [variable.key, variable]),
+        );
 
         updateData.variables = extracted.map((name) => ({
           name,
+          key: name,
+          type: varMap.get(name)?.type ?? "string",
           required: varMap.get(name)?.required ?? false,
+          fallbackValue: varMap.get(name)?.fallbackValue ?? null,
         }));
       }
     }
 
     // Manual variable override
     if (body.variables !== undefined) {
-      updateData.variables = (
-        body.variables as Array<{ name: string; required?: boolean }>
-      ).map((v) => ({
-        name: v.name,
-        required: v.required ?? false,
-      }));
+      const variableResult = normalizeTemplateVariablesInput(body.variables);
+      if (!variableResult.ok) {
+        return NextResponse.json(
+          { error: variableResult.error },
+          { status: 422 },
+        );
+      }
+      updateData.variables = variableResult.variables;
     }
 
     const [updated] = await db
@@ -149,18 +155,12 @@ export async function PATCH(
       preview_text: updated.previewText,
       html: updated.html,
       text: updated.text,
-      variables:
-        (updated.variables as Array<{ name: string; required?: boolean }>)?.map(
-          (v, index) => ({
-            id: `var-${index}`,
-            key: v.name,
-            type: "string",
-            required: v.required ?? false,
-            fallback_value: null,
-            created_at: updated.createdAt,
-            updated_at: updated.createdAt,
+      variables: normalizeStoredTemplateVariables(updated.variables).map(
+        (variable, index) =>
+          templateVariableResponse(variable, index, {
+            createdAt: updated.createdAt,
           }),
-        ) || [],
+      ),
       created_at: updated.createdAt,
       updated_at: updated.createdAt,
     });

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -2,6 +2,7 @@ import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { templates } from "@/lib/db/schema";
+import { normalizeTemplateVariablesInput } from "@/lib/templates/variables";
 import { type SQL, and, count, desc, eq, ilike } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
@@ -13,12 +14,6 @@ function generateAlias(name: string): string {
       .replace(/^-|-$/g, "") || "untitled-template"
   );
 }
-
-const RESERVED_VARIABLE_NAMES = [
-  "UNSUBSCRIBE_URL",
-  "RESEND_UNSUBSCRIBE_URL",
-  "INTERNAL_ID",
-];
 
 export async function GET(request: NextRequest) {
   const auth = await validateApiKey(request.headers.get("authorization"));
@@ -107,30 +102,12 @@ export async function POST(request: NextRequest) {
 
     const alias = body.alias?.trim() || generateAlias(name);
 
-    // Validate variables
-    const variablesArr = body.variables || [];
-    if (!Array.isArray(variablesArr)) {
+    const variableResult = normalizeTemplateVariablesInput(body.variables);
+    if (!variableResult.ok) {
       return NextResponse.json(
-        { error: "variables must be an array" },
+        { error: variableResult.error },
         { status: 422 },
       );
-    }
-
-    if (variablesArr.length > 50) {
-      return NextResponse.json(
-        { error: "Too many variables. Max allowed is 50." },
-        { status: 422 },
-      );
-    }
-
-    for (const v of variablesArr) {
-      if (!v.name) continue;
-      if (RESERVED_VARIABLE_NAMES.includes(v.name.toUpperCase())) {
-        return NextResponse.json(
-          { error: `Variable name ${v.name} is reserved.` },
-          { status: 422 },
-        );
-      }
     }
 
     const [template] = await db
@@ -144,12 +121,7 @@ export async function POST(request: NextRequest) {
         replyTo: body.reply_to || null,
         previewText: body.preview_text || null,
         text: body.text || null,
-        variables: (
-          variablesArr as Array<{ name: string; required?: boolean }>
-        ).map((v) => ({
-          name: v.name,
-          required: v.required ?? false,
-        })),
+        variables: variableResult.variables,
         status: "draft",
       })
       .returning();

--- a/src/lib/api/emails/send.ts
+++ b/src/lib/api/emails/send.ts
@@ -19,6 +19,10 @@ import {
   suppressedRecipientError,
 } from "@/lib/suppressions";
 import {
+  interpolateTemplateVariables,
+  normalizeStoredTemplateVariables,
+} from "@/lib/templates/variables";
+import {
   buildOneClickUnsubscribeHeaders,
   createUnsubscribeUrl,
   getPublicBaseUrl,
@@ -490,19 +494,23 @@ export async function handlePostEmailRequest(
         );
       }
 
-      // Validate required variables
-      const templateVars =
-        (template.variables as Array<{
-          name: string;
-          required: boolean;
-        }>) ?? [];
-      const requiredVars = templateVars
-        .filter((v) => v.required)
-        .map((v) => v.name);
+      const templateVars = normalizeStoredTemplateVariables(template.variables);
       const providedVars = validated.template.variables ?? {};
+      const renderVars: Record<string, unknown> = { ...providedVars };
 
-      for (const requiredVar of requiredVars) {
-        if (providedVars[requiredVar] === undefined) {
+      for (const templateVar of templateVars) {
+        if (
+          Object.prototype.hasOwnProperty.call(providedVars, templateVar.key)
+        ) {
+          continue;
+        }
+
+        if (templateVar.hasFallbackValue) {
+          renderVars[templateVar.key] = templateVar.fallbackValue;
+          continue;
+        }
+
+        if (templateVar.required) {
           recordAcceptMetric(telemetry, {
             durationMs: performance.now() - startedAt,
             outcome: "invalid",
@@ -511,12 +519,12 @@ export async function handlePostEmailRequest(
             jsonWithTelemetry(
               publicApiError(
                 "validation_error",
-                `Missing required template variable: ${requiredVar}`,
+                `Missing required template variable: ${templateVar.key}`,
                 422,
                 {
                   formErrors: [],
                   fieldErrors: {
-                    template: [`Missing required variable: ${requiredVar}`],
+                    template: [`Missing required variable: ${templateVar.key}`],
                   },
                 },
               ),
@@ -529,17 +537,11 @@ export async function handlePostEmailRequest(
 
       finalHtml = template.html || "";
       if (template.subject) finalSubject = template.subject;
+      if (template.text !== null) finalText = template.text ?? "";
 
-      // Simple variable replacement
-      if (validated.template.variables) {
-        for (const [key, value] of Object.entries(
-          validated.template.variables,
-        )) {
-          const regex = new RegExp(`{{\\s*${key}\\s*}}`, "g");
-          finalHtml = finalHtml.replace(regex, String(value));
-          finalSubject = finalSubject.replace(regex, String(value));
-        }
-      }
+      finalHtml = interpolateTemplateVariables(finalHtml, renderVars);
+      finalText = interpolateTemplateVariables(finalText, renderVars);
+      finalSubject = interpolateTemplateVariables(finalSubject, renderVars);
     }
 
     const shouldQueueNow = !scheduledAt || scheduledAt <= new Date();

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -328,7 +328,16 @@ export const templates = pgTable("templates", {
   html: text("html"),
   text: text("text"),
   variables:
-    jsonb("variables").$type<Array<{ name: string; required: boolean }>>(),
+    jsonb("variables").$type<
+      Array<{
+        name: string;
+        key?: string;
+        type?: "string" | "number";
+        required: boolean;
+        fallbackValue?: string | number | null;
+        fallback_value?: string | number | null;
+      }>
+    >(),
   currentVersionId: uuid("current_version_id"),
   publishedAt: timestamp("published_at", { withTimezone: true }),
   hasUnpublishedVersions: boolean("has_unpublished_versions")

--- a/src/lib/templates/parser.ts
+++ b/src/lib/templates/parser.ts
@@ -1,15 +1,16 @@
 /**
  * Simple Mustache-style variable extractor.
- * Finds all unique {{variable}} patterns in a string.
+ * Finds all unique {{variable}} and {{{variable}}} patterns in a string.
  */
 export function extractTemplateVariables(content: string): string[] {
-  const regex = /{{\s*([a-zA-Z0-9_-]+)\s*}}/g;
+  const regex = /{{{\s*([a-zA-Z0-9_-]+)\s*}}}|{{\s*([a-zA-Z0-9_-]+)\s*}}/g;
   const variables = new Set<string>();
   let match: RegExpExecArray | null = regex.exec(content);
 
   while (match !== null) {
-    if (match[1]) {
-      variables.add(match[1]);
+    const variableName = match[1] ?? match[2];
+    if (variableName) {
+      variables.add(variableName);
     }
     match = regex.exec(content);
   }

--- a/src/lib/templates/variables.ts
+++ b/src/lib/templates/variables.ts
@@ -1,0 +1,227 @@
+export type TemplateVariableType = "string" | "number";
+
+export type TemplateFallbackValue = string | number;
+
+export type StoredTemplateVariable = {
+  name: string;
+  key?: string;
+  type?: TemplateVariableType;
+  required: boolean;
+  fallbackValue?: TemplateFallbackValue | null;
+  fallback_value?: TemplateFallbackValue | null;
+};
+
+export type NormalizedTemplateVariable = {
+  key: string;
+  name: string;
+  type: TemplateVariableType;
+  required: boolean;
+  fallbackValue: TemplateFallbackValue | null;
+  hasFallbackValue: boolean;
+};
+
+const RESERVED_VARIABLE_NAMES = new Set([
+  "FIRST_NAME",
+  "LAST_NAME",
+  "EMAIL",
+  "UNSUBSCRIBE_URL",
+  "RESEND_UNSUBSCRIBE_URL",
+  "INTERNAL_ID",
+  "CONTACT",
+  "THIS",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function isTemplateVariableType(value: unknown): value is TemplateVariableType {
+  return value === "string" || value === "number";
+}
+
+function isFallbackValue(value: unknown): value is TemplateFallbackValue {
+  return typeof value === "string" || typeof value === "number";
+}
+
+function getRawFallbackValue(record: Record<string, unknown>): unknown {
+  if (hasOwn(record, "fallbackValue")) return record.fallbackValue;
+  if (hasOwn(record, "fallback_value")) return record.fallback_value;
+  return undefined;
+}
+
+function getRawKey(record: Record<string, unknown>): unknown {
+  if (typeof record.key === "string") return record.key;
+  if (typeof record.name === "string") return record.name;
+  return undefined;
+}
+
+export function isReservedTemplateVariableName(name: string): boolean {
+  return RESERVED_VARIABLE_NAMES.has(name.toUpperCase());
+}
+
+export function normalizeTemplateVariableInput(
+  value: unknown,
+):
+  | { ok: true; variable: StoredTemplateVariable }
+  | { ok: false; error: string } {
+  if (!isRecord(value)) {
+    return { ok: false, error: "variables must contain objects" };
+  }
+
+  const rawKey = getRawKey(value);
+  if (typeof rawKey !== "string" || rawKey.trim().length === 0) {
+    return { ok: false, error: "Variable key is required." };
+  }
+
+  const key = rawKey.trim();
+  if (isReservedTemplateVariableName(key)) {
+    return { ok: false, error: `Variable name ${key} is reserved.` };
+  }
+
+  if (value.type !== undefined && !isTemplateVariableType(value.type)) {
+    return {
+      ok: false,
+      error: `Variable ${key} type must be either string or number.`,
+    };
+  }
+
+  const rawFallbackValue = getRawFallbackValue(value);
+  const hasFallbackValue =
+    rawFallbackValue !== undefined && rawFallbackValue !== null;
+  if (hasFallbackValue && !isFallbackValue(rawFallbackValue)) {
+    return {
+      ok: false,
+      error: `Variable ${key} fallback value must be a string or number.`,
+    };
+  }
+
+  if (value.required !== undefined && typeof value.required !== "boolean") {
+    return {
+      ok: false,
+      error: `Variable ${key} required must be a boolean.`,
+    };
+  }
+
+  const isResendStyle =
+    hasOwn(value, "key") ||
+    hasOwn(value, "type") ||
+    hasOwn(value, "fallbackValue") ||
+    hasOwn(value, "fallback_value");
+  const required =
+    typeof value.required === "boolean"
+      ? value.required
+      : isResendStyle
+        ? !hasFallbackValue
+        : false;
+
+  return {
+    ok: true,
+    variable: {
+      name: key,
+      key,
+      type: isTemplateVariableType(value.type) ? value.type : "string",
+      required,
+      fallbackValue: hasFallbackValue ? rawFallbackValue : null,
+    },
+  };
+}
+
+export function normalizeTemplateVariablesInput(
+  value: unknown,
+):
+  | { ok: true; variables: StoredTemplateVariable[] }
+  | { ok: false; error: string } {
+  const variables = value ?? [];
+  if (!Array.isArray(variables)) {
+    return { ok: false, error: "variables must be an array" };
+  }
+
+  if (variables.length > 50) {
+    return { ok: false, error: "Too many variables. Max allowed is 50." };
+  }
+
+  const normalized: StoredTemplateVariable[] = [];
+  for (const variable of variables) {
+    const result = normalizeTemplateVariableInput(variable);
+    if (!result.ok) return result;
+    normalized.push(result.variable);
+  }
+
+  return { ok: true, variables: normalized };
+}
+
+export function normalizeStoredTemplateVariable(
+  value: unknown,
+): NormalizedTemplateVariable | null {
+  if (!isRecord(value)) return null;
+
+  const rawKey = getRawKey(value);
+  if (typeof rawKey !== "string" || rawKey.trim().length === 0) return null;
+
+  const rawFallbackValue = getRawFallbackValue(value);
+  const hasFallbackValue = isFallbackValue(rawFallbackValue);
+
+  return {
+    key: rawKey.trim(),
+    name: rawKey.trim(),
+    type: isTemplateVariableType(value.type) ? value.type : "string",
+    required: typeof value.required === "boolean" ? value.required : false,
+    fallbackValue: hasFallbackValue ? rawFallbackValue : null,
+    hasFallbackValue,
+  };
+}
+
+export function normalizeStoredTemplateVariables(
+  value: unknown,
+): NormalizedTemplateVariable[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((variable) => normalizeStoredTemplateVariable(variable))
+    .filter((variable): variable is NormalizedTemplateVariable =>
+      Boolean(variable),
+    );
+}
+
+export function templateVariableResponse(
+  variable: NormalizedTemplateVariable,
+  index: number,
+  timestamps: {
+    createdAt: Date | string | null;
+    updatedAt?: Date | string | null;
+  },
+) {
+  return {
+    id: `var-${index}`,
+    key: variable.key,
+    name: variable.name,
+    type: variable.type,
+    required: variable.required,
+    fallback_value: variable.fallbackValue,
+    created_at: timestamps.createdAt,
+    updated_at: timestamps.updatedAt ?? timestamps.createdAt,
+  };
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function interpolateTemplateVariables(
+  content: string,
+  variables: Record<string, unknown>,
+): string {
+  let rendered = content;
+  for (const [key, value] of Object.entries(variables)) {
+    const escapedKey = escapeRegex(key);
+    const regex = new RegExp(
+      `{{{\\s*${escapedKey}\\s*}}}|{{\\s*${escapedKey}\\s*}}`,
+      "g",
+    );
+    rendered = rendered.replace(regex, String(value));
+  }
+  return rendered;
+}

--- a/src/lib/validation/emails.ts
+++ b/src/lib/validation/emails.ts
@@ -197,7 +197,7 @@ export const sendEmailSchema = z
     template: z
       .object({
         id: z.string().uuid(),
-        variables: z.record(z.string(), z.any()).optional(),
+        variables: z.record(z.string(), z.unknown()).optional(),
       })
       .optional(),
   })

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -293,6 +293,7 @@ describe("POST /api/emails", () => {
     Object.assign(mockDb.query, {
       emails: { findFirst: vi.fn().mockResolvedValue(null) },
       contacts: { findFirst: vi.fn().mockResolvedValue(null) },
+      templates: { findFirst: vi.fn().mockResolvedValue(null) },
     });
     mockDb.insert = vi.fn().mockReturnValue({
       values: vi.fn().mockResolvedValue(undefined),
@@ -450,6 +451,185 @@ describe("POST /api/emails", () => {
         groupId: "email.send",
       }),
     );
+  });
+
+  it("renders template triple-brace placeholders with fallback values", async () => {
+    const emailId = "templated-email-uuid";
+    const valuesMock = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: emailId }]),
+    });
+    mockDb.insert = vi.fn().mockReturnValue({ values: valuesMock });
+    Object.assign(mockDb.query, {
+      emails: { findFirst: vi.fn().mockResolvedValue(null) },
+      contacts: { findFirst: vi.fn().mockResolvedValue(null) },
+      templates: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: "11111111-1111-4111-8111-111111111111",
+          userId: AUTH_RESULT.userId,
+          subject: "Receipt for {{{PRODUCT}}}",
+          html: "<p>{{{PRODUCT}}}</p><p>{{ PRICE }}</p>",
+          text: "Text {{{PRODUCT}}} {{ PRICE }}",
+          variables: [
+            {
+              name: "PRODUCT",
+              key: "PRODUCT",
+              type: "string",
+              required: false,
+              fallbackValue: "item",
+            },
+            {
+              name: "PRICE",
+              key: "PRICE",
+              type: "number",
+              required: false,
+              fallbackValue: 25,
+            },
+          ],
+        }),
+      },
+    });
+
+    const { POST } = await import("@/app/api/emails/route");
+    const res = await POST(
+      makeRequest(
+        "POST",
+        {
+          from: "sender@domain.com",
+          to: ["user@test.com"],
+          subject: "Ignored when template has subject",
+          template: {
+            id: "11111111-1111-4111-8111-111111111111",
+            variables: {},
+          },
+        },
+        { Authorization: "Bearer re_test123" },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(valuesMock.mock.calls[0][0]).toMatchObject({
+      subject: "Receipt for item",
+      html: "<p>item</p><p>25</p>",
+      text: "Text item 25",
+      status: "queued",
+    });
+  });
+
+  it("renders provided template variables over fallbacks across triple and double braces", async () => {
+    const valuesMock = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: "templated-email-2" }]),
+    });
+    mockDb.insert = vi.fn().mockReturnValue({ values: valuesMock });
+    Object.assign(mockDb.query, {
+      emails: { findFirst: vi.fn().mockResolvedValue(null) },
+      contacts: { findFirst: vi.fn().mockResolvedValue(null) },
+      templates: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: "11111111-1111-4111-8111-111111111111",
+          userId: AUTH_RESULT.userId,
+          subject: "Receipt for {{ PRODUCT }}",
+          html: "<p>{{{PRODUCT}}}</p><p>{{{PRICE}}}</p>",
+          text: null,
+          variables: [
+            {
+              name: "PRODUCT",
+              key: "PRODUCT",
+              type: "string",
+              required: true,
+              fallbackValue: null,
+            },
+            {
+              name: "PRICE",
+              key: "PRICE",
+              type: "number",
+              required: false,
+              fallbackValue: 25,
+            },
+          ],
+        }),
+      },
+    });
+
+    const { POST } = await import("@/app/api/emails/route");
+    const res = await POST(
+      makeRequest(
+        "POST",
+        {
+          from: "sender@domain.com",
+          to: ["user@test.com"],
+          subject: "Ignored when template has subject",
+          template: {
+            id: "11111111-1111-4111-8111-111111111111",
+            variables: { PRODUCT: "Widget" },
+          },
+        },
+        { Authorization: "Bearer re_test123" },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(valuesMock.mock.calls[0][0]).toMatchObject({
+      subject: "Receipt for Widget",
+      html: "<p>Widget</p><p>25</p>",
+      text: "",
+    });
+  });
+
+  it("keeps the public validation_error envelope for missing template variables without fallbacks", async () => {
+    Object.assign(mockDb.query, {
+      emails: { findFirst: vi.fn().mockResolvedValue(null) },
+      contacts: { findFirst: vi.fn().mockResolvedValue(null) },
+      templates: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: "11111111-1111-4111-8111-111111111111",
+          userId: AUTH_RESULT.userId,
+          subject: "Receipt for {{{PRODUCT}}}",
+          html: "<p>{{{PRODUCT}}}</p>",
+          text: null,
+          variables: [
+            {
+              name: "PRODUCT",
+              key: "PRODUCT",
+              type: "string",
+              required: true,
+              fallbackValue: null,
+            },
+          ],
+        }),
+      },
+    });
+
+    const { POST } = await import("@/app/api/emails/route");
+    const res = await POST(
+      makeRequest(
+        "POST",
+        {
+          from: "sender@domain.com",
+          to: ["user@test.com"],
+          subject: "Ignored when template has subject",
+          template: {
+            id: "11111111-1111-4111-8111-111111111111",
+            variables: {},
+          },
+        },
+        { Authorization: "Bearer re_test123" },
+      ),
+    );
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "validation_error",
+      code: "validation_error",
+      statusCode: 422,
+      message: "Missing required template variable: PRODUCT",
+      details: {
+        fieldErrors: {
+          template: ["Missing required variable: PRODUCT"],
+        },
+      },
+    });
+    expect(mockReserveEmailQuota).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
   });
 
   it("audits queue publish failures before returning 500 and releasing quota", async () => {

--- a/tests/api-template-variables.test.ts
+++ b/tests/api-template-variables.test.ts
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockSelect = vi.hoisted(() => vi.fn());
+const mockInsert = vi.hoisted(() => vi.fn());
+const mockUpdate = vi.hoisted(() => vi.fn());
+const mockFindFirst = vi.hoisted(() => vi.fn());
+
+function makeChain<T>(rows: T[]) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    set: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue(rows),
+    // biome-ignore lint/suspicious/noThenProperty: mocks Drizzle's thenable query builder
+    then: (resolve: (value: T[]) => unknown) => Promise.resolve(resolve(rows)),
+  };
+}
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      templates: { findFirst: mockFindFirst },
+    },
+    select: mockSelect,
+    insert: mockInsert,
+    update: mockUpdate,
+  },
+}));
+
+vi.mock("@/lib/api-auth", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/api-auth")>("@/lib/api-auth");
+  return {
+    ...actual,
+    validateApiKey: mockValidateApiKey,
+  };
+});
+
+vi.mock("drizzle-orm", async () => {
+  const actual = await vi.importActual("drizzle-orm");
+  return {
+    ...actual,
+    eq: vi.fn((...args: unknown[]) => ({ op: "eq", args })),
+  };
+});
+
+function makeRequest(url: string, init?: RequestInit) {
+  const request = new Request(url, init) as Request & { nextUrl: URL };
+  request.nextUrl = new URL(url);
+  return request;
+}
+
+describe("template variable metadata APIs", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue({
+      apiKeyId: "key-1",
+      permission: "full_access",
+      domain: null,
+      userId: "user-1",
+    });
+  });
+
+  it("accepts Resend-style variables on create and stores type/fallback metadata", async () => {
+    const createdAt = new Date("2026-05-09T00:00:00.000Z");
+    const values = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([
+        {
+          id: "tmpl-1",
+          name: "Receipt",
+          alias: "receipt",
+          createdAt,
+        },
+      ]),
+    });
+    mockInsert.mockReturnValue({ values });
+
+    const { POST } = await import("@/app/api/templates/route");
+    const response = await POST(
+      makeRequest("http://localhost/api/templates", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "Receipt",
+          subject: "Order {{{PRODUCT}}}",
+          html: "<p>{{{PRODUCT}}} costs {{{PRICE}}}</p>",
+          variables: [
+            { key: "PRODUCT", type: "string", fallbackValue: "item" },
+            { key: "PRICE", type: "number", fallback_value: 25 },
+            { name: "legacy_name", required: true },
+          ],
+        }),
+      }) as never,
+    );
+
+    expect(response.status).toBe(201);
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: [
+          {
+            name: "PRODUCT",
+            key: "PRODUCT",
+            type: "string",
+            required: false,
+            fallbackValue: "item",
+          },
+          {
+            name: "PRICE",
+            key: "PRICE",
+            type: "number",
+            required: false,
+            fallbackValue: 25,
+          },
+          {
+            name: "legacy_name",
+            key: "legacy_name",
+            type: "string",
+            required: true,
+            fallbackValue: null,
+          },
+        ],
+      }),
+    );
+  });
+
+  it("preserves reserved-name and 50-variable validation on create", async () => {
+    const { POST } = await import("@/app/api/templates/route");
+
+    const reserved = await POST(
+      makeRequest("http://localhost/api/templates", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "Bad",
+          html: "<p>Bad</p>",
+          variables: [{ key: "EMAIL", type: "string" }],
+        }),
+      }) as never,
+    );
+    expect(reserved.status).toBe(422);
+    await expect(reserved.json()).resolves.toEqual({
+      error: "Variable name EMAIL is reserved.",
+    });
+
+    const tooMany = await POST(
+      makeRequest("http://localhost/api/templates", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "Too many",
+          html: "<p>Bad</p>",
+          variables: Array.from({ length: 51 }, (_, index) => ({
+            key: `VAR_${index}`,
+            type: "string",
+          })),
+        }),
+      }) as never,
+    );
+    expect(tooMany.status).toBe(422);
+    await expect(tooMany.json()).resolves.toEqual({
+      error: "Too many variables. Max allowed is 50.",
+    });
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("returns configured fallback_value and legacy variable metadata on detail", async () => {
+    const createdAt = new Date("2026-05-09T00:00:00.000Z");
+    mockSelect.mockReturnValue(
+      makeChain([
+        {
+          id: "tmpl-1",
+          name: "Receipt",
+          alias: "receipt",
+          status: "draft",
+          subject: "Order {{{PRODUCT}}}",
+          from: null,
+          replyTo: null,
+          previewText: null,
+          html: "<p>{{{PRODUCT}}}</p>",
+          text: "Product: {{{PRODUCT}}}",
+          variables: [
+            {
+              name: "PRODUCT",
+              key: "PRODUCT",
+              type: "string",
+              required: false,
+              fallbackValue: "item",
+            },
+            { name: "legacy_name", required: true },
+          ],
+          createdAt,
+        },
+      ]),
+    );
+
+    const { GET } = await import("@/app/api/templates/[id]/route");
+    const response = await GET(
+      makeRequest("http://localhost/api/templates/tmpl-1", {
+        headers: { authorization: "Bearer token" },
+      }) as never,
+      { params: Promise.resolve({ id: "tmpl-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      variables: [
+        {
+          key: "PRODUCT",
+          name: "PRODUCT",
+          type: "string",
+          required: false,
+          fallback_value: "item",
+        },
+        {
+          key: "legacy_name",
+          name: "legacy_name",
+          type: "string",
+          required: true,
+          fallback_value: null,
+        },
+      ],
+    });
+  });
+
+  it("accepts fallback_value on update and returns normalized metadata", async () => {
+    const updatedAt = new Date("2026-05-09T00:00:00.000Z");
+    const set = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([
+          {
+            id: "tmpl-1",
+            name: "Receipt",
+            alias: "receipt",
+            status: "draft",
+            subject: "Order {{{PRODUCT}}}",
+            from: null,
+            replyTo: null,
+            previewText: null,
+            html: "<p>{{{PRODUCT}}}</p>",
+            text: null,
+            variables: [
+              {
+                name: "PRODUCT",
+                key: "PRODUCT",
+                type: "string",
+                required: false,
+                fallbackValue: "item",
+              },
+            ],
+            createdAt: updatedAt,
+          },
+        ]),
+      }),
+    });
+    mockUpdate.mockReturnValue({ set });
+
+    const { PATCH } = await import("@/app/api/templates/[id]/route");
+    const response = await PATCH(
+      makeRequest("http://localhost/api/templates/tmpl-1", {
+        method: "PATCH",
+        headers: {
+          authorization: "Bearer token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          variables: [
+            { key: "PRODUCT", type: "string", fallback_value: "item" },
+          ],
+        }),
+      }) as never,
+      { params: Promise.resolve({ id: "tmpl-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(set).toHaveBeenCalledWith({
+      variables: [
+        {
+          name: "PRODUCT",
+          key: "PRODUCT",
+          type: "string",
+          required: false,
+          fallbackValue: "item",
+        },
+      ],
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      variables: [
+        {
+          key: "PRODUCT",
+          type: "string",
+          required: false,
+          fallback_value: "item",
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Closes #294

## Summary
- Accept and persist Resend-style template variable metadata (`key`, `type`, `fallbackValue` / `fallback_value`) while preserving legacy `{ name, required }` records.
- Return normalized template variable metadata with `type`, `required`, and non-null `fallback_value` when configured.
- Render send-time template variables across triple-brace and double-brace placeholders in subject/html/text, using fallbacks before missing-variable validation errors.

## Tests
- `bun run test tests/api-template-variables.test.ts tests/api-emails.test.ts`
- `make check`
- `make test`

## Not tested
- Playwright e2e suite.