### PR TITLE
architecture: extract contacts API service boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-10-issue-313-contacts-boundary.md
+++ b/agent_docs/learnings/active/2026-05-10-issue-313-contacts-boundary.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-10
+issue: "#313"
+type: pattern
+promoted_to: null
+---
+
+## Contacts boundary owns legacy segment sync until storage is migrated
+
+**What:** The contacts service boundary now keeps contact CRUD and contact↔segment association rules in `packages/core`, including the transitional dual-write between `contacts_to_segments` and the legacy `contacts.segments` JSON name array.
+
+**Why:** Existing API responses and dashboard filters still read segment names from `contacts.segments`, while newer association routes also maintain `contacts_to_segments`. Moving only the route adapter without preserving that legacy sync would silently break list filtering and contact segment reads.
+
+**Fix:** For future contacts/segments boundary slices, treat join-table writes and legacy JSON segment-name updates as one service-owned business rule until the public read paths are migrated off `contacts.segments`. Also keep `packages/core/src/db/schema.ts` synchronized with app schema additions needed by core repositories.

--- a/packages/core/src/db/repositories/contactRepo.ts
+++ b/packages/core/src/db/repositories/contactRepo.ts
@@ -1,6 +1,20 @@
-import { type SQL, and, desc, eq, gt, lt, or } from "drizzle-orm";
+import {
+  type SQL,
+  and,
+  desc,
+  eq,
+  ilike,
+  inArray,
+  lt,
+  or,
+  sql,
+} from "drizzle-orm";
 import { db } from "../client";
-import { contacts } from "../schema";
+import { contacts, contactsToSegments, segments, topics } from "../schema";
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
 
 export const contactRepo = {
   async findById(id: string) {
@@ -21,6 +35,17 @@ export const contactRepo = {
     });
   },
 
+  async findByIdOrEmailForUser(idOrEmail: string, userId: string) {
+    return await db.query.contacts.findFirst({
+      where: and(
+        isUuid(idOrEmail)
+          ? or(eq(contacts.id, idOrEmail), eq(contacts.email, idOrEmail))
+          : eq(contacts.email, idOrEmail),
+        eq(contacts.userId, userId),
+      ),
+    });
+  },
+
   async create(data: typeof contacts.$inferInsert) {
     return await db.insert(contacts).values(data).returning();
   },
@@ -33,11 +58,30 @@ export const contactRepo = {
       .returning();
   },
 
+  async updateForUser(
+    id: string,
+    userId: string,
+    data: Record<string, unknown>,
+  ) {
+    return await db
+      .update(contacts)
+      .set(data as Partial<typeof contacts.$inferInsert>)
+      .where(and(eq(contacts.id, id), eq(contacts.userId, userId)))
+      .returning();
+  },
+
   async delete(id: string) {
     return await db
       .delete(contacts)
       .where(eq(contacts.id, id))
       .returning({ id: contacts.id });
+  },
+
+  async deleteForUser(id: string, userId: string) {
+    return await db
+      .delete(contacts)
+      .where(and(eq(contacts.id, id), eq(contacts.userId, userId)))
+      .returning({ id: contacts.id, email: contacts.email });
   },
 
   async list(options: { limit?: number; after?: string; where?: SQL } = {}) {
@@ -57,5 +101,112 @@ export const contactRepo = {
     const data = hasMore ? results.slice(0, limit) : results;
 
     return { data, hasMore };
+  },
+
+  async listForApi(options: {
+    userId: string;
+    limit: number;
+    after?: string;
+    search?: string;
+    status?: string;
+    segmentName?: string;
+  }) {
+    const conditions: SQL[] = [eq(contacts.userId, options.userId)];
+
+    if (options.search) {
+      conditions.push(
+        or(
+          ilike(contacts.email, `%${options.search}%`),
+          ilike(contacts.firstName, `%${options.search}%`),
+          ilike(contacts.lastName, `%${options.search}%`),
+        ) as SQL,
+      );
+    }
+
+    if (options.status === "subscribed") {
+      conditions.push(eq(contacts.unsubscribed, false));
+    } else if (options.status === "unsubscribed") {
+      conditions.push(eq(contacts.unsubscribed, true));
+    }
+
+    if (options.segmentName) {
+      conditions.push(sql`${contacts.segments} ? ${options.segmentName}`);
+    }
+
+    if (options.after) {
+      conditions.push(lt(contacts.id, options.after));
+    }
+
+    const rows = await db
+      .select({
+        id: contacts.id,
+        email: contacts.email,
+        firstName: contacts.firstName,
+        lastName: contacts.lastName,
+        unsubscribed: contacts.unsubscribed,
+        segments: contacts.segments,
+        createdAt: contacts.createdAt,
+      })
+      .from(contacts)
+      .where(and(...conditions))
+      .orderBy(desc(contacts.id))
+      .limit(options.limit + 1);
+
+    const hasMore = rows.length > options.limit;
+    const data = hasMore ? rows.slice(0, options.limit) : rows;
+
+    return { data, hasMore };
+  },
+
+  async findSegmentByIdForUser(segmentId: string, userId: string) {
+    return await db.query.segments.findFirst({
+      where: and(eq(segments.id, segmentId), eq(segments.userId, userId)),
+    });
+  },
+
+  async findSegmentByIdOrNameForUser(idOrName: string, userId: string) {
+    return await db.query.segments.findFirst({
+      where: and(
+        or(eq(segments.id, idOrName), eq(segments.name, idOrName)),
+        eq(segments.userId, userId),
+      ),
+    });
+  },
+
+  async findSegmentsByNamesForUser(names: string[], userId: string) {
+    if (names.length === 0) return [];
+
+    return await db
+      .select({
+        id: segments.id,
+        name: segments.name,
+        createdAt: segments.createdAt,
+      })
+      .from(segments)
+      .where(and(inArray(segments.name, names), eq(segments.userId, userId)));
+  },
+
+  async findTopicByIdForUser(topicId: string, userId: string) {
+    return await db.query.topics.findFirst({
+      where: and(eq(topics.id, topicId), eq(topics.userId, userId)),
+    });
+  },
+
+  async addContactToSegment(contactId: string, segmentId: string) {
+    await db
+      .insert(contactsToSegments)
+      .values({ contactId, segmentId })
+      .onConflictDoNothing();
+  },
+
+  async removeContactFromSegment(contactId: string, segmentId: string) {
+    await db
+      .delete(contactsToSegments)
+      .where(
+        and(
+          eq(contactsToSegments.contactId, contactId),
+          eq(contactsToSegments.segmentId, segmentId),
+        ),
+      );
   },
 };

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -457,6 +457,25 @@ export const webhookDeliveries = pgTable(
   ],
 );
 
