### PR TITLE
Extract template API service boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-10-issue-311-template-service-boundary.md
+++ b/agent_docs/learnings/active/2026-05-10-issue-311-template-service-boundary.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-10
+issue: "#311"
+type: pattern
+promoted_to: null
+---
+
+## Template routes thin-adapter extraction
+
+Issue #311 moved template create/list/detail/update/delete/publish/duplicate business rules into `packages/core/src/services/template.ts` while keeping Next.js route files responsible for auth, request JSON/params, service calls, and HTTP response/status mapping.
+
+The existing core template schema was missing `currentVersionId`, `publishedAt`, and `hasUnpublishedVersions`, so service/repository extraction required aligning `packages/core/src/db/schema.ts` before `templateRepo.listForApi` could preserve list response fields.
+
+Preserve variable normalization behavior in the service layer, not route-local helpers, and keep route tests focused on adapter mapping while service tests lock normalization, automatic extraction, publish, duplicate, and not-found behavior.

--- a/packages/core/src/db/repositories/templateRepo.ts
+++ b/packages/core/src/db/repositories/templateRepo.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, ilike, lt } from "drizzle-orm";
+import { type SQL, and, count, desc, eq, ilike, lt } from "drizzle-orm";
 import { db } from "../client";
 import { templates } from "../schema";
 
