### PR TITLE
Automations: advanced dashboard controls polish

### DIFF
--- a/src/components/automation-builder-form.tsx
+++ b/src/components/automation-builder-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  type AutomationAdvancedStepType,
   type AutomationFormState,
   type AutomationFormValidationError,
   validateFormState,
@@ -19,6 +20,43 @@ interface Props {
   formErrors?: AutomationFormValidationError[];
 }
 
+const ADVANCED_STEP_OPTIONS: Array<{
+  value: AutomationAdvancedStepType;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "condition",
+    label: "Condition branch",
+    description: "Continue to email only when one predicate matches.",
+  },
+  {
+    value: "wait_for_event",
+    label: "Wait for event",
+    description: "Pause this run until the same contact emits another event.",
+  },
+  {
+    value: "contact_update",
+    label: "Update contact",
+    description: "Set safe first-class contact fields or custom properties.",
+  },
+  {
+    value: "add_to_segment",
+    label: "Add to segment",
+    description: "Add the current contact to an existing segment by ID.",
+  },
+  {
+    value: "contact_delete",
+    label: "Delete contact",
+    description: "Permanently delete the matched contact and finish the run.",
+  },
+];
+
+interface FieldErrorProps {
+  errors: AutomationFormValidationError[];
+  field: keyof AutomationFormState;
+}
+
 function getApiKey(): string | null {
   if (typeof window === "undefined") return null;
   try {
@@ -35,6 +73,279 @@ function findError(
   return errors.find((e) => e.field === field)?.message;
 }
 
+function FieldError({ errors, field }: FieldErrorProps) {
+  const error = findError(errors, field);
+  if (!error) return null;
+  return <span className="mt-1 block text-[12px] text-red-400">{error}</span>;
+}
+
+function stepNumber(
+  state: AutomationFormState,
+  step: "advanced" | "send" | "end",
+) {
+  const delayOffset = state.delayEnabled ? 1 : 0;
+  const advancedOffset = state.advancedStepEnabled ? 1 : 0;
+  if (step === "advanced") return 3 + delayOffset;
+  if (step === "send") return 3 + delayOffset + advancedOffset;
+  if (
+    state.advancedStepEnabled &&
+    state.advancedStepType === "contact_delete"
+  ) {
+    return 3 + delayOffset + advancedOffset;
+  }
+  return 4 + delayOffset + advancedOffset;
+}
+
+function AdvancedStepFields({
+  state,
+  update,
+  errors,
+}: {
+  state: AutomationFormState;
+  update: (patch: Partial<AutomationFormState>) => void;
+  errors: AutomationFormValidationError[];
+}) {
+  if (!state.advancedStepEnabled) {
+    return (
+      <p className="text-[13px] text-[#666]">
+        Keep the MVP linear path, or add one supported advanced step without
+        changing the full canvas engine.
+      </p>
+    );
+  }
+
+  if (state.advancedStepType === "condition") {
+    return (
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        <label className="block md:col-span-1">
+          <span className="text-[13px] text-[#A1A4A5]">Left side</span>
+          <input
+            type="text"
+            value={state.conditionLeft}
+            onChange={(e) => update({ conditionLeft: e.target.value })}
+            placeholder="event.plan"
+            className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+            aria-invalid={Boolean(findError(errors, "conditionLeft"))}
+          />
+          <FieldError errors={errors} field="conditionLeft" />
+        </label>
+        <label className="block">
+          <span className="text-[13px] text-[#A1A4A5]">Operator</span>
+          <select
+            value={state.conditionOperator}
+            onChange={(e) =>
+              update({
+                conditionOperator: e.target
+                  .value as AutomationFormState["conditionOperator"],
+              })
+            }
+            className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+          >
+            <option value="equals">Equals</option>
+            <option value="not_equals">Does not equal</option>
+            <option value="greater_than">Greater than</option>
+            <option value="greater_than_or_equal">Greater than or equal</option>
+            <option value="less_than">Less than</option>
+            <option value="less_than_or_equal">Less than or equal</option>
+            <option value="contains">Contains</option>
+            <option value="exists">Exists</option>
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-[13px] text-[#A1A4A5]">Right value</span>
+          <input
+            type="text"
+            value={state.conditionRight}
+            disabled={state.conditionOperator === "exists"}
+            onChange={(e) => update({ conditionRight: e.target.value })}
+            placeholder="pro"
+            className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)] disabled:opacity-50"
+            aria-invalid={Boolean(findError(errors, "conditionRight"))}
+          />
+          <span className="mt-1 block text-[12px] text-[#666]">
+            true, false, null, and numbers are sent as scalar values; other
+            input is sent as text.
+          </span>
+          <FieldError errors={errors} field="conditionRight" />
+        </label>
+        <p className="md:col-span-3 text-[12px] text-[#A1A4A5]">
+          Matching contacts follow the email path. Non-matches skip to End.
+        </p>
+      </div>
+    );
+  }
+
+  if (state.advancedStepType === "wait_for_event") {
+    return (
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <label className="block">
+          <span className="text-[13px] text-[#A1A4A5]">Event to wait for</span>
+          <input
+            type="text"
+            value={state.waitForEventName}
+            onChange={(e) => update({ waitForEventName: e.target.value })}
+            placeholder="invoice.paid"
+            className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+            aria-invalid={Boolean(findError(errors, "waitForEventName"))}
+          />
+          <FieldError errors={errors} field="waitForEventName" />
+        </label>
+        <label className="block">
+          <span className="text-[13px] text-[#A1A4A5]">
+            Timeout seconds (optional)
+          </span>
+          <input
+            type="number"
+            min={1}
+            value={state.waitForEventTimeoutSeconds}
+            onChange={(e) =>
+              update({ waitForEventTimeoutSeconds: e.target.value })
+            }
+            placeholder="86400"
+            className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+            aria-invalid={Boolean(
+              findError(errors, "waitForEventTimeoutSeconds"),
+            )}
+          />
+          <span className="mt-1 block text-[12px] text-[#666]">
+            Leave blank to wait indefinitely. Max 30 days.
+          </span>
+          <FieldError errors={errors} field="waitForEventTimeoutSeconds" />
+        </label>
+      </div>
+    );
+  }
+
+  if (state.advancedStepType === "contact_update") {
+    return (
+      <div className="space-y-3">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <label className="block">
+            <span className="text-[13px] text-[#A1A4A5]">Email</span>
+            <input
+              type="email"
+              value={state.contactUpdateEmail}
+              onChange={(e) => update({ contactUpdateEmail: e.target.value })}
+              placeholder="optional"
+              className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+              aria-invalid={Boolean(findError(errors, "contactUpdateEmail"))}
+            />
+            <FieldError errors={errors} field="contactUpdateEmail" />
+          </label>
+          <label className="block">
+            <span className="text-[13px] text-[#A1A4A5]">Unsubscribed</span>
+            <select
+              value={state.contactUpdateUnsubscribed}
+              onChange={(e) =>
+                update({
+                  contactUpdateUnsubscribed: e.target
+                    .value as AutomationFormState["contactUpdateUnsubscribed"],
+                })
+              }
+              className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+            >
+              <option value="">Leave unchanged</option>
+              <option value="false">Subscribed</option>
+              <option value="true">Unsubscribed</option>
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-[13px] text-[#A1A4A5]">First name</span>
+            <input
+              type="text"
+              value={state.contactUpdateFirstName}
+              onChange={(e) =>
+                update({ contactUpdateFirstName: e.target.value })
+              }
+              placeholder="optional"
+              className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+            />
+          </label>
+          <label className="block">
+            <span className="text-[13px] text-[#A1A4A5]">Last name</span>
+            <input
+              type="text"
+              value={state.contactUpdateLastName}
+              onChange={(e) =>
+                update({ contactUpdateLastName: e.target.value })
+              }
+              placeholder="optional"
+              className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+            />
+          </label>
+        </div>
+        <label className="block">
+          <span className="text-[13px] text-[#A1A4A5]">
+            Custom properties JSON
+          </span>
+          <textarea
+            value={state.contactUpdatePropertiesJson}
+            onChange={(e) =>
+              update({ contactUpdatePropertiesJson: e.target.value })
+            }
+            placeholder={'{"plan":"pro","score":42}'}
+            rows={3}
+            className="mt-1 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 py-2 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+            aria-invalid={Boolean(
+              findError(errors, "contactUpdatePropertiesJson"),
+            )}
+          />
+          <span className="mt-1 block text-[12px] text-[#666]">
+            Reserved identity, segment, topic, and unsubscribe keys are blocked
+            from properties.
+          </span>
+          <FieldError errors={errors} field="contactUpdatePropertiesJson" />
+        </label>
+      </div>
+    );
+  }
+
+  if (state.advancedStepType === "add_to_segment") {
+    return (
+      <label className="block">
+        <span className="text-[13px] text-[#A1A4A5]">Segment ID</span>
+        <input
+          type="text"
+          value={state.addToSegmentId}
+          onChange={(e) => update({ addToSegmentId: e.target.value })}
+          placeholder="00000000-0000-0000-0000-000000000000"
+          className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+          aria-invalid={Boolean(findError(errors, "addToSegmentId"))}
+        />
+        <span className="mt-1 block text-[12px] text-[#666]">
+          This uses the existing segment UUID contract; no segment is created
+          here.
+        </span>
+        <FieldError errors={errors} field="addToSegmentId" />
+      </label>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3">
+      <p className="text-[13px] font-medium text-red-200">
+        Destructive step: delete matched contact
+      </p>
+      <p className="mt-1 text-[12px] text-red-200/80">
+        This automation will permanently delete the contact matched to the run,
+        clear the run contact reference, and finish immediately. The email step
+        is skipped for this bounded builder slice.
+      </p>
+      <label className="mt-3 flex items-start gap-2 text-[12px] text-red-100">
+        <input
+          type="checkbox"
+          checked={state.contactDeleteConfirmed}
+          onChange={(e) => update({ contactDeleteConfirmed: e.target.checked })}
+          className="mt-0.5 accent-red-400"
+        />
+        I understand this can remove customer data and should only be enabled
+        for intentionally destructive cleanup automations.
+      </label>
+      <FieldError errors={errors} field="contactDeleteConfirmed" />
+    </div>
+  );
+}
+
 export function AutomationBuilderForm({
   state,
   onChange,
@@ -45,6 +356,9 @@ export function AutomationBuilderForm({
   const [templatesLoading, setTemplatesLoading] = useState(true);
   const [templatesError, setTemplatesError] = useState<string | null>(null);
   const errors = formErrors ?? validateFormState(state);
+  const includesSendEmail = !(
+    state.advancedStepEnabled && state.advancedStepType === "contact_delete"
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -95,7 +409,7 @@ export function AutomationBuilderForm({
 
   return (
     <div className="space-y-6">
-      <div className="rounded-lg border border-[rgba(176,199,217,0.145)] p-5 space-y-4">
+      <div className="space-y-4 rounded-lg border border-[rgba(176,199,217,0.145)] p-5">
         <h2 className="text-[14px] font-semibold text-[#F0F0F0]">Settings</h2>
         <label className="block">
           <span className="text-[13px] text-[#A1A4A5]">Name</span>
@@ -103,14 +417,10 @@ export function AutomationBuilderForm({
             type="text"
             value={state.name}
             onChange={(e) => update({ name: e.target.value })}
-            className="mt-1 w-full h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+            className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
             aria-invalid={Boolean(findError(errors, "name"))}
           />
-          {findError(errors, "name") ? (
-            <span className="mt-1 block text-[12px] text-red-400">
-              {findError(errors, "name")}
-            </span>
-          ) : null}
+          <FieldError errors={errors} field="name" />
         </label>
         {showStatus ? (
           <label className="block">
@@ -122,7 +432,7 @@ export function AutomationBuilderForm({
                   status: e.target.value as AutomationFormState["status"],
                 })
               }
-              className="mt-1 w-full h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+              className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
             >
               <option value="draft">Draft</option>
               <option value="enabled">Enabled</option>
@@ -137,8 +447,8 @@ export function AutomationBuilderForm({
           className="rounded-lg border border-[rgba(176,199,217,0.145)] p-5"
           data-step="trigger"
         >
-          <div className="flex items-center gap-3 mb-3">
-            <span className="rounded-full border border-[rgba(176,199,217,0.3)] text-[11px] font-semibold text-[#A1A4A5] px-2 py-0.5">
+          <div className="mb-3 flex items-center gap-3">
+            <span className="rounded-full border border-[rgba(176,199,217,0.3)] px-2 py-0.5 text-[11px] font-semibold text-[#A1A4A5]">
               1
             </span>
             <h3 className="text-[14px] font-semibold text-[#F0F0F0]">
@@ -155,14 +465,10 @@ export function AutomationBuilderForm({
               value={state.triggerEventName}
               onChange={(e) => update({ triggerEventName: e.target.value })}
               placeholder="user.signed_up"
-              className="mt-1 w-full h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+              className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
               aria-invalid={Boolean(findError(errors, "triggerEventName"))}
             />
-            {findError(errors, "triggerEventName") ? (
-              <span className="mt-1 block text-[12px] text-red-400">
-                {findError(errors, "triggerEventName")}
-              </span>
-            ) : null}
+            <FieldError errors={errors} field="triggerEventName" />
           </label>
         </li>
 
@@ -170,12 +476,12 @@ export function AutomationBuilderForm({
           className="rounded-lg border border-[rgba(176,199,217,0.145)] p-5"
           data-step="delay"
         >
-          <div className="flex items-center gap-3 mb-3">
-            <span className="rounded-full border border-[rgba(176,199,217,0.3)] text-[11px] font-semibold text-[#A1A4A5] px-2 py-0.5">
+          <div className="mb-3 flex items-center gap-3">
+            <span className="rounded-full border border-[rgba(176,199,217,0.3)] px-2 py-0.5 text-[11px] font-semibold text-[#A1A4A5]">
               2
             </span>
             <h3 className="text-[14px] font-semibold text-[#F0F0F0]">Delay</h3>
-            <label className="ml-auto inline-flex items-center gap-2 text-[12px] text-[#A1A4A5] cursor-pointer">
+            <label className="ml-auto inline-flex cursor-pointer items-center gap-2 text-[12px] text-[#A1A4A5]">
               <input
                 type="checkbox"
                 checked={state.delayEnabled}
@@ -193,17 +499,13 @@ export function AutomationBuilderForm({
                 value={state.delayDuration}
                 onChange={(e) => update({ delayDuration: e.target.value })}
                 placeholder="1 hour"
-                className="mt-1 w-full h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+                className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
                 aria-invalid={Boolean(findError(errors, "delayDuration"))}
               />
               <span className="mt-1 block text-[12px] text-[#666]">
                 Examples: 30 minutes, 1 hour, 3 days. Max 30 days.
               </span>
-              {findError(errors, "delayDuration") ? (
-                <span className="mt-1 block text-[12px] text-red-400">
-                  {findError(errors, "delayDuration")}
-                </span>
-              ) : null}
+              <FieldError errors={errors} field="delayDuration" />
             </label>
           ) : (
             <p className="text-[13px] text-[#666]">
@@ -214,96 +516,153 @@ export function AutomationBuilderForm({
 
         <li
           className="rounded-lg border border-[rgba(176,199,217,0.145)] p-5"
-          data-step="send_email"
+          data-step="advanced"
         >
-          <div className="flex items-center gap-3 mb-3">
-            <span className="rounded-full border border-[rgba(176,199,217,0.3)] text-[11px] font-semibold text-[#A1A4A5] px-2 py-0.5">
-              {state.delayEnabled ? 3 : 2}
+          <div className="mb-3 flex items-center gap-3">
+            <span className="rounded-full border border-[rgba(176,199,217,0.3)] px-2 py-0.5 text-[11px] font-semibold text-[#A1A4A5]">
+              {stepNumber(state, "advanced")}
             </span>
             <h3 className="text-[14px] font-semibold text-[#F0F0F0]">
-              Send email
+              Advanced step
             </h3>
-            <span className="text-[12px] text-[#A1A4A5]">
-              Use a published template
-            </span>
-          </div>
-          <label className="block">
-            <span className="text-[13px] text-[#A1A4A5]">
-              Published template
-            </span>
-            <select
-              value={state.templateId}
-              onChange={(e) => update({ templateId: e.target.value })}
-              className="mt-1 w-full h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
-              aria-invalid={Boolean(findError(errors, "templateId"))}
-            >
-              <option value="">
-                {templatesLoading
-                  ? "Loading published templates..."
-                  : "Select a published template"}
-              </option>
-              {templates.map((t) => (
-                <option key={t.id} value={t.id}>
-                  {t.name}
-                </option>
-              ))}
-            </select>
-            {templatesError ? (
-              <span className="mt-1 block text-[12px] text-red-400">
-                {templatesError}
-              </span>
-            ) : null}
-            {findError(errors, "templateId") ? (
-              <span className="mt-1 block text-[12px] text-red-400">
-                {findError(errors, "templateId")}
-              </span>
-            ) : null}
-          </label>
-          <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-3">
-            <label className="block">
-              <span className="text-[13px] text-[#A1A4A5]">From override</span>
+            <label className="ml-auto inline-flex cursor-pointer items-center gap-2 text-[12px] text-[#A1A4A5]">
               <input
-                type="text"
-                value={state.fromOverride}
-                onChange={(e) => update({ fromOverride: e.target.value })}
-                placeholder="optional"
-                className="mt-1 w-full h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+                type="checkbox"
+                checked={state.advancedStepEnabled}
+                onChange={(e) =>
+                  update({ advancedStepEnabled: e.target.checked })
+                }
+                className="accent-white"
               />
-            </label>
-            <label className="block">
-              <span className="text-[13px] text-[#A1A4A5]">
-                Subject override
-              </span>
-              <input
-                type="text"
-                value={state.subjectOverride}
-                onChange={(e) => update({ subjectOverride: e.target.value })}
-                placeholder="optional"
-                className="mt-1 w-full h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
-              />
-            </label>
-            <label className="block md:col-span-2">
-              <span className="text-[13px] text-[#A1A4A5]">
-                Reply-to override
-              </span>
-              <input
-                type="text"
-                value={state.replyToOverride}
-                onChange={(e) => update({ replyToOverride: e.target.value })}
-                placeholder="optional"
-                className="mt-1 w-full h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
-              />
+              Add advanced step
             </label>
           </div>
+          {state.advancedStepEnabled ? (
+            <div className="mb-4">
+              <label className="block">
+                <span className="text-[13px] text-[#A1A4A5]">Step type</span>
+                <select
+                  value={state.advancedStepType}
+                  onChange={(e) =>
+                    update({
+                      advancedStepType: e.target
+                        .value as AutomationAdvancedStepType,
+                      contactDeleteConfirmed: false,
+                    })
+                  }
+                  className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+                >
+                  {ADVANCED_STEP_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <p className="mt-2 text-[12px] text-[#666]">
+                {
+                  ADVANCED_STEP_OPTIONS.find(
+                    (option) => option.value === state.advancedStepType,
+                  )?.description
+                }
+              </p>
+            </div>
+          ) : null}
+          <AdvancedStepFields state={state} update={update} errors={errors} />
         </li>
+
+        {includesSendEmail ? (
+          <li
+            className="rounded-lg border border-[rgba(176,199,217,0.145)] p-5"
+            data-step="send_email"
+          >
+            <div className="mb-3 flex items-center gap-3">
+              <span className="rounded-full border border-[rgba(176,199,217,0.3)] px-2 py-0.5 text-[11px] font-semibold text-[#A1A4A5]">
+                {stepNumber(state, "send")}
+              </span>
+              <h3 className="text-[14px] font-semibold text-[#F0F0F0]">
+                Send email
+              </h3>
+              <span className="text-[12px] text-[#A1A4A5]">
+                Use a published template
+              </span>
+            </div>
+            <label className="block">
+              <span className="text-[13px] text-[#A1A4A5]">
+                Published template
+              </span>
+              <select
+                value={state.templateId}
+                onChange={(e) => update({ templateId: e.target.value })}
+                className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+                aria-invalid={Boolean(findError(errors, "templateId"))}
+              >
+                <option value="">
+                  {templatesLoading
+                    ? "Loading published templates..."
+                    : "Select a published template"}
+                </option>
+                {templates.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {t.name}
+                  </option>
+                ))}
+              </select>
+              {templatesError ? (
+                <span className="mt-1 block text-[12px] text-red-400">
+                  {templatesError}
+                </span>
+              ) : null}
+              <FieldError errors={errors} field="templateId" />
+            </label>
+            <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
+              <label className="block">
+                <span className="text-[13px] text-[#A1A4A5]">
+                  From override
+                </span>
+                <input
+                  type="text"
+                  value={state.fromOverride}
+                  onChange={(e) => update({ fromOverride: e.target.value })}
+                  placeholder="optional"
+                  className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+                />
+              </label>
+              <label className="block">
+                <span className="text-[13px] text-[#A1A4A5]">
+                  Subject override
+                </span>
+                <input
+                  type="text"
+                  value={state.subjectOverride}
+                  onChange={(e) => update({ subjectOverride: e.target.value })}
+                  placeholder="optional"
+                  className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+                />
+              </label>
+              <label className="block md:col-span-2">
+                <span className="text-[13px] text-[#A1A4A5]">
+                  Reply-to override
+                </span>
+                <input
+                  type="text"
+                  value={state.replyToOverride}
+                  onChange={(e) => update({ replyToOverride: e.target.value })}
+                  placeholder="optional"
+                  className="mt-1 h-9 w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-transparent px-3 text-[13px] text-[#F0F0F0] outline-none focus:border-[rgba(176,199,217,0.3)]"
+                />
+              </label>
+            </div>
+          </li>
+        ) : null}
 
         <li
           className="rounded-lg border border-dashed border-[rgba(176,199,217,0.145)] p-5"
           data-step="end"
         >
           <div className="flex items-center gap-3">
-            <span className="rounded-full border border-[rgba(176,199,217,0.3)] text-[11px] font-semibold text-[#A1A4A5] px-2 py-0.5">
-              {state.delayEnabled ? 4 : 3}
+            <span className="rounded-full border border-[rgba(176,199,217,0.3)] px-2 py-0.5 text-[11px] font-semibold text-[#A1A4A5]">
+              {stepNumber(state, "end")}
             </span>
             <h3 className="text-[14px] font-semibold text-[#F0F0F0]">End</h3>
             <span className="text-[12px] text-[#A1A4A5]">

--- a/src/components/automation-builder.tsx
+++ b/src/components/automation-builder.tsx
@@ -83,7 +83,8 @@ export function AutomationBuilder({ mode }: Props) {
             New automation
           </h1>
           <p className="mt-1 text-[13px] text-[#A1A4A5]">
-            MVP path: trigger → optional delay → send_email → end.
+            Build a trigger path with optional delay, one advanced step, email,
+            and end.
           </p>
         </div>
         <button

--- a/src/components/automation-run-detail.tsx
+++ b/src/components/automation-run-detail.tsx
@@ -3,7 +3,7 @@
 import { formatDuration } from "@/components/automation-runs-list";
 import { formatRelativeTime } from "@/components/emails-sending-data-table";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 interface RunStepState {
   status: string;
@@ -37,6 +37,18 @@ interface Props {
   runId: string;
 }
 
+const CANCELLABLE_RUN_STATUSES = new Set(["queued", "waiting"]);
+const SENSITIVE_OUTPUT_KEYS = [
+  "payload",
+  "email",
+  "token",
+  "secret",
+  "password",
+  "authorization",
+  "headers",
+  "body",
+];
+
 function getApiKey(): string | null {
   if (typeof window === "undefined") return null;
   try {
@@ -44,6 +56,14 @@ function getApiKey(): string | null {
   } catch {
     return null;
   }
+}
+
+function apiHeaders(contentType = false): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (contentType) headers["Content-Type"] = "application/json";
+  const apiKey = getApiKey();
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+  return headers;
 }
 
 function capitalize(value: string): string {
@@ -55,12 +75,57 @@ function formatDate(value: string | null | undefined): string {
   return `${formatRelativeTime(value)} · ${new Date(value).toLocaleString()}`;
 }
 
-function JsonBlock({ value }: { value: Record<string, unknown> | undefined }) {
-  if (!value || Object.keys(value).length === 0) return <span>—</span>;
+function isSensitiveOutputKey(key: string): boolean {
+  const lowered = key.toLowerCase();
+  return SENSITIVE_OUTPUT_KEYS.some((token) => lowered.includes(token));
+}
+
+function summarizeUnknown(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value))
+    return `${value.length} item${value.length === 1 ? "" : "s"}`;
+  if (typeof value === "object") {
+    const keyCount = Object.keys(value as Record<string, unknown>).length;
+    return `${keyCount} key${keyCount === 1 ? "" : "s"}`;
+  }
+  return "—";
+}
+
+function outputSummaryRows(output: Record<string, unknown> | undefined) {
+  if (!output || Object.keys(output).length === 0) return [];
+  return Object.entries(output).map(([key, value]) => {
+    if (key === "payload" && typeof value === "object" && value !== null) {
+      const keys = Object.keys(value as Record<string, unknown>);
+      return {
+        key,
+        value: `Hidden event payload (${keys.length} key${keys.length === 1 ? "" : "s"})`,
+      };
+    }
+    if (isSensitiveOutputKey(key)) {
+      return { key, value: "Redacted" };
+    }
+    return { key, value: summarizeUnknown(value) };
+  });
+}
+
+function OutputSummary({
+  value,
+}: { value: Record<string, unknown> | undefined }) {
+  const rows = outputSummaryRows(value);
+  if (rows.length === 0) return <span>—</span>;
   return (
-    <pre className="mt-2 max-h-48 overflow-auto rounded-md border border-[rgba(176,199,217,0.145)] bg-black/30 p-3 text-[12px] text-[#A1A4A5]">
-      {JSON.stringify(value, null, 2)}
-    </pre>
+    <dl className="mt-3 grid grid-cols-1 gap-2 rounded-md border border-[rgba(176,199,217,0.145)] bg-black/20 p-3 text-[12px] md:grid-cols-2">
+      {rows.map((row) => (
+        <div key={row.key}>
+          <dt className="text-[#666]">{row.key}</dt>
+          <dd className="break-words text-[#A1A4A5]">{row.value}</dd>
+        </div>
+      ))}
+    </dl>
   );
 }
 
@@ -69,48 +134,75 @@ export function AutomationRunDetail({ automationId, runId }: Props) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [notFound, setNotFound] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+
+  const loadRun = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setNotFound(false);
+    try {
+      const res = await fetch(
+        `/api/automations/${automationId}/runs/${runId}`,
+        {
+          headers: apiHeaders(),
+        },
+      );
+      if (res.status === 404) {
+        setNotFound(true);
+        return;
+      }
+      if (!res.ok) {
+        setError(
+          res.status === 401
+            ? "Set an API key to view this run."
+            : "Failed to load run.",
+        );
+        return;
+      }
+      setRun((await res.json()) as AutomationRunDetailPayload);
+    } catch {
+      setError("Failed to load run.");
+    } finally {
+      setLoading(false);
+    }
+  }, [automationId, runId]);
 
   useEffect(() => {
     let cancelled = false;
-    async function loadRun() {
-      setLoading(true);
-      setError(null);
-      setNotFound(false);
-      try {
-        const apiKey = getApiKey();
-        const headers: Record<string, string> = {};
-        if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
-        const res = await fetch(
-          `/api/automations/${automationId}/runs/${runId}`,
-          {
-            headers,
-          },
-        );
-        if (cancelled) return;
-        if (res.status === 404) {
-          setNotFound(true);
-          return;
-        }
-        if (!res.ok) {
-          setError(
-            res.status === 401
-              ? "Set an API key to view this run."
-              : "Failed to load run.",
-          );
-          return;
-        }
-        setRun((await res.json()) as AutomationRunDetailPayload);
-      } catch {
-        if (!cancelled) setError("Failed to load run.");
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
+    async function guardedLoadRun() {
+      await loadRun();
+      if (cancelled) return;
     }
-    loadRun();
+    guardedLoadRun();
     return () => {
       cancelled = true;
     };
-  }, [automationId, runId]);
+  }, [loadRun]);
+
+  const cancelRun = async () => {
+    setCancelling(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/automations/${automationId}/runs/${runId}/cancel`,
+        {
+          method: "POST",
+          headers: apiHeaders(true),
+          body: JSON.stringify({ reason: "cancelled_from_dashboard" }),
+        },
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body?.error ?? "Could not cancel run.");
+        return;
+      }
+      setRun((await res.json()) as AutomationRunDetailPayload);
+    } catch {
+      setError("Could not cancel run.");
+    } finally {
+      setCancelling(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -136,37 +228,63 @@ export function AutomationRunDetail({ automationId, runId }: Props) {
     );
   }
 
-  if (error || !run) {
+  if (error && !run) {
     return (
       <div className="mx-auto max-w-3xl py-16">
         <p
           role="alert"
           className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-[13px] text-red-300"
         >
-          {error ?? "Failed to load run."}
+          {error}
         </p>
       </div>
     );
   }
 
+  if (!run) {
+    return null;
+  }
+
   const stepEntries = Object.entries(run.step_states);
+  const canCancel = CANCELLABLE_RUN_STATUSES.has(run.status);
 
   return (
     <div className="mx-auto max-w-4xl">
-      <div className="mb-6">
-        <Link
-          href={`/automations/${automationId}`}
-          className="text-[12px] text-[#A1A4A5] hover:text-[#F0F0F0]"
-        >
-          &larr; Back to automation
-        </Link>
-        <h1 className="mt-2 text-2xl font-semibold text-[#F0F0F0]">
-          Run {run.id}
-        </h1>
-        <p className="mt-1 text-[13px] text-[#A1A4A5]">
-          {capitalize(run.status)} · {formatDuration(run.duration_ms)}
-        </p>
+      <div className="mb-6 flex items-start justify-between gap-3">
+        <div>
+          <Link
+            href={`/automations/${automationId}`}
+            className="text-[12px] text-[#A1A4A5] hover:text-[#F0F0F0]"
+          >
+            &larr; Back to automation
+          </Link>
+          <h1 className="mt-2 text-2xl font-semibold text-[#F0F0F0]">
+            Run {run.id}
+          </h1>
+          <p className="mt-1 text-[13px] text-[#A1A4A5]">
+            {capitalize(run.status)} · {formatDuration(run.duration_ms)}
+          </p>
+        </div>
+        {canCancel ? (
+          <button
+            type="button"
+            disabled={cancelling}
+            onClick={cancelRun}
+            className="h-9 rounded-md border border-red-500/30 px-3 text-[13px] font-medium text-red-200 transition-colors hover:border-red-400 hover:text-red-100 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {cancelling ? "Cancelling..." : "Cancel run"}
+          </button>
+        ) : null}
       </div>
+
+      {error ? (
+        <p
+          role="alert"
+          className="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-[13px] text-red-300"
+        >
+          {error}
+        </p>
+      ) : null}
 
       <section className="mb-6 grid grid-cols-1 gap-3 md:grid-cols-2">
         {[
@@ -196,6 +314,10 @@ export function AutomationRunDetail({ automationId, runId }: Props) {
           <h2 className="text-[14px] font-semibold text-[#F0F0F0]">
             Step states
           </h2>
+          <p className="mt-1 text-[12px] text-[#A1A4A5]">
+            Outputs are summarized and sensitive payload-like fields are
+            redacted.
+          </p>
         </div>
         {stepEntries.length === 0 ? (
           <p className="px-4 py-8 text-center text-[13px] text-[#A1A4A5]">
@@ -236,7 +358,7 @@ export function AutomationRunDetail({ automationId, runId }: Props) {
                 {state.error ? (
                   <p className="mt-3 text-[13px] text-red-300">{state.error}</p>
                 ) : null}
-                <JsonBlock value={state.output} />
+                <OutputSummary value={state.output} />
               </div>
             ))}
           </div>

--- a/src/components/automation-runs-list.tsx
+++ b/src/components/automation-runs-list.tsx
@@ -18,6 +18,16 @@ export interface AutomationRunListItem {
   created_at: string;
 }
 
+interface AutomationRunMetrics {
+  total_runs: number;
+  by_status: Record<string, number>;
+  completion_rate: number;
+  failure_rate: number;
+  average_duration_ms: number | null;
+  waiting_count: number;
+  failed_steps: Array<{ step_key: string; count: number }>;
+}
+
 const RUN_STATUSES = [
   "queued",
   "running",
@@ -27,6 +37,7 @@ const RUN_STATUSES = [
   "cancelled",
   "skipped",
 ] as const;
+const CANCELLABLE_RUN_STATUSES = new Set(["queued", "waiting"]);
 
 function getApiKey(): string | null {
   if (typeof window === "undefined") return null;
@@ -35,6 +46,14 @@ function getApiKey(): string | null {
   } catch {
     return null;
   }
+}
+
+function apiHeaders(contentType = false): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (contentType) headers["Content-Type"] = "application/json";
+  const apiKey = getApiKey();
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+  return headers;
 }
 
 function capitalize(s: string): string {
@@ -54,17 +73,61 @@ export function formatDuration(ms: number | null): string {
   return remMin ? `${hr}h ${remMin}m` : `${hr}h`;
 }
 
+function formatPercent(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function MetricCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-[rgba(176,199,217,0.145)] p-3">
+      <div className="text-[12px] text-[#A1A4A5]">{label}</div>
+      <div className="mt-1 text-[18px] font-semibold text-[#F0F0F0]">
+        {value}
+      </div>
+    </div>
+  );
+}
+
 interface Props {
   automationId: string;
 }
 
 export function AutomationRunsList({ automationId }: Props) {
   const [runs, setRuns] = useState<AutomationRunListItem[]>([]);
+  const [metrics, setMetrics] = useState<AutomationRunMetrics | null>(null);
   const [loading, setLoading] = useState(true);
+  const [metricsLoading, setMetricsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [metricsError, setMetricsError] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState("");
   const [statusOpen, setStatusOpen] = useState(false);
+  const [cancellingRunId, setCancellingRunId] = useState<string | null>(null);
   const statusRef = useRef<HTMLDivElement>(null);
+
+  const fetchMetrics = useCallback(async () => {
+    setMetricsLoading(true);
+    setMetricsError(null);
+    try {
+      const res = await fetch(`/api/automations/${automationId}/runs/metrics`, {
+        headers: apiHeaders(),
+      });
+      if (!res.ok) {
+        setMetrics(null);
+        setMetricsError(
+          res.status === 401
+            ? "Set an API key to view run metrics."
+            : "Failed to load run metrics.",
+        );
+        return;
+      }
+      setMetrics((await res.json()) as AutomationRunMetrics);
+    } catch {
+      setMetrics(null);
+      setMetricsError("Failed to load run metrics.");
+    } finally {
+      setMetricsLoading(false);
+    }
+  }, [automationId]);
 
   const fetchRuns = useCallback(async () => {
     setLoading(true);
@@ -72,12 +135,10 @@ export function AutomationRunsList({ automationId }: Props) {
     try {
       const params = new URLSearchParams();
       if (statusFilter) params.set("status", statusFilter);
-      const apiKey = getApiKey();
-      const headers: Record<string, string> = {};
-      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+      const query = params.toString();
       const res = await fetch(
-        `/api/automations/${automationId}/runs?${params.toString()}`,
-        { headers },
+        `/api/automations/${automationId}/runs${query ? `?${query}` : ""}`,
+        { headers: apiHeaders() },
       );
       if (!res.ok) {
         setRuns([]);
@@ -103,6 +164,10 @@ export function AutomationRunsList({ automationId }: Props) {
   }, [fetchRuns]);
 
   useEffect(() => {
+    fetchMetrics();
+  }, [fetchMetrics]);
+
+  useEffect(() => {
     const onClick = (e: MouseEvent) => {
       if (statusRef.current && !statusRef.current.contains(e.target as Node)) {
         setStatusOpen(false);
@@ -112,14 +177,97 @@ export function AutomationRunsList({ automationId }: Props) {
     return () => document.removeEventListener("mousedown", onClick);
   }, []);
 
+  const refreshAll = async () => {
+    await Promise.all([fetchRuns(), fetchMetrics()]);
+  };
+
+  const cancelRun = async (runId: string) => {
+    setCancellingRunId(runId);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/automations/${automationId}/runs/${runId}/cancel`,
+        {
+          method: "POST",
+          headers: apiHeaders(true),
+          body: JSON.stringify({ reason: "cancelled_from_dashboard" }),
+        },
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body?.error ?? "Could not cancel run.");
+        return;
+      }
+      await refreshAll();
+    } catch {
+      setError("Could not cancel run.");
+    } finally {
+      setCancellingRunId(null);
+    }
+  };
+
   return (
     <div>
-      <div className="flex items-center gap-3 mb-4">
+      <section className="mb-5 rounded-lg border border-[rgba(176,199,217,0.145)] p-4">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div>
+            <h3 className="text-[14px] font-semibold text-[#F0F0F0]">
+              Run metrics
+            </h3>
+            <p className="mt-1 text-[12px] text-[#A1A4A5]">
+              Aggregated from the automation run metrics endpoint.
+            </p>
+          </div>
+          {metricsLoading ? (
+            <span className="text-[12px] text-[#666]">Loading metrics...</span>
+          ) : null}
+        </div>
+        {metricsError ? (
+          <p className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-[13px] text-red-300">
+            {metricsError}
+          </p>
+        ) : metrics ? (
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
+              <MetricCard
+                label="Total runs"
+                value={String(metrics.total_runs)}
+              />
+              <MetricCard
+                label="Completion"
+                value={formatPercent(metrics.completion_rate)}
+              />
+              <MetricCard
+                label="Failure"
+                value={formatPercent(metrics.failure_rate)}
+              />
+              <MetricCard
+                label="Waiting"
+                value={String(metrics.waiting_count)}
+              />
+              <MetricCard
+                label="Avg duration"
+                value={formatDuration(metrics.average_duration_ms)}
+              />
+            </div>
+            {metrics.failed_steps.length > 0 ? (
+              <div className="text-[12px] text-[#A1A4A5]">
+                Top failed steps:{" "}
+                {metrics.failed_steps
+                  .map((step) => `${step.step_key} (${step.count})`)
+                  .join(", ")}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </section>
+
+      <div className="mb-4 flex items-center gap-3">
         <div className="relative" ref={statusRef}>
           <button
             type="button"
             onClick={() => setStatusOpen((v) => !v)}
-            className="h-9 px-3 text-[13px] border border-[rgba(176,199,217,0.145)] rounded-md text-[#A1A4A5] hover:text-[#F0F0F0] hover:border-[rgba(176,199,217,0.3)] transition-colors flex items-center gap-1.5 min-w-[140px]"
+            className="flex h-9 min-w-[140px] items-center gap-1.5 rounded-md border border-[rgba(176,199,217,0.145)] px-3 text-[13px] text-[#A1A4A5] transition-colors hover:border-[rgba(176,199,217,0.3)] hover:text-[#F0F0F0]"
           >
             <span>
               {statusFilter ? capitalize(statusFilter) : "All Statuses"}
@@ -140,7 +288,7 @@ export function AutomationRunsList({ automationId }: Props) {
           {statusOpen ? (
             <div
               role="menu"
-              className="absolute top-full left-0 mt-1 w-[200px] bg-[#0a0a0a] border border-[rgba(176,199,217,0.145)] rounded-md shadow-lg z-50 py-1"
+              className="absolute top-full left-0 z-50 mt-1 w-[200px] rounded-md border border-[rgba(176,199,217,0.145)] bg-[#0a0a0a] py-1 shadow-lg"
             >
               <button
                 type="button"
@@ -149,7 +297,7 @@ export function AutomationRunsList({ automationId }: Props) {
                   setStatusFilter("");
                   setStatusOpen(false);
                 }}
-                className={`w-full px-3 py-1.5 text-left text-[13px] hover:bg-[rgba(176,199,217,0.08)] transition-colors ${!statusFilter ? "text-[#F0F0F0]" : "text-[#A1A4A5]"}`}
+                className={`w-full px-3 py-1.5 text-left text-[13px] transition-colors hover:bg-[rgba(176,199,217,0.08)] ${!statusFilter ? "text-[#F0F0F0]" : "text-[#A1A4A5]"}`}
               >
                 All Statuses
               </button>
@@ -162,7 +310,7 @@ export function AutomationRunsList({ automationId }: Props) {
                     setStatusFilter(s);
                     setStatusOpen(false);
                   }}
-                  className={`w-full px-3 py-1.5 text-left text-[13px] hover:bg-[rgba(176,199,217,0.08)] transition-colors ${statusFilter === s ? "text-[#F0F0F0]" : "text-[#A1A4A5]"}`}
+                  className={`w-full px-3 py-1.5 text-left text-[13px] transition-colors hover:bg-[rgba(176,199,217,0.08)] ${statusFilter === s ? "text-[#F0F0F0]" : "text-[#A1A4A5]"}`}
                 >
                   {capitalize(s)}
                 </button>
@@ -172,8 +320,8 @@ export function AutomationRunsList({ automationId }: Props) {
         </div>
         <button
           type="button"
-          onClick={fetchRuns}
-          className="h-9 px-3 text-[13px] border border-[rgba(176,199,217,0.145)] rounded-md text-[#A1A4A5] hover:text-[#F0F0F0] hover:border-[rgba(176,199,217,0.3)] transition-colors"
+          onClick={refreshAll}
+          className="h-9 rounded-md border border-[rgba(176,199,217,0.145)] px-3 text-[13px] text-[#A1A4A5] transition-colors hover:border-[rgba(176,199,217,0.3)] hover:text-[#F0F0F0]"
         >
           Refresh
         </button>
@@ -194,7 +342,7 @@ export function AutomationRunsList({ automationId }: Props) {
         </div>
       ) : runs.length === 0 ? (
         <div className="rounded-md border border-dashed border-[rgba(176,199,217,0.145)] py-12 px-6 text-center">
-          <h3 className="text-[14px] font-semibold text-[#F0F0F0] mb-1">
+          <h3 className="mb-1 text-[14px] font-semibold text-[#F0F0F0]">
             No runs yet
           </h3>
           <p className="text-[13px] text-[#A1A4A5]">
@@ -224,50 +372,72 @@ export function AutomationRunsList({ automationId }: Props) {
               <th className="px-3 py-2 text-left text-[12px] font-medium text-[#A1A4A5]">
                 Failure reason
               </th>
+              <th className="px-3 py-2 text-left text-[12px] font-medium text-[#A1A4A5]">
+                Actions
+              </th>
             </tr>
           </thead>
           <tbody>
-            {runs.map((run) => (
-              <tr
-                key={run.id}
-                className="border-b border-[rgba(176,199,217,0.145)] hover:bg-[rgba(24,25,28,0.5)] transition-colors"
-              >
-                <td className="px-3 py-2 text-[14px] text-[#F0F0F0]">
-                  <Link
-                    href={`/automations/${automationId}/runs/${run.id}`}
-                    className="hover:underline"
-                  >
-                    {capitalize(run.status)}
-                  </Link>
-                </td>
-                <td
-                  className="px-3 py-2 text-[14px] text-[#A1A4A5]"
-                  title={
-                    run.started_at
-                      ? new Date(run.started_at).toLocaleString()
-                      : ""
-                  }
+            {runs.map((run) => {
+              const cancellable = CANCELLABLE_RUN_STATUSES.has(run.status);
+              return (
+                <tr
+                  key={run.id}
+                  className="border-b border-[rgba(176,199,217,0.145)] transition-colors hover:bg-[rgba(24,25,28,0.5)]"
                 >
-                  {run.started_at
-                    ? formatRelativeTime(run.started_at)
-                    : run.next_step_at
-                      ? `Scheduled ${formatRelativeTime(run.next_step_at)}`
-                      : formatRelativeTime(run.created_at)}
-                </td>
-                <td className="px-3 py-2 text-[14px] text-[#A1A4A5]">
-                  {formatDuration(run.duration_ms)}
-                </td>
-                <td className="px-3 py-2 text-[14px] text-[#A1A4A5]">
-                  {run.current_step_key ?? "—"}
-                </td>
-                <td className="px-3 py-2 text-[14px] text-red-300">
-                  {run.failed_step_key ?? "—"}
-                </td>
-                <td className="px-3 py-2 text-[14px] text-red-300 max-w-[280px] truncate">
-                  {run.failure_reason ?? "—"}
-                </td>
-              </tr>
-            ))}
+                  <td className="px-3 py-2 text-[14px] text-[#F0F0F0]">
+                    <Link
+                      href={`/automations/${automationId}/runs/${run.id}`}
+                      className="hover:underline"
+                    >
+                      {capitalize(run.status)}
+                    </Link>
+                  </td>
+                  <td
+                    className="px-3 py-2 text-[14px] text-[#A1A4A5]"
+                    title={
+                      run.started_at
+                        ? new Date(run.started_at).toLocaleString()
+                        : ""
+                    }
+                  >
+                    {run.started_at
+                      ? formatRelativeTime(run.started_at)
+                      : run.next_step_at
+                        ? `Scheduled ${formatRelativeTime(run.next_step_at)}`
+                        : formatRelativeTime(run.created_at)}
+                  </td>
+                  <td className="px-3 py-2 text-[14px] text-[#A1A4A5]">
+                    {formatDuration(run.duration_ms)}
+                  </td>
+                  <td className="px-3 py-2 text-[14px] text-[#A1A4A5]">
+                    {run.current_step_key ?? "—"}
+                  </td>
+                  <td className="px-3 py-2 text-[14px] text-red-300">
+                    {run.failed_step_key ?? "—"}
+                  </td>
+                  <td className="max-w-[280px] truncate px-3 py-2 text-[14px] text-red-300">
+                    {run.failure_reason ?? "—"}
+                  </td>
+                  <td className="px-3 py-2 text-[14px] text-[#A1A4A5]">
+                    {cancellable ? (
+                      <button
+                        type="button"
+                        disabled={cancellingRunId === run.id}
+                        onClick={() => cancelRun(run.id)}
+                        className="rounded-md border border-red-500/30 px-2 py-1 text-[12px] text-red-200 transition-colors hover:border-red-400 hover:text-red-100 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {cancellingRunId === run.id
+                          ? "Cancelling..."
+                          : "Cancel"}
+                      </button>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       )}

--- a/src/lib/automations/form.ts
+++ b/src/lib/automations/form.ts
@@ -1,8 +1,32 @@
 export type AutomationStatus = "draft" | "enabled" | "disabled";
 
+export type AutomationAdvancedStepType =
+  | "condition"
+  | "wait_for_event"
+  | "contact_update"
+  | "contact_delete"
+  | "add_to_segment";
+
+export type ConditionOperator =
+  | "equals"
+  | "not_equals"
+  | "greater_than"
+  | "greater_than_or_equal"
+  | "less_than"
+  | "less_than_or_equal"
+  | "contains"
+  | "exists";
+
+type AutomationStepType =
+  | "trigger"
+  | "delay"
+  | "send_email"
+  | "end"
+  | AutomationAdvancedStepType;
+
 export interface AutomationFormStep {
   key: string;
-  type: "trigger" | "delay" | "send_email" | "end";
+  type: AutomationStepType;
   config: Record<string, unknown>;
   position: number;
 }
@@ -17,6 +41,20 @@ export interface AutomationFormState {
   fromOverride: string;
   subjectOverride: string;
   replyToOverride: string;
+  advancedStepEnabled: boolean;
+  advancedStepType: AutomationAdvancedStepType;
+  conditionLeft: string;
+  conditionOperator: ConditionOperator;
+  conditionRight: string;
+  waitForEventName: string;
+  waitForEventTimeoutSeconds: string;
+  contactUpdateEmail: string;
+  contactUpdateFirstName: string;
+  contactUpdateLastName: string;
+  contactUpdateUnsubscribed: "" | "true" | "false";
+  contactUpdatePropertiesJson: string;
+  addToSegmentId: string;
+  contactDeleteConfirmed: boolean;
 }
 
 export const DEFAULT_FORM_STATE: AutomationFormState = {
@@ -29,7 +67,159 @@ export const DEFAULT_FORM_STATE: AutomationFormState = {
   fromOverride: "",
   subjectOverride: "",
   replyToOverride: "",
+  advancedStepEnabled: false,
+  advancedStepType: "condition",
+  conditionLeft: "event.plan",
+  conditionOperator: "equals",
+  conditionRight: "pro",
+  waitForEventName: "",
+  waitForEventTimeoutSeconds: "",
+  contactUpdateEmail: "",
+  contactUpdateFirstName: "",
+  contactUpdateLastName: "",
+  contactUpdateUnsubscribed: "",
+  contactUpdatePropertiesJson: "",
+  addToSegmentId: "",
+  contactDeleteConfirmed: false,
 };
+
+export function parseAutomationScalar(
+  value: string,
+): string | number | boolean | null {
+  const trimmed = value.trim();
+  if (trimmed === "null") return null;
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) {
+    const parsed = Number(trimmed);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return value;
+}
+
+function isScalar(value: unknown): value is string | number | boolean | null {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+}
+
+function parseScalarRecord(
+  value: string,
+): Record<string, string | number | boolean | null> | null {
+  if (!value.trim()) return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return null;
+    }
+    const record: Record<string, string | number | boolean | null> = {};
+    for (const [key, item] of Object.entries(parsed)) {
+      if (!key.trim() || !isScalar(item)) return null;
+      record[key.trim()] = item;
+    }
+    return record;
+  } catch {
+    return null;
+  }
+}
+
+function contactUpdateConfig(
+  state: AutomationFormState,
+): Record<string, unknown> {
+  const fields: Record<string, unknown> = {};
+  if (state.contactUpdateEmail.trim())
+    fields.email = state.contactUpdateEmail.trim();
+  if (state.contactUpdateFirstName.trim()) {
+    fields.first_name = state.contactUpdateFirstName.trim();
+  }
+  if (state.contactUpdateLastName.trim()) {
+    fields.last_name = state.contactUpdateLastName.trim();
+  }
+  if (state.contactUpdateUnsubscribed) {
+    fields.unsubscribed = state.contactUpdateUnsubscribed === "true";
+  }
+
+  const config: Record<string, unknown> = {};
+  if (Object.keys(fields).length > 0) config.fields = fields;
+  const properties = parseScalarRecord(state.contactUpdatePropertiesJson);
+  if (properties && Object.keys(properties).length > 0) {
+    config.properties = properties;
+  }
+  return config;
+}
+
+function buildAdvancedStep(
+  state: AutomationFormState,
+  position: number,
+): AutomationFormStep {
+  switch (state.advancedStepType) {
+    case "condition": {
+      const predicate: Record<string, unknown> = {
+        left: state.conditionLeft.trim(),
+        operator: state.conditionOperator,
+      };
+      if (state.conditionOperator !== "exists") {
+        predicate.right = parseAutomationScalar(state.conditionRight);
+      }
+      return {
+        key: "condition",
+        type: "condition",
+        config: { predicate },
+        position,
+      };
+    }
+    case "wait_for_event": {
+      const config: Record<string, unknown> = {
+        event_name: state.waitForEventName.trim(),
+      };
+      if (state.waitForEventTimeoutSeconds.trim()) {
+        config.timeout_seconds = Number(
+          state.waitForEventTimeoutSeconds.trim(),
+        );
+      }
+      return {
+        key: "wait_for_event",
+        type: "wait_for_event",
+        config,
+        position,
+      };
+    }
+    case "contact_update":
+      return {
+        key: "contact_update",
+        type: "contact_update",
+        config: contactUpdateConfig(state),
+        position,
+      };
+    case "contact_delete":
+      return {
+        key: "contact_delete",
+        type: "contact_delete",
+        config: {},
+        position,
+      };
+    case "add_to_segment":
+      return {
+        key: "add_to_segment",
+        type: "add_to_segment",
+        config: { segment_id: state.addToSegmentId.trim() },
+        position,
+      };
+  }
+}
+
+function shouldIncludeSendEmail(state: AutomationFormState): boolean {
+  return !(
+    state.advancedStepEnabled && state.advancedStepType === "contact_delete"
+  );
+}
 
 export function buildSteps(state: AutomationFormState): AutomationFormStep[] {
   const steps: AutomationFormStep[] = [];
@@ -51,21 +241,29 @@ export function buildSteps(state: AutomationFormState): AutomationFormStep[] {
     });
   }
 
-  const sendConfig: Record<string, unknown> = {
-    template: { id: state.templateId },
-  };
-  if (state.fromOverride.trim()) sendConfig.from = state.fromOverride.trim();
-  if (state.subjectOverride.trim())
-    sendConfig.subject = state.subjectOverride.trim();
-  if (state.replyToOverride.trim())
-    sendConfig.reply_to = state.replyToOverride.trim();
+  if (state.advancedStepEnabled) {
+    steps.push(buildAdvancedStep(state, position++));
+  }
 
-  steps.push({
-    key: "send_email",
-    type: "send_email",
-    config: sendConfig,
-    position: position++,
-  });
+  if (shouldIncludeSendEmail(state)) {
+    const sendConfig: Record<string, unknown> = {
+      template: { id: state.templateId },
+    };
+    if (state.fromOverride.trim()) sendConfig.from = state.fromOverride.trim();
+    if (state.subjectOverride.trim()) {
+      sendConfig.subject = state.subjectOverride.trim();
+    }
+    if (state.replyToOverride.trim()) {
+      sendConfig.reply_to = state.replyToOverride.trim();
+    }
+
+    steps.push({
+      key: "send_email",
+      type: "send_email",
+      config: sendConfig,
+      position: position++,
+    });
+  }
 
   steps.push({
     key: "end",
@@ -80,10 +278,33 @@ export function buildSteps(state: AutomationFormState): AutomationFormStep[] {
 export function buildConnections(state: AutomationFormState): Array<{
   from: string;
   to: string;
+  type?: "default" | "condition_met" | "condition_not_met";
 }> {
   const order: string[] = ["trigger"];
   if (state.delayEnabled) order.push("delay");
-  order.push("send_email", "end");
+
+  if (state.advancedStepEnabled) {
+    order.push(state.advancedStepType);
+    if (state.advancedStepType === "condition") {
+      return [
+        ...order.slice(0, -1).map((from, index) => ({
+          from,
+          to: order[index + 1],
+        })),
+        { from: "condition", to: "send_email", type: "condition_met" },
+        { from: "condition", to: "end", type: "condition_not_met" },
+        { from: "send_email", to: "end" },
+      ];
+    }
+    if (state.advancedStepType === "contact_delete") {
+      order.push("end");
+    } else {
+      order.push("send_email", "end");
+    }
+  } else {
+    order.push("send_email", "end");
+  }
+
   const connections: Array<{ from: string; to: string }> = [];
   for (let i = 0; i < order.length - 1; i += 1) {
     connections.push({ from: order[i], to: order[i + 1] });
@@ -123,6 +344,77 @@ const UNIT_TO_SECONDS: Record<string, number> = {
   weeks: 604800,
 };
 const MAX_DELAY_SECONDS = 30 * 24 * 60 * 60;
+const CONDITION_PATH_PATTERN =
+  /^(event|contact)\.[A-Za-z0-9_.-]+$|^steps\.[A-Za-z0-9_:-]+\.output(\.[A-Za-z0-9_.-]+)?$/;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const CONTACT_UPDATE_RESERVED_PROPERTY_KEYS = new Set([
+  "email",
+  "first_name",
+  "firstName",
+  "last_name",
+  "lastName",
+  "unsubscribed",
+  "segments",
+  "topics",
+  "topic_subscriptions",
+  "topicSubscriptions",
+]);
+
+function validateDuration(
+  duration: string,
+  field: keyof AutomationFormState,
+  errors: AutomationFormValidationError[],
+  label: string,
+): void {
+  const match = DURATION_PATTERN.exec(duration);
+  if (!match) {
+    errors.push({
+      field,
+      message: `${label} must be a natural-language duration like "1 hour" or "3 days".`,
+    });
+    return;
+  }
+
+  const amount = Number.parseFloat(match[1]);
+  const unit = match[2].toLowerCase();
+  const factor = UNIT_TO_SECONDS[unit];
+  if (!Number.isFinite(amount) || amount <= 0 || !factor) {
+    errors.push({ field, message: `${label} must be a positive duration.` });
+    return;
+  }
+
+  const seconds = Math.round(amount * factor);
+  if (seconds > MAX_DELAY_SECONDS) {
+    errors.push({ field, message: `${label} must be 30 days or less.` });
+  }
+}
+
+function validateContactUpdateProperties(
+  propertiesJson: string,
+  errors: AutomationFormValidationError[],
+): boolean {
+  if (!propertiesJson.trim()) return true;
+  const properties = parseScalarRecord(propertiesJson);
+  if (!properties) {
+    errors.push({
+      field: "contactUpdatePropertiesJson",
+      message:
+        "Properties must be a JSON object with string, number, boolean, or null values.",
+    });
+    return false;
+  }
+  for (const key of Object.keys(properties)) {
+    if (CONTACT_UPDATE_RESERVED_PROPERTY_KEYS.has(key)) {
+      errors.push({
+        field: "contactUpdatePropertiesJson",
+        message: `Properties cannot modify reserved contact field "${key}".`,
+      });
+      return false;
+    }
+  }
+  return true;
+}
 
 export function validateFormState(
   state: AutomationFormState,
@@ -147,39 +439,102 @@ export function validateFormState(
   }
 
   if (state.delayEnabled) {
-    const match = DURATION_PATTERN.exec(state.delayDuration);
-    if (!match) {
-      errors.push({
-        field: "delayDuration",
-        message:
-          'Delay must be a natural-language duration like "1 hour" or "3 days".',
-      });
-    } else {
-      const amount = Number.parseFloat(match[1]);
-      const unit = match[2].toLowerCase();
-      const factor = UNIT_TO_SECONDS[unit];
-      if (!Number.isFinite(amount) || amount <= 0 || !factor) {
-        errors.push({
-          field: "delayDuration",
-          message: "Delay must be a positive duration.",
-        });
-      } else {
-        const seconds = Math.round(amount * factor);
-        if (seconds > MAX_DELAY_SECONDS) {
-          errors.push({
-            field: "delayDuration",
-            message: "Delay must be 30 days or less.",
-          });
-        }
-      }
-    }
+    validateDuration(state.delayDuration, "delayDuration", errors, "Delay");
   }
 
-  if (!state.templateId) {
+  if (shouldIncludeSendEmail(state) && !state.templateId) {
     errors.push({
       field: "templateId",
       message: "Pick a published template to send.",
     });
+  }
+
+  if (state.advancedStepEnabled) {
+    if (state.advancedStepType === "condition") {
+      if (!CONDITION_PATH_PATTERN.test(state.conditionLeft.trim())) {
+        errors.push({
+          field: "conditionLeft",
+          message:
+            "Condition left side must reference event.*, contact.*, or steps.<key>.output.*.",
+        });
+      }
+      if (
+        state.conditionOperator !== "exists" &&
+        !state.conditionRight.trim()
+      ) {
+        errors.push({
+          field: "conditionRight",
+          message:
+            "Condition right value is required unless the operator is exists.",
+        });
+      }
+    }
+
+    if (state.advancedStepType === "wait_for_event") {
+      if (!state.waitForEventName.trim()) {
+        errors.push({
+          field: "waitForEventName",
+          message: "Event to wait for is required.",
+        });
+      }
+      if (state.waitForEventTimeoutSeconds.trim()) {
+        const timeout = Number(state.waitForEventTimeoutSeconds.trim());
+        if (
+          !Number.isInteger(timeout) ||
+          timeout < 1 ||
+          timeout > MAX_DELAY_SECONDS
+        ) {
+          errors.push({
+            field: "waitForEventTimeoutSeconds",
+            message:
+              "Timeout must be a whole number of seconds between 1 and 2,592,000.",
+          });
+        }
+      }
+    }
+
+    if (state.advancedStepType === "contact_update") {
+      const hasFieldUpdate = Boolean(
+        state.contactUpdateEmail.trim() ||
+          state.contactUpdateFirstName.trim() ||
+          state.contactUpdateLastName.trim() ||
+          state.contactUpdateUnsubscribed,
+      );
+      const propertiesValid = validateContactUpdateProperties(
+        state.contactUpdatePropertiesJson,
+        errors,
+      );
+      const properties = parseScalarRecord(state.contactUpdatePropertiesJson);
+      const hasProperties = Boolean(
+        properties && Object.keys(properties).length > 0,
+      );
+      if (propertiesValid && !hasFieldUpdate && !hasProperties) {
+        errors.push({
+          field: "contactUpdateEmail",
+          message: "Contact update requires at least one field or property.",
+        });
+      }
+    }
+
+    if (
+      state.advancedStepType === "contact_delete" &&
+      !state.contactDeleteConfirmed
+    ) {
+      errors.push({
+        field: "contactDeleteConfirmed",
+        message:
+          "Confirm that this automation may permanently delete the matched contact.",
+      });
+    }
+
+    if (state.advancedStepType === "add_to_segment") {
+      if (!UUID_PATTERN.test(state.addToSegmentId.trim())) {
+        errors.push({
+          field: "addToSegmentId",
+          message: "Segment ID must be a UUID.",
+        });
+      }
+    }
   }
 
   return errors;
@@ -200,6 +555,18 @@ export interface ApiAutomation {
   steps?: ApiAutomationStep[];
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringifyProperties(value: unknown): string {
+  const record = asRecord(value);
+  if (!record || Object.keys(record).length === 0) return "";
+  return JSON.stringify(record, null, 2);
+}
+
 export function fromAutomation(automation: ApiAutomation): AutomationFormState {
   const state: AutomationFormState = {
     ...DEFAULT_FORM_STATE,
@@ -218,6 +585,67 @@ export function fromAutomation(automation: ApiAutomation): AutomationFormState {
     state.delayEnabled = true;
     const dur = (delay.config as Record<string, unknown>)?.duration;
     if (typeof dur === "string") state.delayDuration = dur;
+  }
+  const advanced = steps.find((s) =>
+    [
+      "condition",
+      "wait_for_event",
+      "contact_update",
+      "contact_delete",
+      "add_to_segment",
+    ].includes(s.type),
+  );
+  if (advanced) {
+    state.advancedStepEnabled = true;
+    state.advancedStepType = advanced.type as AutomationAdvancedStepType;
+    const cfg = advanced.config as Record<string, unknown>;
+    if (advanced.type === "condition") {
+      const predicate = asRecord(cfg.predicate);
+      if (predicate) {
+        if (typeof predicate.left === "string")
+          state.conditionLeft = predicate.left;
+        if (typeof predicate.operator === "string") {
+          state.conditionOperator = predicate.operator as ConditionOperator;
+        }
+        if ("right" in predicate)
+          state.conditionRight = String(predicate.right ?? "null");
+      }
+    }
+    if (advanced.type === "wait_for_event") {
+      if (typeof cfg.event_name === "string")
+        state.waitForEventName = cfg.event_name;
+      if (typeof cfg.timeout_seconds === "number") {
+        state.waitForEventTimeoutSeconds = String(cfg.timeout_seconds);
+      }
+    }
+    if (advanced.type === "contact_update") {
+      const fields = asRecord(cfg.fields);
+      if (fields) {
+        if (typeof fields.email === "string")
+          state.contactUpdateEmail = fields.email;
+        if (typeof fields.first_name === "string") {
+          state.contactUpdateFirstName = fields.first_name;
+        }
+        if (typeof fields.last_name === "string") {
+          state.contactUpdateLastName = fields.last_name;
+        }
+        if (typeof fields.unsubscribed === "boolean") {
+          state.contactUpdateUnsubscribed = fields.unsubscribed
+            ? "true"
+            : "false";
+        }
+      }
+      state.contactUpdatePropertiesJson = stringifyProperties(cfg.properties);
+    }
+    if (advanced.type === "contact_delete") {
+      state.contactDeleteConfirmed = true;
+    }
+    if (
+      advanced.type === "add_to_segment" &&
+      typeof cfg.segment_id === "string"
+    ) {
+      state.addToSegmentId = cfg.segment_id;
+    }
   }
   const send = steps.find((s) => s.type === "send_email");
   if (send) {

--- a/tests/automation-form.test.ts
+++ b/tests/automation-form.test.ts
@@ -114,4 +114,127 @@ describe("automation MVP form helpers", () => {
       subjectOverride: "Welcome!",
     });
   });
+
+  it("builds a condition branch that skips email when not matched", () => {
+    const state: AutomationFormState = {
+      ...validState,
+      delayEnabled: false,
+      advancedStepEnabled: true,
+      advancedStepType: "condition",
+      conditionLeft: "event.plan",
+      conditionOperator: "equals",
+      conditionRight: "pro",
+    };
+
+    expect(validateFormState(state)).toEqual([]);
+    expect(buildSteps(state)).toEqual([
+      {
+        key: "trigger",
+        type: "trigger",
+        config: { event_name: "user.signed_up" },
+        position: 0,
+      },
+      {
+        key: "condition",
+        type: "condition",
+        config: {
+          predicate: { left: "event.plan", operator: "equals", right: "pro" },
+        },
+        position: 1,
+      },
+      {
+        key: "send_email",
+        type: "send_email",
+        config: {
+          template: { id: "tmpl_published" },
+          from: "hello@example.com",
+          subject: "Welcome!",
+          reply_to: "support@example.com",
+        },
+        position: 2,
+      },
+      { key: "end", type: "end", config: {}, position: 3 },
+    ]);
+    expect(buildConnections(state)).toEqual([
+      { from: "trigger", to: "condition" },
+      { from: "condition", to: "send_email", type: "condition_met" },
+      { from: "condition", to: "end", type: "condition_not_met" },
+      { from: "send_email", to: "end" },
+    ]);
+  });
+
+  it("builds supported advanced step configs without changing backend shapes", () => {
+    const waitState: AutomationFormState = {
+      ...validState,
+      advancedStepEnabled: true,
+      advancedStepType: "wait_for_event",
+      waitForEventName: "invoice.paid",
+      waitForEventTimeoutSeconds: "86400",
+    };
+    expect(buildSteps(waitState)[2]).toMatchObject({
+      key: "wait_for_event",
+      type: "wait_for_event",
+      config: { event_name: "invoice.paid", timeout_seconds: 86400 },
+    });
+
+    const updateState: AutomationFormState = {
+      ...validState,
+      advancedStepEnabled: true,
+      advancedStepType: "contact_update",
+      contactUpdateFirstName: "Ada",
+      contactUpdateUnsubscribed: "false",
+      contactUpdatePropertiesJson: '{"plan":"pro","score":42}',
+    };
+    expect(validateFormState(updateState)).toEqual([]);
+    expect(buildSteps(updateState)[2]).toMatchObject({
+      key: "contact_update",
+      type: "contact_update",
+      config: {
+        fields: { first_name: "Ada", unsubscribed: false },
+        properties: { plan: "pro", score: 42 },
+      },
+    });
+
+    const segmentState: AutomationFormState = {
+      ...validState,
+      advancedStepEnabled: true,
+      advancedStepType: "add_to_segment",
+      addToSegmentId: "71111111-1111-1111-1111-111111111111",
+    };
+    expect(validateFormState(segmentState)).toEqual([]);
+    expect(buildSteps(segmentState)[2]).toMatchObject({
+      key: "add_to_segment",
+      type: "add_to_segment",
+      config: { segment_id: "71111111-1111-1111-1111-111111111111" },
+    });
+  });
+
+  it("requires explicit confirmation and skips email for contact_delete", () => {
+    const state: AutomationFormState = {
+      ...validState,
+      advancedStepEnabled: true,
+      advancedStepType: "contact_delete",
+      contactDeleteConfirmed: false,
+    };
+
+    expect(validateFormState(state)).toContainEqual({
+      field: "contactDeleteConfirmed",
+      message:
+        "Confirm that this automation may permanently delete the matched contact.",
+    });
+
+    const confirmed = { ...state, contactDeleteConfirmed: true };
+    expect(validateFormState(confirmed)).toEqual([]);
+    expect(buildSteps(confirmed).map((step) => step.type)).toEqual([
+      "trigger",
+      "delay",
+      "contact_delete",
+      "end",
+    ]);
+    expect(buildConnections(confirmed)).toEqual([
+      { from: "trigger", to: "delay" },
+      { from: "delay", to: "contact_delete" },
+      { from: "contact_delete", to: "end" },
+    ]);
+  });
 });

--- a/tests/automation-run-detail.test.tsx
+++ b/tests/automation-run-detail.test.tsx
@@ -1,0 +1,93 @@
+import { AutomationRunDetail } from "@/components/automation-run-detail";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const baseRun = {
+  id: "run_1",
+  automation_id: "auto_1",
+  trigger_event_id: "event_1",
+  contact_id: "contact_1",
+  status: "waiting",
+  current_step_key: "wait_for_event",
+  failed_step_key: null,
+  failure_reason: null,
+  step_states: {
+    condition: {
+      status: "completed",
+      output: { matched: true, branch: "condition_met" },
+    },
+    wait_for_event: {
+      status: "waiting",
+      output: {
+        waiting_for_event: "invoice.paid",
+        payload: { secret: "do-not-render", amount: 42 },
+        email: "customer@example.com",
+      },
+    },
+  },
+  started_at: "2026-05-02T10:00:00.000Z",
+  completed_at: null,
+  next_step_at: "2026-05-03T10:00:00.000Z",
+  duration_ms: null,
+  created_at: "2026-05-02T10:00:00.000Z",
+  updated_at: "2026-05-02T10:00:00.000Z",
+};
+
+describe("AutomationRunDetail", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  afterEach(cleanup);
+
+  it("summarizes advanced outputs without dumping sensitive payloads", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(baseRun),
+    });
+
+    render(<AutomationRunDetail automationId="auto_1" runId="run_1" />);
+
+    await waitFor(() =>
+      expect(screen.getAllByText("wait_for_event").length).toBeGreaterThan(0),
+    );
+    expect(screen.getByText("waiting_for_event")).toBeTruthy();
+    expect(screen.getByText("invoice.paid")).toBeTruthy();
+    expect(screen.getByText("Hidden event payload (2 keys)")).toBeTruthy();
+    expect(screen.getByText("Redacted")).toBeTruthy();
+    expect(screen.queryByText("do-not-render")).toBeNull();
+    expect(screen.queryByText("customer@example.com")).toBeNull();
+  });
+
+  it("cancels waiting runs through the run cancel endpoint", async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(baseRun) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ ...baseRun, status: "cancelled" }),
+      });
+
+    render(<AutomationRunDetail automationId="auto_1" runId="run_1" />);
+
+    const cancelButton = await screen.findByRole("button", {
+      name: "Cancel run",
+    });
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        "/api/automations/auto_1/runs/run_1/cancel",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+  });
+});

--- a/tests/e2e/automations-dashboard.spec.ts
+++ b/tests/e2e/automations-dashboard.spec.ts
@@ -55,6 +55,8 @@ async function signIn(context: BrowserContext) {
 }
 
 async function mockAutomationApis(page: Page) {
+  let createdAutomationBody: unknown = null;
+  let cancelCalled = false;
   await page.route("**/api/auth/get-session", async (route) => {
     await route.fulfill({
       json: {
@@ -75,6 +77,7 @@ async function mockAutomationApis(page: Page) {
   });
   await page.route(/.*\/api\/automations(?:\?.*)?$/, async (route) => {
     if (route.request().method() === "POST") {
+      createdAutomationBody = route.request().postDataJSON();
       await route.fulfill({
         json: { ...automation, id: "auto_created", name: "Created automation" },
       });
@@ -87,29 +90,88 @@ async function mockAutomationApis(page: Page) {
   await page.route("**/api/automations/auto_1", async (route) => {
     await route.fulfill({ json: automation });
   });
-  await page.route("**/api/automations/auto_1/runs?**", async (route) => {
+  await page.route("**/api/automations/auto_1/runs/metrics", async (route) => {
     await route.fulfill({
       json: {
-        object: "list",
-        data: [
-          {
-            id: "run_1",
-            automation_id: "auto_1",
-            status: "failed",
-            current_step_key: null,
-            failed_step_key: "send_email",
-            failure_reason: "Template render failed",
-            started_at: "2026-05-02T10:00:00.000Z",
-            completed_at: "2026-05-02T10:00:05.000Z",
-            next_step_at: null,
-            duration_ms: 5000,
-            created_at: "2026-05-02T10:00:00.000Z",
-          },
-        ],
-        has_more: false,
+        object: "automation_run_metrics",
+        automation_id: "auto_1",
+        total_runs: 3,
+        by_status: {
+          queued: 1,
+          running: 0,
+          waiting: 1,
+          completed: 1,
+          failed: 1,
+          cancelled: 0,
+          skipped: 0,
+        },
+        completion_rate: 0.33,
+        failure_rate: 0.33,
+        average_duration_ms: 5000,
+        waiting_count: 1,
+        failed_steps: [{ step_key: "send_email", count: 1 }],
+        range: { from: null, to: null },
       },
     });
   });
+  await page.route(
+    "**/api/automations/auto_1/runs/run_wait/cancel",
+    async (route) => {
+      cancelCalled = true;
+      await route.fulfill({
+        json: {
+          id: "run_wait",
+          automation_id: "auto_1",
+          status: "cancelled",
+          current_step_key: null,
+          failure_reason: "cancelled_from_dashboard",
+        },
+      });
+    },
+  );
+  await page.route(
+    /.*\/api\/automations\/auto_1\/runs(?:\?.*)?$/,
+    async (route) => {
+      await route.fulfill({
+        json: {
+          object: "list",
+          data: [
+            {
+              id: "run_wait",
+              automation_id: "auto_1",
+              status: "waiting",
+              current_step_key: "wait_for_event",
+              failed_step_key: null,
+              failure_reason: null,
+              started_at: "2026-05-02T10:05:00.000Z",
+              completed_at: null,
+              next_step_at: "2026-05-03T10:05:00.000Z",
+              duration_ms: null,
+              created_at: "2026-05-02T10:05:00.000Z",
+            },
+            {
+              id: "run_1",
+              automation_id: "auto_1",
+              status: "failed",
+              current_step_key: null,
+              failed_step_key: "send_email",
+              failure_reason: "Template render failed",
+              started_at: "2026-05-02T10:00:00.000Z",
+              completed_at: "2026-05-02T10:00:05.000Z",
+              next_step_at: null,
+              duration_ms: 5000,
+              created_at: "2026-05-02T10:00:00.000Z",
+            },
+          ],
+          has_more: false,
+        },
+      });
+    },
+  );
+  return {
+    getCreatedAutomationBody: () => createdAutomationBody,
+    wasCancelCalled: () => cancelCalled,
+  };
 }
 
 test("automations dashboard lists automations and shows run failure fields", async ({
@@ -117,7 +179,7 @@ test("automations dashboard lists automations and shows run failure fields", asy
   page,
 }) => {
   await signIn(context);
-  await mockAutomationApis(page);
+  const mocks = await mockAutomationApis(page);
 
   await page.goto("/automations");
   await expect(
@@ -131,17 +193,26 @@ test("automations dashboard lists automations and shows run failure fields", asy
 
   await page.getByRole("link", { name: "Welcome automation" }).click();
   await page.getByRole("tab", { name: "Runs" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Run metrics" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Top failed steps: send_email (1)"),
+  ).toBeVisible();
+  await expect(page.getByRole("link", { name: "Waiting" })).toBeVisible();
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await expect.poll(() => mocks.wasCancelCalled()).toBe(true);
   await expect(page.getByRole("link", { name: "Failed" })).toBeVisible();
-  await expect(page.getByText("send_email")).toBeVisible();
+  await expect(page.getByRole("cell", { name: "send_email" })).toBeVisible();
   await expect(page.getByText("Template render failed")).toBeVisible();
 });
 
-test("automation create form submits the MVP linear flow", async ({
+test("automation create form submits an advanced condition flow", async ({
   context,
   page,
 }) => {
   await signIn(context);
-  await mockAutomationApis(page);
+  const mocks = await mockAutomationApis(page);
 
   await page.goto("/automations/new");
   await page
@@ -150,9 +221,36 @@ test("automation create form submits the MVP linear flow", async ({
   await page.getByLabel("Event name").fill("user.created");
   await page.getByLabel("Add a delay").check();
   await page.getByLabel("Duration").fill("1 hour");
+  await page.getByLabel("Add advanced step").check();
+  await page.getByLabel("Step type").selectOption("condition");
+  await page.getByLabel("Left side").fill("event.plan");
+  await page.getByLabel("Operator").selectOption("equals");
+  await page.getByLabel("Right value").fill("pro");
   await page.getByLabel("Published template").selectOption("tmpl_1");
   await page.getByLabel("Subject override").fill("Welcome");
   await page.getByRole("button", { name: "Create automation" }).click();
 
   await expect(page).toHaveURL(/\/automations\/auto_created/);
+  expect(mocks.getCreatedAutomationBody()).toMatchObject({
+    steps: [
+      { key: "trigger", type: "trigger" },
+      { key: "delay", type: "delay" },
+      {
+        key: "condition",
+        type: "condition",
+        config: {
+          predicate: { left: "event.plan", operator: "equals", right: "pro" },
+        },
+      },
+      { key: "send_email", type: "send_email" },
+      { key: "end", type: "end" },
+    ],
+    connections: [
+      { from: "trigger", to: "delay" },
+      { from: "delay", to: "condition" },
+      { from: "condition", to: "send_email", type: "condition_met" },
+      { from: "condition", to: "end", type: "condition_not_met" },
+      { from: "send_email", to: "end" },
+    ],
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a bounded advanced-step lane to the existing automation builder for condition, wait_for_event, contact_update, contact_delete, and add_to_segment configs without redesigning the canvas engine.
- Adds destructive contact_delete warning/confirmation copy and skips the email step for that destructive terminal path.
- Surfaces run metrics/cancellation in the runs tab and summarizes run detail outputs with payload-like fields redacted instead of dumping raw event data.

Closes #305

## Changes
- **Builder/form**: extend form state/builders/validation/hydration for the supported advanced backend contracts and condition branch edges.
- **Runs UI**: fetch metrics endpoint data, expose cancel for queued/waiting runs, and refresh run/metrics state after cancellation.
- **Run detail**: add cancel action for cancellable runs and safe output summaries for advanced step output/error inspection.
- **Tests**: add form-helper coverage, run-detail component coverage, and update Playwright to cover advanced condition creation plus metrics/cancel UI.

## How to Test
- `make check`
- `bunx vitest run tests/automation-form.test.ts tests/automation-run-detail.test.tsx`
- `bunx playwright test tests/e2e/automations-dashboard.spec.ts`

## Notes
- Scope is intentionally dashboard automation builder/run UI only; backend runner/API shapes are preserved.
- Full `make test` was not run because the diff is bounded to automation form/run UI and has targeted Vitest plus Playwright coverage.
- Playwright emitted existing Next.js/dev-server warnings about `experimental.nodeMiddleware`, middleware deprecation, and missing Google OAuth env; tests still passed.