+export const contactsToSegments = pgTable(
+  "contacts_to_segments",
+  {
+    contactId: uuid("contact_id")
+      .notNull()
+      .references(() => contacts.id, { onDelete: "cascade" }),
+    segmentId: uuid("segment_id")
+      .notNull()
+      .references(() => segments.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    uniqueIndex("contacts_to_segments_idx").on(t.contactId, t.segmentId),
+    index("contacts_to_segments_segment_id_idx").on(t.segmentId),
+  ],
+);
+
 // ── Automations ─────────────────────────────────────────────────────
 
 export type AutomationConnection = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,7 @@ export * from "./services/domain";
 export * from "./services/domain-events";
 export * from "./services/webhook";
 export * from "./services/apiKeys";
+export * from "./services/contact";
 export * from "./services/email";
 export * from "./services/emailProvider";
 export * from "./services/sandboxTestRecipients";

--- a/packages/core/src/services/contact.ts
+++ b/packages/core/src/services/contact.ts
@@ -1,0 +1,616 @@
+import { contactRepo } from "../db/repositories/contactRepo";
+import type { contacts, segments, topics } from "../db/schema";
+
+type ContactRow = typeof contacts.$inferSelect;
+type ContactInsert = typeof contacts.$inferInsert;
+type SegmentRow = typeof segments.$inferSelect;
+type TopicRow = typeof topics.$inferSelect;
+
+type ContactTopicSubscription = { topicId: string; subscribed: boolean };
+
+type PublicContactTopic = { id: string; subscription: "opt_in" | "opt_out" };
+
+export type CreateContactTopicInput =
+  | string
+  | { id: string; subscription?: "opt_in" | "opt_out" };
+
+export type CreateContactInput = {
+  userId: string;
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  unsubscribed?: boolean;
+  properties?: Record<string, string>;
+  segments?: string[];
+  topics?: CreateContactTopicInput[];
+};
+
+export type UpdateContactInput = {
+  userId: string;
+  idOrEmail: string;
+  changes: Record<string, unknown>;
+};
+
+export type ListContactsInput = {
+  userId: string;
+  search?: string;
+  limit?: number;
+  status?: string;
+  segmentId?: string;
+  after?: string;
+};
+
+export type ContactWebhookPayload = {
+  id: string;
+  email: string;
+  first_name: string | null;
+  last_name: string | null;
+  unsubscribed: boolean;
+  properties: Record<string, string>;
+  segments: string[];
+  topics: ContactTopicSubscription[];
+  created_at: string | Date | null;
+};
+
+export type ContactServiceListItem = {
+  id: string;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  unsubscribed: boolean;
+  status: "subscribed" | "unsubscribed";
+  segments: string[];
+  created_at: ContactRow["createdAt"];
+};
+
+export type ContactDetail = {
+  object: "contact";
+  id: string;
+  email: string;
+  first_name: string | null;
+  last_name: string | null;
+  unsubscribed: boolean;
+  properties: Record<string, string> | null;
+  segments: string[];
+  topics: PublicContactTopic[];
+  created_at: ContactRow["createdAt"];
+};
+
+export type ContactMutationResult = ContactDetail & {
+  webhookPayload: ContactWebhookPayload;
+};
+
+export type ContactUpdateResult = ContactDetail & {
+  changedFields: string[];
+  webhookPayload: ContactWebhookPayload;
+};
+
+export type DeleteContactResult = {
+  id: string;
+  email: string;
+};
+
+export type ContactSegmentListItem = {
+  id: string;
+  name: string;
+  created_at: SegmentRow["createdAt"];
+};
+
+export type ContactSegmentMutationResult = {
+  contactId: string;
+  segmentId: string;
+};
+
+export type ContactListResult = {
+  data: ContactServiceListItem[];
+  hasMore: boolean;
+};
+
+export type ContactServiceErrorCode = "duplicate_email" | "not_found";
+
+export class ContactServiceError extends Error {
+  constructor(
+    readonly code: ContactServiceErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ContactServiceError";
+  }
+}
+
+export type ContactRepository = {
+  findByIdOrEmailForUser(
+    idOrEmail: string,
+    userId: string,
+  ): Promise<ContactRow | undefined>;
+  create(data: ContactInsert): Promise<ContactRow[]>;
+  updateForUser(
+    id: string,
+    userId: string,
+    data: Record<string, unknown>,
+  ): Promise<ContactRow[]>;
+  deleteForUser(
+    id: string,
+    userId: string,
+  ): Promise<Array<{ id: string; email: string }>>;
+  listForApi(options: {
+    userId: string;
+    limit: number;
+    after?: string;
+    search?: string;
+    status?: string;
+    segmentName?: string;
+  }): Promise<{
+    data: Pick<
+      ContactRow,
+      | "id"
+      | "email"
+      | "firstName"
+      | "lastName"
+      | "unsubscribed"
+      | "segments"
+      | "createdAt"
+    >[];
+    hasMore: boolean;
+  }>;
+  findSegmentByIdForUser(
+    segmentId: string,
+    userId: string,
+  ): Promise<SegmentRow | undefined>;
+  findSegmentByIdOrNameForUser(
+    idOrName: string,
+    userId: string,
+  ): Promise<SegmentRow | undefined>;
+  findSegmentsByNamesForUser(
+    names: string[],
+    userId: string,
+  ): Promise<Pick<SegmentRow, "id" | "name" | "createdAt">[]>;
+  findTopicByIdForUser(
+    topicId: string,
+    userId: string,
+  ): Promise<TopicRow | undefined>;
+  addContactToSegment(contactId: string, segmentId: string): Promise<void>;
+  removeContactFromSegment(contactId: string, segmentId: string): Promise<void>;
+};
+
+export type ContactServiceDependencies = {
+  repository?: ContactRepository;
+};
+
+function normalizeLimit(limit: number | undefined): number {
+  return Math.min(100, Math.max(1, limit || 40));
+}
+
+function normalizeEmail(email: string): string {
+  return email.toLowerCase();
+}
+
+function normalizeSegments(value: ContactRow["segments"]): string[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeTopics(
+  value: ContactRow["topicSubscriptions"],
+): ContactTopicSubscription[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeProperties(
+  value: ContactRow["customProperties"],
+): Record<string, string> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : null;
+}
+
+function toCreatedAtPayload(
+  value: ContactRow["createdAt"],
+): string | Date | null {
+  if (!value) return null;
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function toWebhookPayload(contact: ContactRow): ContactWebhookPayload {
+  return {
+    id: contact.id,
+    email: contact.email,
+    first_name: contact.firstName,
+    last_name: contact.lastName,
+    unsubscribed: contact.unsubscribed,
+    properties: normalizeProperties(contact.customProperties) ?? {},
+    segments: normalizeSegments(contact.segments),
+    topics: normalizeTopics(contact.topicSubscriptions),
+    created_at: toCreatedAtPayload(contact.createdAt),
+  };
+}
+
+function toPublicTopics(contact: ContactRow): PublicContactTopic[] {
+  return normalizeTopics(contact.topicSubscriptions).map((topic) => ({
+    id: topic.topicId,
+    subscription: topic.subscribed ? "opt_in" : "opt_out",
+  }));
+}
+
+function toContactDetail(contact: ContactRow): ContactDetail {
+  return {
+    object: "contact",
+    id: contact.id,
+    email: contact.email,
+    first_name: contact.firstName,
+    last_name: contact.lastName,
+    unsubscribed: contact.unsubscribed,
+    properties: normalizeProperties(contact.customProperties),
+    segments: normalizeSegments(contact.segments),
+    topics: toPublicTopics(contact),
+    created_at: contact.createdAt,
+  };
+}
+
+function toContactServiceListItem(
+  contact: Pick<
+    ContactRow,
+    | "id"
+    | "email"
+    | "firstName"
+    | "lastName"
+    | "unsubscribed"
+    | "segments"
+    | "createdAt"
+  >,
+): ContactServiceListItem {
+  return {
+    id: contact.id,
+    email: contact.email,
+    firstName: contact.firstName,
+    lastName: contact.lastName,
+    first_name: contact.firstName,
+    last_name: contact.lastName,
+    unsubscribed: contact.unsubscribed,
+    status: contact.unsubscribed ? "unsubscribed" : "subscribed",
+    segments: normalizeSegments(contact.segments),
+    created_at: contact.createdAt,
+  };
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "23505"
+  );
+}
+
+async function resolveSegmentNames(
+  repository: ContactRepository,
+  userId: string,
+  requestedSegments: string[] | undefined,
+): Promise<string[]> {
+  if (!requestedSegments) return [];
+
+  const segments = await Promise.all(
+    requestedSegments.map((segment) =>
+      repository.findSegmentByIdOrNameForUser(segment, userId),
+    ),
+  );
+
+  return segments
+    .map((segment) => segment?.name ?? null)
+    .filter((name): name is string => name !== null);
+}
+
+async function resolveTopicSubscriptions(
+  repository: ContactRepository,
+  userId: string,
+  requestedTopics: CreateContactTopicInput[] | undefined,
+): Promise<ContactTopicSubscription[]> {
+  if (!requestedTopics) return [];
+
+  const topics = await Promise.all(
+    requestedTopics.map(async (topic) => {
+      const topicId = typeof topic === "string" ? topic : topic.id;
+      const subscription =
+        typeof topic === "string" ? "opt_in" : topic.subscription || "opt_in";
+      const found = await repository.findTopicByIdForUser(topicId, userId);
+      if (!found) return null;
+      return {
+        topicId: found.id,
+        subscribed: subscription === "opt_in",
+      };
+    }),
+  );
+
+  return topics.filter(
+    (topic): topic is ContactTopicSubscription => topic !== null,
+  );
+}
+
+function toUpdateData(
+  changes: Record<string, unknown>,
+): Record<string, unknown> {
+  const updateData: Record<string, unknown> = {};
+  if (changes.email !== undefined) updateData.email = changes.email;
+  if (changes.first_name !== undefined)
+    updateData.firstName = changes.first_name;
+  if (changes.last_name !== undefined) updateData.lastName = changes.last_name;
+  if (changes.unsubscribed !== undefined) {
+    updateData.unsubscribed = changes.unsubscribed;
+  }
+  if (changes.properties !== undefined) {
+    updateData.customProperties = changes.properties;
+  }
+  return updateData;
+}
+
+function getCurrentFieldValue(contact: ContactRow, field: string): unknown {
+  if (field === "first_name") return contact.firstName;
+  if (field === "last_name") return contact.lastName;
+  if (field === "properties") return contact.customProperties;
+  if (field === "unsubscribed") return contact.unsubscribed;
+  return contact.email;
+}
+
+function getChangedFields(
+  contact: ContactRow,
+  updateData: Record<string, unknown>,
+): string[] {
+  return Object.entries({
+    email: updateData.email,
+    first_name: updateData.firstName,
+    last_name: updateData.lastName,
+    unsubscribed: updateData.unsubscribed,
+    properties: updateData.customProperties,
+  })
+    .filter(([, value]) => value !== undefined)
+    .filter(
+      ([field, value]) =>
+        !valuesEqual(getCurrentFieldValue(contact, field), value),
+    )
+    .map(([field]) => field);
+}
+
+export function createContactService({
+  repository = contactRepo,
+}: ContactServiceDependencies = {}) {
+  return {
+    async createContact(
+      input: CreateContactInput,
+    ): Promise<ContactMutationResult> {
+      const resolvedSegments = await resolveSegmentNames(
+        repository,
+        input.userId,
+        input.segments,
+      );
+      const resolvedTopics = await resolveTopicSubscriptions(
+        repository,
+        input.userId,
+        input.topics,
+      );
+
+      try {
+        const [inserted] = await repository.create({
+          email: normalizeEmail(input.email),
+          firstName: input.firstName || null,
+          lastName: input.lastName || null,
+          unsubscribed: input.unsubscribed ?? false,
+          customProperties: input.properties || null,
+          segments: resolvedSegments.length > 0 ? resolvedSegments : null,
+          topicSubscriptions: resolvedTopics.length > 0 ? resolvedTopics : null,
+          userId: input.userId,
+        });
+
+        return {
+          ...toContactDetail(inserted),
+          webhookPayload: toWebhookPayload(inserted),
+        };
+      } catch (error) {
+        if (isUniqueViolation(error)) {
+          throw new ContactServiceError(
+            "duplicate_email",
+            "A contact with this email already exists",
+          );
+        }
+        throw error;
+      }
+    },
+
+    async listContacts(input: ListContactsInput): Promise<ContactListResult> {
+      let segmentName: string | undefined;
+      if (input.segmentId) {
+        const segment = await repository.findSegmentByIdForUser(
+          input.segmentId,
+          input.userId,
+        );
+        if (!segment) return { data: [], hasMore: false };
+        segmentName = segment.name;
+      }
+
+      const result = await repository.listForApi({
+        userId: input.userId,
+        limit: normalizeLimit(input.limit),
+        after: input.after || undefined,
+        search: input.search || undefined,
+        status: input.status || undefined,
+        segmentName,
+      });
+
+      return {
+        data: result.data.map((contact) => toContactServiceListItem(contact)),
+        hasMore: result.hasMore,
+      };
+    },
+
+    async getContact(
+      idOrEmail: string,
+      userId: string,
+    ): Promise<ContactDetail> {
+      const contact = await repository.findByIdOrEmailForUser(
+        idOrEmail,
+        userId,
+      );
+      if (!contact) {
+        throw new ContactServiceError("not_found", "Contact not found");
+      }
+      return toContactDetail(contact);
+    },
+
+    async updateContact(
+      input: UpdateContactInput,
+    ): Promise<ContactUpdateResult> {
+      const contact = await repository.findByIdOrEmailForUser(
+        input.idOrEmail,
+        input.userId,
+      );
+      if (!contact) {
+        throw new ContactServiceError("not_found", "Contact not found");
+      }
+
+      const updateData = toUpdateData(input.changes);
+      const changedFields = getChangedFields(contact, updateData);
+
+      if (changedFields.length === 0) {
+        return {
+          ...toContactDetail(contact),
+          changedFields,
+          webhookPayload: toWebhookPayload(contact),
+        };
+      }
+
+      const [updated] = await repository.updateForUser(
+        contact.id,
+        input.userId,
+        updateData,
+      );
+
+      if (!updated) {
+        throw new ContactServiceError("not_found", "Contact not found");
+      }
+
+      return {
+        ...toContactDetail(updated),
+        changedFields,
+        webhookPayload: toWebhookPayload(updated),
+      };
+    },
+
+    async deleteContact(
+      idOrEmail: string,
+      userId: string,
+    ): Promise<DeleteContactResult> {
+      const contact = await repository.findByIdOrEmailForUser(
+        idOrEmail,
+        userId,
+      );
+      if (!contact) {
+        throw new ContactServiceError("not_found", "Contact not found");
+      }
+
+      const [deleted] = await repository.deleteForUser(contact.id, userId);
+      if (!deleted) {
+        throw new ContactServiceError("not_found", "Contact not found");
+      }
+
+      return deleted;
+    },
+
+    async listContactSegments(
+      idOrEmail: string,
+      userId: string,
+    ): Promise<ContactSegmentListItem[]> {
+      const contact = await repository.findByIdOrEmailForUser(
+        idOrEmail,
+        userId,
+      );
+      if (!contact) {
+        throw new ContactServiceError("not_found", "Contact not found");
+      }
+
+      const segmentNames = normalizeSegments(contact.segments);
+      const foundSegments = await repository.findSegmentsByNamesForUser(
+        segmentNames,
+        userId,
+      );
+      const byName = new Map(
+        foundSegments.map((segment) => [segment.name, segment]),
+      );
+
+      return segmentNames
+        .map((name) => byName.get(name) ?? null)
+        .filter(
+          (segment): segment is Pick<SegmentRow, "id" | "name" | "createdAt"> =>
+            segment !== null,
+        )
+        .map((segment) => ({
+          id: segment.id,
+          name: segment.name,
+          created_at: segment.createdAt,
+        }));
+    },
+
+    async addContactToSegment(input: {
+      idOrEmail: string;
+      segmentId: string;
+      userId: string;
+    }): Promise<ContactSegmentMutationResult> {
+      const [contact, segment] = await Promise.all([
+        repository.findByIdOrEmailForUser(input.idOrEmail, input.userId),
+        repository.findSegmentByIdForUser(input.segmentId, input.userId),
+      ]);
+
+      if (!contact) {
+        throw new ContactServiceError("not_found", "Contact not found");
+      }
+      if (!segment) {
+        throw new ContactServiceError("not_found", "Segment not found");
+      }
+
+      await repository.addContactToSegment(contact.id, segment.id);
+
+      const existingSegments = normalizeSegments(contact.segments);
+      if (!existingSegments.includes(segment.name)) {
+        await repository.updateForUser(contact.id, input.userId, {
+          segments: [...existingSegments, segment.name],
+        });
+      }
+
+      return { contactId: contact.id, segmentId: segment.id };
+    },
+
+    async removeContactFromSegment(input: {
+      idOrEmail: string;
+      segmentId: string;
+      userId: string;
+    }): Promise<ContactSegmentMutationResult> {
+      const [contact, segment] = await Promise.all([
+        repository.findByIdOrEmailForUser(input.idOrEmail, input.userId),
+        repository.findSegmentByIdForUser(input.segmentId, input.userId),
+      ]);
+
+      if (!contact) {
+        throw new ContactServiceError("not_found", "Contact not found");
+      }
+      if (!segment) {
+        throw new ContactServiceError("not_found", "Segment not found");
+      }
+
+      await repository.removeContactFromSegment(contact.id, segment.id);
+
+      const existingSegments = normalizeSegments(contact.segments);
+      if (existingSegments.includes(segment.name)) {
+        await repository.updateForUser(contact.id, input.userId, {
+          segments: existingSegments.filter((name) => name !== segment.name),
+        });
+      }
+
+      return { contactId: contact.id, segmentId: segment.id };
+    },
+  };
+}
+
+export const contactService = createContactService();

--- a/src/app/api/contacts/[id]/route.ts
+++ b/src/app/api/contacts/[id]/route.ts
@@ -1,44 +1,41 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { contacts } from "@/lib/db/schema";
 import { queueEvent } from "@/lib/events";
-import { and, eq, or } from "drizzle-orm";
+import { ContactServiceError, createContactService } from "@opensend/core";
 
-type ContactWebhookRow = typeof contacts.$inferSelect;
+function contactService() {
+  return createContactService();
+}
 
-function toContactWebhookPayload(contact: ContactWebhookRow) {
+function mapContactServiceError(error: unknown, fallback: string): Response {
+  if (error instanceof ContactServiceError) {
+    return Response.json({ error: error.message }, { status: 404 });
+  }
+
+  const message = error instanceof Error ? error.message : fallback;
+  return Response.json({ error: message }, { status: 500 });
+}
+
+function toContactUpdateResponse(contact: {
+  object: "contact";
+  id: string;
+  email: string;
+  first_name: string | null;
+  last_name: string | null;
+  unsubscribed: boolean;
+  properties: Record<string, string> | null;
+  created_at: Date | string | null;
+}) {
   return {
+    object: contact.object,
     id: contact.id,
     email: contact.email,
-    first_name: contact.firstName,
-    last_name: contact.lastName,
+    first_name: contact.first_name,
+    last_name: contact.last_name,
     unsubscribed: contact.unsubscribed,
-    properties: contact.customProperties ?? {},
-    segments: contact.segments ?? [],
-    topics: contact.topicSubscriptions ?? [],
-    created_at: contact.createdAt?.toISOString?.() ?? contact.createdAt,
+    properties: contact.properties,
+    created_at: contact.created_at,
   };
-}
-
-function valuesEqual(a: unknown, b: unknown): boolean {
-  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
-}
-
-async function findContact(idOrEmail: string, userId: string) {
-  const isUuid =
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-      idOrEmail,
-    );
-
-  return await db.query.contacts.findFirst({
-    where: and(
-      isUuid
-        ? or(eq(contacts.id, idOrEmail), eq(contacts.email, idOrEmail))
-        : eq(contacts.email, idOrEmail),
-      eq(contacts.userId, userId),
-    ),
-  });
 }
 
 export async function GET(
@@ -55,40 +52,10 @@ export async function GET(
   const { id } = await params;
 
   try {
-    const contact = await findContact(id, userId);
-
-    if (!contact) {
-      return Response.json({ error: "Contact not found" }, { status: 404 });
-    }
-
-    // Map internal topic shape to documented opt_in/opt_out shape
-    const topics =
-      (
-        contact.topicSubscriptions as Array<{
-          topicId: string;
-          subscribed: boolean;
-        }> | null
-      )?.map((t) => ({
-        id: t.topicId,
-        subscription: t.subscribed ? "opt_in" : "opt_out",
-      })) ?? [];
-
-    return Response.json({
-      object: "contact",
-      id: contact.id,
-      email: contact.email,
-      first_name: contact.firstName,
-      last_name: contact.lastName,
-      unsubscribed: contact.unsubscribed,
-      properties: contact.customProperties,
-      segments: contact.segments ?? [],
-      topics,
-      created_at: contact.createdAt,
-    });
+    const contact = await contactService().getContact(id, userId);
+    return Response.json(contact);
   } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to retrieve contact";
-    return Response.json({ error: message }, { status: 500 });
+    return mapContactServiceError(err, "Failed to retrieve contact");
   }
 }
 
@@ -107,96 +74,33 @@ export async function PATCH(
 
   let body: Record<string, unknown>;
   try {
-    body = await request.json();
+    body = (await request.json()) as Record<string, unknown>;
   } catch {
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
   try {
-    const contact = await findContact(id, userId);
-    if (!contact) {
-      return Response.json({ error: "Contact not found" }, { status: 404 });
-    }
+    const updated = await contactService().updateContact({
+      userId,
+      idOrEmail: id,
+      changes: body,
+    });
 
-    const updateData: Record<string, unknown> = {};
-    if (body.email !== undefined) updateData.email = body.email;
-    if (body.first_name !== undefined) updateData.firstName = body.first_name;
-    if (body.last_name !== undefined) updateData.lastName = body.last_name;
-    if (body.unsubscribed !== undefined)
-      updateData.unsubscribed = body.unsubscribed;
-    if (body.properties !== undefined)
-      updateData.customProperties = body.properties;
-
-    const changedFields = Object.entries({
-      email: updateData.email,
-      first_name: updateData.firstName,
-      last_name: updateData.lastName,
-      unsubscribed: updateData.unsubscribed,
-      properties: updateData.customProperties,
-    })
-      .filter(([, value]) => value !== undefined)
-      .filter(([field, value]) => {
-        const currentValue =
-          field === "first_name"
-            ? contact.firstName
-            : field === "last_name"
-              ? contact.lastName
-              : field === "properties"
-                ? contact.customProperties
-                : field === "unsubscribed"
-                  ? contact.unsubscribed
-                  : contact.email;
-        return !valuesEqual(currentValue, value);
-      })
-      .map(([field]) => field);
-
-    if (changedFields.length === 0) {
-      return Response.json({
-        object: "contact",
-        id: contact.id,
-        email: contact.email,
-        first_name: contact.firstName,
-        last_name: contact.lastName,
-        unsubscribed: contact.unsubscribed,
-        properties: contact.customProperties,
-        created_at: contact.createdAt,
+    if (updated.changedFields.length > 0) {
+      await queueEvent({
+        type: "contact.updated",
+        userId,
+        payload: {
+          id: updated.id,
+          changed_fields: updated.changedFields,
+          contact: updated.webhookPayload,
+        },
       });
     }
 
-    const [updated] = await db
-      .update(contacts)
-      .set(updateData)
-      .where(and(eq(contacts.id, contact.id), eq(contacts.userId, userId)))
-      .returning();
-
-    if (!updated) {
-      return Response.json({ error: "Contact not found" }, { status: 404 });
-    }
-
-    await queueEvent({
-      type: "contact.updated",
-      userId,
-      payload: {
-        id: updated.id,
-        changed_fields: changedFields,
-        contact: toContactWebhookPayload(updated),
-      },
-    });
-
-    return Response.json({
-      object: "contact",
-      id: updated.id,
-      email: updated.email,
-      first_name: updated.firstName,
-      last_name: updated.lastName,
-      unsubscribed: updated.unsubscribed,
-      properties: updated.customProperties,
-      created_at: updated.createdAt,
-    });
+    return Response.json(toContactUpdateResponse(updated));
   } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to update contact";
-    return Response.json({ error: message }, { status: 500 });
+    return mapContactServiceError(err, "Failed to update contact");
   }
 }
 
@@ -214,19 +118,7 @@ export async function DELETE(
   const { id } = await params;
 
   try {
-    const contact = await findContact(id, userId);
-    if (!contact) {
-      return Response.json({ error: "Contact not found" }, { status: 404 });
-    }
-
-    const [deleted] = await db
-      .delete(contacts)
-      .where(and(eq(contacts.id, contact.id), eq(contacts.userId, userId)))
-      .returning({ id: contacts.id, email: contacts.email });
-
-    if (!deleted) {
-      return Response.json({ error: "Contact not found" }, { status: 404 });
-    }
+    const deleted = await contactService().deleteContact(id, userId);
 
     await queueEvent({
       type: "contact.deleted",
@@ -243,8 +135,6 @@ export async function DELETE(
       deleted: true,
     });
   } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to delete contact";
-    return Response.json({ error: message }, { status: 500 });
+    return mapContactServiceError(err, "Failed to delete contact");
   }
 }

--- a/src/app/api/contacts/[id]/segments/[segment_id]/route.ts
+++ b/src/app/api/contacts/[id]/segments/[segment_id]/route.ts
@@ -1,31 +1,26 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { contacts, contactsToSegments, segments } from "@/lib/db/schema";
-import { and, eq, or } from "drizzle-orm";
+import { ContactServiceError, createContactService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 
-async function findContact(idOrEmail: string, userId: string) {
-  const isUuid =
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-      idOrEmail,
-    );
+function contactService() {
+  return createContactService();
+}
 
-  return await db.query.contacts.findFirst({
-    where: and(
-      isUuid
-        ? or(eq(contacts.id, idOrEmail), eq(contacts.email, idOrEmail))
-        : eq(contacts.email, idOrEmail),
-      eq(contacts.userId, userId),
-    ),
-  });
+function mapContactServiceError(error: unknown, fallback: string) {
+  if (error instanceof ContactServiceError) {
+    return NextResponse.json({ error: error.message }, { status: 404 });
+  }
+
+  console.error(fallback, error);
+  return NextResponse.json({ error: fallback }, { status: 500 });
 }
 
 export async function POST(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string; segment_id: string }> },
 ) {
-  const auth = await validateApiKey(_request.headers.get("authorization"));
+  const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
   const permissionError = requireFullAccessApiKey(auth);
   if (permissionError) return permissionError;
@@ -33,61 +28,29 @@ export async function POST(
   const userId = auth.userId;
 
   try {
-    const { id: idOrEmail, segment_id } = await params;
-
-    const [contact, segment] = await Promise.all([
-      findContact(idOrEmail, userId),
-      db.query.segments.findFirst({
-        where: and(eq(segments.id, segment_id), eq(segments.userId, userId)),
-      }),
-    ]);
-
-    if (!contact) {
-      return NextResponse.json({ error: "Contact not found" }, { status: 404 });
-    }
-    if (!segment) {
-      return NextResponse.json({ error: "Segment not found" }, { status: 404 });
-    }
-
-    // Update join table
-    await db
-      .insert(contactsToSegments)
-      .values({
-        contactId: contact.id,
-        segmentId: segment.id,
-      })
-      .onConflictDoNothing();
-
-    // Legacy sync (to be removed after migration)
-    const existingSegments = (contact.segments as string[]) ?? [];
-    if (!existingSegments.includes(segment.name)) {
-      const updatedSegments = [...existingSegments, segment.name];
-      await db
-        .update(contacts)
-        .set({ segments: updatedSegments })
-        .where(and(eq(contacts.id, contact.id), eq(contacts.userId, userId)));
-    }
+    const { id: idOrEmail, segment_id: segmentId } = await params;
+    const result = await contactService().addContactToSegment({
+      idOrEmail,
+      segmentId,
+      userId,
+    });
 
     return NextResponse.json({
       object: "contact_segment",
-      contact_id: contact.id,
-      segment_id: segment.id,
+      contact_id: result.contactId,
+      segment_id: result.segmentId,
       added: true,
     });
   } catch (error) {
-    console.error("Failed to add contact to segment:", error);
-    return NextResponse.json(
-      { error: "Failed to add contact to segment" },
-      { status: 500 },
-    );
+    return mapContactServiceError(error, "Failed to add contact to segment");
   }
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string; segment_id: string }> },
 ) {
-  const auth = await validateApiKey(_request.headers.get("authorization"));
+  const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
   const permissionError = requireFullAccessApiKey(auth);
   if (permissionError) return permissionError;
@@ -95,55 +58,23 @@ export async function DELETE(
   const userId = auth.userId;
 
   try {
-    const { id: idOrEmail, segment_id } = await params;
-
-    const [contact, segment] = await Promise.all([
-      findContact(idOrEmail, userId),
-      db.query.segments.findFirst({
-        where: and(eq(segments.id, segment_id), eq(segments.userId, userId)),
-      }),
-    ]);
-
-    if (!contact) {
-      return NextResponse.json({ error: "Contact not found" }, { status: 404 });
-    }
-    if (!segment) {
-      return NextResponse.json({ error: "Segment not found" }, { status: 404 });
-    }
-
-    // Update join table
-    await db
-      .delete(contactsToSegments)
-      .where(
-        and(
-          eq(contactsToSegments.contactId, contact.id),
-          eq(contactsToSegments.segmentId, segment.id),
-        ),
-      );
-
-    // Legacy sync (to be removed after migration)
-    const existingSegments = (contact.segments as string[]) ?? [];
-    if (existingSegments.includes(segment.name)) {
-      const updatedSegments = existingSegments.filter(
-        (s) => s !== segment.name,
-      );
-      await db
-        .update(contacts)
-        .set({ segments: updatedSegments })
-        .where(and(eq(contacts.id, contact.id), eq(contacts.userId, userId)));
-    }
+    const { id: idOrEmail, segment_id: segmentId } = await params;
+    const result = await contactService().removeContactFromSegment({
+      idOrEmail,
+      segmentId,
+      userId,
+    });
 
     return NextResponse.json({
       object: "contact_segment",
-      contact_id: contact.id,
-      segment_id: segment.id,
+      contact_id: result.contactId,
+      segment_id: result.segmentId,
       deleted: true,
     });
   } catch (error) {
-    console.error("Failed to remove contact from segment:", error);
-    return NextResponse.json(
-      { error: "Failed to remove contact from segment" },
-      { status: 500 },
+    return mapContactServiceError(
+      error,
+      "Failed to remove contact from segment",
     );
   }
 }

--- a/src/app/api/contacts/[id]/segments/route.ts
+++ b/src/app/api/contacts/[id]/segments/route.ts
@@ -1,24 +1,22 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { contacts, segments } from "@/lib/db/schema";
-import { and, eq, or } from "drizzle-orm";
+import { ContactServiceError, createContactService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 
-async function findContact(idOrEmail: string, userId: string) {
-  const isUuid =
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-      idOrEmail,
-    );
+function contactService() {
+  return createContactService();
+}
 
-  return await db.query.contacts.findFirst({
-    where: and(
-      isUuid
-        ? or(eq(contacts.id, idOrEmail), eq(contacts.email, idOrEmail))
-        : eq(contacts.email, idOrEmail),
-      eq(contacts.userId, userId),
-    ),
-  });
+function mapContactServiceError(error: unknown) {
+  if (error instanceof ContactServiceError) {
+    return NextResponse.json({ error: error.message }, { status: 404 });
+  }
+
+  console.error("Failed to fetch contact segments:", error);
+  return NextResponse.json(
+    { error: "Failed to fetch contact segments" },
+    { status: 500 },
+  );
 }
 
 export async function GET(
@@ -34,31 +32,7 @@ export async function GET(
 
   try {
     const { id: idOrEmail } = await params;
-    const contact = await findContact(idOrEmail, userId);
-
-    if (!contact) {
-      return NextResponse.json({ error: "Contact not found" }, { status: 404 });
-    }
-
-    const contactSegments = (contact.segments as string[]) ?? [];
-
-    // Fetch segment details for the names in the contact's segments array
-    const data = await Promise.all(
-      contactSegments.map(async (name) => {
-        const [seg] = await db
-          .select({
-            id: segments.id,
-            name: segments.name,
-            createdAt: segments.createdAt,
-          })
-          .from(segments)
-          .where(and(eq(segments.name, name), eq(segments.userId, userId)))
-          .limit(1);
-        return seg
-          ? { id: seg.id, name: seg.name, created_at: seg.createdAt }
-          : null;
-      }),
-    ).then((results) => results.filter((r) => r !== null));
+    const data = await contactService().listContactSegments(idOrEmail, userId);
 
     return NextResponse.json({
       object: "list",
@@ -66,10 +40,6 @@ export async function GET(
       has_more: false,
     });
   } catch (error) {
-    console.error("Failed to fetch contact segments:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch contact segments" },
-      { status: 500 },
-    );
+    return mapContactServiceError(error);
   }
 }

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -4,38 +4,34 @@ import {
   unauthorizedResponse,
 } from "@/lib/api-auth";
 import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { contacts, segments, topics } from "@/lib/db/schema";
 import { queueEvent } from "@/lib/events";
 import { createContactSchema } from "@/lib/validation/contacts";
-import { type SQL, and, desc, eq, ilike, lt, or, sql } from "drizzle-orm";
+import { ContactServiceError, createContactService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 
 type ContactRouteAuth = NonNullable<
   Awaited<ReturnType<typeof authorizeDashboardOrApiKey>>
 >;
 
-type ContactWebhookRow = typeof contacts.$inferSelect;
-
-function toContactWebhookPayload(contact: ContactWebhookRow) {
-  return {
-    id: contact.id,
-    email: contact.email,
-    first_name: contact.firstName,
-    last_name: contact.lastName,
-    unsubscribed: contact.unsubscribed,
-    properties: contact.customProperties ?? {},
-    segments: contact.segments ?? [],
-    topics: contact.topicSubscriptions ?? [],
-    created_at: contact.createdAt?.toISOString?.() ?? contact.createdAt,
-  };
-}
-
 async function resolveUserId(auth: ContactRouteAuth): Promise<string | null> {
   if ("userId" in auth) return auth.userId;
 
   const session = await getServerSession();
   return session?.user?.id ?? null;
+}
+
+function contactService() {
+  return createContactService();
+}
+
+function mapContactServiceError(error: unknown, fallback: string) {
+  if (error instanceof ContactServiceError) {
+    const status = error.code === "duplicate_email" ? 409 : 404;
+    return NextResponse.json({ error: error.message }, { status });
+  }
+
+  console.error(fallback, error);
+  return NextResponse.json({ error: fallback }, { status: 500 });
 }
 
 export async function POST(request: NextRequest) {
@@ -58,102 +54,32 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const validated = result.data;
-    const email = validated.email.toLowerCase();
+    const created = await contactService().createContact({
+      userId,
+      email: result.data.email,
+      firstName: result.data.first_name,
+      lastName: result.data.last_name,
+      unsubscribed: result.data.unsubscribed,
+      properties: result.data.properties,
+      segments: result.data.segments,
+      topics: result.data.topics,
+    });
 
-    // Resolve segment names if provided as IDs
-    let resolvedSegments: string[] = [];
-    if (validated.segments) {
-      resolvedSegments = await Promise.all(
-        validated.segments.map(async (s: string) => {
-          const seg = await db.query.segments.findFirst({
-            where: and(
-              or(eq(segments.id, s), eq(segments.name, s)),
-              eq(segments.userId, userId),
-            ),
-          });
-          return seg ? seg.name : null;
-        }),
-      ).then((results) => results.filter((r): r is string => r !== null));
-    }
+    await queueEvent({
+      type: "contact.created",
+      userId,
+      payload: created.webhookPayload,
+    });
 
-    // Map topics to internal shape
-    let resolvedTopics: Array<{ topicId: string; subscribed: boolean }> = [];
-    if (validated.topics) {
-      resolvedTopics = await Promise.all(
-        validated.topics.map(
-          async (t: string | { id: string; subscription?: string }) => {
-            const topicId = typeof t === "string" ? t : t.id;
-            const subscription =
-              typeof t === "string" ? "opt_in" : t.subscription || "opt_in";
-            const found = await db.query.topics.findFirst({
-              where: and(eq(topics.id, topicId), eq(topics.userId, userId)),
-            });
-            if (!found) return null;
-            return {
-              topicId: found.id,
-              subscribed: subscription === "opt_in",
-            };
-          },
-        ),
-      ).then((results) =>
-        results.filter(
-          (r): r is { topicId: string; subscribed: boolean } => r !== null,
-        ),
-      );
-    }
-
-    // Attempt insertion - the uniqueIndex on email will throw on duplicate
-    try {
-      const [inserted] = await db
-        .insert(contacts)
-        .values({
-          email,
-          firstName: validated.first_name || null,
-          lastName: validated.last_name || null,
-          unsubscribed: validated.unsubscribed ?? false,
-          customProperties:
-            (validated.properties as Record<string, string>) || null,
-          segments: resolvedSegments.length > 0 ? resolvedSegments : null,
-          topicSubscriptions: resolvedTopics.length > 0 ? resolvedTopics : null,
-          userId,
-        })
-        .returning();
-
-      await queueEvent({
-        type: "contact.created",
-        userId,
-        payload: toContactWebhookPayload(inserted),
-      });
-
-      return NextResponse.json(
-        {
-          object: "contact",
-          id: inserted.id,
-        },
-        { status: 201 },
-      );
-    } catch (dbError) {
-      if (
-        dbError &&
-        typeof dbError === "object" &&
-        "code" in dbError &&
-        dbError.code === "23505"
-      ) {
-        // PostgreSQL unique violation code
-        return NextResponse.json(
-          { error: "A contact with this email already exists" },
-          { status: 409 },
-        );
-      }
-      throw dbError;
-    }
-  } catch (error) {
-    console.error("Failed to create contact:", error);
     return NextResponse.json(
-      { error: "Failed to create contact" },
-      { status: 500 },
+      {
+        object: "contact",
+        id: created.id,
+      },
+      { status: 201 },
     );
+  } catch (error) {
+    return mapContactServiceError(error, "Failed to create contact");
   }
 }
 
@@ -168,101 +94,23 @@ export async function GET(request: Request) {
   if (!userId) return unauthorizedResponse();
 
   const url = new URL(request.url);
-  const search = url.searchParams.get("search") || "";
-  const limit = Math.min(
-    100,
-    Math.max(1, Number(url.searchParams.get("limit")) || 40),
-  );
-  const status = url.searchParams.get("status") || "";
-  const segmentId = url.searchParams.get("segment_id") || "";
-  const after = url.searchParams.get("after") || "";
 
   try {
-    let segmentName = "";
-    if (segmentId) {
-      const [seg] = await db
-        .select({ name: segments.name })
-        .from(segments)
-        .where(and(eq(segments.id, segmentId), eq(segments.userId, userId)))
-        .limit(1);
-      if (seg) {
-        segmentName = seg.name;
-      } else {
-        return NextResponse.json({
-          object: "list",
-          data: [],
-          has_more: false,
-        });
-      }
-    }
-
-    const conditions: SQL[] = [eq(contacts.userId, userId)];
-
-    if (search) {
-      conditions.push(
-        or(
-          ilike(contacts.email, `%${search}%`),
-          ilike(contacts.firstName, `%${search}%`),
-          ilike(contacts.lastName, `%${search}%`),
-        ) as SQL,
-      );
-    }
-
-    if (status === "subscribed") {
-      conditions.push(eq(contacts.unsubscribed, false));
-    } else if (status === "unsubscribed") {
-      conditions.push(eq(contacts.unsubscribed, true));
-    }
-
-    if (segmentName) {
-      conditions.push(sql`${contacts.segments} ? ${segmentName}`);
-    }
-
-    if (after) {
-      conditions.push(lt(contacts.id, after));
-    }
-
-    const rows = await db
-      .select({
-        id: contacts.id,
-        email: contacts.email,
-        firstName: contacts.firstName,
-        lastName: contacts.lastName,
-        unsubscribed: contacts.unsubscribed,
-        segments: contacts.segments,
-        createdAt: contacts.createdAt,
-      })
-      .from(contacts)
-      .where(and(...conditions))
-      .orderBy(desc(contacts.id))
-      .limit(limit + 1);
-
-    const hasMore = rows.length > limit;
-    const dataRows = hasMore ? rows.slice(0, limit) : rows;
-
-    const data = dataRows.map((c) => ({
-      id: c.id,
-      email: c.email,
-      first_name: c.firstName,
-      last_name: c.lastName,
-      unsubscribed: c.unsubscribed,
-      firstName: c.firstName,
-      lastName: c.lastName,
-      status: c.unsubscribed ? "unsubscribed" : "subscribed",
-      segments: (c.segments as string[]) ?? [],
-      created_at: c.createdAt,
-    }));
+    const result = await contactService().listContacts({
+      userId,
+      search: url.searchParams.get("search") || "",
+      limit: Number(url.searchParams.get("limit")) || 40,
+      status: url.searchParams.get("status") || "",
+      segmentId: url.searchParams.get("segment_id") || "",
+      after: url.searchParams.get("after") || "",
+    });
 
     return NextResponse.json({
       object: "list",
-      data,
-      has_more: hasMore,
+      data: result.data,
+      has_more: result.hasMore,
     });
   } catch (error) {
-    console.error("Failed to fetch contacts:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch contacts" },
-      { status: 500 },
-    );
+    return mapContactServiceError(error, "Failed to fetch contacts");
   }
 }

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -12,6 +12,16 @@ const mockCountFn = vi.hoisted(() => vi.fn());
 const mockCreateWebhookService = vi.hoisted(() => vi.fn());
 const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
+const mockContactService = vi.hoisted(() => ({
+  createContact: vi.fn(),
+  listContacts: vi.fn(),
+  getContact: vi.fn(),
+  updateContact: vi.fn(),
+  deleteContact: vi.fn(),
+  listContactSegments: vi.fn(),
+  addContactToSegment: vi.fn(),
+  removeContactFromSegment: vi.fn(),
+}));
 
 function makeChain<T>(rows: T[]) {
   return {
@@ -203,10 +213,21 @@ describe("route smoke coverage", () => {
           this.name = "TemplateServiceError";
         }
       }
+      class ContactServiceError extends Error {
+        constructor(
+          readonly code: string,
+          message: string,
+        ) {
+          super(message);
+          this.name = "ContactServiceError";
+        }
+      }
 
       return {
         createWebhookService: mockCreateWebhookService,
         TemplateServiceError,
+        ContactServiceError,
+        createContactService: () => mockContactService,
         createTemplateService: () => ({
           async getTemplate(id: string) {
             const [template] = await mockSelect().from().where({ id }).limit(1);
@@ -299,6 +320,14 @@ describe("route smoke coverage", () => {
       updateWebhook: vi.fn(),
       deleteWebhook: vi.fn(),
     });
+    mockContactService.createContact.mockReset();
+    mockContactService.listContacts.mockReset();
+    mockContactService.getContact.mockReset();
+    mockContactService.updateContact.mockReset();
+    mockContactService.deleteContact.mockReset();
+    mockContactService.listContactSegments.mockReset();
+    mockContactService.addContactToSegment.mockReset();
+    mockContactService.removeContactFromSegment.mockReset();
     vi.doMock("@/lib/api-auth", async () => {
       const actual =
         await vi.importActual<typeof import("@/lib/api-auth")>(
@@ -415,19 +444,23 @@ describe("route smoke coverage", () => {
 
   it("allows dashboard-session auth for audience list routes", async () => {
     mockAuthorizeDashboardOrApiKey.mockResolvedValueOnce({ dashboard: true });
-    mockSelect.mockReturnValueOnce(
-      makeChain([
+    mockContactService.listContacts.mockResolvedValueOnce({
+      hasMore: false,
+      data: [
         {
           id: "c1",
           email: "alice@example.com",
           firstName: "Alice",
           lastName: "Example",
+          first_name: "Alice",
+          last_name: "Example",
           unsubscribed: false,
+          status: "subscribed",
           segments: ["VIP"],
-          createdAt: new Date("2026-04-27T00:00:00.000Z"),
+          created_at: new Date("2026-04-27T00:00:00.000Z"),
         },
-      ]),
-    );
+      ],
+    });
 
     const contactsRoute = await import("@/app/api/contacts/route");
     const response = await contactsRoute.GET(
@@ -1271,10 +1304,13 @@ describe("route smoke coverage", () => {
       "@/app/api/contacts/[id]/segments/[segment_id]/route"
     );
 
-    mockFindFirst.mockResolvedValueOnce({ id: "c1", segments: ["VIP"] }); // contact
-    mockSelect.mockImplementationOnce(() =>
-      makeChain([{ id: "s1", name: "VIP" }]),
-    ); // segment detail
+    mockContactService.listContactSegments.mockResolvedValueOnce([
+      {
+        id: "s1",
+        name: "VIP",
+        created_at: new Date("2026-04-27T00:00:00.000Z"),
+      },
+    ]);
     const contactSegmentsGet = await contactSegmentsRoute.GET(
       makeNextRequest("http://localhost/api/contacts/c1/segments", {
         headers: { authorization: "Bearer token" },
@@ -1283,10 +1319,10 @@ describe("route smoke coverage", () => {
     );
     expect(contactSegmentsGet.status).toBe(200);
 
-    mockFindFirst.mockResolvedValueOnce({ id: "c1", segments: [] }); // contact
-    mockFindFirst.mockResolvedValueOnce({ id: "s1", name: "VIP" }); // segment
-    mockInsert.mockImplementationOnce(() => makeChain([]));
-    mockUpdate.mockImplementationOnce(() => makeChain([{ id: "c1" }]));
+    mockContactService.addContactToSegment.mockResolvedValueOnce({
+      contactId: "c1",
+      segmentId: "s1",
+    });
     const contactSegmentPost = await contactSegmentRoute.POST(
       makeNextRequest("http://localhost/api/contacts/c1/segments/s1", {
         method: "POST",

--- a/tests/contact-root-api.test.ts
+++ b/tests/contact-root-api.test.ts
@@ -3,43 +3,31 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
 const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockValidateApiKey = vi.hoisted(() => vi.fn());
-const mockContactFindFirst = vi.hoisted(() => vi.fn());
-const mockSelect = vi.hoisted(() => vi.fn());
-const mockInsert = vi.hoisted(() => vi.fn());
-const mockUpdate = vi.hoisted(() => vi.fn());
-const mockDelete = vi.hoisted(() => vi.fn());
 const mockQueueEvent = vi.hoisted(() => vi.fn());
+const mockContactService = vi.hoisted(() => ({
+  createContact: vi.fn(),
+  listContacts: vi.fn(),
+  getContact: vi.fn(),
+  updateContact: vi.fn(),
+  deleteContact: vi.fn(),
+}));
+const MockContactServiceError = vi.hoisted(
+  () =>
+    class ContactServiceError extends Error {
+      constructor(
+        readonly code: "duplicate_email" | "not_found",
+        message: string,
+      ) {
+        super(message);
+        this.name = "ContactServiceError";
+      }
+    },
+);
 
 function makeRequest(url: string, init?: RequestInit) {
   const request = new Request(url, init) as Request & { nextUrl: URL };
   request.nextUrl = new URL(url);
   return request;
-}
-
-type Chain<T> = {
-  from: ReturnType<typeof vi.fn>;
-  where: ReturnType<typeof vi.fn>;
-  orderBy: ReturnType<typeof vi.fn>;
-  limit: ReturnType<typeof vi.fn>;
-  set: ReturnType<typeof vi.fn>;
-  values: ReturnType<typeof vi.fn>;
-  returning: ReturnType<typeof vi.fn>;
-  then: (resolve: (value: T[]) => unknown) => Promise<unknown>;
-};
-
-function makeChain<T>(rows: T[]): Chain<T> {
-  const chain = {
-    from: vi.fn(() => chain),
-    where: vi.fn(() => chain),
-    orderBy: vi.fn(() => chain),
-    limit: vi.fn(() => chain),
-    set: vi.fn(() => chain),
-    values: vi.fn(() => chain),
-    returning: vi.fn(() => Promise.resolve(rows)),
-    // biome-ignore lint/suspicious/noThenProperty: mocks Drizzle's thenable query builder
-    then: (resolve: (value: T[]) => unknown) => Promise.resolve(resolve(rows)),
-  };
-  return chain;
 }
 
 vi.mock("@/lib/api-auth", () => ({
@@ -54,18 +42,9 @@ vi.mock("@/lib/events", () => ({
   queueEvent: mockQueueEvent,
 }));
 
-vi.mock("@/lib/db", () => ({
-  db: {
-    query: {
-      contacts: { findFirst: mockContactFindFirst },
-      segments: { findFirst: vi.fn() },
-      topics: { findFirst: vi.fn() },
-    },
-    select: mockSelect,
-    insert: mockInsert,
-    update: mockUpdate,
-    delete: mockDelete,
-  },
+vi.mock("@opensend/core", () => ({
+  ContactServiceError: MockContactServiceError,
+  createContactService: () => mockContactService,
 }));
 
 describe("Resend-compatible root contacts API", () => {
@@ -86,34 +65,77 @@ describe("Resend-compatible root contacts API", () => {
 
   it("creates, lists, retrieves, updates, and deletes contacts at /contacts", async () => {
     const createdAt = new Date("2026-05-08T00:00:00.000Z");
-    const insertedContact = {
+    mockContactService.createContact.mockResolvedValueOnce({
+      object: "contact",
       id: "contact-1",
       email: "user@example.com",
-      firstName: "User",
-      lastName: "One",
+      webhookPayload: {
+        id: "contact-1",
+        email: "user@example.com",
+        first_name: "User",
+        last_name: "One",
+        unsubscribed: false,
+        properties: { plan: "pro" },
+        segments: [],
+        topics: [],
+        created_at: createdAt.toISOString(),
+      },
+    });
+    mockContactService.listContacts.mockResolvedValueOnce({
+      hasMore: false,
+      data: [
+        {
+          id: "contact-1",
+          email: "user@example.com",
+          first_name: "User",
+          last_name: "One",
+          firstName: "User",
+          lastName: "One",
+          unsubscribed: false,
+          status: "subscribed",
+          segments: [],
+          created_at: createdAt,
+        },
+      ],
+    });
+    mockContactService.getContact.mockResolvedValueOnce({
+      object: "contact",
+      id: "contact-1",
+      email: "user@example.com",
+      first_name: "User",
+      last_name: "One",
       unsubscribed: false,
-      customProperties: { plan: "pro" },
-      segments: null,
-      topicSubscriptions: null,
-      createdAt,
-      document: null,
-      userId: "user-1",
-    };
-    const updatedContact = {
-      ...insertedContact,
+      properties: { plan: "pro" },
+      segments: [],
+      topics: [],
+      created_at: createdAt,
+    });
+    mockContactService.updateContact.mockResolvedValueOnce({
+      object: "contact",
+      id: "contact-1",
+      email: "user@example.com",
+      first_name: "User",
+      last_name: "One",
       unsubscribed: true,
-    };
-
-    mockInsert.mockReturnValueOnce(makeChain([insertedContact]));
-    mockSelect.mockReturnValueOnce(makeChain([insertedContact]));
-    mockContactFindFirst
-      .mockResolvedValueOnce(insertedContact)
-      .mockResolvedValueOnce(insertedContact)
-      .mockResolvedValueOnce(updatedContact);
-    mockUpdate.mockReturnValueOnce(makeChain([updatedContact]));
-    mockDelete.mockReturnValueOnce(
-      makeChain([{ id: "contact-1", email: "user@example.com" }]),
-    );
+      properties: { plan: "pro" },
+      created_at: createdAt,
+      changedFields: ["unsubscribed"],
+      webhookPayload: {
+        id: "contact-1",
+        email: "user@example.com",
+        first_name: "User",
+        last_name: "One",
+        unsubscribed: true,
+        properties: { plan: "pro" },
+        segments: [],
+        topics: [],
+        created_at: createdAt.toISOString(),
+      },
+    });
+    mockContactService.deleteContact.mockResolvedValueOnce({
+      id: "contact-1",
+      email: "user@example.com",
+    });
 
     const collectionRoute = await import("@/app/contacts/route");
     const detailRoute = await import("@/app/contacts/[contact_id]/route");
@@ -138,6 +160,13 @@ describe("Resend-compatible root contacts API", () => {
       id: "contact-1",
     });
     expect(createResponse.status).toBe(201);
+    expect(mockContactService.createContact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        email: "USER@EXAMPLE.COM",
+        firstName: "User",
+      }),
+    );
 
     const listResponse = await collectionRoute.GET(
       makeRequest("http://localhost/contacts", {
@@ -207,12 +236,12 @@ describe("Resend-compatible root contacts API", () => {
     expect(mockQueueEvent).toHaveBeenCalledWith(
       expect.objectContaining({ type: "contact.deleted", userId: "user-1" }),
     );
-    expect(mockUpdate).toHaveBeenCalledTimes(1);
-    expect(mockDelete).toHaveBeenCalledTimes(1);
   });
 
   it("returns 404 for root email lookups outside the caller tenant", async () => {
-    mockContactFindFirst.mockResolvedValueOnce(null);
+    mockContactService.getContact.mockRejectedValueOnce(
+      new MockContactServiceError("not_found", "Contact not found"),
+    );
 
     const detailRoute = await import("@/app/contacts/[contact_id]/route");
     const response = await detailRoute.GET(
@@ -226,5 +255,9 @@ describe("Resend-compatible root contacts API", () => {
     await expect(response.json()).resolves.toEqual({
       error: "Contact not found",
     });
+    expect(mockContactService.getContact).toHaveBeenCalledWith(
+      "other@example.com",
+      "user-1",
+    );
   });
 });

--- a/tests/contact-service.test.ts
+++ b/tests/contact-service.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ContactRepository,
+  type ContactServiceError,
+  createContactService,
+} from "../packages/core/src/services/contact";
+
+type ContactRow = NonNullable<
+  Awaited<ReturnType<ContactRepository["findByIdOrEmailForUser"]>>
+>;
+type SegmentRow = NonNullable<
+  Awaited<ReturnType<ContactRepository["findSegmentByIdForUser"]>>
+>;
+type TopicRow = NonNullable<
+  Awaited<ReturnType<ContactRepository["findTopicByIdForUser"]>>
+>;
+type ContactInsert = Parameters<ContactRepository["create"]>[0];
+
+const createdAt = new Date("2026-05-10T00:00:00.000Z");
+
+function contactRow(overrides: Partial<ContactRow> = {}): ContactRow {
+  return {
+    id: "contact-1",
+    email: "user@example.com",
+    firstName: "User",
+    lastName: "One",
+    unsubscribed: false,
+    customProperties: { plan: "pro" },
+    segments: ["VIP"],
+    topicSubscriptions: [{ topicId: "topic-1", subscribed: true }],
+    createdAt,
+    document: null,
+    userId: "user-1",
+    ...overrides,
+  };
+}
+
+function segmentRow(overrides: Partial<SegmentRow> = {}): SegmentRow {
+  return {
+    id: "segment-1",
+    name: "VIP",
+    contactsCount: 0,
+    unsubscribedCount: 0,
+    createdAt,
+    document: null,
+    userId: "user-1",
+    ...overrides,
+  };
+}
+
+function topicRow(overrides: Partial<TopicRow> = {}): TopicRow {
+  return {
+    id: "topic-1",
+    name: "Product Updates",
+    description: null,
+    defaultSubscription: "opt_out",
+    visibility: "public",
+    createdAt,
+    document: null,
+    userId: "user-1",
+    ...overrides,
+  };
+}
+
+function createRepository(
+  overrides: Partial<ContactRepository> = {},
+): ContactRepository {
+  return {
+    async findByIdOrEmailForUser() {
+      return contactRow();
+    },
+    async create(data: ContactInsert) {
+      return [
+        contactRow({
+          email: data.email,
+          firstName: data.firstName ?? null,
+          lastName: data.lastName ?? null,
+          unsubscribed: data.unsubscribed ?? false,
+          customProperties: data.customProperties ?? null,
+          segments: data.segments ?? null,
+          topicSubscriptions: data.topicSubscriptions ?? null,
+          userId: data.userId ?? null,
+        }),
+      ];
+    },
+    async updateForUser(_id, _userId, data) {
+      return [contactRow(data as Partial<ContactRow>)];
+    },
+    async deleteForUser(id) {
+      return [{ id, email: "user@example.com" }];
+    },
+    async listForApi() {
+      return { data: [contactRow()], hasMore: false };
+    },
+    async findSegmentByIdForUser() {
+      return segmentRow();
+    },
+    async findSegmentByIdOrNameForUser() {
+      return segmentRow();
+    },
+    async findSegmentsByNamesForUser(names) {
+      return names.map((name, index) => ({
+        id: `segment-${index + 1}`,
+        name,
+        createdAt,
+      }));
+    },
+    async findTopicByIdForUser() {
+      return topicRow();
+    },
+    async addContactToSegment() {},
+    async removeContactFromSegment() {},
+    ...overrides,
+  };
+}
+
+describe("contact service", () => {
+  it("creates contacts with normalized email, tenant-scoped segment/topic resolution, and webhook payload", async () => {
+    let inserted: ContactInsert | null = null;
+    const findSegmentByIdOrNameForUser = vi
+      .fn<ContactRepository["findSegmentByIdOrNameForUser"]>()
+      .mockResolvedValue(segmentRow());
+    const findTopicByIdForUser = vi
+      .fn<ContactRepository["findTopicByIdForUser"]>()
+      .mockResolvedValue(topicRow());
+    const service = createContactService({
+      repository: createRepository({
+        findSegmentByIdOrNameForUser,
+        findTopicByIdForUser,
+        async create(data) {
+          inserted = data;
+          return [contactRow({ ...data, id: "created-contact" })];
+        },
+      }),
+    });
+
+    const result = await service.createContact({
+      userId: "user-1",
+      email: "USER@EXAMPLE.COM",
+      firstName: "User",
+      lastName: "One",
+      properties: { plan: "pro" },
+      segments: ["segment-1"],
+      topics: [{ id: "topic-1", subscription: "opt_out" }],
+    });
+
+    expect(findSegmentByIdOrNameForUser).toHaveBeenCalledWith(
+      "segment-1",
+      "user-1",
+    );
+    expect(findTopicByIdForUser).toHaveBeenCalledWith("topic-1", "user-1");
+    expect(inserted).toMatchObject({
+      email: "user@example.com",
+      firstName: "User",
+      lastName: "One",
+      customProperties: { plan: "pro" },
+      segments: ["VIP"],
+      topicSubscriptions: [{ topicId: "topic-1", subscribed: false }],
+      userId: "user-1",
+    });
+    expect(result).toMatchObject({
+      object: "contact",
+      id: "created-contact",
+      email: "user@example.com",
+      webhookPayload: {
+        id: "created-contact",
+        email: "user@example.com",
+        first_name: "User",
+        properties: { plan: "pro" },
+        segments: ["VIP"],
+        topics: [{ topicId: "topic-1", subscribed: false }],
+        created_at: "2026-05-10T00:00:00.000Z",
+      },
+    });
+  });
+
+  it("maps duplicate email persistence failures to a service error", async () => {
+    const service = createContactService({
+      repository: createRepository({
+        async create() {
+          throw { code: "23505" };
+        },
+      }),
+    });
+
+    await expect(
+      service.createContact({ userId: "user-1", email: "taken@example.com" }),
+    ).rejects.toMatchObject({
+      code: "duplicate_email",
+      message: "A contact with this email already exists",
+    } satisfies Partial<ContactServiceError>);
+  });
+
+  it("returns an empty list when the requested tenant segment does not exist", async () => {
+    const listForApi = vi.fn<ContactRepository["listForApi"]>();
+    const service = createContactService({
+      repository: createRepository({
+        listForApi,
+        async findSegmentByIdForUser() {
+          return undefined;
+        },
+      }),
+    });
+
+    const result = await service.listContacts({
+      userId: "user-1",
+      segmentId: "missing-segment",
+      limit: 500,
+    });
+
+    expect(result).toEqual({ data: [], hasMore: false });
+    expect(listForApi).not.toHaveBeenCalled();
+  });
+
+  it("normalizes list pagination and preserves public list shape", async () => {
+    let options: Parameters<ContactRepository["listForApi"]>[0] | null = null;
+    const service = createContactService({
+      repository: createRepository({
+        async listForApi(input) {
+          options = input;
+          return {
+            data: [contactRow({ unsubscribed: true, segments: null })],
+            hasMore: true,
+          };
+        },
+      }),
+    });
+
+    const result = await service.listContacts({
+      userId: "user-1",
+      search: "user",
+      status: "unsubscribed",
+      after: "contact-0",
+      limit: 500,
+    });
+
+    expect(options).toEqual({
+      userId: "user-1",
+      limit: 100,
+      after: "contact-0",
+      search: "user",
+      status: "unsubscribed",
+      segmentName: undefined,
+    });
+    expect(result).toEqual({
+      data: [
+        {
+          id: "contact-1",
+          email: "user@example.com",
+          firstName: "User",
+          lastName: "One",
+          first_name: "User",
+          last_name: "One",
+          unsubscribed: true,
+          status: "unsubscribed",
+          segments: [],
+          created_at: createdAt,
+        },
+      ],
+      hasMore: true,
+    });
+  });
+
+  it("updates only changed fields and skips persistence for no-op patches", async () => {
+    const updateForUser = vi
+      .fn<ContactRepository["updateForUser"]>()
+      .mockResolvedValue([contactRow({ firstName: "After" })]);
+    const service = createContactService({
+      repository: createRepository({ updateForUser }),
+    });
+
+    const updated = await service.updateContact({
+      userId: "user-1",
+      idOrEmail: "contact-1",
+      changes: { first_name: "After" },
+    });
+
+    expect(updateForUser).toHaveBeenCalledWith("contact-1", "user-1", {
+      firstName: "After",
+    });
+    expect(updated.changedFields).toEqual(["first_name"]);
+    expect(updated.webhookPayload.first_name).toBe("After");
+
+    updateForUser.mockClear();
+    const unchanged = await service.updateContact({
+      userId: "user-1",
+      idOrEmail: "contact-1",
+      changes: { first_name: "User" },
+    });
+
+    expect(updateForUser).not.toHaveBeenCalled();
+    expect(unchanged.changedFields).toEqual([]);
+  });
+
+  it("adds and removes contact segment associations with legacy segment array sync", async () => {
+    const addContactToSegment =
+      vi.fn<ContactRepository["addContactToSegment"]>();
+    const removeContactFromSegment =
+      vi.fn<ContactRepository["removeContactFromSegment"]>();
+    const updateForUser = vi
+      .fn<ContactRepository["updateForUser"]>()
+      .mockResolvedValue([contactRow()]);
+    const service = createContactService({
+      repository: createRepository({
+        addContactToSegment,
+        removeContactFromSegment,
+        updateForUser,
+        async findByIdOrEmailForUser() {
+          return contactRow({ segments: ["Newsletter"] });
+        },
+        async findSegmentByIdForUser() {
+          return segmentRow({ id: "segment-1", name: "VIP" });
+        },
+      }),
+    });
+
+    await expect(
+      service.addContactToSegment({
+        userId: "user-1",
+        idOrEmail: "contact-1",
+        segmentId: "segment-1",
+      }),
+    ).resolves.toEqual({ contactId: "contact-1", segmentId: "segment-1" });
+    expect(addContactToSegment).toHaveBeenCalledWith("contact-1", "segment-1");
+    expect(updateForUser).toHaveBeenCalledWith("contact-1", "user-1", {
+      segments: ["Newsletter", "VIP"],
+    });
+
+    updateForUser.mockClear();
+    await expect(
+      service.removeContactFromSegment({
+        userId: "user-1",
+        idOrEmail: "contact-1",
+        segmentId: "segment-1",
+      }),
+    ).resolves.toEqual({ contactId: "contact-1", segmentId: "segment-1" });
+    expect(removeContactFromSegment).toHaveBeenCalledWith(
+      "contact-1",
+      "segment-1",
+    );
+    expect(updateForUser).not.toHaveBeenCalled();
+  });
+});

--- a/tests/contact-tenant-isolation.test.ts
+++ b/tests/contact-tenant-isolation.test.ts
@@ -12,6 +12,25 @@ const mockInsert = vi.hoisted(() => vi.fn());
 const mockUpdate = vi.hoisted(() => vi.fn());
 const mockDelete = vi.hoisted(() => vi.fn());
 const mockQueueEvent = vi.hoisted(() => vi.fn());
+const mockContactService = vi.hoisted(() => ({
+  createContact: vi.fn(),
+  listContacts: vi.fn(),
+  getContact: vi.fn(),
+  updateContact: vi.fn(),
+  deleteContact: vi.fn(),
+}));
+const MockContactServiceError = vi.hoisted(
+  () =>
+    class ContactServiceError extends Error {
+      constructor(
+        readonly code: "duplicate_email" | "not_found",
+        message: string,
+      ) {
+        super(message);
+        this.name = "ContactServiceError";
+      }
+    },
+);
 
 function makeRequest(url: string, init?: RequestInit) {
   const request = new Request(url, init) as Request & { nextUrl: URL };
@@ -82,6 +101,11 @@ vi.mock("@/lib/events", () => ({
   queueEvent: mockQueueEvent,
 }));
 
+vi.mock("@opensend/core", () => ({
+  ContactServiceError: MockContactServiceError,
+  createContactService: () => mockContactService,
+}));
+
 vi.mock("@/lib/db", () => ({
   db: {
     query: {
@@ -102,7 +126,7 @@ vi.mock("@/lib/db", () => ({
 describe("contact API tenant isolation", () => {
   beforeEach(() => {
     vi.resetModules();
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     mockValidateApiKey.mockResolvedValue({
       apiKeyId: "key-b",
       permission: "full_access",
@@ -120,6 +144,11 @@ describe("contact API tenant isolation", () => {
       eventId: "event-1",
       deliveryIds: ["delivery-1"],
     });
+    mockContactService.createContact.mockReset();
+    mockContactService.listContacts.mockReset();
+    mockContactService.getContact.mockReset();
+    mockContactService.updateContact.mockReset();
+    mockContactService.deleteContact.mockReset();
   });
 
   it("enqueues contact.created for the caller tenant after creating a contact", async () => {
@@ -136,8 +165,22 @@ describe("contact API tenant isolation", () => {
       document: null,
       userId: "user-b",
     };
-    const insertChain = makeChain([insertedContact]);
-    mockInsert.mockReturnValueOnce(insertChain);
+    mockContactService.createContact.mockResolvedValueOnce({
+      object: "contact",
+      id: insertedContact.id,
+      email: insertedContact.email,
+      webhookPayload: {
+        id: insertedContact.id,
+        email: insertedContact.email,
+        first_name: insertedContact.firstName,
+        last_name: insertedContact.lastName,
+        unsubscribed: insertedContact.unsubscribed,
+        properties: insertedContact.customProperties,
+        segments: [],
+        topics: [],
+        created_at: insertedContact.createdAt.toISOString(),
+      },
+    });
 
     const route = await import("@/app/api/contacts/route");
     const response = await route.POST(
@@ -157,10 +200,12 @@ describe("contact API tenant isolation", () => {
     );
 
     expect(response.status).toBe(201);
-    expect(insertChain.values.mock.calls[0]?.[0]).toMatchObject({
-      email: "b@example.com",
-      userId: "user-b",
-    });
+    expect(mockContactService.createContact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "B@Example.com",
+        userId: "user-b",
+      }),
+    );
     expect(mockQueueEvent).toHaveBeenCalledWith({
       type: "contact.created",
       userId: "user-b",
@@ -203,6 +248,28 @@ describe("contact API tenant isolation", () => {
       },
     ]);
     mockUpdate.mockReturnValueOnce(updateChain);
+    mockContactService.updateContact.mockResolvedValueOnce({
+      object: "contact",
+      id: "contact-b",
+      email: "b@example.com",
+      first_name: "After",
+      last_name: null,
+      unsubscribed: false,
+      properties: null,
+      created_at: new Date("2026-05-06T00:00:00.000Z"),
+      changedFields: ["first_name"],
+      webhookPayload: {
+        id: "contact-b",
+        email: "b@example.com",
+        first_name: "After",
+        last_name: null,
+        unsubscribed: false,
+        properties: {},
+        segments: [],
+        topics: [],
+        created_at: "2026-05-06T00:00:00.000Z",
+      },
+    });
 
     const route = await import("@/app/api/contacts/[id]/route");
     const response = await route.PATCH(
@@ -225,7 +292,7 @@ describe("contact API tenant isolation", () => {
       }),
     });
 
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     mockValidateApiKey.mockResolvedValue({
       apiKeyId: "key-b",
       permission: "full_access",
@@ -244,6 +311,28 @@ describe("contact API tenant isolation", () => {
       createdAt: new Date("2026-05-06T00:00:00.000Z"),
       document: null,
       userId: "user-b",
+    });
+    mockContactService.updateContact.mockResolvedValueOnce({
+      object: "contact",
+      id: "contact-b",
+      email: "b@example.com",
+      first_name: "After",
+      last_name: null,
+      unsubscribed: false,
+      properties: null,
+      created_at: new Date("2026-05-06T00:00:00.000Z"),
+      changedFields: [],
+      webhookPayload: {
+        id: "contact-b",
+        email: "b@example.com",
+        first_name: "After",
+        last_name: null,
+        unsubscribed: false,
+        properties: {},
+        segments: [],
+        topics: [],
+        created_at: "2026-05-06T00:00:00.000Z",
+      },
     });
 
     const unchanged = await route.PATCH(
@@ -270,6 +359,10 @@ describe("contact API tenant isolation", () => {
       { id: "contact-b", email: "b@example.com" },
     ]);
     mockDelete.mockReturnValueOnce(deleteChain);
+    mockContactService.deleteContact.mockResolvedValueOnce({
+      id: "contact-b",
+      email: "b@example.com",
+    });
 
     const route = await import("@/app/api/contacts/[id]/route");
     const response = await route.DELETE(
@@ -291,6 +384,10 @@ describe("contact API tenant isolation", () => {
   it("returns an empty contact list scoped to the caller user", async () => {
     const listChain = makeChain([]);
     mockSelect.mockReturnValueOnce(listChain);
+    mockContactService.listContacts.mockResolvedValueOnce({
+      data: [],
+      hasMore: false,
+    });
 
     const route = await import("@/app/api/contacts/route");
     const response = await route.GET(
@@ -305,16 +402,16 @@ describe("contact API tenant isolation", () => {
       has_more: false,
     });
     expect(response.status).toBe(200);
-    expect(
-      expressionContains(listChain.where.mock.calls[0]?.[0], "user_id"),
-    ).toBe(true);
-    expect(
-      expressionContains(listChain.where.mock.calls[0]?.[0], "user-b"),
-    ).toBe(true);
+    expect(mockContactService.listContacts).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-b" }),
+    );
   });
 
   it("returns 404 when user B requests user A's contact detail", async () => {
     mockContactFindFirst.mockResolvedValueOnce(null);
+    mockContactService.getContact.mockRejectedValueOnce(
+      new MockContactServiceError("not_found", "Contact not found"),
+    );
 
     const route = await import("@/app/api/contacts/[id]/route");
     const response = await route.GET(
@@ -328,22 +425,17 @@ describe("contact API tenant isolation", () => {
       error: "Contact not found",
     });
     expect(response.status).toBe(404);
-    expect(
-      expressionContains(
-        mockContactFindFirst.mock.calls[0]?.[0]?.where,
-        "user_id",
-      ),
-    ).toBe(true);
-    expect(
-      expressionContains(
-        mockContactFindFirst.mock.calls[0]?.[0]?.where,
-        "user-b",
-      ),
-    ).toBe(true);
+    expect(mockContactService.getContact).toHaveBeenCalledWith(
+      "contact-a",
+      "user-b",
+    );
   });
 
   it("does not update user A's contact when called as user B", async () => {
     mockContactFindFirst.mockResolvedValueOnce(null);
+    mockContactService.updateContact.mockRejectedValueOnce(
+      new MockContactServiceError("not_found", "Contact not found"),
+    );
 
     const route = await import("@/app/api/contacts/[id]/route");
     const response = await route.PATCH(
@@ -361,6 +453,9 @@ describe("contact API tenant isolation", () => {
 
   it("does not delete user A's contact when called as user B", async () => {
     mockContactFindFirst.mockResolvedValueOnce(null);
+    mockContactService.deleteContact.mockRejectedValueOnce(
+      new MockContactServiceError("not_found", "Contact not found"),
+    );
 
     const route = await import("@/app/api/contacts/[id]/route");
     const response = await route.DELETE(

--- a/tests/contacts-list.test.ts
+++ b/tests/contacts-list.test.ts
@@ -1,6 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock next/navigation
+
+const mockContactService = vi.hoisted(() => ({
+  listContacts: vi.fn(),
+}));
+
+vi.mock("@opensend/core", () => ({
+  ContactServiceError: class ContactServiceError extends Error {
+    constructor(
+      readonly code: "duplicate_email" | "not_found",
+      message: string,
+    ) {
+      super(message);
+      this.name = "ContactServiceError";
+    }
+  },
+  createContactService: () => mockContactService,
+}));
+
+// Mock next/navigation
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
   usePathname: () => "/audience",
@@ -74,10 +93,25 @@ describe("Contacts List — API route", () => {
 
   beforeEach(() => {
     vi.resetModules();
+    vi.clearAllMocks();
   });
 
   it("returns contacts with correct shape", async () => {
-    vi.doMock("@/lib/db", () => createChainMock(mockRows, 2));
+    mockContactService.listContacts.mockResolvedValueOnce({
+      data: mockRows.map((row) => ({
+        id: row.id,
+        email: row.email,
+        first_name: row.firstName,
+        last_name: row.lastName,
+        firstName: row.firstName,
+        lastName: row.lastName,
+        unsubscribed: row.unsubscribed,
+        status: row.unsubscribed ? "unsubscribed" : "subscribed",
+        segments: row.segments ?? [],
+        created_at: row.createdAt,
+      })),
+      hasMore: false,
+    });
 
     handler = await import("@/app/api/contacts/route");
     const req = new Request("http://localhost:3015/api/contacts");
@@ -93,7 +127,10 @@ describe("Contacts List — API route", () => {
   });
 
   it("supports search query filtering", async () => {
-    vi.doMock("@/lib/db", () => createChainMock([], 0));
+    mockContactService.listContacts.mockResolvedValueOnce({
+      data: [],
+      hasMore: false,
+    });
 
     handler = await import("@/app/api/contacts/route");
     const req = new Request("http://localhost:3015/api/contacts?search=alice");
@@ -106,7 +143,10 @@ describe("Contacts List — API route", () => {
   });
 
   it("supports pagination with after and limit params", async () => {
-    vi.doMock("@/lib/db", () => createChainMock([], 100));
+    mockContactService.listContacts.mockResolvedValueOnce({
+      data: [],
+      hasMore: false,
+    });
 
     handler = await import("@/app/api/contacts/route");
     const req = new Request(


### PR DESCRIPTION
## Summary
- Closes #313 (parent tracker: #71).
- Scope: bounded to `/api/contacts` list/create/detail/update/delete plus contact-owned segment association routes:
  - `src/app/api/contacts/route.ts`
  - `src/app/api/contacts/[id]/route.ts`
  - `src/app/api/contacts/[id]/segments/route.ts`
  - `src/app/api/contacts/[id]/segments/[segment_id]/route.ts`
- Extracts contact CRUD, tenant-scoped lookup/listing, create topic/segment resolution, changed-field detection, webhook payload shaping, and contact↔segment legacy sync into `packages/core/src/services/contact.ts` plus core repository helpers.
- Keeps Next routes as thin adapters for auth/session lookup, request parsing, service call, event enqueue, and HTTP/status mapping.
- Adds a learning note for the non-obvious `contacts_to_segments` + legacy `contacts.segments` dual-write migration pitfall.

## Preserved behavior
- Public response shapes/statuses for contact CRUD and contact segment association routes.
- Tenant scoping via resolved `userId` for all moved reads/mutations.
- Existing create validation and duplicate-email `409` mapping.
- Existing PATCH invalid JSON `400`, no-op update behavior, changed-fields webhook payload, and delete event payload.
- Existing contact segment list/mutation responses and legacy segment-name array synchronization.

## Tests / validation
- `bun run test -- tests/contact-service.test.ts tests/contact-root-api.test.ts tests/contact-tenant-isolation.test.ts tests/contacts-list.test.ts` → passed (4 files, 26 tests).
- `make check` → passed (TypeCheck passed; Biome checked 445 files, no fixes applied).
- `make test` → passed (108 test files, 924 tests).
- Push guardrails also passed typecheck and changed-file Biome lint before push.

## Residual risk
- No Hono/control-plane adapter was added in this slice; this PR only prepares the reusable core boundary.
- The service intentionally preserves the transitional dual-write to `contacts_to_segments` and `contacts.segments`; future migrations should move read paths before removing that sync.
- Playwright E2E was not run because this is a backend/API service-boundary slice and full Vitest/API coverage passed.
