### PR TITLE
Ensure domain verification reconciles automatically

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,8 +85,11 @@ GOOGLE_CLIENT_SECRET=
 # ─────────────────────────────────────────────────────────────────
 # Ingester / cron auth tokens
 # ─────────────────────────────────────────────────────────────────
-# Shared secret between the app and the ingester service for /jobs/* calls.
+# Shared secret between the scheduler/EventBridge and the ingester service for /jobs/* calls.
+# When set, the scheduler sends Authorization: Bearer ${INGESTER_JOB_TOKEN}.
 # INGESTER_JOB_TOKEN=
+# Durable scheduler cadence for /jobs/scheduled-emails, /jobs/webhooks, and /jobs/domain-verify.
+# INGESTER_SCHEDULER_INTERVAL_SECONDS=60
 # Bearer token required by /api/cron/* scheduled-email endpoints.
 # CRON_AUTH_TOKEN=
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ go test ./...
 go run .
 ```
 
-The Go ingester is shadow-only for future issue #71 parity slices. The current production ingester remains `packages/ingester` on port **3016** for SES/SNS ingestion, Stripe webhooks, scheduled jobs, and webhook dispatch.
+The Go ingester is shadow-only for future issue #71 parity slices. The current production ingester remains `packages/ingester` on port **3016** for SES/SNS ingestion, Stripe webhooks, scheduled jobs, webhook dispatch, and automatic domain-verification reconciliation. Docker Compose also starts a `scheduler` sidecar that posts to `/jobs/scheduled-emails`, `/jobs/webhooks`, and `/jobs/domain-verify` every minute, using `Authorization: Bearer ${INGESTER_JOB_TOKEN}` when configured.
 
 ### TypeScript SDK
 

--- a/agent_docs/learnings/active/2026-05-10-issue-286-domain-verify-scheduler.md
+++ b/agent_docs/learnings/active/2026-05-10-issue-286-domain-verify-scheduler.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-10
+issue: 286
+type: decision
+promoted_to: null
+---
+
+## Domain verification reconciliation needs both endpoint parity and scheduler wiring on staging
+
+Issue #286 assumed PR #275's `/jobs/domain-verify` path was already present, but the `staging` base for this worktree did not contain that merge. The fix therefore had to restore the shared domain reconciliation service and ingester job endpoint before adding scheduler wiring.
+
+Pattern: when an issue references a recently merged PR, verify the target base branch directly before treating the referenced code as available. If the deploy target lacks the endpoint, ship the endpoint and scheduler together so production cannot have a durable schedule pointing at a missing route.
+
+The Compose scheduler uses HTTP for `/jobs/domain-verify` even when scheduled email and webhook scans are queue-driven, because domain verification currently has no SQS scan job type.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,10 @@
 #   - app        : Next.js dashboard + REST API on http://localhost:${PORT:-3015}.
 #   - ingester   : Production Bun/Hono service that handles SES/SNS, Stripe, and scheduled-email
 #                  webhooks on http://localhost:${INGESTER_PORT:-3016}.
-#                  Experimental Go shadow skeleton lives at services/ingester-go
-#                  and defaults to 3027, but is intentionally not wired into Compose.
+#   - scheduler  : Durable short-interval driver for ingester /jobs/* scans.
+#
+# The experimental Go shadow skeleton lives at services/ingester-go and defaults to 3027,
+# but is intentionally not wired into Compose.
 #
 # Optional overrides (all read from .env):
 #   - PORT                        : host port for the app (default 3015)
@@ -20,6 +22,8 @@
 #   - POSTGRES_PASSWORD           : Postgres password (default `opensend`; CHANGE in production)
 #   - AWS_*                       : SES + S3 credentials. If unset, email sending is disabled.
 #   - BACKGROUND_JOBS_*           : SQS/EventBridge wiring for async send pipeline.
+#   - INGESTER_JOB_TOKEN          : optional bearer token protecting ingester /jobs/* scans.
+#   - INGESTER_SCHEDULER_INTERVAL_SECONDS: scheduler cadence (default 60; minimum 10).
 #   - CLOUDFLARE_API_TOKEN/ZONE_ID: enables auto-DKIM/SPF/DMARC when adding a domain.
 #   - S3_BUCKET_NAME              : S3 bucket for email attachments.
 #
@@ -100,6 +104,7 @@ services:
   #   http://<host>:${INGESTER_PORT:-3016}/events/stripe
   # Set BACKGROUND_WORKER_POLL=true to enable the SQS long-poll loop in this container.
   ingester:
+    image: opensend-ingester:local
     build:
       context: .
       dockerfile: packages/ingester/Dockerfile
@@ -116,6 +121,7 @@ services:
       BACKGROUND_JOBS_EVENT_BUS_NAME: ${BACKGROUND_JOBS_EVENT_BUS_NAME:-}
       BACKGROUND_JOBS_REQUIRE_QUEUE: ${BACKGROUND_JOBS_REQUIRE_QUEUE:-false}
       BACKGROUND_WORKER_POLL: ${BACKGROUND_WORKER_POLL:-false}
+      INGESTER_JOB_TOKEN: ${INGESTER_JOB_TOKEN:-}
     depends_on:
       postgres:
         condition: service_healthy
@@ -133,6 +139,24 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+
+  # Durable local/self-host scheduler for ingester background scan endpoints.
+  # It posts every ${INGESTER_SCHEDULER_INTERVAL_SECONDS:-60}s to:
+  #   - /jobs/scheduled-emails
+  #   - /jobs/webhooks
+  #   - /jobs/domain-verify
+  # If INGESTER_JOB_TOKEN is set, the scheduler sends Authorization: Bearer <token>.
+  scheduler:
+    image: opensend-ingester:local
+    restart: unless-stopped
+    command: ["bun", "/app/job-scheduler.js"]
+    environment:
+      INGESTER_URL: http://ingester:3016
+      INGESTER_JOB_TOKEN: ${INGESTER_JOB_TOKEN:-}
+      INGESTER_SCHEDULER_INTERVAL_SECONDS: ${INGESTER_SCHEDULER_INTERVAL_SECONDS:-60}
+    depends_on:
+      ingester:
+        condition: service_healthy
 
 volumes:
   pgdata:

--- a/docs/ingester-deploy.md
+++ b/docs/ingester-deploy.md
@@ -4,7 +4,7 @@ The production ingester is the Bun/Hono service in `packages/ingester`. It is a 
 
 1. SES/SNS event ingestion at `POST /events/ses`
 2. Background job execution (queued email sends, scheduled-email scans,
-   webhook dispatch, webhook retry scans)
+   webhook dispatch, webhook retry scans, and domain verification reconciliation)
 
 A separate Go skeleton now exists at `services/ingester-go` for the planned issue #71 data-plane migration. It is experimental and shadow-only: it exposes static `GET /health` and `GET /readyz` endpoints on local port `3027` by default, but it does **not** process SES/SNS events, jobs, Stripe webhooks, or webhook fan-out. Keep production traffic on `packages/ingester` until future parity and cutover slices explicitly change this.
 
@@ -103,11 +103,17 @@ BACKGROUND_JOBS_EVENT_BUS_NAME=<event-bus-name>   # optional lifecycle bus
 CLOUDWATCH_METRICS_NAMESPACE=Opensend             # optional EMF namespace
 ```
 
