### PR TITLE
Add webhooks Hono control-plane parity

### DIFF
--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -1,5 +1,14 @@
 import { handleMcpHttpRequest } from "@opensend/mcp";
 import { Hono } from "hono";
+import {
+  DELETE as deleteWebhook,
+  GET as getWebhook,
+  PATCH as patchWebhook,
+} from "../../../src/app/api/webhooks/[id]/route";
+import {
+  GET as listWebhooks,
+  POST as postWebhook,
+} from "../../../src/app/api/webhooks/route";
 import { handlePostEmailBatchRequest } from "../../../src/lib/api/emails/batch-send";
 import { handlePostEmailRequest } from "../../../src/lib/api/emails/send";
 
@@ -40,6 +49,34 @@ export function createApp(options: ControlPlaneAppOptions = {}) {
   app.post(
     "/emails/batch",
     async (c) => await handlePostEmailBatchRequest(c.req.raw),
+  );
+
+  app.get("/webhooks", async (c) => await listWebhooks(c.req.raw));
+
+  app.post("/webhooks", async (c) => await postWebhook(c.req.raw));
+
+  app.get(
+    "/webhooks/:id",
+    async (c) =>
+      await getWebhook(c.req.raw, {
+        params: Promise.resolve({ id: c.req.param("id") }),
+      }),
+  );
+
+  app.patch(
+    "/webhooks/:id",
+    async (c) =>
+      await patchWebhook(c.req.raw, {
+        params: Promise.resolve({ id: c.req.param("id") }),
+      }),
+  );
+
+  app.delete(
+    "/webhooks/:id",
+    async (c) =>
+      await deleteWebhook(c.req.raw, {
+        params: Promise.resolve({ id: c.req.param("id") }),
+      }),
   );
 
   app.all(

--- a/tests/webhooks-api-keys-tenant-isolation.test.ts
+++ b/tests/webhooks-api-keys-tenant-isolation.test.ts
@@ -182,6 +182,220 @@ describe("webhook API tenant isolation", () => {
   });
 });
 
