### PR TITLE
Prepare hosted Stripe cutover validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ and the split app/ingester service shape — read the dedicated guides:
 - **[`docs/self-hosting.md`](docs/self-hosting.md)** — full self-hosting deep dive (environment variables, database, SES, DNS, auth, reverse proxy, background jobs, Redis, upgrades, troubleshooting)
 - **[`docs/ingester-deploy.md`](docs/ingester-deploy.md)** — running the ingester as a separate service with SNS cutover and replay runbook
 - **[`docs/observability.md`](docs/observability.md)** — log/metric/trace catalog and the API-to-provider tracing runbook
+- **[`docs/hosted-stripe-cutover.md`](docs/hosted-stripe-cutover.md)** — hosted Stripe/paywall env, Price ID mapping, preflight, and live validation checklist
 
 The included multi-stage `Dockerfile` builds the app, the migrator, and (via
 `packages/ingester/Dockerfile`) the ingester. Images run on any container

--- a/agent_docs/learnings/active/2026-05-10-issue-297-preflight-location.md
+++ b/agent_docs/learnings/active/2026-05-10-issue-297-preflight-location.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-10
+issue: 297
+type: decision
+promoted_to: null
+---
+
+## Put committed preflight code outside ignored `scripts/`
+
+**What:** Issue #297's hosted Stripe cutover preflight lives at `src/lib/billing/cutover-preflight.ts`, with `package.json` exposing `bun run billing:preflight`.
+
+**Why:** Repository `scripts/*` is ignored by default because infra scripts can contain environment-specific values. New PR-owned automation under `scripts/` can silently be left out unless force-added, so tracked preflight utilities should live in a normal tracked path or be explicitly allowlisted/force-added.
+
+**Pattern:** When adding deploy/check scripts, run `git check-ignore -v <path>` before finalizing and verify `git status --short` includes every intended file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,10 @@ services:
       S3_BUCKET_NAME: ${S3_BUCKET_NAME:-}
       CLOUDFLARE_API_TOKEN: ${CLOUDFLARE_API_TOKEN:-}
       CLOUDFLARE_ZONE_ID: ${CLOUDFLARE_ZONE_ID:-}
+      # Hosted billing/paywall cutover. Self-host/local stacks leave BILLING_BACKEND
+      # unset or disabled and keep Stripe keys empty. Never commit real Stripe secrets.
+      BILLING_BACKEND: ${BILLING_BACKEND:-disabled}
+      STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
     depends_on:
       postgres:
         condition: service_healthy
@@ -101,7 +105,7 @@ services:
   # events, scheduled-email worker). The Go ingester skeleton under services/ingester-go
   # is experimental/shadow-only and must not receive production traffic yet. Point your SES SNS topic and Stripe webhook at:
   #   http://<host>:${INGESTER_PORT:-3016}/events/ses
-  #   http://<host>:${INGESTER_PORT:-3016}/events/stripe
+  #   http://<host>:${INGESTER_PORT:-3016}/webhooks/stripe
   # Set BACKGROUND_WORKER_POLL=true to enable the SQS long-poll loop in this container.
   ingester:
     image: opensend-ingester:local
@@ -122,6 +126,12 @@ services:
       BACKGROUND_JOBS_REQUIRE_QUEUE: ${BACKGROUND_JOBS_REQUIRE_QUEUE:-false}
       BACKGROUND_WORKER_POLL: ${BACKGROUND_WORKER_POLL:-false}
       INGESTER_JOB_TOKEN: ${INGESTER_JOB_TOKEN:-}