-Set this **only** on the ingester service:
+Set these on the ingester service:
 
 ```bash
 BACKGROUND_WORKER_POLL=true
 INGESTER_JOB_TOKEN=<random-bearer-token>
+```
+
+Set the same `INGESTER_JOB_TOKEN` on any scheduler that calls `/jobs/*`. Compose also accepts an optional scheduler cadence override:
+
+```bash
+INGESTER_SCHEDULER_INTERVAL_SECONDS=60
 ```
 
 ### SQS requirements
@@ -121,7 +127,7 @@ INGESTER_JOB_TOKEN=<random-bearer-token>
 
 ### Periodic scans
 
-Two scans need to run every minute. Either pattern works:
+Three scans need to run every minute: `/jobs/scheduled-emails`, `/jobs/webhooks`, and `/jobs/domain-verify`. The Docker Compose `scheduler` sidecar runs all three by default. For managed production, use one of these patterns:
 
 **HTTP-driven** (e.g. AWS EventBridge schedule rule with HTTP target, or any
 cron driver that can issue authenticated POSTs):
@@ -132,17 +138,21 @@ curl -i -X POST "${INGESTER_URL}/jobs/scheduled-emails" \
   -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
 curl -i -X POST "${INGESTER_URL}/jobs/webhooks" \
   -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
+curl -i -X POST "${INGESTER_URL}/jobs/domain-verify" \
+  -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
 ```
 
 **Queue-driven**: publish `scheduled-email.scan` and `webhook-delivery.scan`
 SQS messages on the same minute cadence; the ingester picks them up via the
-normal long-poll loop.
+normal long-poll loop. Domain verification is HTTP-only today, so keep an HTTP schedule for `/jobs/domain-verify`.
 
 Manual probes during a deploy:
 
 ```bash
 INGESTER_URL="https://events.yourdomain.com"
 curl -i -X POST "${INGESTER_URL}/jobs/poll" \