+describe("control-plane webhooks API parity", () => {
+  it("exposes API-key-authenticated Hono webhook CRUD through the existing route service path", async () => {
+    mockListWebhooks.mockResolvedValue({
+      data: [
+        {
+          id: "wh-b",
+          endpoint: "https://example.com/b",
+          events: ["email.delivered"],
+          status: "enabled",
+          createdAt: "2026-05-05T00:00:00.000Z",
+        },
+      ],
+      hasMore: true,
+    });
+    mockCreateWebhook.mockResolvedValue({
+      id: "wh-created",
+      endpoint: "https://example.com/created",
+      events: ["email.sent"],
+      status: "enabled",
+      signingSecret: "whsec_created",
+      createdAt: "2026-05-05T00:01:00.000Z",
+    });
+    mockGetWebhook.mockResolvedValue({
+      id: "wh-b",
+      endpoint: "https://example.com/b",
+      events: ["email.delivered"],
+      status: "enabled",
+      createdAt: "2026-05-05T00:00:00.000Z",
+      recentDeliveries: [
+        {
+          id: "delivery-1",
+          status: "pending",
+          attempt: 2,
+          statusCode: 503,
+          responseBody: "unavailable",
+          attemptedAt: "2026-05-05T00:02:00.000Z",
+          nextRetryAt: "2026-05-05T00:07:00.000Z",
+          createdAt: "2026-05-05T00:01:30.000Z",
+        },
+      ],
+    });
+    mockUpdateWebhook.mockResolvedValue({
+      id: "wh-b",
+      endpoint: "https://example.com/updated",
+      events: ["email.bounced"],
+      status: "disabled",
+      createdAt: "2026-05-05T00:00:00.000Z",
+    });
+    mockDeleteWebhook.mockResolvedValue({ id: "wh-b" });
+
+    const { createApp } = await import("../services/api/src/index");
+    const app = createApp();
+
+    const listResponse = await app.request("/webhooks?limit=50&after=wh-a", {
+      headers: { authorization: "Bearer user-b-key" },
+    });
+    expect(listResponse.status).toBe(200);
+    await expect(listResponse.json()).resolves.toEqual({
+      object: "list",
+      data: [
+        {
+          id: "wh-b",
+          endpoint: "https://example.com/b",
+          events: ["email.delivered"],
+          status: "enabled",
+          created_at: "2026-05-05T00:00:00.000Z",
+        },
+      ],
+      has_more: true,
+    });
+    expect(mockListWebhooks).toHaveBeenCalledWith({
+      userId: "user-b",
+      limit: 50,
+      after: "wh-a",
+    });
+
+    const createResponse = await app.request("/webhooks", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer user-b-key",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        endpoint: "https://example.com/created",
+        events: ["email.sent"],
+      }),
+    });
+    expect(createResponse.status).toBe(201);
+    await expect(createResponse.json()).resolves.toEqual({
+      object: "webhook",
+      id: "wh-created",
+      endpoint: "https://example.com/created",
+      events: ["email.sent"],
+      status: "enabled",
+      signing_secret: "whsec_created",
+      created_at: "2026-05-05T00:01:00.000Z",
+    });
+    expect(mockCreateWebhook).toHaveBeenCalledWith({
+      userId: "user-b",
+      endpoint: "https://example.com/created",
+      events: ["email.sent"],
+    });
+
+    const detailResponse = await app.request("/webhooks/wh-b", {
+      headers: { authorization: "Bearer user-b-key" },
+    });
+    expect(detailResponse.status).toBe(200);
+    const detailBody = await detailResponse.json();
+    expect(detailBody).toEqual({
+      object: "webhook",
+      id: "wh-b",
+      endpoint: "https://example.com/b",
+      events: ["email.delivered"],
+      status: "enabled",
+      created_at: "2026-05-05T00:00:00.000Z",
+      recent_deliveries: [
+        {
+          id: "delivery-1",
+          status: "pending",
+          attempt: 2,
+          status_code: 503,
+          response_body: "unavailable",
+          attempted_at: "2026-05-05T00:02:00.000Z",
+          next_retry_at: "2026-05-05T00:07:00.000Z",
+          created_at: "2026-05-05T00:01:30.000Z",
+        },
+      ],
+    });
+    expect(detailBody).not.toHaveProperty("signing_secret");
+    expect(mockGetWebhook).toHaveBeenCalledWith("wh-b", "user-b");
+
+    const updateResponse = await app.request("/webhooks/wh-b", {
+      method: "PATCH",
+      headers: {
+        authorization: "Bearer user-b-key",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        url: "https://example.com/updated",
+        event_types: ["email.bounced"],
+        active: false,
+      }),
+    });
+    expect(updateResponse.status).toBe(200);
+    const updateBody = await updateResponse.json();
+    expect(updateBody).toEqual({
+      object: "webhook",
+      id: "wh-b",
+      endpoint: "https://example.com/updated",
+      events: ["email.bounced"],
+      status: "disabled",
+      created_at: "2026-05-05T00:00:00.000Z",
+    });
+    expect(updateBody).not.toHaveProperty("signing_secret");
+    expect(mockUpdateWebhook).toHaveBeenCalledWith("wh-b", "user-b", {
+      endpoint: "https://example.com/updated",
+      events: ["email.bounced"],
+      status: undefined,
+      active: false,
+    });
+
+    const deleteResponse = await app.request("/webhooks/wh-b", {
+      method: "DELETE",
+      headers: { authorization: "Bearer user-b-key" },
+    });
+    expect(deleteResponse.status).toBe(200);
+    await expect(deleteResponse.json()).resolves.toEqual({
+      object: "webhook",
+      id: "wh-b",
+      deleted: true,
+    });
+    expect(mockDeleteWebhook).toHaveBeenCalledWith("wh-b", "user-b");
+  });
+
+  it("preserves Hono webhooks auth and permission failures before service calls", async () => {
+    const { createApp } = await import("../services/api/src/index");
+    const app = createApp();
+
+    mockValidateApiKey.mockResolvedValueOnce(null);
+    const unauthenticated = await app.request("/webhooks", {
+      headers: { authorization: "Bearer invalid" },
+    });
+    expect(unauthenticated.status).toBe(401);
+    await expect(unauthenticated.json()).resolves.toEqual({
+      error: "Missing or invalid API key",
+    });
+    expect(mockListWebhooks).not.toHaveBeenCalled();
+
+    mockValidateApiKey.mockResolvedValueOnce({
+      apiKeyId: "sending-key",
+      permission: "sending_access",
+      domain: null,
+      userId: "user-b",
+    });
+    const forbidden = await app.request("/webhooks", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer sending-key",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        endpoint: "https://example.com/b",
+        events: ["email.delivered"],
+      }),
+    });
+    expect(forbidden.status).toBe(403);
+    await expect(forbidden.json()).resolves.toMatchObject({
+      code: "insufficient_api_key_permission",
+      statusCode: 403,
+    });
+    expect(mockCreateWebhook).not.toHaveBeenCalled();
+  });
+});
+
 describe("API key API tenant isolation", () => {
   it("returns an empty API-key list scoped to the caller", async () => {
     mockListApiKeys.mockResolvedValue({ data: [], hasMore: false });


### PR DESCRIPTION
## Summary
- Add Hono control-plane `/webhooks` and `/webhooks/:id` endpoints by forwarding to the existing Next webhooks route handlers, preserving the current core service path and response mapping.
- Cover the Hono webhooks CRUD path with API-key-authenticated parity tests, including create-only `signing_secret`, no secret on detail/update, auth failure, and permission failure behavior.

Closes #309

## Changed files
- `services/api/src/index.ts`
- `tests/webhooks-api-keys-tenant-isolation.test.ts`

## Validation
- `make check`
- `bunx vitest run tests/webhook-service.test.ts tests/webhooks-api-keys-tenant-isolation.test.ts`
- `bun run build:api`

## Residual risk
- Full Vitest suite and Playwright E2E were not run because this is a bounded webhooks adapter slice with targeted service/route coverage plus API build smoke.
- Hono webhooks currently reuse the existing Next route handlers to keep public behavior byte-stable; a later deeper extraction should first lock any intended route contract changes in tests.
