### PR TITLE
Automations: add run cancellation controls and metrics API

### DIFF
--- a/agent_docs/learnings/active/2026-05-10-issue-303-run-cancel-metadata.md
+++ b/agent_docs/learnings/active/2026-05-10-issue-303-run-cancel-metadata.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-10
+issue: "#303"
+type: decision
+promoted_to: null
+---
+
+## Automation run cancellation uses terminal status plus step-state metadata
+
+**What:** Run cancellation is an additive API control that sets `automation_runs.status = cancelled`, `completed_at`, clears `next_step_at`, preserves `current_step_key`, and stores the operator reason in both `failure_reason` and the current step state's `output.cancellation_reason`.
+
+**Why:** This avoids a schema migration while keeping run history intact and making cancelled queued/waiting runs terminal for cron/runner dispatch.
+
+**Fix:** Future dashboard controls should treat `cancelled` as terminal history, not deletion, and should not requeue cancelled runs unless a new explicit retry/restart contract is designed.

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -467,6 +467,7 @@ export type AutomationStepStateEntry = {
     | "waiting"
     | "completed"
     | "failed"
+    | "cancelled"
     | "skipped";
   startedAt?: string;
   completedAt?: string;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -72,7 +72,8 @@ export interface AutomationStepPayload {
     | "condition"
     | "wait_for_event"
     | "contact_update"
-    | "contact_delete";
+    | "contact_delete"
+    | "add_to_segment";
   config?: Record<string, unknown>;
   position?: number;
 }
@@ -80,6 +81,7 @@ export interface AutomationStepPayload {
 export interface AutomationConnectionPayload {
   from: string;
   to: string;
+  type?: "default" | "condition_met" | "condition_not_met";
 }
 
 export interface CreateAutomationPayload {
@@ -113,6 +115,15 @@ export interface ListOptions {
 
 export interface AutomationRunListOptions extends ListOptions {
   status?: string;
+}
+
+export interface CancelAutomationRunPayload {
+  reason?: string;
+}
+
+export interface AutomationRunMetricsOptions {
+  from?: string;
+  to?: string;
 }
 
 function normalizeBaseUrl(baseUrl: string = DEFAULT_BASE_URL): string {
@@ -461,6 +472,34 @@ class Automations {
     return this.http.request<unknown>(
       "GET",
       `/api/automations/${id}/runs/${runId}`,
+    );
+  }
+
+  async cancelRun(
+    id: string,
+    runId: string,
+    payload: CancelAutomationRunPayload = {},
+  ): Promise<ApiResponse<unknown>> {
+    return this.http.request<unknown>(
+      "POST",
+      `/api/automations/${id}/runs/${runId}/cancel`,
+      payload,
+    );
+  }
+
+  async getRunMetrics(
+    id: string,
+    options: AutomationRunMetricsOptions = {},
+  ): Promise<ApiResponse<unknown>> {
+    const params = new URLSearchParams();
+    if (options.from) params.set("from", options.from);
+    if (options.to) params.set("to", options.to);
+    const query = params.toString();
+    return this.http.request<unknown>(
+      "GET",
+      query
+        ? `/api/automations/${id}/runs/metrics?${query}`
+        : `/api/automations/${id}/runs/metrics`,
     );
   }
 }

--- a/src/app/api/automations/[id]/runs/[runId]/cancel/route.ts
+++ b/src/app/api/automations/[id]/runs/[runId]/cancel/route.ts
@@ -1,0 +1,122 @@
+import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
+import { formatRunDetail } from "@/lib/automations";
+import { db } from "@/lib/db";
+import { automationRuns, automations } from "@/lib/db/schema";
+import { cancelAutomationRunSchema } from "@/lib/validation/automations";
+import { and, eq, inArray } from "drizzle-orm";
+
+const CANCELLABLE_RUN_STATUSES = ["queued", "waiting"] as const;
+
+async function readJsonBody(request: Request): Promise<unknown> {
+  const body = await request.text();
+  if (!body.trim()) return {};
+  return JSON.parse(body) as unknown;
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string; runId: string }> },
+): Promise<Response> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
+
+  let body: unknown;
+  try {
+    body = await readJsonBody(request);
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = cancelAutomationRunSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  const { id, runId } = await params;
+  try {
+    const ownerConditions = [eq(automations.id, id)];
+    if (auth.userId) ownerConditions.push(eq(automations.userId, auth.userId));
+    const automation = await db.query.automations.findFirst({
+      where: and(...ownerConditions),
+    });
+    if (!automation) {
+      return Response.json({ error: "Automation not found" }, { status: 404 });
+    }
+
+    const run = await db.query.automationRuns.findFirst({
+      where: and(
+        eq(automationRuns.id, runId),
+        eq(automationRuns.automationId, automation.id),
+      ),
+    });
+    if (!run) return Response.json({ error: "Run not found" }, { status: 404 });
+
+    if (
+      !CANCELLABLE_RUN_STATUSES.includes(run.status as "queued" | "waiting")
+    ) {
+      return Response.json(
+        {
+          error: "Run is not cancellable",
+          code: "run_not_cancellable",
+        },
+        { status: 409 },
+      );
+    }
+
+    const now = new Date();
+    const reason = parsed.data.reason ?? "cancelled_by_api";
+    const stepStates = { ...(run.stepStates ?? {}) };
+    if (run.currentStepKey) {
+      stepStates[run.currentStepKey] = {
+        ...(stepStates[run.currentStepKey] ?? { status: "pending" }),
+        status: "cancelled",
+        completedAt: now.toISOString(),
+        output: {
+          ...(stepStates[run.currentStepKey]?.output ?? {}),
+          cancellation_reason: reason,
+        },
+      };
+    }
+
+    const [updated] = await db
+      .update(automationRuns)
+      .set({
+        status: "cancelled",
+        stepStates,
+        completedAt: now,
+        nextStepAt: null,
+        failureReason: reason,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(automationRuns.id, run.id),
+          eq(automationRuns.automationId, automation.id),
+          inArray(automationRuns.status, [...CANCELLABLE_RUN_STATUSES]),
+        ),
+      )
+      .returning();
+
+    if (!updated) {
+      return Response.json(
+        {
+          error: "Run is not cancellable",
+          code: "run_not_cancellable",
+        },
+        { status: 409 },
+      );
+    }
+
+    return Response.json(formatRunDetail(updated));
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to cancel automation run";
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/automations/[id]/runs/metrics/route.ts
+++ b/src/app/api/automations/[id]/runs/metrics/route.ts
@@ -1,0 +1,60 @@
+import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
+import { formatRunMetrics } from "@/lib/automations";
+import { db } from "@/lib/db";
+import { automationRuns, automations } from "@/lib/db/schema";
+import { automationRunMetricsQuerySchema } from "@/lib/validation/automations";
+import { type SQL, and, eq, gte, lte } from "drizzle-orm";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
+
+  const url = new URL(request.url);
+  const parsed = automationRunMetricsQuerySchema.safeParse({
+    from: url.searchParams.get("from") ?? undefined,
+    to: url.searchParams.get("to") ?? undefined,
+  });
+  if (!parsed.success) {
+    return Response.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  const { id } = await params;
+  try {
+    const ownerConditions = [eq(automations.id, id)];
+    if (auth.userId) ownerConditions.push(eq(automations.userId, auth.userId));
+    const automation = await db.query.automations.findFirst({
+      where: and(...ownerConditions),
+    });
+    if (!automation) {
+      return Response.json({ error: "Automation not found" }, { status: 404 });
+    }
+
+    const from = parsed.data.from ? new Date(parsed.data.from) : undefined;
+    const to = parsed.data.to ? new Date(parsed.data.to) : undefined;
+    const conditions: SQL[] = [eq(automationRuns.automationId, automation.id)];
+    if (from) conditions.push(gte(automationRuns.createdAt, from));
+    if (to) conditions.push(lte(automationRuns.createdAt, to));
+
+    const runs = await db
+      .select()
+      .from(automationRuns)
+      .where(and(...conditions));
+
+    return Response.json(formatRunMetrics(automation.id, runs, { from, to }));
+  } catch (err) {
+    const message =
+      err instanceof Error
+        ? err.message
+        : "Failed to retrieve automation run metrics";
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/lib/automations.ts
+++ b/src/lib/automations.ts
@@ -13,6 +13,24 @@ export type CustomEventRow = typeof customEvents.$inferSelect;
 export type CustomEventDeliveryRow = typeof customEventDeliveries.$inferSelect;
 
 type StepState = NonNullable<AutomationRunRow["stepStates"]>[string];
+type RunMetricsStatus =
+  | "queued"
+  | "running"
+  | "waiting"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "skipped";
+
+const RUN_METRIC_STATUSES: RunMetricsStatus[] = [
+  "queued",
+  "running",
+  "waiting",
+  "completed",
+  "failed",
+  "cancelled",
+  "skipped",
+];
 
 export function formatStep(step: AutomationStepRow) {
   return {
@@ -116,6 +134,63 @@ export function parseRunStatusFilter(value: string | null): string[] {
     .split(",")
     .map((token) => token.trim())
     .filter(Boolean);
+}
+
+function emptyStatusCounts(): Record<RunMetricsStatus, number> {
+  return Object.fromEntries(
+    RUN_METRIC_STATUSES.map((status) => [status, 0]),
+  ) as Record<RunMetricsStatus, number>;
+}
+
+export function formatRunMetrics(
+  automationId: string,
+  runs: AutomationRunRow[],
+  range: { from?: Date; to?: Date } = {},
+) {
+  const byStatus = emptyStatusCounts();
+  const failedSteps = new Map<string, number>();
+  let durationTotal = 0;
+  let durationCount = 0;
+
+  for (const run of runs) {
+    if (RUN_METRIC_STATUSES.includes(run.status as RunMetricsStatus)) {
+      byStatus[run.status as RunMetricsStatus] += 1;
+    }
+
+    const duration = durationMs(run);
+    if (duration !== null) {
+      durationTotal += duration;
+      durationCount += 1;
+    }
+
+    const failedStepKey = findFailedStepKey(run.stepStates);
+    if (failedStepKey) {
+      failedSteps.set(failedStepKey, (failedSteps.get(failedStepKey) ?? 0) + 1);
+    }
+  }
+
+  const totalRuns = runs.length;
+  const failedStepSummary = [...failedSteps.entries()]
+    .map(([stepKey, count]) => ({ step_key: stepKey, count }))
+    .sort((a, b) => b.count - a.count || a.step_key.localeCompare(b.step_key))
+    .slice(0, 10);
+
+  return {
+    object: "automation_run_metrics" as const,
+    automation_id: automationId,
+    total_runs: totalRuns,
+    by_status: byStatus,
+    completion_rate: totalRuns > 0 ? byStatus.completed / totalRuns : 0,
+    failure_rate: totalRuns > 0 ? byStatus.failed / totalRuns : 0,
+    average_duration_ms:
+      durationCount > 0 ? Math.round(durationTotal / durationCount) : null,
+    waiting_count: byStatus.waiting,
+    failed_steps: failedStepSummary,
+    range: {
+      from: range.from?.toISOString() ?? null,
+      to: range.to?.toISOString() ?? null,
+    },
+  };
 }
 
 export function formatCustomEvent(event: CustomEventRow) {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -494,6 +494,7 @@ export type AutomationStepStateEntry = {
     | "waiting"
     | "completed"
     | "failed"
+    | "cancelled"
     | "skipped";
   startedAt?: string;
   completedAt?: string;

--- a/src/lib/validation/automations.ts
+++ b/src/lib/validation/automations.ts
@@ -260,5 +260,27 @@ export const listRunsQuerySchema = z.object({
   after: z.string().min(1).optional(),
 });
 
+export const cancelAutomationRunSchema = z
+  .object({
+    reason: z.string().trim().min(1).max(500).optional(),
+  })
+  .strict();
+
+export const automationRunMetricsQuerySchema = z
+  .object({
+    from: z.string().datetime({ offset: true }).optional(),
+    to: z.string().datetime({ offset: true }).optional(),
+  })
+  .superRefine((query, ctx) => {
+    if (!query.from || !query.to) return;
+    if (new Date(query.from).getTime() > new Date(query.to).getTime()) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["from"],
+        message: "from must be before to",
+      });
+    }
+  });
+
 export type CreateAutomationRequest = z.infer<typeof createAutomationSchema>;
 export type UpdateAutomationRequest = z.infer<typeof updateAutomationSchema>;

--- a/src/lib/workers/automation-runner.ts
+++ b/src/lib/workers/automation-runner.ts
@@ -1121,6 +1121,10 @@ export async function processAutomationRunStep(
   run: AutomationRun,
   deps: AutomationRunnerDeps = defaultDeps,
 ): Promise<AutomationRun | null> {
+  if (run.status !== "queued" && run.status !== "waiting") {
+    return run;
+  }
+
   const now = deps.now();
   const automation = await deps.getAutomation(run.automationId);
   if (!automation) {

--- a/tests/api-automations-events.test.ts
+++ b/tests/api-automations-events.test.ts
@@ -51,6 +51,22 @@ function insertRows<T>(rows: T[]) {
   };
 }
 
+function updateRows<T>(
+  rows: T[],
+  setCalls: Array<Record<string, unknown>> = [],
+) {
+  return {
+    set: vi.fn((data: Record<string, unknown>) => {
+      setCalls.push(data);
+      return {
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue(rows),
+        }),
+      };
+    }),
+  };
+}
+
 vi.mock("@/lib/api-auth", () => ({
   validateApiKey: mockValidateApiKey,
   unauthorizedResponse: () =>
@@ -108,6 +124,8 @@ vi.mock("drizzle-orm", async () => {
     asc: vi.fn((col: unknown) => ({ op: "asc", col })),
     desc: vi.fn((col: unknown) => ({ op: "desc", col })),
     lt: vi.fn((...args: unknown[]) => ({ op: "lt", args })),
+    gte: vi.fn((...args: unknown[]) => ({ op: "gte", args })),
+    lte: vi.fn((...args: unknown[]) => ({ op: "lte", args })),
     inArray: vi.fn((...args: unknown[]) => ({ op: "inArray", args })),
   };
 });
@@ -142,6 +160,26 @@ const customEvent = {
   id: "evt_1",
   name: "user.signed_up",
   schema: null,
+  createdAt: now,
+  updatedAt: now,
+};
+const queuedRun = {
+  id: "run_1",
+  automationId: "auto_1",
+  triggerEventId: "delivery_1",
+  contactId: "contact_1",
+  status: "queued",
+  currentStepKey: "wait",
+  stepStates: {
+    wait: {
+      status: "waiting",
+      output: { waiting_for_event: "invoice.paid" },
+    },
+  },
+  startedAt: now,
+  completedAt: null,
+  nextStepAt: now,
+  failureReason: null,
   createdAt: now,
   updatedAt: now,
 };
@@ -599,6 +637,141 @@ describe("automation API routes", () => {
     await expect(detail.json()).resolves.toMatchObject({
       id: "auto_1",
       trigger_event_name: "user.signed_up",
+    });
+  });
+
+  it("cancels a queued run with reason metadata and no history loss", async () => {
+    const setCalls: Array<Record<string, unknown>> = [];
+    mockAutomationFindFirst.mockResolvedValue(automation);
+    mockRunFindFirst.mockResolvedValue(queuedRun);
+    mockDbUpdate.mockReturnValue(
+      updateRows([{ ...queuedRun, status: "cancelled" }], setCalls),
+    );
+    const { POST } = await import(
+      "@/app/api/automations/[id]/runs/[runId]/cancel/route"
+    );
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/automations/auto_1/runs/run_1/cancel", {
+        reason: "customer requested stop",
+      }),
+      { params: Promise.resolve({ id: "auto_1", runId: "run_1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(setCalls[0]).toMatchObject({
+      status: "cancelled",
+      nextStepAt: null,
+      failureReason: "customer requested stop",
+    });
+    expect(setCalls[0]?.stepStates).toMatchObject({
+      wait: {
+        status: "cancelled",
+        output: {
+          waiting_for_event: "invoice.paid",
+          cancellation_reason: "customer requested stop",
+        },
+      },
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      object: "automation_run",
+      id: "run_1",
+      status: "cancelled",
+    });
+  });
+
+  it("rejects cancellation for terminal runs deterministically", async () => {
+    mockAutomationFindFirst.mockResolvedValue(automation);
+    mockRunFindFirst.mockResolvedValue({
+      ...queuedRun,
+      status: "completed",
+      completedAt: now,
+      nextStepAt: null,
+    });
+    const { POST } = await import(
+      "@/app/api/automations/[id]/runs/[runId]/cancel/route"
+    );
+
+    const response = await POST(
+      jsonRequest("http://localhost/api/automations/auto_1/runs/run_1/cancel", {
+        reason: "too late",
+      }),
+      { params: Promise.resolve({ id: "auto_1", runId: "run_1" }) },
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "run_not_cancellable",
+    });
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+  });
+
+  it("aggregates tenant-scoped automation run metrics", async () => {
+    mockAutomationFindFirst.mockResolvedValue(automation);
+    mockDbSelect.mockReturnValue(
+      queryRows([
+        {
+          ...queuedRun,
+          id: "run_completed",
+          status: "completed",
+          currentStepKey: null,
+          completedAt: new Date("2026-05-02T00:00:10.000Z"),
+        },
+        {
+          ...queuedRun,
+          id: "run_failed",
+          status: "failed",
+          currentStepKey: "send",
+          completedAt: new Date("2026-05-02T00:00:30.000Z"),
+          failureReason: "send_email template is missing or unpublished",
+          stepStates: {
+            send: {
+              status: "failed",
+              error: "send_email template is missing or unpublished",
+            },
+          },
+        },
+        {
+          ...queuedRun,
+          id: "run_waiting",
+          status: "waiting",
+          currentStepKey: "wait",
+          startedAt: null,
+          completedAt: null,
+        },
+      ]),
+    );
+    const { GET } = await import(
+      "@/app/api/automations/[id]/runs/metrics/route"
+    );
+
+    const response = await GET(
+      new Request(
+        "http://localhost/api/automations/auto_1/runs/metrics?from=2026-05-02T00%3A00%3A00.000Z&to=2026-05-03T00%3A00%3A00.000Z",
+        { headers: { Authorization: "Bearer re_test" } },
+      ),
+      { params: Promise.resolve({ id: "auto_1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      object: "automation_run_metrics",
+      automation_id: "auto_1",
+      total_runs: 3,
+      by_status: {
+        completed: 1,
+        failed: 1,
+        waiting: 1,
+      },
+      completion_rate: 1 / 3,
+      failure_rate: 1 / 3,
+      average_duration_ms: 20000,
+      waiting_count: 1,
+      failed_steps: [{ step_key: "send", count: 1 }],
+      range: {
+        from: "2026-05-02T00:00:00.000Z",
+        to: "2026-05-03T00:00:00.000Z",
+      },
     });
   });
 });

--- a/tests/automation-runner.test.ts
+++ b/tests/automation-runner.test.ts
@@ -182,6 +182,33 @@ function deps(overrides: Partial<AutomationRunnerDeps> = {}) {
 }
 
 describe("automation runner", () => {
+  it("does not resume cancelled runs even if a step would otherwise be due", async () => {
+    const setup = deps();
+
+    const result = await processAutomationRunStep(
+      run({
+        status: "cancelled",
+        currentStepKey: "delay",
+        stepStates: {
+          delay: {
+            status: "cancelled",
+            completedAt: now.toISOString(),
+            output: { cancellation_reason: "operator stopped it" },
+          },
+        },
+        completedAt: now,
+        nextStepAt: null,
+        failureReason: "operator stopped it",
+      }),
+      setup.deps,
+    );
+
+    expect(result?.status).toBe("cancelled");
+    expect(setup.deps.getAutomation).not.toHaveBeenCalled();
+    expect(setup.updates).toHaveLength(0);
+    expect(setup.sendEmail).not.toHaveBeenCalled();
+  });
+
   it("advances trigger then schedules delay next_step_at without sleeping", async () => {
     const setup = deps();
 

--- a/tests/sdk-client.test.tsx
+++ b/tests/sdk-client.test.tsx
@@ -371,6 +371,13 @@ describe("Opensend SDK", () => {
       ],
     });
     await client.automations.listRuns("auto_1", { status: "queued", limit: 5 });
+    await client.automations.cancelRun("auto_1", "run_1", {
+      reason: "operator stop",
+    });
+    await client.automations.getRunMetrics("auto_1", {
+      from: "2026-05-02T00:00:00.000Z",
+      to: "2026-05-03T00:00:00.000Z",
+    });
     await client.events.send({
       event: "user.signed_up",
       email: "user@example.com",
@@ -388,6 +395,16 @@ describe("Opensend SDK", () => {
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       3,
+      "https://api.example.com/api/automations/auto_1/runs/run_1/cancel",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      "https://api.example.com/api/automations/auto_1/runs/metrics?from=2026-05-02T00%3A00%3A00.000Z&to=2026-05-03T00%3A00%3A00.000Z",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      5,
       "https://api.example.com/api/events/send",
       expect.objectContaining({ method: "POST" }),
     );


### PR DESCRIPTION
## Summary
- Adds `POST /api/automations/:id/runs/:runId/cancel` for tenant-scoped cancellation of queued/waiting automation runs without deleting run history.
- Adds `GET /api/automations/:id/runs/metrics` for tenant-scoped run counts, rates, average duration, waiting count, and failed-step summary.
- Ensures cancelled/non-active runs are treated as terminal by the runner, and exposes cancellation/metrics helpers in the TypeScript SDK.

Closes #303.

## Changed files
- `src/app/api/automations/[id]/runs/[runId]/cancel/route.ts`
- `src/app/api/automations/[id]/runs/metrics/route.ts`
- `src/lib/automations.ts`
- `src/lib/validation/automations.ts`
- `src/lib/workers/automation-runner.ts`
- `src/lib/db/schema.ts`
- `packages/core/src/db/schema.ts`
- `packages/sdk/src/index.ts`
- `tests/api-automations-events.test.ts`
- `tests/automation-runner.test.ts`
- `tests/sdk-client.test.tsx`
- `agent_docs/learnings/active/2026-05-10-issue-303-run-cancel-metadata.md`

## Validation evidence
- `bun run test tests/automation-runner.test.ts tests/api-automations-events.test.ts tests/sdk-client.test.tsx` — 67 passed.
- `make check` — typecheck + Biome passed.
- `make test` — 106 files / 910 tests passed.
- Push guardrail — full-project typecheck and changed-file Biome passed.

## Notes / residual risk
- No dashboard controls were added; this is intentionally API/SDK/backend only.
- Metrics are route-level bounded aggregation over a single automation’s runs. If run volume becomes large, this can be optimized with indexed/materialized aggregates later.