+  -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
+curl -i -X POST "${INGESTER_URL}/jobs/domain-verify" \
   -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
 ```
 
@@ -204,8 +214,8 @@ Before pointing production SES SNS at a freshly stood-up ingester, verify:
 - The events host (`events.<your-domain>`) resolves and serves a 200 on
   `/health`.
 - The SQS queue exists with a redrive policy + DLQ.
-- Periodic scan rules (`/jobs/scheduled-emails`, `/jobs/webhooks`) are
-  scheduled on a 1-minute cadence.
+- Periodic scan rules (`/jobs/scheduled-emails`, `/jobs/webhooks`, `/jobs/domain-verify`) are scheduled on a 1-minute cadence and use `Authorization: Bearer ${INGESTER_JOB_TOKEN}` when the token is configured.
+- Domain verification runbook passed: create/use a pending domain, confirm SES is verified, do not click **Verify DNS Records**, wait for the scheduler, and confirm the OpenSend DB/dashboard flips to `verified`.
 - Migrations ran successfully against the production database before the new
   image started.
 - Rolling back is possible: keep the previous image tag pinned somewhere you

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -120,7 +120,8 @@ contributor-facing set; the table below adds the production-only entries.
 | `BACKGROUND_JOBS_REQUIRE_QUEUE=true` | Fail API publish when the queue URL is missing instead of silently skipping. Required in production. |
 | `BACKGROUND_JOBS_EVENT_BUS_NAME` | Optional EventBridge bus for job lifecycle events. |
 | `BACKGROUND_WORKER_POLL=true` | Set on the **ingester** service only. Enables long-poll SQS consumer. |
-| `INGESTER_JOB_TOKEN` | Bearer token required for `/jobs/*` endpoints when EventBridge invokes them over HTTP. |
+| `INGESTER_JOB_TOKEN` | Bearer token required for `/jobs/*` endpoints when the scheduler/EventBridge invokes them over HTTP. |
+| `INGESTER_SCHEDULER_INTERVAL_SECONDS` | Compose scheduler cadence for `/jobs/scheduled-emails`, `/jobs/webhooks`, and `/jobs/domain-verify`. Default `60`; minimum `10`. |
 | `RATE_LIMIT_BACKEND` | `disabled` (single-process dev), or `redis` (production). |
 | `REDIS_URL` | TLS Redis endpoint, e.g. `rediss://default:<password>@<endpoint>:6379`. Used for rate limiting AND auth/domain metadata cache. |
 | `CLOUDWATCH_METRICS_NAMESPACE` | Override the default `Opensend` EMF metrics namespace. |
@@ -290,13 +291,17 @@ This means **you need SQS in production**. Without it, sends never leave
 
 ### Scheduled jobs
 
-Two periodic scans need to run every minute:
+Three periodic scans need to run every minute:
 
 - **Scheduled emails**: enqueue due `email.send` jobs.
 - **Webhook retry**: re-attempt failed webhook deliveries whose
   `next_retry_at` has arrived.
+- **Domain verification**: reconcile SES-verified domains and flip OpenSend
+  domain/record status to `verified` without clicking **Verify DNS Records**.
 
-Two ways to drive them:
+Docker Compose runs the durable `scheduler` sidecar by default. It posts to all three ingester job endpoints every `INGESTER_SCHEDULER_INTERVAL_SECONDS` seconds and includes `Authorization: Bearer ${INGESTER_JOB_TOKEN}` when the token is configured.
+
+Two other production patterns can drive the same endpoints:
 
 **Option 1: EventBridge → HTTP**. Schedule rules that POST to the ingester
 with the `INGESTER_JOB_TOKEN` bearer:
@@ -307,11 +312,24 @@ curl -i -X POST "${INGESTER_URL}/jobs/scheduled-emails" \
   -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
 curl -i -X POST "${INGESTER_URL}/jobs/webhooks" \
   -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
+curl -i -X POST "${INGESTER_URL}/jobs/domain-verify" \
+  -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
 ```
 
 **Option 2: SQS scan jobs**. Publish `scheduled-email.scan` and
-`webhook-delivery.scan` messages on a schedule. The ingester picks them up via
-the same long-poll loop.
+`webhook-delivery.scan` messages on a schedule. Domain verification is HTTP-only today, so keep an HTTP schedule for `/jobs/domain-verify` even if scheduled emails and webhook retries are queue-driven.
+
+
+### Domain verification scheduler runbook
+
+To verify the automatic domain reconciler in a deployment:
+
+1. Create a new domain from the dashboard/API, or use an existing domain whose OpenSend status is `not_started` or `pending`.
+2. Publish the DKIM/SPF/DMARC records and confirm AWS SES reports the identity as verified (`VerifiedForSendingStatus=true` and DKIM `SUCCESS`).
+3. Do **not** click **Verify DNS Records** in OpenSend.
+4. Wait one scheduler interval plus SES/API latency (normally 1-2 minutes with the default 60-second cadence).
+5. Confirm the OpenSend dashboard or database now shows the domain status and DNS record badges as `verified`.
+6. If it does not flip, inspect the scheduler and ingester logs for `/jobs/domain-verify` responses and verify the scheduler is sending `Authorization: Bearer ${INGESTER_JOB_TOKEN}` when `INGESTER_JOB_TOKEN` is set on the ingester.
 
 ### Local dev fallback
 

--- a/packages/core/src/db/repositories/domainRepo.ts
+++ b/packages/core/src/db/repositories/domainRepo.ts
@@ -1,6 +1,8 @@
-import { and, desc, eq, lt } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, lt } from "drizzle-orm";
 import { db } from "../client";
 import { domains } from "../schema";
+
+const PENDING_VERIFICATION_STATUSES = ["not_started", "pending"] as const;
 
 export const domainRepo = {
   async findById(id: string) {
@@ -32,6 +34,16 @@ export const domainRepo = {
       .delete(domains)
       .where(eq(domains.id, id))
       .returning({ id: domains.id });
+  },
+
+  async listPendingVerification(options: { limit?: number } = {}) {
+    const { limit = 100 } = options;
+    return await db
+      .select()
+      .from(domains)
+      .where(inArray(domains.status, [...PENDING_VERIFICATION_STATUSES]))
+      .orderBy(asc(domains.createdAt))
+      .limit(limit);
   },
 
   async list(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export * from "./webhook-signing";
 export * from "./webhook-events";
 export * from "./services/dns";
 export * from "./services/domain";
+export * from "./services/domain-events";
 export * from "./services/webhook";
 export * from "./services/apiKeys";
 export * from "./services/email";

--- a/packages/core/src/services/domain-events.ts
+++ b/packages/core/src/services/domain-events.ts
@@ -1,0 +1,83 @@
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "../db/client";
+import { emailEvents, webhookDeliveries, webhooks } from "../db/schema";
+import {
+  type SupportedWebhookEventType,
+  isSupportedWebhookEventType,
+} from "../webhook-events";
+
+export type DomainEventPayload = {
+  id: string;
+  name: string;
+  status: string;
+  previous_status: string;
+  records: unknown[];
+  capabilities: unknown[];
+};
+
+export type EnqueueDomainEventInput = {
+  type: SupportedWebhookEventType;
+  userId: string;
+  payload: DomainEventPayload;
+};
+
+export type EnqueueDomainEventResult = {
+  eventId: string;
+  deliveryIds: string[];
+};
+
+export async function enqueueDomainEvent(
+  input: EnqueueDomainEventInput,
+): Promise<EnqueueDomainEventResult> {
+  const { type, payload, userId } = input;
+
+  if (!isSupportedWebhookEventType(type)) {
+    throw new Error(`Unsupported webhook event type: ${type}`);
+  }
+
+  return await db.transaction(async (tx) => {
+    const [event] = await tx
+      .insert(emailEvents)
+      .values({
+        emailId: null,
+        sourceId: null,
+        type,
+        payload,
+        userId,
+      })
+      .returning({ id: emailEvents.id });
+
+    const matchingWebhooks = await tx
+      .select({ id: webhooks.id })
+      .from(webhooks)
+      .where(
+        and(
+          eq(webhooks.userId, userId),
+          eq(webhooks.status, "active"),
+          sql`${webhooks.eventTypes} ? ${type}`,
+        ),
+      );
+
+    if (matchingWebhooks.length === 0) {
+      return { eventId: event.id, deliveryIds: [] };
+    }
+
+    const deliveries = await tx
+      .insert(webhookDeliveries)
+      .values(
+        matchingWebhooks.map((webhook) => ({
+          webhookId: webhook.id,
+          eventId: event.id,
+          status: "pending",
+          attempt: 0,
+          nextRetryAt: null,
+        })),
+      )
+      .returning({ id: webhookDeliveries.id });
+
+    return {
+      eventId: event.id,
+      deliveryIds: deliveries.map((delivery) => delivery.id),
+    };
+  });
+}

--- a/packages/core/src/services/domain.ts
+++ b/packages/core/src/services/domain.ts
@@ -86,10 +86,39 @@ export type DomainRepository = {
     data: DomainRow[];
     hasMore: boolean;
   }>;
+  listPendingVerification(options?: { limit?: number }): Promise<DomainRow[]>;
   create(data: DomainInsert): Promise<DomainRow[]>;
   findById(id: string): Promise<DomainRow | undefined>;
   update(id: string, data: Partial<DomainInsert>): Promise<DomainRow[]>;
   delete(id: string): Promise<Array<{ id: string }>>;
+};
+
+export type DomainReconcileResult =
+  | { status: "not_found" }
+  | {
+      status: "unchanged";
+      domain: DomainRow;
+    }
+  | {
+      status: "updated";
+      domain: DomainRow;
+      previousStatus: string;
+    };
+
+export type DomainReconcileBatchResult = {
+  scanned: number;
+  updated: number;
+  unchanged: number;
+  failed: number;
+  changes: Array<{
+    domainId: string;
+    domainName: string;
+    userId: string | null;
+    previousStatus: string;
+    nextStatus: string;
+    records: NonNullable<DomainRow["records"]>;
+    capabilities: NonNullable<DomainRow["capabilities"]>;
+  }>;
 };
 
 export type DomainServiceDependencies = {
@@ -276,16 +305,106 @@ export function createDomainService({
       return toDomainDetail(row);
     },
 
-    async verify(id: string) {
+    async reconcileVerification(id: string): Promise<DomainReconcileResult> {
       const domain = await repository.findById(id);
-      if (!domain) throw new Error("Domain not found");
+      if (!domain) return { status: "not_found" };
 
       const identity = await getDomainIdentity(domain.name);
-      const status: "pending" | "verified" | "failed" = identity.verified
+      const nextStatus: "pending" | "verified" = identity.verified
         ? "verified"
         : "pending";
 
-      return await repository.update(id, { status });
+      const existingRecords = (domain.records ?? []) as DomainRecord[];
+      const recordsForUpdate: DomainRecord[] = existingRecords.map(
+        (record) => ({
+          ...record,
+          status: identity.verified ? "verified" : "pending",
+        }),
+      );
+
+      const recordsChanged =
+        existingRecords.length !== recordsForUpdate.length ||
+        existingRecords.some(
+          (record, idx) => record.status !== recordsForUpdate[idx].status,
+        );
+      const statusChanged = domain.status !== nextStatus;
+
+      if (!statusChanged && !recordsChanged) {
+        return { status: "unchanged", domain };
+      }
+
+      const previousStatus = domain.status;
+      const [updated] = await repository.update(id, {
+        status: nextStatus,
+        records: recordsForUpdate,
+      });
+
+      if (!updated) {
+        await invalidateDomainCaches({ id, name: domain.name });
+        return { status: "not_found" };
+      }
+
+      await invalidateDomainCaches({ id: updated.id, name: updated.name });
+
+      if (!statusChanged) {
+        return { status: "unchanged", domain: updated };
+      }
+
+      return {
+        status: "updated",
+        domain: updated,
+        previousStatus,
+      };
+    },
+
+    async verify(id: string) {
+      const result = await this.reconcileVerification(id);
+      if (result.status === "not_found") {
+        throw new Error("Domain not found");
+      }
+      return [result.domain];
+    },
+
+    async reconcileAllPendingVerifications(
+      options: { limit?: number } = {},
+    ): Promise<DomainReconcileBatchResult> {
+      const pending = await repository.listPendingVerification({
+        limit: options.limit,
+      });
+
+      const result: DomainReconcileBatchResult = {
+        scanned: pending.length,
+        updated: 0,
+        unchanged: 0,
+        failed: 0,
+        changes: [],
+      };
+
+      for (const domain of pending) {
+        try {
+          const reconciled = await this.reconcileVerification(domain.id);
+          if (reconciled.status === "updated") {
+            result.updated++;
+            result.changes.push({
+              domainId: reconciled.domain.id,
+              domainName: reconciled.domain.name,
+              userId: reconciled.domain.userId ?? null,
+              previousStatus: reconciled.previousStatus,
+              nextStatus: reconciled.domain.status,
+              records: reconciled.domain.records ?? [],
+              capabilities: reconciled.domain.capabilities ?? [],
+            });
+          } else if (reconciled.status === "unchanged") {
+            result.unchanged++;
+          } else {
+            result.failed++;
+          }
+        } catch {
+          result.failed++;
+        }
+      }
+
+      return result;
     },
 
     async delete(id: string) {

--- a/packages/ingester/Dockerfile
+++ b/packages/ingester/Dockerfile
@@ -9,7 +9,11 @@ COPY . .
 RUN bun build ./packages/ingester/src/server.ts \
   --target bun \
   --minify \
-  --outfile /tmp/ingester-server.js
+  --outfile /tmp/ingester-server.js \
+  && bun build ./packages/ingester/src/job-scheduler.ts \
+    --target bun \
+    --minify \
+    --outfile /tmp/ingester-job-scheduler.js
 
 FROM oven/bun:1.3.8-alpine AS runner
 
@@ -20,6 +24,7 @@ ENV PORT=3016
 RUN addgroup --system --gid 1001 bunjs \
   && adduser --system --uid 1001 ingester
 COPY --from=build /tmp/ingester-server.js ./server.js
+COPY --from=build /tmp/ingester-job-scheduler.js ./job-scheduler.js
 USER ingester
 EXPOSE 3016
 CMD ["bun", "/app/server.js"]

--- a/packages/ingester/src/index.ts
+++ b/packages/ingester/src/index.ts
@@ -1,9 +1,11 @@
 import {
   createBackgroundJob,
   createTelemetryContext,
+  domainService,
   emailEventRepo,
   emailService,
   emitCloudWatchMetric,
+  enqueueDomainEvent,
   getTelemetryCarrier,
   logTelemetry,
   publishBackgroundJob,
@@ -119,6 +121,76 @@ app.post("/jobs/webhooks", async (c) =>
     c,
     async () => await webhookDispatcher.dispatchPendingDeliveries(),
   ),
+);
+
+app.post("/jobs/domain-verify", async (c) =>
+  runJobEndpoint(c, async () => {
+    const telemetry = createTelemetryContext({
+      service: "ingester",
+      operation: "POST /jobs/domain-verify",
+    });
+
+    let result: Awaited<
+      ReturnType<typeof domainService.reconcileAllPendingVerifications>
+    >;
+    try {
+      result = await domainService.reconcileAllPendingVerifications();
+    } catch (error) {
+      recordTelemetryError(telemetry, "domain.verify.reconcile_failed", error);
+      throw error;
+    }
+
+    for (const change of result.changes) {
+      if (!change.userId) continue;
+      try {
+        await enqueueDomainEvent({
+          type: "domain.updated",
+          userId: change.userId,
+          payload: {
+            id: change.domainId,
+            name: change.domainName,
+            status: change.nextStatus,
+            previous_status: change.previousStatus,
+            records: change.records,
+            capabilities: change.capabilities,
+          },
+        });
+      } catch (error) {
+        recordTelemetryError(
+          telemetry,
+          "domain.verify.event_enqueue_failed",
+          error,
+          { domain_id: change.domainId },
+        );
+      }
+    }
+
+    logTelemetry("info", "domain.verify.reconcile_completed", telemetry, {
+      scanned: result.scanned,
+      updated: result.updated,
+      unchanged: result.unchanged,
+      failed: result.failed,
+    });
+
+    emitCloudWatchMetric(telemetry, {
+      metrics: [
+        { name: "DomainVerifyScanned", value: result.scanned, unit: "Count" },
+        { name: "DomainVerifyUpdated", value: result.updated, unit: "Count" },
+        { name: "DomainVerifyFailed", value: result.failed, unit: "Count" },
+      ],
+      dimensions: {
+        Service: "ingester",
+        Operation: "domain.verify.reconcile",
+      },
+    });
+
+    return {
+      scanned: result.scanned,
+      updated: result.updated,
+      unchanged: result.unchanged,
+      failed: result.failed,
+    };
+  }),
 );
 
 app.post("/webhooks/stripe", async (c) => {

--- a/packages/ingester/src/job-scheduler.ts
+++ b/packages/ingester/src/job-scheduler.ts
@@ -1,0 +1,127 @@
+const DEFAULT_INGESTER_URL = "http://ingester:3016";
+const DEFAULT_INTERVAL_SECONDS = 60;
+const REQUEST_TIMEOUT_MS = 20_000;
+
+type ScheduledJob = {
+  name: string;
+  path: string;
+};
+
+const scheduledJobs = [
+  { name: "scheduled-emails", path: "/jobs/scheduled-emails" },
+  { name: "webhooks", path: "/jobs/webhooks" },
+  { name: "domain-verify", path: "/jobs/domain-verify" },
+] satisfies ScheduledJob[];
+
+function getEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value && value.length > 0 ? value : undefined;
+}
+
+function getIntervalMs(): number {
+  const raw = getEnv("INGESTER_SCHEDULER_INTERVAL_SECONDS");
+  if (!raw) return DEFAULT_INTERVAL_SECONDS * 1000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 10) {
+    console.warn(
+      JSON.stringify({
+        level: "warn",
+        event: "scheduler.invalid_interval",
+        raw,
+        default_seconds: DEFAULT_INTERVAL_SECONDS,
+      }),
+    );
+    return DEFAULT_INTERVAL_SECONDS * 1000;
+  }
+  return Math.floor(parsed * 1000);
+}
+
+function buildHeaders(): HeadersInit {
+  const token = getEnv("INGESTER_JOB_TOKEN");
+  return token ? { authorization: `Bearer ${token}` } : {};
+}
+
+async function runJob(baseUrl: string, job: ScheduledJob): Promise<void> {
+  const url = new URL(job.path, baseUrl);
+  const startedAt = Date.now();
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: buildHeaders(),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    const body = await response.text();
+    const durationMs = Date.now() - startedAt;
+
+    console.log(
+      JSON.stringify({
+        level: response.ok ? "info" : "error",
+        event: "scheduler.job_completed",
+        job: job.name,
+        status: response.status,
+        duration_ms: durationMs,
+        body: body.slice(0, 500),
+      }),
+    );
+  } catch (error) {
+    const durationMs = Date.now() - startedAt;
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "scheduler.job_failed",
+        job: job.name,
+        duration_ms: durationMs,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+  }
+}
+
+async function runAllJobs(baseUrl: string): Promise<void> {
+  for (const job of scheduledJobs) {
+    await runJob(baseUrl, job);
+  }
+}
+
+const ingesterUrl = getEnv("INGESTER_URL") ?? DEFAULT_INGESTER_URL;
+const intervalMs = getIntervalMs();
+let isRunning = false;
+
+async function runScheduledBatch(): Promise<void> {
+  if (isRunning) {
+    console.warn(
+      JSON.stringify({
+        level: "warn",
+        event: "scheduler.batch_skipped",
+        reason: "previous_batch_still_running",
+      }),
+    );
+    return;
+  }
+
+  isRunning = true;
+  try {
+    await runAllJobs(ingesterUrl);
+  } finally {
+    isRunning = false;
+  }
+}
+
+console.log(
+  JSON.stringify({
+    level: "info",
+    event: "scheduler.started",
+    ingester_url: ingesterUrl,
+    interval_seconds: intervalMs / 1000,
+    jobs: scheduledJobs.map((job) => job.path),
+    auth: getEnv("INGESTER_JOB_TOKEN") ? "bearer" : "none",
+  }),
+);
+
+await runScheduledBatch();
+setInterval(() => {
+  void runScheduledBatch();
+}, intervalMs);
+
+export {};

--- a/src/app/api/domains/[id]/verify/route.ts
+++ b/src/app/api/domains/[id]/verify/route.ts
@@ -4,17 +4,13 @@ import {
   unauthorizedResponse,
 } from "@/lib/api-auth";
 import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { domains } from "@/lib/db/schema";
 import {
   getCachedDomainById,
-  getCachedDomainIdentity,
   invalidateDomainCaches,
 } from "@/lib/domain-cache";
 import { queueEvent } from "@/lib/events";
 import { verifyDomainParamsSchema } from "@/lib/validation/domains";
-import { getEffectiveReturnPathLabel } from "@opensend/core";
-import { and, eq } from "drizzle-orm";
+import { domainService, getEffectiveReturnPathLabel } from "@opensend/core";
 
 export async function POST(
   request: Request,
@@ -48,68 +44,40 @@ export async function POST(
       return Response.json({ error: "Domain not found" }, { status: 404 });
     }
 
-    const identity = await getCachedDomainIdentity(domain.name);
+    const result = await domainService.reconcileVerification(id);
 
-    type DomainRecord = {
-      type: string;
-      name: string;
-      value: string;
-      status: string;
-      ttl: string;
-      priority?: number;
-    };
-    const existingRecords = (domain.records as DomainRecord[] | null) ?? [];
-    const recordsForUpdate: DomainRecord[] = existingRecords.map((record) => ({
-      ...record,
-      status: identity.verified ? "verified" : "pending",
-    }));
-
-    const verificationStatus: "pending" | "verified" = identity.verified
-      ? "verified"
-      : "pending";
-
-    const previousStatus = domain.status;
-
-    const [updated] = await db
-      .update(domains)
-      .set({
-        status: verificationStatus,
-        records: recordsForUpdate,
-      })
-      .where(and(eq(domains.id, id), eq(domains.userId, userId)))
-      .returning();
-
-    if (!updated) {
+    if (result.status === "not_found") {
       await invalidateDomainCaches({ id, name: domain.name });
       return Response.json({ error: "Domain not found" }, { status: 404 });
     }
 
-    await invalidateDomainCaches({ id: updated.id, name: updated.name });
+    const reconciled = result.domain;
+    await invalidateDomainCaches({ id: reconciled.id, name: reconciled.name });
 
-    if (updated.status !== previousStatus) {
+    if (result.status === "updated") {
       await queueEvent({
         type: "domain.updated",
         userId,
         payload: {
-          id: updated.id,
-          name: updated.name,
-          status: updated.status,
-          previous_status: previousStatus,
-          records: updated.records || [],
-          capabilities: updated.capabilities || [],
+          id: reconciled.id,
+          name: reconciled.name,
+          status: reconciled.status,
+          previous_status: result.previousStatus,
+          records: reconciled.records || [],
+          capabilities: reconciled.capabilities || [],
         },
       });
     }
 
     return Response.json({
       object: "domain",
-      id: updated.id,
-      name: updated.name,
-      status: updated.status,
-      records: updated.records || [],
-      custom_return_path: updated.customReturnPath,
-      return_path: getEffectiveReturnPathLabel(updated.customReturnPath),
-      created_at: updated.createdAt,
+      id: reconciled.id,
+      name: reconciled.name,
+      status: reconciled.status,
+      records: reconciled.records || [],
+      custom_return_path: reconciled.customReturnPath,
+      return_path: getEffectiveReturnPathLabel(reconciled.customReturnPath),
+      created_at: reconciled.createdAt,
     });
   } catch (err) {
     const message =

--- a/tests/api-domains.test.ts
+++ b/tests/api-domains.test.ts
@@ -10,6 +10,7 @@ const mockGetDomainIdentity = vi.hoisted(() => vi.fn());
 const mockCreateDomainIdentity = vi.hoisted(() => vi.fn());
 const mockCheckDomainQuota = vi.hoisted(() => vi.fn());
 const mockCreateDomain = vi.hoisted(() => vi.fn());
+const mockReconcileVerification = vi.hoisted(() => vi.fn());
 const mockDb = vi.hoisted(() => ({
   insert: vi.fn(),
   update: vi.fn(),
@@ -47,6 +48,9 @@ vi.mock("@opensend/core", () => ({
     createDomain: mockCreateDomain,
     listDomains: vi.fn(),
   }),
+  domainService: {
+    reconcileVerification: mockReconcileVerification,
+  },
   getEffectiveReturnPathLabel: (value: string | null | undefined) =>
     value?.trim() || "send",
 }));
@@ -106,6 +110,7 @@ describe("Domain API validation", () => {
     mockDeleteDomainIdentity.mockReset();
     mockGetDomainIdentity.mockReset();
     mockCreateDomainIdentity.mockReset();
+    mockReconcileVerification.mockReset();
     mockCheckDomainQuota.mockResolvedValue({
       ok: true,
       info: { limit: 10, used: 0 },
@@ -391,17 +396,25 @@ describe("Domain API validation", () => {
     const updated = {
       ...domain,
       status: "verified",
+      records: [
+        {
+          type: "TXT",
+          name: "_dmarc.example.com",
+          value: "v=DMARC1; p=none;",
+          status: "verified",
+          ttl: "Auto",
+        },
+      ],
+      capabilities: [],
+      customReturnPath: null,
       createdAt: new Date("2024-01-01T00:00:00.000Z"),
     };
 
     mockDb.query.domains.findFirst.mockResolvedValue(domain);
-    mockGetDomainIdentity.mockResolvedValue({ verified: true });
-    mockDb.update.mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([updated]),
-        }),
-      }),
+    mockReconcileVerification.mockResolvedValue({
+      status: "updated",
+      domain: updated,
+      previousStatus: "pending",
     });
 
     const { POST } = await import("@/app/api/domains/[id]/verify/route");
@@ -421,10 +434,10 @@ describe("Domain API validation", () => {
       type: "TXT",
       name: "_dmarc.example.com",
       value: "v=DMARC1; p=none;",
-      status: "pending",
+      status: "verified",
       ttl: "Auto",
     });
-    expect(mockDb.query.domains.findFirst).toHaveBeenCalledTimes(1);
+    expect(mockReconcileVerification).toHaveBeenCalledWith(VALID_DOMAIN_ID);
     expect(mockQueueEvent).toHaveBeenCalledWith({
       type: "domain.updated",
       userId: "user-1",
@@ -457,8 +470,7 @@ describe("Domain API validation", () => {
     });
 
     expect(res.status).toBe(404);
-    expect(mockGetDomainIdentity).not.toHaveBeenCalled();
-    expect(mockDb.update).not.toHaveBeenCalled();
+    expect(mockReconcileVerification).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/cache-invalidation-routes.test.ts
+++ b/tests/cache-invalidation-routes.test.ts
@@ -14,6 +14,7 @@ const mockDeleteDomainIdentity = vi.hoisted(() => vi.fn());
 const mockListDNSRecords = vi.hoisted(() => vi.fn());
 const mockDeleteDNSRecord = vi.hoisted(() => vi.fn());
 const mockQueueEvent = vi.hoisted(() => vi.fn());
+const mockReconcileVerification = vi.hoisted(() => vi.fn());
 
 const VALID_DOMAIN_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -35,6 +36,9 @@ vi.mock("@opensend/core", () => ({
   createDomainService: () => ({
     createDomain: mockCreateDomain,
   }),
+  domainService: {
+    reconcileVerification: mockReconcileVerification,
+  },
   DMARC_RECORD_VALUE: "v=DMARC1; p=none;",
   buildDmarcRecordName: (domainName: string) => `_dmarc.${domainName}`,
   getEffectiveReturnPathLabel: (customReturnPath: string | null | undefined) =>
@@ -257,25 +261,18 @@ describe("cache invalidation routes", () => {
       status: "pending",
       records: [],
     });
-    mockGetCachedDomainIdentity.mockResolvedValue({
-      verified: true,
-      dkimStatus: "SUCCESS",
-      dkimTokens: ["a"],
-    });
-    mockDb.update.mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([
-            {
-              id: VALID_DOMAIN_ID,
-              name: "example.com",
-              status: "verified",
-              records: [],
-              createdAt: new Date("2026-04-28T00:00:00.000Z"),
-            },
-          ]),
-        }),
-      }),
+    mockReconcileVerification.mockResolvedValue({
+      status: "updated",
+      domain: {
+        id: VALID_DOMAIN_ID,
+        name: "example.com",
+        status: "verified",
+        records: [],
+        capabilities: [],
+        customReturnPath: null,
+        createdAt: new Date("2026-04-28T00:00:00.000Z"),
+      },
+      previousStatus: "pending",
     });
 
     const route = await import("@/app/api/domains/[id]/verify/route");

--- a/tests/domain-service.test.ts
+++ b/tests/domain-service.test.ts
@@ -38,6 +38,9 @@ function createRepository(overrides: Partial<DomainRepository> = {}) {
     async list() {
       return { data: [], hasMore: false };
     },
+    async listPendingVerification() {
+      return [];
+    },
     async create(data: DomainInsert) {
       return [domainRow({ ...data, id: "created-domain" })];
     },
@@ -216,6 +219,157 @@ describe("domain service", () => {
         ttl: "Auto",
       },
     ]);
+  });
+
+  it("reconciles verification: maps records[].status from identity.verified", async () => {
+    const updates: Array<{ id: string; data: Partial<DomainInsert> }> = [];
+    const existingDomain = domainRow({
+      id: "dom-1",
+      name: "example.com",
+      status: "pending",
+      records: [
+        {
+          type: "TXT",
+          name: "_dmarc.example.com",
+          value: "v=DMARC1; p=none;",
+          status: "pending",
+          ttl: "Auto",
+        },
+        {
+          type: "TXT",
+          name: "send.example.com",
+          value: "v=spf1 include:amazonses.com ~all",
+          status: "pending",
+          ttl: "Auto",
+        },
+      ],
+    });
+    const repository = createRepository({
+      async findById() {
+        return existingDomain;
+      },
+      async update(id, data) {
+        updates.push({ id, data });
+        return [domainRow({ ...existingDomain, ...data })];
+      },
+    });
+
+    const service = createDomainService({
+      repository,
+      getDomainIdentity: async () => ({ verified: true }),
+    });
+
+    const result = await service.reconcileVerification("dom-1");
+
+    expect(result.status).toBe("updated");
+    expect(updates).toHaveLength(1);
+    expect(updates[0].data.status).toBe("verified");
+    expect(updates[0].data.records).toEqual([
+      expect.objectContaining({
+        name: "_dmarc.example.com",
+        status: "verified",
+      }),
+      expect.objectContaining({
+        name: "send.example.com",
+        status: "verified",
+      }),
+    ]);
+    if (result.status === "updated") {
+      expect(result.previousStatus).toBe("pending");
+      expect(result.domain.status).toBe("verified");
+    }
+  });
+
+  it("reconciles verification: returns unchanged when status and records are stable", async () => {
+    const updates: Array<{ id: string; data: Partial<DomainInsert> }> = [];
+    const existingDomain = domainRow({
+      id: "dom-2",
+      status: "pending",
+      records: [
+        {
+          type: "TXT",
+          name: "_dmarc.example.com",
+          value: "v=DMARC1; p=none;",
+          status: "pending",
+          ttl: "Auto",
+        },
+      ],
+    });
+    const repository = createRepository({
+      async findById() {
+        return existingDomain;
+      },
+      async update(id, data) {
+        updates.push({ id, data });
+        return [domainRow({ ...existingDomain, ...data })];
+      },
+    });
+
+    const service = createDomainService({
+      repository,
+      getDomainIdentity: async () => ({ verified: false }),
+    });
+
+    const result = await service.reconcileVerification("dom-2");
+
+    expect(result.status).toBe("unchanged");
+    expect(updates).toHaveLength(0);
+  });
+
+  it("reconcileAllPendingVerifications: tolerates per-domain failures", async () => {
+    const pendingA = domainRow({
+      id: "dom-a",
+      name: "a.example",
+      status: "not_started",
+      userId: "user-a",
+      records: [],
+    });
+    const pendingB = domainRow({
+      id: "dom-b",
+      name: "b.example",
+      status: "pending",
+      userId: "user-b",
+      records: [],
+    });
+
+    const repository = createRepository({
+      async listPendingVerification() {
+        return [pendingA, pendingB];
+      },
+      async findById(id) {
+        return id === "dom-a" ? pendingA : pendingB;
+      },
+      async update(id, data) {
+        return [
+          domainRow({
+            ...(id === "dom-a" ? pendingA : pendingB),
+            ...data,
+          }),
+        ];
+      },
+    });
+
+    const service = createDomainService({
+      repository,
+      getDomainIdentity: async (name) => {
+        if (name === "a.example") return { verified: true };
+        throw new Error("ses unavailable");
+      },
+    });
+
+    const result = await service.reconcileAllPendingVerifications();
+
+    expect(result.scanned).toBe(2);
+    expect(result.updated).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]).toMatchObject({
+      domainId: "dom-a",
+      domainName: "a.example",
+      userId: "user-a",
+      previousStatus: "not_started",
+      nextStatus: "verified",
+    });
   });
 
   it("lists with normalized pagination and maps public list fields", async () => {

--- a/tests/ingester-job-scheduler-coverage.test.ts
+++ b/tests/ingester-job-scheduler-coverage.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readRepoFile(path: string): string {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+function jobEndpointsFromIngester(): string[] {
+  const source = readRepoFile("packages/ingester/src/index.ts");
+  const matches = source.matchAll(/app\.post\("(\/jobs\/[^"]+)"/g);
+  return Array.from(matches, (match) => match[1]).sort();
+}
+
+describe("ingester job scheduler coverage", () => {
+  it("schedules and documents every non-manual ingester job endpoint", () => {
+    const manualOnlyEndpoints = new Set(["/jobs/poll"]);
+    const scheduledEndpoints = jobEndpointsFromIngester().filter(
+      (endpoint) => !manualOnlyEndpoints.has(endpoint),
+    );
+
+    expect(scheduledEndpoints).toEqual([
+      "/jobs/domain-verify",
+      "/jobs/scheduled-emails",
+      "/jobs/webhooks",
+    ]);
+
+    const schedulerSource = readRepoFile(
+      "packages/ingester/src/job-scheduler.ts",
+    );
+    const compose = readRepoFile("docker-compose.yml");
+    const deploymentDocs = [
+      readRepoFile("README.md"),
+      readRepoFile("docs/ingester-deploy.md"),
+      readRepoFile("docs/self-hosting.md"),
+      readRepoFile(".env.example"),
+    ].join("\n");
+
+    for (const endpoint of scheduledEndpoints) {
+      expect(schedulerSource).toContain(endpoint);
+      expect(compose).toContain(endpoint);
+      expect(deploymentDocs).toContain(endpoint);
+    }
+  });
+
+  it("keeps scheduler bearer auth aligned with INGESTER_JOB_TOKEN", () => {
+    const schedulerSource = readRepoFile(
+      "packages/ingester/src/job-scheduler.ts",
+    );
+    const compose = readRepoFile("docker-compose.yml");
+    const docs = [
+      readRepoFile("docs/ingester-deploy.md"),
+      readRepoFile("docs/self-hosting.md"),
+      readRepoFile(".env.example"),
+    ].join("\n");
+
+    expect(schedulerSource).toContain('getEnv("INGESTER_JOB_TOKEN")');
+    expect(schedulerSource).toContain("authorization: `Bearer ${token}`");
+    expect(compose).toContain("INGESTER_JOB_TOKEN: ${INGESTER_JOB_TOKEN:-}");
+    expect(docs).toContain("Authorization: Bearer ${INGESTER_JOB_TOKEN}");
+  });
+});

--- a/tests/ingester-ses-route.test.ts
+++ b/tests/ingester-ses-route.test.ts
@@ -2,6 +2,8 @@ import { generateKeyPairSync, sign } from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockCreateOrIgnoreDuplicate = vi.fn();
+const mockDomainReconcileAllPendingVerifications = vi.fn();
+const mockEnqueueDomainEvent = vi.fn();
 const mockWebhookList = vi.fn();
 const mockEnqueue = vi.fn();
 const mockDispatchDelivery = vi.fn();
@@ -51,10 +53,15 @@ vi.mock("@opensend/core", () => {
         getHeader(input.headers, "x-correlation-id") ??
         "corr-ingester-test",
     }),
+    domainService: {
+      reconcileAllPendingVerifications:
+        mockDomainReconcileAllPendingVerifications,
+    },
     emailEventRepo: {
       createOrIgnoreDuplicate: mockCreateOrIgnoreDuplicate,
     },
     emitCloudWatchMetric: mockEmitCloudWatchMetric,
+    enqueueDomainEvent: mockEnqueueDomainEvent,
     getTelemetryCarrier: (context: {
       traceparent: string;
       correlationId: string;
@@ -97,6 +104,7 @@ vi.mock("hono", () => {
       header: (name: string) => string | undefined;
       json: () => Promise<unknown>;
     };
+    json: (data: unknown, status?: number) => Response;
     text: (body: string, status?: number) => Response;
   }) => Response | Promise<Response>;
 
@@ -125,6 +133,7 @@ vi.mock("hono", () => {
           header: (name: string) => request.headers.get(name) ?? undefined,
           json: async () => await request.json(),
         },
+        json: (data: unknown, status = 200) => Response.json(data, { status }),
         text: (body: string, status = 200) => new Response(body, { status }),
       });
     }
@@ -229,7 +238,19 @@ describe("SES SNS ingestion route", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
 
+    mockDomainReconcileAllPendingVerifications.mockResolvedValue({
+      scanned: 0,
+      updated: 0,
+      unchanged: 0,
+      failed: 0,
+      changes: [],
+    });
+    mockEnqueueDomainEvent.mockResolvedValue({
+      eventId: "domain-event-1",
+      deliveryIds: [],
+    });
     mockEnqueue.mockResolvedValue({ id: "delivery-1" });
     mockDispatchDelivery.mockResolvedValue(undefined);
     mockPublishBackgroundJob.mockResolvedValue({
@@ -258,6 +279,67 @@ describe("SES SNS ingestion route", () => {
         text: async () => publicKeyPem,
       }),
     );
+  });
+
+  it("runs domain verification reconciliation through the authenticated job endpoint", async () => {
+    vi.stubEnv("INGESTER_JOB_TOKEN", "test-job-token");
+    mockDomainReconcileAllPendingVerifications.mockResolvedValue({
+      scanned: 1,
+      updated: 1,
+      unchanged: 0,
+      failed: 0,
+      changes: [
+        {
+          domainId: "domain-1",
+          domainName: "example.com",
+          userId: "user-1",
+          previousStatus: "pending",
+          nextStatus: "verified",
+          records: [],
+          capabilities: ["sending"],
+        },
+      ],
+    });
+
+    const app = (await import("../packages/ingester/src/index")).default;
+    const response = await app.request("http://localhost/jobs/domain-verify", {
+      method: "POST",
+      headers: { authorization: "Bearer test-job-token" },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      scanned: 1,
+      updated: 1,
+      unchanged: 0,
+      failed: 0,
+    });
+    expect(mockDomainReconcileAllPendingVerifications).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueDomainEvent).toHaveBeenCalledWith({
+      type: "domain.updated",
+      userId: "user-1",
+      payload: {
+        id: "domain-1",
+        name: "example.com",
+        status: "verified",
+        previous_status: "pending",
+        records: [],
+        capabilities: ["sending"],
+      },
+    });
+  });
+
+  it("rejects domain verification job calls without the configured bearer token", async () => {
+    vi.stubEnv("INGESTER_JOB_TOKEN", "test-job-token");
+
+    const app = (await import("../packages/ingester/src/index")).default;
+    const response = await app.request("http://localhost/jobs/domain-verify", {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.text()).toBe("Unauthorized");
+    expect(mockDomainReconcileAllPendingVerifications).not.toHaveBeenCalled();
   });
 
   it("verifies the SNS signature, persists a normalized event, and queues webhook delivery", async () => {


### PR DESCRIPTION
## Summary
- Restores the missing domain verification reconciler path on `staging`: shared core reconciliation service plus `POST /jobs/domain-verify` on the ingester.
- Adds a durable Docker Compose `scheduler` sidecar that posts every minute to `/jobs/scheduled-emails`, `/jobs/webhooks`, and `/jobs/domain-verify`.
- Keeps job auth aligned with existing ingester behavior: when `INGESTER_JOB_TOKEN` is configured, the scheduler sends `Authorization: Bearer ${INGESTER_JOB_TOKEN}`.
- Updates self-hosting/ingester docs, `.env.example`, README, and runbook verification steps for automatic domain verification.
- Adds regression coverage so non-manual ingester job endpoints must be scheduled/documented, plus route-level bearer auth coverage for `/jobs/domain-verify`.

## Notes
`origin/staging` did not contain PR #275's `/jobs/domain-verify` route or `reconcileAllPendingVerifications()` service, despite the issue context referencing it. This PR includes that missing backend path because the scheduler would otherwise point at a missing endpoint.

## Validation
- `bunx vitest run tests/domain-service.test.ts tests/ingester-job-scheduler-coverage.test.ts tests/api-domains.test.ts tests/cache-invalidation-routes.test.ts`
- `bunx vitest run tests/ingester-ses-route.test.ts tests/ingester-job-scheduler-coverage.test.ts tests/domain-service.test.ts`
- `make check`
- `make test`
- `docker compose config --quiet`
- `bun build ./packages/ingester/src/server.ts --target bun --outfile /tmp/opensend-ingester-server.js`
- `bun build ./packages/ingester/src/job-scheduler.ts --target bun --outfile /tmp/opensend-ingester-job-scheduler.js`

## Residual deployment risk
- Live end-to-end SES flip was not exercised locally; validating it requires a deployed scheduler plus a real pending domain whose SES identity has reached verified/DKIM SUCCESS.