@@ -57,5 +57,44 @@ export const templateRepo = {
     const data = hasMore ? results.slice(0, limit) : results;
 
     return { data, hasMore };
+  },
+
+  async listForApi(
+    options: {
+      search?: string;
+      status?: string;
+    } = {},
+  ) {
+    const { search, status } = options;
+    const conditions: SQL[] = [];
+
+    if (search) conditions.push(ilike(templates.name, `%${search}%`));
+    if (status === "published" || status === "draft") {
+      conditions.push(eq(templates.status, status));
+    }
+
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+    const [totalRow] = await db
+      .select({ count: count() })
+      .from(templates)
+      .where(whereClause);
+
+    const data = await db
+      .select({
+        id: templates.id,
+        name: templates.name,
+        alias: templates.alias,
+        status: templates.status,
+        currentVersionId: templates.currentVersionId,
+        publishedAt: templates.publishedAt,
+        hasUnpublishedVersions: templates.hasUnpublishedVersions,
+        createdAt: templates.createdAt,
+      })
+      .from(templates)
+      .where(whereClause)
+      .orderBy(desc(templates.createdAt))
+      .limit(200);
+
+    return { data, total: totalRow?.count ?? 0 };
   },
 };

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -336,6 +336,11 @@ export const templates = pgTable("templates", {
         fallback_value?: string | number | null;
       }>
     >(),
+  currentVersionId: uuid("current_version_id"),
+  publishedAt: timestamp("published_at", { withTimezone: true }),
+  hasUnpublishedVersions: boolean("has_unpublished_versions")
+    .notNull()
+    .default(true),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,5 +38,6 @@ export * from "./services/email";
 export * from "./services/emailProvider";
 export * from "./services/sandboxTestRecipients";
 export * from "./services/storage";
+export * from "./services/template";
 export * from "./jobs/background-jobs";
 export * from "./observability/telemetry";

--- a/packages/core/src/services/template.ts
+++ b/packages/core/src/services/template.ts
@@ -1,0 +1,562 @@
+import { templateRepo } from "../db/repositories/templateRepo";
+import type { templates } from "../db/schema";
+
+type TemplateRow = typeof templates.$inferSelect;
+type TemplateInsert = typeof templates.$inferInsert;
+
+type TemplateVariableType = "string" | "number";
+type TemplateFallbackValue = string | number;
+
+type StoredTemplateVariable = {
+  name: string;
+  key?: string;
+  type?: TemplateVariableType;
+  required: boolean;
+  fallbackValue?: TemplateFallbackValue | null;
+  fallback_value?: TemplateFallbackValue | null;
+};
+
+type NormalizedTemplateVariable = {
+  key: string;
+  name: string;
+  type: TemplateVariableType;
+  required: boolean;
+  fallbackValue: TemplateFallbackValue | null;
+  hasFallbackValue: boolean;
+};
+
+export type TemplateVariableResponseItem = {
+  id: string;
+  key: string;
+  name: string;
+  type: TemplateVariableType;
+  required: boolean;
+  fallback_value: TemplateFallbackValue | null;
+  created_at: Date | string | null;
+  updated_at: Date | string | null;
+};
+
+export type TemplateListItem = Pick<
+  TemplateRow,
+  | "id"
+  | "name"
+  | "alias"
+  | "status"
+  | "currentVersionId"
+  | "publishedAt"
+  | "hasUnpublishedVersions"
+  | "createdAt"
+>;
+
+export type TemplateListResult = {
+  data: TemplateListItem[];
+  total: number;
+};
+
+export type TemplateDetail = Pick<
+  TemplateRow,
+  | "id"
+  | "name"
+  | "alias"
+  | "status"
+  | "subject"
+  | "from"
+  | "replyTo"
+  | "previewText"
+  | "html"
+  | "text"
+  | "createdAt"
+> & {
+  variables: TemplateVariableResponseItem[];
+  updatedAt: TemplateRow["createdAt"];
+};
+
+export type TemplateCreateResult = Pick<TemplateRow, "id" | "name" | "alias">;
+
+export type TemplateDuplicateResult = Pick<
+  TemplateRow,
+  "id" | "name" | "status"
+>;
+
+export type TemplatePublishResult = Pick<
+  TemplateRow,
+  "id" | "status" | "publishedAt" | "hasUnpublishedVersions"
+>;
+
+export type TemplateServiceErrorCode =
+  | "invalid_input"
+  | "invalid_variables"
+  | "not_draft"
+  | "not_found";
+
+export class TemplateServiceError extends Error {
+  constructor(
+    readonly code: TemplateServiceErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "TemplateServiceError";
+  }
+}
+
+export type TemplateRepository = {
+  findById(id: string): Promise<TemplateRow | undefined>;
+  create(data: TemplateInsert): Promise<TemplateRow[]>;
+  update(id: string, data: Partial<TemplateInsert>): Promise<TemplateRow[]>;
+  delete(id: string): Promise<TemplateRow[]>;
+  listForApi(options: {
+    search?: string;
+    status?: string;
+  }): Promise<TemplateListResult>;
+};
+
+export type TemplateServiceDependencies = {
+  repository?: TemplateRepository;
+  now?: () => Date;
+};
+
+const RESERVED_VARIABLE_NAMES = new Set([
+  "FIRST_NAME",
+  "LAST_NAME",
+  "EMAIL",
+  "UNSUBSCRIBE_URL",
+  "RESEND_UNSUBSCRIBE_URL",
+  "INTERNAL_ID",
+  "CONTACT",
+  "THIS",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function isTemplateVariableType(value: unknown): value is TemplateVariableType {
+  return value === "string" || value === "number";
+}
+
+function isFallbackValue(value: unknown): value is TemplateFallbackValue {
+  return typeof value === "string" || typeof value === "number";
+}
+
+function getRawFallbackValue(record: Record<string, unknown>): unknown {
+  if (hasOwn(record, "fallbackValue")) return record.fallbackValue;
+  if (hasOwn(record, "fallback_value")) return record.fallback_value;
+  return undefined;
+}
+
+function getRawKey(record: Record<string, unknown>): unknown {
+  if (typeof record.key === "string") return record.key;
+  if (typeof record.name === "string") return record.name;
+  return undefined;
+}
+
+function normalizeTemplateVariableInput(
+  value: unknown,
+):
+  | { ok: true; variable: StoredTemplateVariable }
+  | { ok: false; error: string } {
+  if (!isRecord(value)) {
+    return { ok: false, error: "variables must contain objects" };
+  }
+
+  const rawKey = getRawKey(value);
+  if (typeof rawKey !== "string" || rawKey.trim().length === 0) {
+    return { ok: false, error: "Variable key is required." };
+  }
+
+  const key = rawKey.trim();
+  if (RESERVED_VARIABLE_NAMES.has(key.toUpperCase())) {
+    return { ok: false, error: `Variable name ${key} is reserved.` };
+  }
+
+  if (value.type !== undefined && !isTemplateVariableType(value.type)) {
+    return {
+      ok: false,
+      error: `Variable ${key} type must be either string or number.`,
+    };
+  }
+
+  const rawFallbackValue = getRawFallbackValue(value);
+  const hasFallbackValue =
+    rawFallbackValue !== undefined && rawFallbackValue !== null;
+  if (hasFallbackValue && !isFallbackValue(rawFallbackValue)) {
+    return {
+      ok: false,
+      error: `Variable ${key} fallback value must be a string or number.`,
+    };
+  }
+
+  if (value.required !== undefined && typeof value.required !== "boolean") {
+    return {
+      ok: false,
+      error: `Variable ${key} required must be a boolean.`,
+    };
+  }
+
+  const isResendStyle =
+    hasOwn(value, "key") ||
+    hasOwn(value, "type") ||
+    hasOwn(value, "fallbackValue") ||
+    hasOwn(value, "fallback_value");
+  const required =
+    typeof value.required === "boolean"
+      ? value.required
+      : isResendStyle
+        ? !hasFallbackValue
+        : false;
+
+  return {
+    ok: true,
+    variable: {
+      name: key,
+      key,
+      type: isTemplateVariableType(value.type) ? value.type : "string",
+      required,
+      fallbackValue: hasFallbackValue ? rawFallbackValue : null,
+    },
+  };
+}
+
+function normalizeTemplateVariablesInput(
+  value: unknown,
+):
+  | { ok: true; variables: StoredTemplateVariable[] }
+  | { ok: false; error: string } {
+  const variables = value ?? [];
+  if (!Array.isArray(variables)) {
+    return { ok: false, error: "variables must be an array" };
+  }
+
+  if (variables.length > 50) {
+    return { ok: false, error: "Too many variables. Max allowed is 50." };
+  }
+
+  const normalized: StoredTemplateVariable[] = [];
+  for (const variable of variables) {
+    const result = normalizeTemplateVariableInput(variable);
+    if (!result.ok) return result;
+    normalized.push(result.variable);
+  }
+
+  return { ok: true, variables: normalized };
+}
+
+function normalizeStoredTemplateVariable(
+  value: unknown,
+): NormalizedTemplateVariable | null {
+  if (!isRecord(value)) return null;
+
+  const rawKey = getRawKey(value);
+  if (typeof rawKey !== "string" || rawKey.trim().length === 0) return null;
+
+  const rawFallbackValue = getRawFallbackValue(value);
+  const hasFallbackValue = isFallbackValue(rawFallbackValue);
+
+  return {
+    key: rawKey.trim(),
+    name: rawKey.trim(),
+    type: isTemplateVariableType(value.type) ? value.type : "string",
+    required: typeof value.required === "boolean" ? value.required : false,
+    fallbackValue: hasFallbackValue ? rawFallbackValue : null,
+    hasFallbackValue,
+  };
+}
+
+function normalizeStoredTemplateVariables(
+  value: unknown,
+): NormalizedTemplateVariable[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((variable) => normalizeStoredTemplateVariable(variable))
+    .filter((variable): variable is NormalizedTemplateVariable =>
+      Boolean(variable),
+    );
+}
+
+function templateVariableResponse(
+  variable: NormalizedTemplateVariable,
+  index: number,
+  timestamps: {
+    createdAt: Date | string | null;
+    updatedAt?: Date | string | null;
+  },
+): TemplateVariableResponseItem {
+  return {
+    id: `var-${index}`,
+    key: variable.key,
+    name: variable.name,
+    type: variable.type,
+    required: variable.required,
+    fallback_value: variable.fallbackValue,
+    created_at: timestamps.createdAt,
+    updated_at: timestamps.updatedAt ?? timestamps.createdAt,
+  };
+}
+
+function extractTemplateVariables(content: string): string[] {
+  const regex = /{{{\s*([a-zA-Z0-9_-]+)\s*}}}|{{\s*([a-zA-Z0-9_-]+)\s*}}/g;
+  const variables = new Set<string>();
+  let match: RegExpExecArray | null = regex.exec(content);
+
+  while (match !== null) {
+    const variableName = match[1] ?? match[2];
+    if (variableName) variables.add(variableName);
+    match = regex.exec(content);
+  }
+
+  return Array.from(variables);
+}
+
+function toTruthyStoredString(value: unknown): string | null {
+  return value ? (value as string) : null;
+}
+
+function generateAlias(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "") || "untitled-template"
+  );
+}
+
+function normalizeVariablesOrThrow(value: unknown): StoredTemplateVariable[] {
+  const variableResult = normalizeTemplateVariablesInput(value);
+  if (!variableResult.ok) {
+    throw new TemplateServiceError("invalid_variables", variableResult.error);
+  }
+  return variableResult.variables;
+}
+
+function toTemplateDetail(row: TemplateRow): TemplateDetail {
+  return {
+    id: row.id,
+    name: row.name,
+    alias: row.alias,
+    status: row.status,
+    subject: row.subject,
+    from: row.from,
+    replyTo: row.replyTo,
+    previewText: row.previewText,
+    html: row.html,
+    text: row.text,
+    variables: normalizeStoredTemplateVariables(row.variables).map(
+      (variable, index) =>
+        templateVariableResponse(variable, index, {
+          createdAt: row.createdAt,
+        }),
+    ),
+    createdAt: row.createdAt,
+    updatedAt: row.createdAt,
+  };
+}
+
+function buildAutomaticVariables(
+  existing: TemplateRow,
+  body: Record<string, unknown>,
+): StoredTemplateVariable[] {
+  const fullContent = `${body.subject ?? existing.subject ?? ""} ${body.html ?? existing.html ?? ""} ${body.text ?? existing.text ?? ""}`;
+  const extracted = extractTemplateVariables(fullContent);
+  const currentVars = normalizeStoredTemplateVariables(existing.variables);
+  const varMap = new Map(
+    currentVars.map((variable) => [variable.key, variable]),
+  );
+
+  return extracted.map((name) => ({
+    name,
+    key: name,
+    type: varMap.get(name)?.type ?? "string",
+    required: varMap.get(name)?.required ?? false,
+    fallbackValue: varMap.get(name)?.fallbackValue ?? null,
+  }));
+}
+
+export function createTemplateService({
+  repository = templateRepo,
+  now = () => new Date(),
+}: TemplateServiceDependencies = {}) {
+  return {
+    async listTemplates(options: {
+      search?: string;
+      status?: string;
+    }): Promise<TemplateListResult> {
+      const search = options.search?.trim() || "";
+      const rawStatus = options.status?.trim() || "";
+      const status =
+        rawStatus === "published" || rawStatus === "draft" ? rawStatus : "";
+
+      return await repository.listForApi({ search, status });
+    },
+
+    async createTemplate(input: unknown): Promise<TemplateCreateResult> {
+      const body = asRecord(input);
+      const name = typeof body.name === "string" ? body.name.trim() : "";
+      const html = typeof body.html === "string" ? body.html.trim() : "";
+
+      if (!name || !html) {
+        throw new TemplateServiceError(
+          "invalid_input",
+          "name and html are required",
+        );
+      }
+
+      const alias =
+        typeof body.alias === "string" && body.alias.trim()
+          ? body.alias.trim()
+          : generateAlias(name);
+
+      const [template] = await repository.create({
+        name,
+        alias,
+        html,
+        subject: toTruthyStoredString(body.subject),
+        from: toTruthyStoredString(body.from),
+        replyTo: toTruthyStoredString(body.reply_to),
+        previewText: toTruthyStoredString(body.preview_text),
+        text: toTruthyStoredString(body.text),
+        variables: normalizeVariablesOrThrow(body.variables),
+        status: "draft",
+      });
+
+      return {
+        id: template.id,
+        name: template.name,
+        alias: template.alias,
+      };
+    },
+
+    async getTemplate(id: string): Promise<TemplateDetail> {
+      const template = await repository.findById(id);
+      if (!template) {
+        throw new TemplateServiceError("not_found", "Template not found");
+      }
+
+      return toTemplateDetail(template);
+    },
+
+    async updateTemplate(id: string, input: unknown): Promise<TemplateDetail> {
+      const body = asRecord(input);
+      const updateData: Partial<TemplateInsert> = {};
+
+      if (body.name !== undefined) {
+        updateData.name = body.name as TemplateInsert["name"];
+      }
+      if (body.alias !== undefined) {
+        updateData.alias = body.alias as TemplateInsert["alias"];
+      }
+      if (body.status !== undefined) {
+        updateData.status = body.status as TemplateInsert["status"];
+      }
+      if (body.subject !== undefined) {
+        updateData.subject = body.subject as TemplateInsert["subject"];
+      }
+      if (body.from !== undefined) {
+        updateData.from = body.from as TemplateInsert["from"];
+      }
+      if (body.replyTo !== undefined) {
+        updateData.replyTo = body.replyTo as TemplateInsert["replyTo"];
+      }
+      if (body.previewText !== undefined) {
+        updateData.previewText =
+          body.previewText as TemplateInsert["previewText"];
+      }
+      if (body.html !== undefined) {
+        updateData.html = body.html as TemplateInsert["html"];
+      }
+      if (body.text !== undefined) {
+        updateData.text = body.text as TemplateInsert["text"];
+      }
+
+      if (body.html !== undefined || body.subject !== undefined) {
+        const existing = await repository.findById(id);
+        if (existing) {
+          updateData.variables = buildAutomaticVariables(existing, body);
+        }
+      }
+
+      if (body.variables !== undefined) {
+        updateData.variables = normalizeVariablesOrThrow(body.variables);
+      }
+
+      const [updated] = await repository.update(id, updateData);
+      if (!updated) {
+        throw new TemplateServiceError("not_found", "Template not found");
+      }
+
+      return toTemplateDetail(updated);
+    },
+
+    async deleteTemplate(id: string): Promise<void> {
+      const [deleted] = await repository.delete(id);
+      if (!deleted) {
+        throw new TemplateServiceError("not_found", "Template not found");
+      }
+    },
+
+    async duplicateTemplate(id: string): Promise<TemplateDuplicateResult> {
+      const existing = await repository.findById(id);
+      if (!existing) {
+        throw new TemplateServiceError("not_found", "Template not found");
+      }
+
+      const [duplicated] = await repository.create({
+        name: `${existing.name} (Copy)`,
+        alias: existing.alias ? `${existing.alias}-copy` : null,
+        status: "draft",
+        subject: existing.subject,
+        from: existing.from,
+        replyTo: existing.replyTo,
+        previewText: existing.previewText,
+        html: existing.html,
+        text: existing.text,
+        variables: existing.variables,
+      });
+
+      return {
+        id: duplicated.id,
+        name: duplicated.name,
+        status: duplicated.status,
+      };
+    },
+
+    async publishTemplate(id: string): Promise<TemplatePublishResult> {
+      const existing = await repository.findById(id);
+      if (!existing) {
+        throw new TemplateServiceError("not_found", "Template not found");
+      }
+
+      if (existing.status !== "draft") {
+        throw new TemplateServiceError(
+          "not_draft",
+          "Only draft templates can be published",
+        );
+      }
+
+      const [updated] = await repository.update(id, {
+        status: "published",
+        publishedAt: now(),
+        hasUnpublishedVersions: false,
+      });
+      if (!updated) {
+        throw new TemplateServiceError("not_found", "Template not found");
+      }
+
+      return {
+        id: updated.id,
+        status: updated.status,
+        publishedAt: updated.publishedAt,
+        hasUnpublishedVersions: updated.hasUnpublishedVersions,
+      };
+    },
+  };
+}
+
+export const templateService = createTemplateService();

--- a/src/app/api/templates/[id]/duplicate/route.ts
+++ b/src/app/api/templates/[id]/duplicate/route.ts
@@ -1,51 +1,34 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { templates } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { TemplateServiceError, createTemplateService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 
+function mapTemplateError(error: unknown, fallback: string) {
+  if (error instanceof TemplateServiceError) {
+    const status = error.code === "not_found" ? 404 : 422;
+    return NextResponse.json({ error: error.message }, { status });
+  }
+
+  console.error(`${fallback}:`, error);
+  return NextResponse.json({ error: fallback }, { status: 500 });
+}
+
+function templateService() {
+  return createTemplateService();
+}
+
 export async function POST(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await validateApiKey(_request.headers.get("authorization"));
+  const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
   const permissionError = requireFullAccessApiKey(auth);
   if (permissionError) return permissionError;
 
   try {
     const { id } = await params;
-
-    const [existing] = await db
-      .select()
-      .from(templates)
-      .where(eq(templates.id, id))
-      .limit(1);
-
-    if (!existing) {
-      return NextResponse.json(
-        { error: "Template not found" },
-        { status: 404 },
-      );
-    }
-
-    // Duplicate all fields except ID and reset status to draft
-    const [duplicated] = await db
-      .insert(templates)
-      .values({
-        name: `${existing.name} (Copy)`,
-        alias: existing.alias ? `${existing.alias}-copy` : null,
-        status: "draft",
-        subject: existing.subject,
-        from: existing.from,
-        replyTo: existing.replyTo,
-        previewText: existing.previewText,
-        html: existing.html,
-        text: existing.text,
-        variables: existing.variables,
-      })
-      .returning();
+    const duplicated = await templateService().duplicateTemplate(id);
 
     return NextResponse.json({
       object: "template",
@@ -54,10 +37,6 @@ export async function POST(
       status: duplicated.status,
     });
   } catch (error) {
-    console.error("Failed to duplicate template:", error);
-    return NextResponse.json(
-      { error: "Failed to duplicate template" },
-      { status: 500 },
-    );
+    return mapTemplateError(error, "Failed to duplicate template");
   }
 }

--- a/src/app/api/templates/[id]/publish/route.ts
+++ b/src/app/api/templates/[id]/publish/route.ts
@@ -1,64 +1,44 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { templates } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { TemplateServiceError, createTemplateService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 
+function mapTemplateError(error: unknown, fallback: string) {
+  if (error instanceof TemplateServiceError) {
+    const status =
+      error.code === "not_found" ? 404 : error.code === "not_draft" ? 400 : 422;
+    return NextResponse.json({ error: error.message }, { status });
+  }
+
+  console.error(`${fallback}:`, error);
+  return NextResponse.json({ error: fallback }, { status: 500 });
+}
+
+function templateService() {
+  return createTemplateService();
+}
+
 export async function POST(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await validateApiKey(_request.headers.get("authorization"));
+  const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
   const permissionError = requireFullAccessApiKey(auth);
   if (permissionError) return permissionError;
 
   try {
     const { id } = await params;
-
-    const [existing] = await db
-      .select({ status: templates.status })
-      .from(templates)
-      .where(eq(templates.id, id))
-      .limit(1);
-
-    if (!existing) {
-      return NextResponse.json(
-        { error: "Template not found" },
-        { status: 404 },
-      );
-    }
-
-    if (existing.status !== "draft") {
-      return NextResponse.json(
-        { error: "Only draft templates can be published" },
-        { status: 400 },
-      );
-    }
-
-    const [updated] = await db
-      .update(templates)
-      .set({
-        status: "published",
-        publishedAt: new Date(),
-        hasUnpublishedVersions: false,
-      })
-      .where(eq(templates.id, id))
-      .returning();
+    const published = await templateService().publishTemplate(id);
 
     return NextResponse.json({
       object: "template",
-      id: updated.id,
-      status: updated.status,
-      published_at: updated.publishedAt,
-      has_unpublished_versions: updated.hasUnpublishedVersions,
+      id: published.id,
+      status: published.status,
+      published_at: published.publishedAt,
+      has_unpublished_versions: published.hasUnpublishedVersions,
     });
   } catch (error) {
-    console.error("Failed to publish template:", error);
-    return NextResponse.json(
-      { error: "Failed to publish template" },
-      { status: 500 },
-    );
+    return mapTemplateError(error, "Failed to publish template");
   }
 }

--- a/src/app/api/templates/[id]/route.ts
+++ b/src/app/api/templates/[id]/route.ts
@@ -1,67 +1,60 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { templates } from "@/lib/db/schema";
-import { extractTemplateVariables } from "@/lib/templates/parser";
 import {
-  normalizeStoredTemplateVariables,
-  normalizeTemplateVariablesInput,
-  templateVariableResponse,
-} from "@/lib/templates/variables";
-import { eq } from "drizzle-orm";
+  type TemplateDetail,
+  TemplateServiceError,
+  createTemplateService,
+} from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 
+function mapTemplateError(error: unknown, fallback: string) {
+  if (error instanceof TemplateServiceError) {
+    const status = error.code === "not_found" ? 404 : 422;
+    return NextResponse.json({ error: error.message }, { status });
+  }
+
+  console.error(`${fallback}:`, error);
+  return NextResponse.json({ error: fallback }, { status: 500 });
+}
+
+function templateService() {
+  return createTemplateService();
+}
+
+function templateResponse(template: TemplateDetail) {
+  return {
+    object: "template",
+    id: template.id,
+    name: template.name,
+    alias: template.alias,
+    status: template.status,
+    subject: template.subject,
+    from: template.from,
+    reply_to: template.replyTo,
+    preview_text: template.previewText,
+    html: template.html,
+    text: template.text,
+    variables: template.variables,
+    created_at: template.createdAt,
+    updated_at: template.updatedAt,
+  };
+}
+
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await validateApiKey(_request.headers.get("authorization"));
+  const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
   const permissionError = requireFullAccessApiKey(auth);
   if (permissionError) return permissionError;
 
   try {
     const { id } = await params;
-    const [template] = await db
-      .select()
-      .from(templates)
-      .where(eq(templates.id, id))
-      .limit(1);
-
-    if (!template) {
-      return NextResponse.json(
-        { error: "Template not found" },
-        { status: 404 },
-      );
-    }
-
-    return NextResponse.json({
-      object: "template",
-      id: template.id,
-      name: template.name,
-      alias: template.alias,
-      status: template.status,
-      subject: template.subject,
-      from: template.from,
-      reply_to: template.replyTo,
-      preview_text: template.previewText,
-      html: template.html,
-      text: template.text,
-      variables: normalizeStoredTemplateVariables(template.variables).map(
-        (variable, index) =>
-          templateVariableResponse(variable, index, {
-            createdAt: template.createdAt,
-          }),
-      ),
-      created_at: template.createdAt,
-      updated_at: template.createdAt,
-    });
+    const template = await templateService().getTemplate(id);
+    return NextResponse.json(templateResponse(template));
   } catch (error) {
-    console.error("Failed to fetch template:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch template" },
-      { status: 500 },
-    );
+    return mapTemplateError(error, "Failed to fetch template");
   }
 }
 
@@ -76,132 +69,31 @@ export async function PATCH(
 
   try {
     const { id } = await params;
-    const body = await request.json();
-
-    const updateData: Record<string, unknown> = {};
-    if (body.name !== undefined) updateData.name = body.name;
-    if (body.alias !== undefined) updateData.alias = body.alias;
-    if (body.status !== undefined) updateData.status = body.status;
-    if (body.subject !== undefined) updateData.subject = body.subject;
-    if (body.from !== undefined) updateData.from = body.from;
-    if (body.replyTo !== undefined) updateData.replyTo = body.replyTo;
-    if (body.previewText !== undefined)
-      updateData.previewText = body.previewText;
-    if (body.html !== undefined) updateData.html = body.html;
-    if (body.text !== undefined) updateData.text = body.text;
-
-    // Automatic variable extraction if html or subject is updated
-    if (body.html !== undefined || body.subject !== undefined) {
-      const existing = await db.query.templates.findFirst({
-        where: eq(templates.id, id),
-      });
-
-      if (existing) {
-        const fullContent = `${body.subject ?? existing.subject ?? ""} ${body.html ?? existing.html ?? ""} ${body.text ?? existing.text ?? ""}`;
-        const extracted = extractTemplateVariables(fullContent);
-
-        // Merge with existing manual variable requirements if they exist
-        const currentVars = normalizeStoredTemplateVariables(
-          existing.variables,
-        );
-        const varMap = new Map(
-          currentVars.map((variable) => [variable.key, variable]),
-        );
-
-        updateData.variables = extracted.map((name) => ({
-          name,
-          key: name,
-          type: varMap.get(name)?.type ?? "string",
-          required: varMap.get(name)?.required ?? false,
-          fallbackValue: varMap.get(name)?.fallbackValue ?? null,
-        }));
-      }
-    }
-
-    // Manual variable override
-    if (body.variables !== undefined) {
-      const variableResult = normalizeTemplateVariablesInput(body.variables);
-      if (!variableResult.ok) {
-        return NextResponse.json(
-          { error: variableResult.error },
-          { status: 422 },
-        );
-      }
-      updateData.variables = variableResult.variables;
-    }
-
-    const [updated] = await db
-      .update(templates)
-      .set(updateData)
-      .where(eq(templates.id, id))
-      .returning();
-
-    if (!updated) {
-      return NextResponse.json(
-        { error: "Template not found" },
-        { status: 404 },
-      );
-    }
-
-    return NextResponse.json({
-      object: "template",
-      id: updated.id,
-      name: updated.name,
-      alias: updated.alias,
-      status: updated.status,
-      subject: updated.subject,
-      from: updated.from,
-      reply_to: updated.replyTo,
-      preview_text: updated.previewText,
-      html: updated.html,
-      text: updated.text,
-      variables: normalizeStoredTemplateVariables(updated.variables).map(
-        (variable, index) =>
-          templateVariableResponse(variable, index, {
-            createdAt: updated.createdAt,
-          }),
-      ),
-      created_at: updated.createdAt,
-      updated_at: updated.createdAt,
-    });
-  } catch (error) {
-    console.error("Failed to update template:", error);
-    return NextResponse.json(
-      { error: "Failed to update template" },
-      { status: 500 },
+    const updated = await templateService().updateTemplate(
+      id,
+      await request.json(),
     );
+
+    return NextResponse.json(templateResponse(updated));
+  } catch (error) {
+    return mapTemplateError(error, "Failed to update template");
   }
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await validateApiKey(_request.headers.get("authorization"));
+  const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
   const permissionError = requireFullAccessApiKey(auth);
   if (permissionError) return permissionError;
 
   try {
     const { id } = await params;
-    const [deleted] = await db
-      .delete(templates)
-      .where(eq(templates.id, id))
-      .returning();
-
-    if (!deleted) {
-      return NextResponse.json(
-        { error: "Template not found" },
-        { status: 404 },
-      );
-    }
-
+    await templateService().deleteTemplate(id);
     return NextResponse.json({ success: true });
   } catch (error) {
-    console.error("Failed to delete template:", error);
-    return NextResponse.json(
-      { error: "Failed to delete template" },
-      { status: 500 },
-    );
+    return mapTemplateError(error, "Failed to delete template");
   }
 }

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -1,18 +1,20 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { templates } from "@/lib/db/schema";
-import { normalizeTemplateVariablesInput } from "@/lib/templates/variables";
-import { type SQL, and, count, desc, eq, ilike } from "drizzle-orm";
+import { TemplateServiceError, createTemplateService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 
-function generateAlias(name: string): string {
-  return (
-    name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-|-$/g, "") || "untitled-template"
-  );
+function mapTemplateError(error: unknown, fallback: string) {
+  if (error instanceof TemplateServiceError) {
+    const status = error.code === "not_found" ? 404 : 422;
+    return NextResponse.json({ error: error.message }, { status });
+  }
+
+  console.error(`${fallback}:`, error);
+  return NextResponse.json({ error: fallback }, { status: 500 });
+}
+
+function templateService() {
+  return createTemplateService();
 }
 
 export async function GET(request: NextRequest) {
@@ -22,46 +24,14 @@ export async function GET(request: NextRequest) {
   if (permissionError) return permissionError;
 
   try {
-    const url = request.nextUrl;
-    const search = url.searchParams.get("search")?.trim() || "";
-    const status = url.searchParams.get("status")?.trim() || "";
-
-    const conditions: SQL[] = [];
-    if (search) {
-      conditions.push(ilike(templates.name, `%${search}%`));
-    }
-    if (status === "published") {
-      conditions.push(eq(templates.status, "published"));
-    } else if (status === "draft") {
-      conditions.push(eq(templates.status, "draft"));
-    }
-
-    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
-
-    const [totalRow] = await db
-      .select({ count: count() })
-      .from(templates)
-      .where(whereClause);
-
-    const rows = await db
-      .select({
-        id: templates.id,
-        name: templates.name,
-        alias: templates.alias,
-        status: templates.status,
-        currentVersionId: templates.currentVersionId,
-        publishedAt: templates.publishedAt,
-        hasUnpublishedVersions: templates.hasUnpublishedVersions,
-        createdAt: templates.createdAt,
-      })
-      .from(templates)
-      .where(whereClause)
-      .orderBy(desc(templates.createdAt))
-      .limit(200);
+    const result = await templateService().listTemplates({
+      search: request.nextUrl.searchParams.get("search") ?? undefined,
+      status: request.nextUrl.searchParams.get("status") ?? undefined,
+    });
 
     return NextResponse.json({
       object: "list",
-      data: rows.map((r) => ({
+      data: result.data.map((r) => ({
         id: r.id,
         name: r.name,
         alias: r.alias,
@@ -71,14 +41,10 @@ export async function GET(request: NextRequest) {
         has_unpublished_versions: r.hasUnpublishedVersions,
         created_at: r.createdAt,
       })),
-      total: totalRow?.count ?? 0,
+      total: result.total,
     });
   } catch (error) {
-    console.error("Failed to fetch templates:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch templates" },
-      { status: 500 },
-    );
+    return mapTemplateError(error, "Failed to fetch templates");
   }
 }
 
@@ -89,57 +55,20 @@ export async function POST(request: NextRequest) {
   if (permissionError) return permissionError;
 
   try {
-    const body = await request.json();
-    const name = body.name?.trim();
-    const html = body.html?.trim();
-
-    if (!name || !html) {
-      return NextResponse.json(
-        { error: "name and html are required" },
-        { status: 422 },
-      );
-    }
-
-    const alias = body.alias?.trim() || generateAlias(name);
-
-    const variableResult = normalizeTemplateVariablesInput(body.variables);
-    if (!variableResult.ok) {
-      return NextResponse.json(
-        { error: variableResult.error },
-        { status: 422 },
-      );
-    }
-
-    const [template] = await db
-      .insert(templates)
-      .values({
-        name,
-        alias,
-        html,
-        subject: body.subject || null,
-        from: body.from || null,
-        replyTo: body.reply_to || null,
-        previewText: body.preview_text || null,
-        text: body.text || null,
-        variables: variableResult.variables,
-        status: "draft",
-      })
-      .returning();
+    const created = await templateService().createTemplate(
+      await request.json(),
+    );
 
     return NextResponse.json(
       {
         object: "template",
-        id: template.id,
-        name: template.name,
-        alias: template.alias,
+        id: created.id,
+        name: created.name,
+        alias: created.alias,
       },
       { status: 201 },
     );
   } catch (error) {
-    console.error("Failed to create template:", error);
-    return NextResponse.json(
-      { error: "Failed to create template" },
-      { status: 500 },
-    );
+    return mapTemplateError(error, "Failed to create template");
   }
 }

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -193,9 +193,105 @@ describe("route smoke coverage", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    vi.doMock("@opensend/core", () => ({
-      createWebhookService: mockCreateWebhookService,
-    }));
+    vi.doMock("@opensend/core", () => {
+      class TemplateServiceError extends Error {
+        constructor(
+          readonly code: string,
+          message: string,
+        ) {
+          super(message);
+          this.name = "TemplateServiceError";
+        }
+      }
+
+      return {
+        createWebhookService: mockCreateWebhookService,
+        TemplateServiceError,
+        createTemplateService: () => ({
+          async getTemplate(id: string) {
+            const [template] = await mockSelect().from().where({ id }).limit(1);
+            if (!template) {
+              throw new TemplateServiceError("not_found", "Template not found");
+            }
+            return {
+              ...template,
+              replyTo: template.replyTo,
+              previewText: template.previewText,
+              variables: [],
+              updatedAt: template.createdAt,
+            };
+          },
+          async updateTemplate(id: string, data: Record<string, unknown>) {
+            const [template] = await mockUpdate()
+              .set(data)
+              .where({ id })
+              .returning();
+            if (!template) {
+              throw new TemplateServiceError("not_found", "Template not found");
+            }
+            return {
+              ...template,
+              replyTo: template.replyTo,
+              previewText: template.previewText,
+              variables: [],
+              updatedAt: template.createdAt,
+            };
+          },
+          async deleteTemplate(id: string) {
+            const [template] = await mockDelete().where({ id }).returning();
+            if (!template) {
+              throw new TemplateServiceError("not_found", "Template not found");
+            }
+          },
+          async publishTemplate(id: string) {
+            const [existing] = await mockSelect().from().where({ id }).limit(1);
+            if (!existing) {
+              throw new TemplateServiceError("not_found", "Template not found");
+            }
+            if (existing.status !== "draft") {
+              throw new TemplateServiceError(
+                "not_draft",
+                "Only draft templates can be published",
+              );
+            }
+            const [template] = await mockUpdate()
+              .set({
+                status: "published",
+                publishedAt: expect.any(Date),
+                hasUnpublishedVersions: false,
+              })
+              .where({ id })
+              .returning();
+            return {
+              ...template,
+              publishedAt: template.publishedAt,
+              hasUnpublishedVersions: template.hasUnpublishedVersions,
+            };
+          },
+          async duplicateTemplate(id: string) {
+            const [existing] = await mockSelect().from().where({ id }).limit(1);
+            if (!existing) {
+              throw new TemplateServiceError("not_found", "Template not found");
+            }
+            const [template] = await mockInsert()
+              .values({
+                name: `${existing.name} (Copy)`,
+                alias: existing.alias ? `${existing.alias}-copy` : null,
+                status: "draft",
+                subject: existing.subject,
+                from: existing.from,
+                replyTo: existing.replyTo,
+                previewText: existing.previewText,
+                html: existing.html,
+                text: existing.text,
+                variables: existing.variables,
+              })
+              .returning();
+            return template;
+          },
+        }),
+      };
+    });
     mockCreateWebhookService.mockReturnValue({
       listWebhooks: vi.fn().mockResolvedValue({ data: [], hasMore: false }),
       createWebhook: vi.fn(),

--- a/tests/api-template-variables.test.ts
+++ b/tests/api-template-variables.test.ts
@@ -1,221 +1,167 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type TemplateRepository,
+  type TemplateServiceError,
+  createTemplateService,
+} from "../packages/core/src/services/template";
 
-const mockValidateApiKey = vi.hoisted(() => vi.fn());
-const mockSelect = vi.hoisted(() => vi.fn());
-const mockInsert = vi.hoisted(() => vi.fn());
-const mockUpdate = vi.hoisted(() => vi.fn());
-const mockFindFirst = vi.hoisted(() => vi.fn());
+type TemplateRow = NonNullable<
+  Awaited<ReturnType<TemplateRepository["findById"]>>
+>;
+type TemplateInsert = Parameters<TemplateRepository["create"]>[0];
 
-function makeChain<T>(rows: T[]) {
+const CREATED_AT = new Date("2026-05-09T00:00:00.000Z");
+
+function templateRow(overrides: Partial<TemplateRow> = {}): TemplateRow {
   return {
-    from: vi.fn().mockReturnThis(),
-    where: vi.fn().mockReturnThis(),
-    limit: vi.fn().mockReturnThis(),
-    set: vi.fn().mockReturnThis(),
-    values: vi.fn().mockReturnThis(),
-    returning: vi.fn().mockResolvedValue(rows),
-    // biome-ignore lint/suspicious/noThenProperty: mocks Drizzle's thenable query builder
-    then: (resolve: (value: T[]) => unknown) => Promise.resolve(resolve(rows)),
+    id: "tmpl-1",
+    name: "Receipt",
+    alias: "receipt",
+    status: "draft",
+    subject: "Order {{{PRODUCT}}}",
+    from: null,
+    replyTo: null,
+    previewText: null,
+    html: "<p>{{{PRODUCT}}}</p>",
+    text: "Product: {{{PRODUCT}}}",
+    variables: [],
+    currentVersionId: null,
+    publishedAt: null,
+    hasUnpublishedVersions: true,
+    createdAt: CREATED_AT,
+    document: null,
+    userId: null,
+    ...overrides,
   };
 }
 
-vi.mock("@/lib/db", () => ({
-  db: {
-    query: {
-      templates: { findFirst: mockFindFirst },
+function createRepository(
+  overrides: Partial<TemplateRepository> = {},
+): TemplateRepository {
+  return {
+    async findById() {
+      return templateRow();
     },
-    select: mockSelect,
-    insert: mockInsert,
-    update: mockUpdate,
-  },
-}));
-
-vi.mock("@/lib/api-auth", async () => {
-  const actual =
-    await vi.importActual<typeof import("@/lib/api-auth")>("@/lib/api-auth");
-  return {
-    ...actual,
-    validateApiKey: mockValidateApiKey,
+    async create(data) {
+      return [templateRow({ ...data, id: "tmpl-1" })];
+    },
+    async update(id, data) {
+      return [templateRow({ id, ...data })];
+    },
+    async delete(id) {
+      return [templateRow({ id })];
+    },
+    async listForApi() {
+      return { data: [], total: 0 };
+    },
+    ...overrides,
   };
-});
-
-vi.mock("drizzle-orm", async () => {
-  const actual = await vi.importActual("drizzle-orm");
-  return {
-    ...actual,
-    eq: vi.fn((...args: unknown[]) => ({ op: "eq", args })),
-  };
-});
-
-function makeRequest(url: string, init?: RequestInit) {
-  const request = new Request(url, init) as Request & { nextUrl: URL };
-  request.nextUrl = new URL(url);
-  return request;
 }
 
-describe("template variable metadata APIs", () => {
-  beforeEach(() => {
-    vi.resetModules();
-    vi.clearAllMocks();
-    mockValidateApiKey.mockResolvedValue({
-      apiKeyId: "key-1",
-      permission: "full_access",
-      domain: null,
-      userId: "user-1",
-    });
-  });
-
+describe("template variable metadata service", () => {
   it("accepts Resend-style variables on create and stores type/fallback metadata", async () => {
-    const createdAt = new Date("2026-05-09T00:00:00.000Z");
-    const values = vi.fn().mockReturnValue({
-      returning: vi.fn().mockResolvedValue([
-        {
-          id: "tmpl-1",
-          name: "Receipt",
-          alias: "receipt",
-          createdAt,
-        },
-      ]),
+    const inserted: TemplateInsert[] = [];
+    const repository = createRepository({
+      async create(data) {
+        inserted.push(data);
+        return [templateRow({ ...data })];
+      },
     });
-    mockInsert.mockReturnValue({ values });
 
-    const { POST } = await import("@/app/api/templates/route");
-    const response = await POST(
-      makeRequest("http://localhost/api/templates", {
-        method: "POST",
-        headers: {
-          authorization: "Bearer token",
-          "content-type": "application/json",
+    const service = createTemplateService({ repository });
+    const created = await service.createTemplate({
+      name: "Receipt",
+      subject: "Order {{{PRODUCT}}}",
+      html: "<p>{{{PRODUCT}}} costs {{{PRICE}}}</p>",
+      variables: [
+        { key: "PRODUCT", type: "string", fallbackValue: "item" },
+        { key: "PRICE", type: "number", fallback_value: 25 },
+        { name: "legacy_name", required: true },
+      ],
+    });
+
+    expect(created).toMatchObject({ id: "tmpl-1", name: "Receipt" });
+    expect(inserted[0]).toMatchObject({
+      variables: [
+        {
+          name: "PRODUCT",
+          key: "PRODUCT",
+          type: "string",
+          required: false,
+          fallbackValue: "item",
         },
-        body: JSON.stringify({
-          name: "Receipt",
-          subject: "Order {{{PRODUCT}}}",
-          html: "<p>{{{PRODUCT}}} costs {{{PRICE}}}</p>",
-          variables: [
-            { key: "PRODUCT", type: "string", fallbackValue: "item" },
-            { key: "PRICE", type: "number", fallback_value: 25 },
-            { name: "legacy_name", required: true },
-          ],
-        }),
-      }) as never,
-    );
-
-    expect(response.status).toBe(201);
-    expect(values).toHaveBeenCalledWith(
-      expect.objectContaining({
-        variables: [
-          {
-            name: "PRODUCT",
-            key: "PRODUCT",
-            type: "string",
-            required: false,
-            fallbackValue: "item",
-          },
-          {
-            name: "PRICE",
-            key: "PRICE",
-            type: "number",
-            required: false,
-            fallbackValue: 25,
-          },
-          {
-            name: "legacy_name",
-            key: "legacy_name",
-            type: "string",
-            required: true,
-            fallbackValue: null,
-          },
-        ],
-      }),
-    );
+        {
+          name: "PRICE",
+          key: "PRICE",
+          type: "number",
+          required: false,
+          fallbackValue: 25,
+        },
+        {
+          name: "legacy_name",
+          key: "legacy_name",
+          type: "string",
+          required: true,
+          fallbackValue: null,
+        },
+      ],
+    });
   });
 
   it("preserves reserved-name and 50-variable validation on create", async () => {
-    const { POST } = await import("@/app/api/templates/route");
-
-    const reserved = await POST(
-      makeRequest("http://localhost/api/templates", {
-        method: "POST",
-        headers: {
-          authorization: "Bearer token",
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          name: "Bad",
-          html: "<p>Bad</p>",
-          variables: [{ key: "EMAIL", type: "string" }],
-        }),
-      }) as never,
-    );
-    expect(reserved.status).toBe(422);
-    await expect(reserved.json()).resolves.toEqual({
-      error: "Variable name EMAIL is reserved.",
+    const create = vi.fn(async () => [templateRow()]);
+    const service = createTemplateService({
+      repository: createRepository({ create }),
     });
 
-    const tooMany = await POST(
-      makeRequest("http://localhost/api/templates", {
-        method: "POST",
-        headers: {
-          authorization: "Bearer token",
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          name: "Too many",
-          html: "<p>Bad</p>",
-          variables: Array.from({ length: 51 }, (_, index) => ({
-            key: `VAR_${index}`,
-            type: "string",
-          })),
-        }),
-      }) as never,
-    );
-    expect(tooMany.status).toBe(422);
-    await expect(tooMany.json()).resolves.toEqual({
-      error: "Too many variables. Max allowed is 50.",
-    });
-    expect(mockInsert).not.toHaveBeenCalled();
+    await expect(
+      service.createTemplate({
+        name: "Bad",
+        html: "<p>Bad</p>",
+        variables: [{ key: "EMAIL", type: "string" }],
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_variables",
+      message: "Variable name EMAIL is reserved.",
+    } satisfies Partial<TemplateServiceError>);
+
+    await expect(
+      service.createTemplate({
+        name: "Too many",
+        html: "<p>Bad</p>",
+        variables: Array.from({ length: 51 }, (_, index) => ({
+          key: `VAR_${index}`,
+          type: "string",
+        })),
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_variables",
+      message: "Too many variables. Max allowed is 50.",
+    } satisfies Partial<TemplateServiceError>);
+    expect(create).not.toHaveBeenCalled();
   });
 
   it("returns configured fallback_value and legacy variable metadata on detail", async () => {
-    const createdAt = new Date("2026-05-09T00:00:00.000Z");
-    mockSelect.mockReturnValue(
-      makeChain([
-        {
-          id: "tmpl-1",
-          name: "Receipt",
-          alias: "receipt",
-          status: "draft",
-          subject: "Order {{{PRODUCT}}}",
-          from: null,
-          replyTo: null,
-          previewText: null,
-          html: "<p>{{{PRODUCT}}}</p>",
-          text: "Product: {{{PRODUCT}}}",
-          variables: [
-            {
-              name: "PRODUCT",
-              key: "PRODUCT",
-              type: "string",
-              required: false,
-              fallbackValue: "item",
-            },
-            { name: "legacy_name", required: true },
-          ],
-          createdAt,
+    const service = createTemplateService({
+      repository: createRepository({
+        async findById() {
+          return templateRow({
+            variables: [
+              {
+                name: "PRODUCT",
+                key: "PRODUCT",
+                type: "string",
+                required: false,
+                fallbackValue: "item",
+              },
+              { name: "legacy_name", required: true },
+            ],
+          });
         },
-      ]),
-    );
+      }),
+    });
 
-    const { GET } = await import("@/app/api/templates/[id]/route");
-    const response = await GET(
-      makeRequest("http://localhost/api/templates/tmpl-1", {
-        headers: { authorization: "Bearer token" },
-      }) as never,
-      { params: Promise.resolve({ id: "tmpl-1" }) },
-    );
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({
+    await expect(service.getTemplate("tmpl-1")).resolves.toMatchObject({
       variables: [
         {
           key: "PRODUCT",
@@ -236,75 +182,87 @@ describe("template variable metadata APIs", () => {
   });
 
   it("accepts fallback_value on update and returns normalized metadata", async () => {
-    const updatedAt = new Date("2026-05-09T00:00:00.000Z");
-    const set = vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        returning: vi.fn().mockResolvedValue([
-          {
-            id: "tmpl-1",
-            name: "Receipt",
-            alias: "receipt",
-            status: "draft",
-            subject: "Order {{{PRODUCT}}}",
-            from: null,
-            replyTo: null,
-            previewText: null,
-            html: "<p>{{{PRODUCT}}}</p>",
-            text: null,
-            variables: [
-              {
-                name: "PRODUCT",
-                key: "PRODUCT",
-                type: "string",
-                required: false,
-                fallbackValue: "item",
-              },
-            ],
-            createdAt: updatedAt,
-          },
-        ]),
-      }),
+    const updates: Array<{ id: string; data: Partial<TemplateInsert> }> = [];
+    const repository = createRepository({
+      async update(id, data) {
+        updates.push({ id, data });
+        return [templateRow({ id, ...data })];
+      },
     });
-    mockUpdate.mockReturnValue({ set });
 
-    const { PATCH } = await import("@/app/api/templates/[id]/route");
-    const response = await PATCH(
-      makeRequest("http://localhost/api/templates/tmpl-1", {
-        method: "PATCH",
-        headers: {
-          authorization: "Bearer token",
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
+    const service = createTemplateService({ repository });
+    const response = await service.updateTemplate("tmpl-1", {
+      variables: [{ key: "PRODUCT", type: "string", fallback_value: "item" }],
+    });
+
+    expect(updates).toEqual([
+      {
+        id: "tmpl-1",
+        data: {
           variables: [
-            { key: "PRODUCT", type: "string", fallback_value: "item" },
+            {
+              name: "PRODUCT",
+              key: "PRODUCT",
+              type: "string",
+              required: false,
+              fallbackValue: "item",
+            },
           ],
-        }),
-      }) as never,
-      { params: Promise.resolve({ id: "tmpl-1" }) },
-    );
+        },
+      },
+    ]);
+    expect(response.variables).toMatchObject([
+      {
+        key: "PRODUCT",
+        type: "string",
+        required: false,
+        fallback_value: "item",
+      },
+    ]);
+  });
 
-    expect(response.status).toBe(200);
-    expect(set).toHaveBeenCalledWith({
-      variables: [
-        {
-          name: "PRODUCT",
-          key: "PRODUCT",
-          type: "string",
-          required: false,
-          fallbackValue: "item",
-        },
-      ],
+  it("preserves existing variable metadata during automatic extraction", async () => {
+    const updates: Array<{ id: string; data: Partial<TemplateInsert> }> = [];
+    const repository = createRepository({
+      async findById() {
+        return templateRow({
+          html: "<p>{{{PRODUCT}}}</p>",
+          variables: [
+            {
+              name: "PRODUCT",
+              key: "PRODUCT",
+              type: "string",
+              required: true,
+              fallbackValue: "item",
+            },
+          ],
+        });
+      },
+      async update(id, data) {
+        updates.push({ id, data });
+        return [templateRow({ id, ...data })];
+      },
     });
-    await expect(response.json()).resolves.toMatchObject({
-      variables: [
-        {
-          key: "PRODUCT",
-          type: "string",
-          required: false,
-          fallback_value: "item",
-        },
-      ],
+
+    await createTemplateService({ repository }).updateTemplate("tmpl-1", {
+      html: "<p>{{{PRODUCT}}} {{{PRICE}}}</p>",
     });
+
+    expect(updates[0]?.data.variables).toEqual([
+      {
+        name: "PRODUCT",
+        key: "PRODUCT",
+        type: "string",
+        required: true,
+        fallbackValue: "item",
+      },
+      {
+        name: "PRICE",
+        key: "PRICE",
+        type: "string",
+        required: false,
+        fallbackValue: null,
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- Extracted template create/list/detail/update/delete/publish/duplicate business rules into `packages/core/src/services/template.ts`.
- Moved template list querying into `templateRepo.listForApi` and aligned the core template schema with current route response fields.
- Slimmed Next template routes to auth/permission checks, params/body parsing, service calls, and HTTP response/status mapping.
- Preserved variable normalization/validation behavior with focused service coverage and route smoke coverage.

Closes #311

## Service-boundary notes
- Route-local responsibilities are intentionally limited to API-key auth, JSON/URL/params parsing, and HTTP response mapping.
- No Hono migration was started; the extracted service seam is the reusable boundary for a future adapter.
- Variable normalization is implemented in core service code rather than importing app-local `src/lib/templates/*`, because `packages/core` should not depend on app aliases.

## Validation
- [x] `make check`
- [x] `make test`
- [x] `bunx vitest run tests/api-template-variables.test.ts tests/templates-list.test.tsx tests/api-auth-date-range-routes.test.ts`
- [ ] Playwright E2E not run; this slice changes API/service boundaries and full Vitest plus route coverage passed, with no dashboard/editor UI changes.

## Residual risk
- The template variable helper logic now exists in core service code while send-time interpolation still uses the app-local helpers; tests lock current API behavior, but future cleanup could consolidate those helpers behind a core export.