+      # Stripe billing webhook cutover. STRIPE_SECRET_KEY is passed for hosted
+      # parity with the app even though webhook verification only uses STRIPE_WEBHOOK_SECRET today.
+      BILLING_BACKEND: ${BILLING_BACKEND:-disabled}
+      STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
+      STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-}
+      BILLING_NOTIFICATION_FROM_EMAIL: ${BILLING_NOTIFICATION_FROM_EMAIL:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/hosted-stripe-cutover.md
+++ b/docs/hosted-stripe-cutover.md
@@ -1,0 +1,219 @@
+# Hosted Stripe billing cutover runbook
+
+Issue #297 is the hosted deployment cutover for the Stripe paywall slices that
+landed under #132. This runbook separates repo-owned readiness checks from the
+external actions that require Stripe Dashboard and deployment access.
+
+Do not paste Stripe secrets, customer PII, raw card details, or full webhook
+payloads into GitHub issues or PRs.
+
+## Current cutover blockers
+
+Resolve these product/deployment decisions before final production cutover:
+
+1. Confirm the public tier names, limits, and monthly prices before creating
+   Stripe Products/Prices or updating `plans` rows.
+2. Confirm whether hosted billing starts with no trial or a 14-day Pro trial.
+3. Confirm org-level billing remains the intended account model.
+4. Confirm hard-cap quota gating is acceptable; the current implementation
+   blocks over-quota sends instead of grace or metered overage.
+
+Until those decisions are final, use test-mode Stripe Products/Prices and test
+plan rows only.
+
+## Environment matrix
+
+`BILLING_BACKEND` stays unset or `disabled` for local/self-host OSS deploys. The
+hosted app and hosted ingester must both be switched to `stripe` from the secret
+manager/runtime configuration, never by committing secrets.
+
+| Service | Required hosted billing env | Notes |
+| --- | --- | --- |
+| App / dashboard / REST API | `BILLING_BACKEND=stripe`, `STRIPE_SECRET_KEY` | Enables billing pages and `/api/billing/*` checkout/portal routes. |
+| Ingester | `BILLING_BACKEND=stripe`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` | Receives Stripe events at `POST /webhooks/stripe`; `STRIPE_WEBHOOK_SECRET` must match that endpoint's signing secret. |
+| Migrator | `DATABASE_URL` | Run migrations before deploying code that expects billing tables/columns. No Stripe secret is needed for migrations. |
+
+Optional hosted billing env:
+
+- `BILLING_NOTIFICATION_FROM_EMAIL` on the ingester to send payment-failed
+  notifications.
+- `NEXT_PUBLIC_APP_URL` / `BETTER_AUTH_URL` on the app so Stripe returns to the
+  correct hosted URL after Checkout or Customer Portal.
+
+Docker Compose now passes the billing env names through to `app` and `ingester`
+with empty/disabled defaults, so self-host defaults remain unmetered.
+
+## Preflight checks
+
+Run the repo-owned preflight without printing secrets:
+
+```bash
+bun run billing:preflight -- --service all
+```
+
+Expected before hosted cutover: errors if `BILLING_BACKEND=stripe`,
+`STRIPE_SECRET_KEY`, or the ingester `STRIPE_WEBHOOK_SECRET` are not present in
+the current environment.
+
+After pointing `DATABASE_URL` at staging/prod, also validate public plan mapping:
+
+```bash
+bun run billing:preflight -- --service all --check-db --strict
+```
+
+The DB check verifies:
+
+- public paid plans have a non-empty `plans.stripe_price_id`,
+- each paid public plan uses a `price_...` Stripe Price ID shape,
+- duplicate public plan Price IDs are rejected,
+- Free plan rows do not require Checkout.
+
+A warning that no paid public plans exist means Checkout cannot be validated yet;
+seed approved paid tiers first.
+
+## Stripe Products and Prices mapping
+
+Create Products/Prices in Stripe test mode first, then repeat in live mode after
+staging evidence passes.
+
+1. In Stripe Dashboard, create one Product per approved public paid tier.
+2. Create one recurring monthly Price per tier. Keep currency/amount aligned
+   with the approved public pricing decision.
+3. Record only Price IDs (`price_...`) in deployment notes; do not record API
+   keys or customer/payment details.
+4. Update `plans.stripe_price_id` for the matching paid public `plans.slug` rows.
+5. Run `bun run billing:preflight -- --check-db --strict` against the hosted DB.
+
+Example SQL shape; replace placeholders only after Jaeyun confirms tier names and
+prices:
+
+```sql
+update plans set stripe_price_id = 'price_REPLACE_WITH_TEST_OR_LIVE_ID'
+where slug = 'REPLACE_WITH_APPROVED_PLAN_SLUG';
+```
+
+If using the Stripe CLI for an operator-side sanity check, list active prices
+without exposing secrets:
+
+```bash
+stripe prices list --active=true --expand data.product
+```
+
+## Hosted validation checklist
+
+Record exact hosted URLs, Stripe event IDs, and DB row evidence in the issue/PR.
+Do not include secrets, PII, card numbers, or raw payment details.
+
+### 1. Free signup and billing page
+
+1. Open the hosted app URL with `BILLING_BACKEND=stripe` enabled.
+2. Sign up with a fresh test user/org.
+3. Confirm dashboard load succeeds.
+4. Open `/settings/billing` and confirm it renders without Stripe env errors.
+5. DB evidence to capture:
+
+```sql
+select id, slug, name, monthly_price_cents, monthly_email_quota, stripe_price_id
+from plans
+where is_public = true
+order by monthly_price_cents;
+
+select user_id, plan_id, status, stripe_subscription_id, current_period_start, current_period_end
+from subscriptions
+where user_id = '<redacted_user_id>';
+```
+
+### 2. Checkout upgrade return
+
+1. From `/settings/billing` or `/pricing`, choose the approved paid plan.
+2. Confirm the app creates a Stripe Checkout Session and redirects to Stripe.
+3. Complete test-mode payment with Stripe test card details in Stripe-hosted UI.
+4. Confirm the browser returns to:
+
+```text
+/settings/billing?status=success
+```
+
+5. Record the Checkout Session ID and resulting Stripe event IDs, not card data.
+
+### 3. Webhook subscription update
+
+Stripe endpoint target:
+
+```text
+https://<hosted-ingester-host>/webhooks/stripe
+```
+
+After Checkout, verify ingester logs include `stripe.webhook.processed` for the
+relevant event IDs. Then capture DB evidence:
+
+```sql
+select stripe_event_id, event_type, processed_at
+from stripe_events_processed
+order by processed_at desc
+limit 10;
+
+select user_id, plan_id, status, stripe_customer_id, stripe_subscription_id,
+       current_period_start, current_period_end
+from subscriptions
+where user_id = '<redacted_user_id>';
+```
+
+Replay a Stripe event from Dashboard if needed: **Developers → Events → select
+event → Resend**, targeting the hosted ingester webhook endpoint. Replays should
+log `stripe.webhook.duplicate` after the first successful processing.
+
+### 4. Customer Portal return
+
+1. Click **Manage billing** on `/settings/billing`.
+2. Confirm the app opens Stripe Customer Portal.
+3. Return from Stripe and confirm the app lands back on `/settings/billing`.
+4. Confirm no 4xx/5xx errors in app logs for `POST /api/billing/portal`.
+
+### 5. Quota-gating behavior
+
+Validate both hosted metered and self-host/default-disabled behavior.
+
+Hosted over-quota path:
+
+1. Use a test account whose current plan has a low email quota or whose
+   `usage_periods.emails_sent` has been set to the limit in staging/test data.
+2. Send one email through the hosted API using a valid API key.
+3. Confirm response status is `402` with structured `quota_exceeded` body.
+4. Confirm no new downstream send job is queued for the rejected request.
+
+Expected response shape includes:
+
+```json
+{
+  "name": "quota_exceeded",
+  "message": "Quota exceeded.",
+  "statusCode": 402
+}
+```
+
+Disabled/self-host path:
+
+1. Run a local or self-host stack with `BILLING_BACKEND=disabled` or unset.
+2. Send the same kind of email request.
+3. Confirm quota checks are bypassed and no Stripe SDK calls are required.
+
+## Evidence template for issue #297
+
+```md
+## Hosted Stripe cutover validation
+
+- App URL exercised:
+- Ingester URL exercised:
+- Env preflight: pass/fail, command, timestamp:
+- DB plan preflight: pass/fail, command, timestamp:
+- Stripe mode: test/live
+- Stripe Price IDs verified: price_... list, no secrets
+- Free signup + billing page: pass/fail
+- Checkout return: pass/fail, Checkout Session ID:
+- Webhook processing: pass/fail, Stripe event IDs:
+- Customer Portal return: pass/fail
+- Quota exceeded 402: pass/fail
+- Disabled billing bypass: pass/fail
+- Blockers / residual risk:
+```

--- a/docs/ingester-deploy.md
+++ b/docs/ingester-deploy.md
@@ -27,6 +27,7 @@ Endpoints:
 - App: `http://localhost:${PORT:-3015}`
 - Ingester health: `http://localhost:${INGESTER_PORT:-3016}/health`
 - SES SNS webhook target: `http://localhost:${INGESTER_PORT:-3016}/events/ses`
+- Stripe billing webhook target: `http://localhost:${INGESTER_PORT:-3016}/webhooks/stripe`
 - Experimental Go ingester health, when run separately: `http://localhost:3027/health`
 
 ```bash
@@ -109,6 +110,27 @@ Set these on the ingester service:
 BACKGROUND_WORKER_POLL=true
 INGESTER_JOB_TOKEN=<random-bearer-token>
 ```
+
+For hosted Stripe billing cutover, also set these on the ingester service from
+the deployment secret manager:
+
+```bash
+BILLING_BACKEND=stripe
+STRIPE_SECRET_KEY=<from-secret-manager>
+STRIPE_WEBHOOK_SECRET=<stripe-webhook-signing-secret>
+BILLING_NOTIFICATION_FROM_EMAIL=billing@yourdomain.com # optional
+```
+
+The Stripe webhook endpoint is:
+
+```text
+https://events.yourdomain.com/webhooks/stripe
+```
+
+Run `bun run billing:preflight -- --service ingester` in the release
+environment before sending Stripe traffic to the endpoint. See
+[`hosted-stripe-cutover.md`](hosted-stripe-cutover.md) for the full validation
+checklist.
 
 Set the same `INGESTER_JOB_TOKEN` on any scheduler that calls `/jobs/*`. Compose also accepts an optional scheduler cadence override:
 
@@ -213,6 +235,9 @@ Before pointing production SES SNS at a freshly stood-up ingester, verify:
   config, Redis URL, and `INGESTER_JOB_TOKEN` as the app.
 - The events host (`events.<your-domain>`) resolves and serves a 200 on
   `/health`.
+- If hosted billing is enabled, Stripe Dashboard points to
+  `https://events.<your-domain>/webhooks/stripe` and the ingester has
+  `BILLING_BACKEND=stripe`, `STRIPE_SECRET_KEY`, and `STRIPE_WEBHOOK_SECRET`.
 - The SQS queue exists with a redrive policy + DLQ.
 - Periodic scan rules (`/jobs/scheduled-emails`, `/jobs/webhooks`, `/jobs/domain-verify`) are scheduled on a 1-minute cadence and use `Authorization: Bearer ${INGESTER_JOB_TOKEN}` when the token is configured.
 - Domain verification runbook passed: create/use a pending domain, confirm SES is verified, do not click **Verify DNS Records**, wait for the scheduler, and confirm the OpenSend DB/dashboard flips to `verified`.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -24,6 +24,7 @@ there. This document is for production deployments.
 - [Shared rate limiting (Redis)](#shared-rate-limiting-redis)
 - [Splitting the ingester service](#splitting-the-ingester-service)
 - [Observability](#observability)
+- [Hosted Stripe billing](#hosted-stripe-billing)
 - [Upgrades & migrations](#upgrades--migrations)
 - [Troubleshooting](#troubleshooting)
 
@@ -125,6 +126,27 @@ contributor-facing set; the table below adds the production-only entries.
 | `RATE_LIMIT_BACKEND` | `disabled` (single-process dev), or `redis` (production). |
 | `REDIS_URL` | TLS Redis endpoint, e.g. `rediss://default:<password>@<endpoint>:6379`. Used for rate limiting AND auth/domain metadata cache. |
 | `CLOUDWATCH_METRICS_NAMESPACE` | Override the default `Opensend` EMF metrics namespace. |
+
+### Hosted Stripe billing
+
+Billing is disabled by default for self-host/local OSS deploys. Leave
+`BILLING_BACKEND` unset or set it to `disabled` to keep sends unmetered by
+OpenSend plan quotas. The hosted namuh.co deployment sets billing env from its
+secret manager instead of committing secrets.
+
+| Variable | Service | Purpose |
+| --- | --- | --- |
+| `BILLING_BACKEND=stripe` | App + ingester | Enables hosted Stripe/paywall behavior. Any other value is treated as disabled. |
+| `STRIPE_SECRET_KEY` | App + ingester | Stripe API key for hosted billing. Required before the app exposes Checkout/Portal behavior. |
+| `STRIPE_WEBHOOK_SECRET` | Ingester | Signing secret for the Stripe webhook endpoint at `/webhooks/stripe`. |
+| `BILLING_NOTIFICATION_FROM_EMAIL` | Ingester, optional | Sender used for payment-failed notifications. |
+
+Before enabling hosted billing, read the full cutover checklist in
+[`hosted-stripe-cutover.md`](hosted-stripe-cutover.md) and run:
+
+```bash
+bun run billing:preflight -- --service all --check-db --strict
+```
 
 ## Database
 

--- a/docs/stripe-webhooks.md
+++ b/docs/stripe-webhooks.md
@@ -1,7 +1,22 @@
 # Stripe webhook runbook
 
 OpenSend processes Stripe subscription and invoice lifecycle events on the
-ingester service at `POST /webhooks/stripe`.
+ingester service at `POST /webhooks/stripe`. Hosted cutover details live in
+[`hosted-stripe-cutover.md`](hosted-stripe-cutover.md).
+
+Required ingester env for hosted Stripe webhooks:
+
+```bash
+BILLING_BACKEND=stripe
+STRIPE_SECRET_KEY=<from-secret-manager>
+STRIPE_WEBHOOK_SECRET=<stripe-webhook-signing-secret>
+```
+
+Run the non-secret preflight before pointing Stripe at the endpoint:
+
+```bash
+bun run billing:preflight -- --service ingester
+```
 
 ## Replay an event from Stripe
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start:ingester": "bun ./packages/ingester/src/server.ts",
     "check": "node scripts/check-changed-files.mjs",
     "check:full": "bun run typecheck && bun run lint",
+    "billing:preflight": "bun src/lib/billing/cutover-preflight.ts",
     "hooks:install": "node scripts/install-git-hooks.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/src/lib/billing/cutover-preflight.ts
+++ b/src/lib/billing/cutover-preflight.ts
@@ -1,0 +1,336 @@
+#!/usr/bin/env bun
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+type Service = "app" | "ingester" | "all";
+type Level = "error" | "warning";
+
+interface Options {
+  service: Service;
+  checkDb: boolean;
+  strict: boolean;
+  help: boolean;
+}
+
+export interface ValidationIssue {
+  level: Level;
+  service: Service | "database";
+  key: string;
+  message: string;
+}
+
+export interface PlanRow {
+  id: string;
+  slug: string;
+  name: string;
+  monthly_price_cents: number;
+  stripe_price_id: string | null;
+  is_public: boolean;
+}
+
+const DEFAULT_OPTIONS: Options = {
+  service: "all",
+  checkDb: false,
+  strict: false,
+  help: false,
+};
+
+const SECRET_KEYS = new Set(["STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"]);
+
+function normaliseBackend(value: string | undefined): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+function isPresent(value: string | undefined): value is string {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+function servicesFor(service: Service): Array<Exclude<Service, "all">> {
+  return service === "all" ? ["app", "ingester"] : [service];
+}
+
+function envError(
+  service: Exclude<Service, "all">,
+  key: string,
+  message: string,
+): ValidationIssue {
+  return { level: "error", service, key, message };
+}
+
+export function redactEnvValue(key: string, value: string | undefined): string {
+  if (!isPresent(value)) return "(missing)";
+  const trimmed = value.trim();
+  if (!SECRET_KEYS.has(key)) return trimmed;
+  if (trimmed.length <= 8) return "(set, redacted)";
+  return `${trimmed.slice(0, 4)}…${trimmed.slice(-4)}`;
+}
+
+export function validateStripeEnvironment(
+  env: Record<string, string | undefined>,
+  service: Service = "all",
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const backend = normaliseBackend(env.BILLING_BACKEND);
+
+  for (const current of servicesFor(service)) {
+    if (backend !== "stripe") {
+      issues.push(
+        envError(
+          current,
+          "BILLING_BACKEND",
+          `Expected BILLING_BACKEND=stripe for hosted cutover; found ${redactEnvValue("BILLING_BACKEND", env.BILLING_BACKEND)}.`,
+        ),
+      );
+    }
+
+    if (!isPresent(env.STRIPE_SECRET_KEY)) {
+      issues.push(
+        envError(
+          current,
+          "STRIPE_SECRET_KEY",
+          "STRIPE_SECRET_KEY must be set from the deployment secret manager; never commit the key.",
+        ),
+      );
+    }
+
+    if (current === "ingester" && !isPresent(env.STRIPE_WEBHOOK_SECRET)) {
+      issues.push(
+        envError(
+          current,
+          "STRIPE_WEBHOOK_SECRET",
+          "STRIPE_WEBHOOK_SECRET must match the Stripe webhook endpoint signing secret for /webhooks/stripe.",
+        ),
+      );
+    }
+  }
+
+  return issues;
+}
+
+export function validatePlanRows(rows: PlanRow[]): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const publicRows = rows.filter((row) => row.is_public);
+
+  if (publicRows.length === 0) {
+    issues.push({
+      level: "error",
+      service: "database",
+      key: "plans",
+      message:
+        "No public plans found. Seed or create approved Free/paid plans before enabling hosted checkout.",
+    });
+    return issues;
+  }
+
+  const paidPublicRows = publicRows.filter(
+    (row) => row.monthly_price_cents > 0,
+  );
+  if (paidPublicRows.length === 0) {
+    issues.push({
+      level: "warning",
+      service: "database",
+      key: "plans.stripe_price_id",
+      message:
+        "No paid public plans found. Stripe checkout cannot be validated until approved paid tiers and Price IDs are seeded.",
+    });
+  }
+
+  const seenPriceIds = new Map<string, string>();
+  for (const row of publicRows) {
+    const priceId = row.stripe_price_id?.trim() ?? "";
+    const label = `${row.slug} (${row.name})`;
+
+    if (row.monthly_price_cents > 0 && !priceId) {
+      issues.push({
+        level: "error",
+        service: "database",
+        key: `plans.${row.slug}.stripe_price_id`,
+        message: `${label} is a paid public plan but has no Stripe Price ID.`,
+      });
+      continue;
+    }
+
+    if (priceId && !priceId.startsWith("price_")) {
+      issues.push({
+        level: "error",
+        service: "database",
+        key: `plans.${row.slug}.stripe_price_id`,
+        message: `${label} uses ${priceId}, which does not look like a Stripe Price ID (price_...).`,
+      });
+    }
+
+    if (row.monthly_price_cents === 0 && priceId) {
+      issues.push({
+        level: "warning",
+        service: "database",
+        key: `plans.${row.slug}.stripe_price_id`,
+        message: `${label} is free but has a Stripe Price ID. Free signup should not require Stripe Checkout.`,
+      });
+    }
+
+    if (priceId) {
+      const firstSlug = seenPriceIds.get(priceId);
+      if (firstSlug) {
+        issues.push({
+          level: "error",
+          service: "database",
+          key: "plans.stripe_price_id",
+          message: `${row.slug} and ${firstSlug} both use ${priceId}; each paid tier should map to one approved Stripe Price ID.`,
+        });
+      } else {
+        seenPriceIds.set(priceId, row.slug);
+      }
+    }
+  }
+
+  return issues;
+}
+
+function parseArgs(argv: string[]): Options {
+  const options = { ...DEFAULT_OPTIONS };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg === "--check-db") {
+      options.checkDb = true;
+    } else if (arg === "--strict") {
+      options.strict = true;
+    } else if (arg === "--service") {
+      const value = argv[index + 1];
+      if (value !== "app" && value !== "ingester" && value !== "all") {
+        throw new Error("--service must be app, ingester, or all");
+      }
+      options.service = value;
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function printHelp(): void {
+  console.log(`OpenSend hosted Stripe cutover preflight
+
+Usage:
+  bun src/lib/billing/cutover-preflight.ts [--service app|ingester|all] [--check-db] [--strict]
+
+Checks:
+  - Hosted Stripe env intent: BILLING_BACKEND=stripe plus required STRIPE_* keys.
+  - Optional DB plan mapping: public paid plans must have unique price_... IDs.
+
+Notes:
+  - This script never prints Stripe secrets.
+  - Use --strict to fail on warnings as well as errors.
+  - Set DATABASE_URL before --check-db.
+`);
+}
+
+function printIssues(issues: ValidationIssue[]): void {
+  if (issues.length === 0) {
+    console.log("✓ No preflight issues found");
+    return;
+  }
+
+  for (const issue of issues) {
+    const marker = issue.level === "error" ? "✗" : "!";
+    console.log(
+      `${marker} [${issue.level}] ${issue.service}:${issue.key} — ${issue.message}`,
+    );
+  }
+}
+
+async function loadPublicPlans(connectionString: string): Promise<PlanRow[]> {
+  const needsSsl = connectionString.includes("amazonaws.com");
+  const { Pool } = await import("pg");
+  const pool = new Pool({
+    connectionString,
+    ssl: needsSsl ? { rejectUnauthorized: false } : undefined,
+  });
+
+  try {
+    const result = await pool.query(
+      `select id, slug, name, monthly_price_cents, stripe_price_id, is_public
+       from plans
+       where is_public = true
+       order by monthly_price_cents asc, slug asc`,
+    );
+    return result.rows as PlanRow[];
+  } finally {
+    await pool.end();
+  }
+}
+
+async function main(): Promise<void> {
+  try {
+    process.loadEnvFile?.(".env");
+  } catch (error) {
+    const code = error instanceof Error && "code" in error ? error.code : null;
+    if (code !== "ENOENT") throw error;
+  }
+
+  let options: Options;
+  try {
+    options = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 2;
+    return;
+  }
+
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const issues = validateStripeEnvironment(process.env, options.service);
+
+  console.log("Hosted Stripe env preflight");
+  console.log(
+    `  BILLING_BACKEND=${redactEnvValue("BILLING_BACKEND", process.env.BILLING_BACKEND)}`,
+  );
+  console.log(
+    `  STRIPE_SECRET_KEY=${redactEnvValue("STRIPE_SECRET_KEY", process.env.STRIPE_SECRET_KEY)}`,
+  );
+  if (options.service === "ingester" || options.service === "all") {
+    console.log(
+      `  STRIPE_WEBHOOK_SECRET=${redactEnvValue("STRIPE_WEBHOOK_SECRET", process.env.STRIPE_WEBHOOK_SECRET)}`,
+    );
+  }
+
+  if (options.checkDb) {
+    const connectionString = process.env.DATABASE_URL;
+    if (!isPresent(connectionString)) {
+      issues.push({
+        level: "error",
+        service: "database",
+        key: "DATABASE_URL",
+        message: "DATABASE_URL is required when --check-db is used.",
+      });
+    } else {
+      const plans = await loadPublicPlans(connectionString);
+      console.log(`  Loaded ${plans.length} public plan(s) from DATABASE_URL`);
+      for (const plan of plans) {
+        console.log(
+          `    - ${plan.slug}: $${(plan.monthly_price_cents / 100).toFixed(2)}/mo, stripe_price_id=${plan.stripe_price_id ?? "(none)"}`,
+        );
+      }
+      issues.push(...validatePlanRows(plans));
+    }
+  }
+
+  printIssues(issues);
+  const hasError = issues.some((issue) => issue.level === "error");
+  const hasWarning = issues.some((issue) => issue.level === "warning");
+  if (hasError || (options.strict && hasWarning)) {
+    process.exitCode = 1;
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  await main();
+}

--- a/tests/billing-cutover-preflight.test.ts
+++ b/tests/billing-cutover-preflight.test.ts
@@ -1,0 +1,109 @@
+import {
+  type PlanRow,
+  redactEnvValue,
+  validatePlanRows,
+  validateStripeEnvironment,
+} from "@/lib/billing/cutover-preflight";
+import { describe, expect, it } from "vitest";
+
+const basePaidPlan: PlanRow = {
+  id: "plan-pro",
+  slug: "pro",
+  name: "Pro",
+  monthly_price_cents: 1900,
+  stripe_price_id: "price_test_pro",
+  is_public: true,
+};
+
+const freePlan: PlanRow = {
+  id: "plan-free",
+  slug: "free",
+  name: "Free",
+  monthly_price_cents: 0,
+  stripe_price_id: null,
+  is_public: true,
+};
+
+describe("billing cutover preflight", () => {
+  it("requires hosted Stripe env for app and ingester without printing secrets", () => {
+    const issues = validateStripeEnvironment(
+      {
+        BILLING_BACKEND: "stripe",
+        STRIPE_SECRET_KEY: "sk_test_123456789",
+      },
+      "all",
+    );
+
+    expect(issues).toEqual([
+      expect.objectContaining({
+        service: "ingester",
+        key: "STRIPE_WEBHOOK_SECRET",
+        level: "error",
+      }),
+    ]);
+    expect(redactEnvValue("STRIPE_SECRET_KEY", "sk_test_123456789")).toBe(
+      "sk_t…6789",
+    );
+  });
+
+  it("accepts complete Stripe env for the app service", () => {
+    expect(
+      validateStripeEnvironment(
+        {
+          BILLING_BACKEND: " STRIPE ",
+          STRIPE_SECRET_KEY: "sk_test_complete",
+        },
+        "app",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("flags paid public plans without unique Stripe Price IDs", () => {
+    const issues = validatePlanRows([
+      freePlan,
+      { ...basePaidPlan, stripe_price_id: null },
+      {
+        ...basePaidPlan,
+        id: "plan-scale",
+        slug: "scale",
+        stripe_price_id: "not_a_price",
+      },
+      {
+        ...basePaidPlan,
+        id: "plan-growth",
+        slug: "growth",
+        stripe_price_id: "not_a_price",
+      },
+    ]);
+
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "plans.pro.stripe_price_id",
+          level: "error",
+        }),
+        expect.objectContaining({
+          key: "plans.scale.stripe_price_id",
+          level: "error",
+        }),
+        expect.objectContaining({
+          key: "plans.stripe_price_id",
+          level: "error",
+        }),
+      ]),
+    );
+  });
+
+  it("warns when no paid public plans are available for checkout validation", () => {
+    expect(validatePlanRows([freePlan])).toEqual([
+      expect.objectContaining({
+        key: "plans.stripe_price_id",
+        level: "warning",
+      }),
+    ]);
+  });
+
+  it("accepts a free plan plus paid public plan mapped to a Stripe Price ID", () => {
+    expect(validatePlanRows([freePlan, basePaidPlan])).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #297 repo-side cutover prep.

- wires hosted Stripe billing env names through Docker Compose for app + ingester while preserving disabled/self-host defaults
- adds a tracked `bun run billing:preflight` command for non-secret env and `plans.stripe_price_id` readiness checks
- documents hosted Stripe Products/Prices mapping, webhook replay, validation checklist, and evidence template
- links the cutover runbook from production/self-hosting/ingester/Stripe docs

## Checks

- [x] `make check`
- [x] `make test`
- [x] `bun run test tests/billing-cutover-preflight.test.ts`
- [x] `bun run billing:preflight -- --service all` — expected failure with missing local hosted Stripe env/secrets
- [x] `BILLING_BACKEND=stripe STRIPE_SECRET_KEY=sk_test_placeholder STRIPE_WEBHOOK_SECRET=whsec_placeholder bun run billing:preflight -- --service all` — success path, secrets redacted
- [x] `git check-ignore -v src/lib/billing/cutover-preflight.ts tests/billing-cutover-preflight.test.ts docs/hosted-stripe-cutover.md agent_docs/learnings/active/2026-05-10-issue-297-preflight-location.md` — no intended PR files ignored

## External validation still required

Live hosted Stripe/deploy validation was not performed in this worktree because Stripe/deploy secrets, hosted DB access, and final product decisions are external to the repo. The runbook now calls out the blockers explicitly:

- confirm public tier names, limits, and prices before creating/updating Stripe Products/Prices
- confirm trial policy, org-level billing, and hard-cap quota behavior
- configure hosted app with `BILLING_BACKEND=stripe` and `STRIPE_SECRET_KEY`
- configure hosted ingester with `BILLING_BACKEND=stripe`, `STRIPE_SECRET_KEY`, and `STRIPE_WEBHOOK_SECRET`
- update `plans.stripe_price_id` with approved test/live `price_...` IDs and run `bun run billing:preflight -- --check-db --strict`
- execute free signup, billing page, checkout return, webhook subscription update, Customer Portal, and quota-gating hosted validation using the evidence template in `docs/hosted-stripe-cutover.md`

No real Stripe keys or deployment secrets are committed.
