### PR TITLE
Extract API-key service route boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-10-issue-318-api-key-route-boundary.md
+++ b/agent_docs/learnings/active/2026-05-10-issue-318-api-key-route-boundary.md
@@ -1,0 +1,22 @@
+---
+date: 2026-05-10
+issue: "#318"
+type: pattern
+promoted_to: null
+---
+
+## API-key routes keep auth/quota/cache seams in Next while core owns DTO mapping
+
+**What:** API-key route adapters now share a route-local auth resolver for the
+dashboard/API-key split, while `packages/core/src/services/apiKeys.ts` owns the
+create-body normalization and public DTO mapping for list/detail/create.
+
+**Why:** The route family needs to stay Next-compatible for dashboard sessions,
+quota checks, full-access permission gates, and `invalidateApiKeyAuthCache`
+injection, but future adapters should not duplicate token visibility or
+snake-case response shaping.
+
+**Pattern:** Keep route code as auth/permission/quota → JSON read → core parser
+and service → response mapper. Public token material belongs only to the create
+mapper; list/detail mappers must enumerate safe fields so token hashes/previews
+cannot leak if repository/service rows grow.

--- a/packages/core/src/services/apiKeys.ts
+++ b/packages/core/src/services/apiKeys.ts
@@ -22,6 +22,36 @@ export type ApiKeyListResult = {
   hasMore: boolean;
 };
 
+export type ApiKeyPublicListResponseItem = {
+  id: string;
+  name: string;
+  created_at: ApiKeyServiceListItem["createdAt"];
+  last_used_at: ApiKeyServiceListItem["lastUsedAt"];
+  permission: ApiKeyServiceListItem["permission"];
+  domain: string | null;
+};
+
+export type ApiKeyPublicListResponse = {
+  object: "list";
+  data: ApiKeyPublicListResponseItem[];
+  has_more: boolean;
+};
+
+export type ApiKeyPublicDetailResponse = {
+  object: "api_key";
+  id: string;
+  name: string;
+  created_at: ApiKeyDetail["createdAt"];
+  last_used_at: ApiKeyDetail["lastUsedAt"];
+  permission: ApiKeyDetail["permission"];
+  domain: string | null;
+};
+
+export type ApiKeyPublicCreateResponse = {
+  id: string;
+  token: string;
+};
+
 export type CreateApiKeyInput = {
   name: string;
   permission?: ApiKeyPermission;
@@ -85,6 +115,67 @@ function previewApiKey(rawKey: string): string {
 
 function normalizeLimit(limit: number | undefined): number {
   return Math.min(Math.max(limit || 20, 1), 100);
+}
+
+export function parseCreateApiKeyBody(body: unknown): {
+  name: string;
+  permission?: ApiKeyPermission;
+  domainId?: string;
+} {
+  const data =
+    body && typeof body === "object" && !Array.isArray(body) ? body : {};
+  const record = data as Record<string, unknown>;
+  const permission = record.permission;
+  const domainId = record.domain_id;
+
+  return {
+    name: typeof record.name === "string" ? record.name : "",
+    permission:
+      permission === "full_access" || permission === "sending_access"
+        ? permission
+        : undefined,
+    domainId: typeof domainId === "string" ? domainId : undefined,
+  };
+}
+
+export function toApiKeyListResponse(
+  result: ApiKeyListResult,
+): ApiKeyPublicListResponse {
+  return {
+    object: "list",
+    data: result.data.map((key) => ({
+      id: key.id,
+      name: key.name,
+      created_at: key.createdAt,
+      last_used_at: key.lastUsedAt,
+      permission: key.permission,
+      domain: key.domain,
+    })),
+    has_more: result.hasMore,
+  };
+}
+
+export function toApiKeyDetailResponse(
+  key: ApiKeyDetail,
+): ApiKeyPublicDetailResponse {
+  return {
+    object: "api_key",
+    id: key.id,
+    name: key.name,
+    created_at: key.createdAt,
+    last_used_at: key.lastUsedAt,
+    permission: key.permission,
+    domain: key.domain,
+  };
+}
+
+export function toApiKeyCreateResponse(
+  created: CreateApiKeyResult,
+): ApiKeyPublicCreateResponse {
+  return {
+    id: created.id,
+    token: created.token,
+  };
 }
 
 export function createApiKeyService({

--- a/src/app/api/api-keys/[id]/route.ts
+++ b/src/app/api/api-keys/[id]/route.ts
@@ -1,11 +1,6 @@
-import {
-  authorizeDashboardOrApiKey,
-  getServerSession,
-  invalidateApiKeyAuthCache,
-  unauthorizedResponse,
-} from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { ApiKeyServiceError, createApiKeyService } from "@opensend/core";
+import { invalidateApiKeyAuthCache } from "@/lib/api-auth";
+import { createApiKeyService, toApiKeyDetailResponse } from "@opensend/core";
+import { authorizeApiKeyRoute, mapApiKeyServiceError } from "../route-helpers";
 
 function apiKeyService() {
   return createApiKeyService({
@@ -13,47 +8,20 @@ function apiKeyService() {
   });
 }
 
-function mapServiceError(err: unknown, fallback: string): Response {
-  if (err instanceof ApiKeyServiceError) {
-    return Response.json({ error: err.message }, { status: 404 });
-  }
-
-  const message = err instanceof Error ? err.message : fallback;
-  return Response.json({ error: message }, { status: 500 });
-}
-
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
-  const auth = await authorizeDashboardOrApiKey(
-    request.headers.get("authorization"),
-  );
-  if (!auth) {
-    return unauthorizedResponse();
-  }
-  const permissionError =
-    "apiKeyId" in auth ? requireFullAccessApiKey(auth) : null;
-  if (permissionError) return permissionError;
-  const session = "dashboard" in auth ? await getServerSession() : null;
-  const userId = "userId" in auth ? auth.userId : session?.user?.id;
-  if (!userId) return unauthorizedResponse();
+  const auth = await authorizeApiKeyRoute(request);
+  if ("response" in auth) return auth.response;
 
   const { id } = await params;
   try {
-    const key = await apiKeyService().getApiKey(id, userId);
+    const key = await apiKeyService().getApiKey(id, auth.userId);
 
-    return Response.json({
-      object: "api_key",
-      id: key.id,
-      name: key.name,
-      created_at: key.createdAt,
-      last_used_at: key.lastUsedAt,
-      permission: key.permission,
-      domain: key.domain,
-    });
+    return Response.json(toApiKeyDetailResponse(key));
   } catch (err) {
-    return mapServiceError(err, "Failed to get API key");
+    return mapApiKeyServiceError(err, "Failed to get API key");
   }
 }
 
@@ -61,25 +29,15 @@ export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
-  const auth = await authorizeDashboardOrApiKey(
-    request.headers.get("authorization"),
-  );
-  if (!auth) {
-    return unauthorizedResponse();
-  }
-  const permissionError =
-    "apiKeyId" in auth ? requireFullAccessApiKey(auth) : null;
-  if (permissionError) return permissionError;
-  const session = "dashboard" in auth ? await getServerSession() : null;
-  const userId = "userId" in auth ? auth.userId : session?.user?.id;
-  if (!userId) return unauthorizedResponse();
+  const auth = await authorizeApiKeyRoute(request);
+  if ("response" in auth) return auth.response;
 
   const { id } = await params;
   try {
-    await apiKeyService().deleteApiKey(id, userId);
+    await apiKeyService().deleteApiKey(id, auth.userId);
 
     return new Response(null, { status: 200 });
   } catch (err) {
-    return mapServiceError(err, "Failed to delete API key");
+    return mapApiKeyServiceError(err, "Failed to delete API key");
   }
 }

--- a/src/app/api/api-keys/route-helpers.ts
+++ b/src/app/api/api-keys/route-helpers.ts
@@ -1,0 +1,48 @@
+import {
+  authorizeDashboardOrApiKey,
+  getServerSession,
+  unauthorizedResponse,
+} from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
+import { ApiKeyServiceError } from "@opensend/core";
+
+type ApiKeyRouteAuth = NonNullable<
+  Awaited<ReturnType<typeof authorizeDashboardOrApiKey>>
+>;
+
+async function resolveUserId(auth: ApiKeyRouteAuth): Promise<string | null> {
+  if ("userId" in auth) return auth.userId;
+
+  const session = await getServerSession();
+  return session?.user?.id ?? null;
+}
+
+export async function authorizeApiKeyRoute(
+  request: Request,
+): Promise<{ userId: string } | { response: Response }> {
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
+  if (!auth) return { response: unauthorizedResponse() };
+
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return { response: permissionError };
+
+  const userId = await resolveUserId(auth);
+  if (!userId) return { response: unauthorizedResponse() };
+
+  return { userId };
+}
+
+export function mapApiKeyServiceError(
+  err: unknown,
+  fallback: string,
+): Response {
+  if (err instanceof ApiKeyServiceError) {
+    const status = err.code === "not_found" ? 404 : 422;
+    return Response.json({ error: err.message }, { status });
+  }
+
+  const message = err instanceof Error ? err.message : fallback;
+  return Response.json({ error: message }, { status: 500 });
+}

--- a/src/app/api/api-keys/route.ts
+++ b/src/app/api/api-keys/route.ts
@@ -1,16 +1,12 @@
-import {
-  authorizeDashboardOrApiKey,
-  getServerSession,
-  invalidateApiKeyAuthCache,
-  unauthorizedResponse,
-} from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
+import { invalidateApiKeyAuthCache } from "@/lib/api-auth";
 import { checkApiKeyQuota, quotaExceededResponse } from "@/lib/billing/quota";
 import {
-  type ApiKeyPermission,
-  ApiKeyServiceError,
   createApiKeyService,
+  parseCreateApiKeyBody,
+  toApiKeyCreateResponse,
+  toApiKeyListResponse,
 } from "@opensend/core";
+import { authorizeApiKeyRoute, mapApiKeyServiceError } from "./route-helpers";
 
 function apiKeyService() {
   return createApiKeyService({
@@ -18,49 +14,9 @@ function apiKeyService() {
   });
 }
 
-function mapServiceError(err: unknown, fallback: string): Response {
-  if (err instanceof ApiKeyServiceError) {
-    const status = err.code === "not_found" ? 404 : 422;
-    return Response.json({ error: err.message }, { status });
-  }
-
-  const message = err instanceof Error ? err.message : fallback;
-  return Response.json({ error: message }, { status: 500 });
-}
-
-function parseCreateApiKeyBody(body: unknown): {
-  name: string;
-  permission?: ApiKeyPermission;
-  domainId?: string;
-} {
-  const data = body && typeof body === "object" ? body : {};
-  const record = data as Record<string, unknown>;
-  const permission = record.permission;
-  const domainId = record.domain_id;
-
-  return {
-    name: typeof record.name === "string" ? record.name : "",
-    permission:
-      permission === "full_access" || permission === "sending_access"
-        ? permission
-        : undefined,
-    domainId: typeof domainId === "string" ? domainId : undefined,
-  };
-}
-
 export async function GET(request: Request): Promise<Response> {
-  const auth = await authorizeDashboardOrApiKey(
-    request.headers.get("authorization"),
-  );
-  if (!auth) {
-    return unauthorizedResponse();
-  }
-  const permissionError =
-    "apiKeyId" in auth ? requireFullAccessApiKey(auth) : null;
-  if (permissionError) return permissionError;
-  const session = "dashboard" in auth ? await getServerSession() : null;
-  const userId = "userId" in auth ? auth.userId : session?.user?.id;
-  if (!userId) return unauthorizedResponse();
+  const auth = await authorizeApiKeyRoute(request);
+  if ("response" in auth) return auth.response;
 
   const url = new URL(request.url);
   const limit = Number(url.searchParams.get("limit")) || 20;
@@ -68,41 +24,20 @@ export async function GET(request: Request): Promise<Response> {
 
   try {
     const result = await apiKeyService().listApiKeys({
-      userId,
+      userId: auth.userId,
       limit,
       after,
     });
 
-    return Response.json({
-      object: "list",
-      data: result.data.map((key) => ({
-        id: key.id,
-        name: key.name,
-        created_at: key.createdAt,
-        last_used_at: key.lastUsedAt,
-        permission: key.permission,
-        domain: key.domain,
-      })),
-      has_more: result.hasMore,
-    });
+    return Response.json(toApiKeyListResponse(result));
   } catch (err) {
-    return mapServiceError(err, "Failed to list API keys");
+    return mapApiKeyServiceError(err, "Failed to list API keys");
   }
 }
 
 export async function POST(request: Request): Promise<Response> {
-  const auth = await authorizeDashboardOrApiKey(
-    request.headers.get("authorization"),
-  );
-  if (!auth) {
-    return unauthorizedResponse();
-  }
-  const permissionError =
-    "apiKeyId" in auth ? requireFullAccessApiKey(auth) : null;
-  if (permissionError) return permissionError;
-  const session = "dashboard" in auth ? await getServerSession() : null;
-  const userId = "userId" in auth ? auth.userId : session?.user?.id;
-  if (!userId) return unauthorizedResponse();
+  const auth = await authorizeApiKeyRoute(request);
+  if ("response" in auth) return auth.response;
 
   let body: unknown;
   try {
@@ -112,24 +47,18 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   try {
-    const quota = await checkApiKeyQuota(userId);
+    const quota = await checkApiKeyQuota(auth.userId);
     if (!quota.ok) {
       return quotaExceededResponse(quota.info);
     }
 
     const created = await apiKeyService().createApiKey({
       ...parseCreateApiKeyBody(body),
-      userId,
+      userId: auth.userId,
     });
 
-    return Response.json(
-      {
-        id: created.id,
-        token: created.token,
-      },
-      { status: 201 },
-    );
+    return Response.json(toApiKeyCreateResponse(created), { status: 201 });
   } catch (err) {
-    return mapServiceError(err, "Failed to create API key");
+    return mapApiKeyServiceError(err, "Failed to create API key");
   }
 }

--- a/tests/api-key-routes.test.ts
+++ b/tests/api-key-routes.test.ts
@@ -1,0 +1,317 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockInvalidateApiKeyAuthCache = vi.hoisted(() => vi.fn());
+const mockCheckApiKeyQuota = vi.hoisted(() => vi.fn());
+const mockQuotaExceededResponse = vi.hoisted(() => vi.fn());
+const mockCreateApiKeyService = vi.hoisted(() => vi.fn());
+const mockListApiKeys = vi.hoisted(() => vi.fn());
+const mockCreateApiKey = vi.hoisted(() => vi.fn());
+const mockGetApiKey = vi.hoisted(() => vi.fn());
+const mockDeleteApiKey = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api-auth", () => ({
+  authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
+  getServerSession: mockGetServerSession,
+  invalidateApiKeyAuthCache: mockInvalidateApiKeyAuthCache,
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/billing/quota", () => ({
+  checkApiKeyQuota: mockCheckApiKeyQuota,
+  quotaExceededResponse: mockQuotaExceededResponse,
+}));
+
+vi.mock("@opensend/core", async () => {
+  const actual =
+    await vi.importActual<typeof import("@opensend/core")>("@opensend/core");
+
+  return {
+    ...actual,
+    createApiKeyService: mockCreateApiKeyService,
+  };
+});
+
+const createdAt = new Date("2026-05-10T00:00:00.000Z");
+const lastUsedAt = new Date("2026-05-10T01:00:00.000Z");
+
+function request(url: string, init: RequestInit = {}) {
+  const headers = new Headers(init.headers);
+  if (!headers.has("authorization")) {
+    headers.set("authorization", "Bearer re_test");
+  }
+
+  return new Request(url, {
+    ...init,
+    headers,
+  });
+}
+
+function jsonRequest(url: string, body: unknown) {
+  return request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function detailParams(id = "key-1") {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("API key route boundary", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue({
+      apiKeyId: "caller-key",
+      permission: "full_access",
+      domain: null,
+      userId: "user-1",
+    });
+    mockGetServerSession.mockResolvedValue(null);
+    mockCheckApiKeyQuota.mockResolvedValue({ ok: true });
+    mockQuotaExceededResponse.mockImplementation((info: unknown) =>
+      Response.json(
+        { error: "quota_exceeded", details: info },
+        { status: 402 },
+      ),
+    );
+    mockCreateApiKeyService.mockReturnValue({
+      listApiKeys: mockListApiKeys,
+      createApiKey: mockCreateApiKey,
+      getApiKey: mockGetApiKey,
+      deleteApiKey: mockDeleteApiKey,
+    });
+  });
+
+  it("lists caller-scoped API keys without exposing token material", async () => {
+    mockListApiKeys.mockResolvedValue({
+      data: [
+        {
+          id: "key-1",
+          name: "Primary",
+          createdAt,
+          lastUsedAt,
+          permission: "full_access",
+          domain: null,
+          token: "re_should_not_leak",
+          tokenHash: "hash-should-not-leak",
+        },
+      ],
+      hasMore: true,
+    });
+
+    const route = await import("@/app/api/api-keys/route");
+    const response = await route.GET(
+      request("http://localhost/api/api-keys?limit=50&after=key-0"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      object: "list",
+      data: [
+        {
+          id: "key-1",
+          name: "Primary",
+          created_at: createdAt.toISOString(),
+          last_used_at: lastUsedAt.toISOString(),
+          permission: "full_access",
+          domain: null,
+        },
+      ],
+      has_more: true,
+    });
+    expect(mockListApiKeys).toHaveBeenCalledWith({
+      userId: "user-1",
+      limit: 50,
+      after: "key-0",
+    });
+  });
+
+  it("creates API keys after quota check and returns the token only in the create response", async () => {
+    mockCreateApiKey.mockResolvedValue({
+      id: "created-key",
+      token: "re_created",
+      tokenHash: "hash-created",
+    });
+
+    const route = await import("@/app/api/api-keys/route");
+    const response = await route.POST(
+      jsonRequest("http://localhost/api/api-keys", {
+        name: "Primary",
+        permission: "sending_access",
+        domain_id: "domain-1",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      id: "created-key",
+      token: "re_created",
+    });
+    expect(mockCheckApiKeyQuota).toHaveBeenCalledWith("user-1");
+    expect(mockCreateApiKey).toHaveBeenCalledWith({
+      name: "Primary",
+      permission: "sending_access",
+      domainId: "domain-1",
+      userId: "user-1",
+    });
+    expect(mockCreateApiKeyService).toHaveBeenCalledWith({
+      invalidateAuthCache: mockInvalidateApiKeyAuthCache,
+    });
+  });
+
+  it("returns API-key detail without token material", async () => {
+    mockGetApiKey.mockResolvedValue({
+      id: "key-1",
+      name: "Primary",
+      createdAt,
+      lastUsedAt,
+      permission: "full_access",
+      domain: "domain-1",
+      tokenHash: "hash-should-not-leak",
+    });
+
+    const route = await import("@/app/api/api-keys/[id]/route");
+    const response = await route.GET(
+      request("http://localhost/api/api-keys/key-1"),
+      detailParams(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      object: "api_key",
+      id: "key-1",
+      name: "Primary",
+      created_at: createdAt.toISOString(),
+      last_used_at: lastUsedAt.toISOString(),
+      permission: "full_access",
+      domain: "domain-1",
+    });
+    expect(mockGetApiKey).toHaveBeenCalledWith("key-1", "user-1");
+  });
+
+  it("deletes caller-owned API keys with an empty 200 response body", async () => {
+    mockDeleteApiKey.mockResolvedValue({
+      id: "key-1",
+      tokenHash: "hash-deleted",
+    });
+
+    const route = await import("@/app/api/api-keys/[id]/route");
+    const response = await route.DELETE(
+      request("http://localhost/api/api-keys/key-1", { method: "DELETE" }),
+      detailParams(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("");
+    expect(mockDeleteApiKey).toHaveBeenCalledWith("key-1", "user-1");
+    expect(mockCreateApiKeyService).toHaveBeenCalledWith({
+      invalidateAuthCache: mockInvalidateApiKeyAuthCache,
+    });
+  });
+
+  it("preserves dashboard-session callers by resolving the session user before the service call", async () => {
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue({ dashboard: true });
+    mockGetServerSession.mockResolvedValue({
+      user: { id: "dashboard-user" },
+    });
+    mockListApiKeys.mockResolvedValue({ data: [], hasMore: false });
+
+    const route = await import("@/app/api/api-keys/route");
+    const response = await route.GET(request("http://localhost/api/api-keys"));
+
+    expect(response.status).toBe(200);
+    expect(mockListApiKeys).toHaveBeenCalledWith({
+      userId: "dashboard-user",
+      limit: 20,
+      after: "",
+    });
+  });
+
+  it("preserves tenant isolation by mapping service not-found misses to 404", async () => {
+    const { ApiKeyServiceError } = await import("@opensend/core");
+    mockGetApiKey.mockRejectedValue(
+      new ApiKeyServiceError("not_found", "API key not found"),
+    );
+    mockDeleteApiKey.mockRejectedValue(
+      new ApiKeyServiceError("not_found", "API key not found"),
+    );
+
+    const route = await import("@/app/api/api-keys/[id]/route");
+    const getResponse = await route.GET(
+      request("http://localhost/api/api-keys/key-other-user"),
+      detailParams("key-other-user"),
+    );
+    const deleteResponse = await route.DELETE(
+      request("http://localhost/api/api-keys/key-other-user", {
+        method: "DELETE",
+      }),
+      detailParams("key-other-user"),
+    );
+
+    expect(getResponse.status).toBe(404);
+    await expect(getResponse.json()).resolves.toEqual({
+      error: "API key not found",
+    });
+    expect(deleteResponse.status).toBe(404);
+    await expect(deleteResponse.json()).resolves.toEqual({
+      error: "API key not found",
+    });
+    expect(mockGetApiKey).toHaveBeenCalledWith("key-other-user", "user-1");
+    expect(mockDeleteApiKey).toHaveBeenCalledWith("key-other-user", "user-1");
+  });
+
+  it("rejects sending-access callers before quota and create service work", async () => {
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue({
+      apiKeyId: "sending-key",
+      permission: "sending_access",
+      domain: null,
+      userId: "user-1",
+    });
+
+    const route = await import("@/app/api/api-keys/route");
+    const response = await route.POST(
+      jsonRequest("http://localhost/api/api-keys", { name: "Blocked" }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "insufficient_api_key_permission",
+      statusCode: 403,
+    });
+    expect(mockCheckApiKeyQuota).not.toHaveBeenCalled();
+    expect(mockCreateApiKey).not.toHaveBeenCalled();
+  });
+
+  it("preserves quota failure behavior before create service work", async () => {
+    const quotaInfo = {
+      resource: "api_keys",
+      limit: 2,
+      used: 2,
+      plan: "free",
+      upgrade_url: "/dashboard/billing",
+    };
+    mockCheckApiKeyQuota.mockResolvedValue({
+      ok: false,
+      info: quotaInfo,
+    });
+
+    const route = await import("@/app/api/api-keys/route");
+    const response = await route.POST(
+      jsonRequest("http://localhost/api/api-keys", { name: "Blocked" }),
+    );
+
+    expect(response.status).toBe(402);
+    await expect(response.json()).resolves.toEqual({
+      error: "quota_exceeded",
+      details: quotaInfo,
+    });
+    expect(mockQuotaExceededResponse).toHaveBeenCalledWith(quotaInfo);
+    expect(mockCreateApiKey).not.toHaveBeenCalled();
+  });
+});

--- a/tests/api-key-service.test.ts
+++ b/tests/api-key-service.test.ts
@@ -3,6 +3,10 @@ import {
   type ApiKeyRepository,
   type ApiKeyServiceError,
   createApiKeyService,
+  parseCreateApiKeyBody,
+  toApiKeyCreateResponse,
+  toApiKeyDetailResponse,
+  toApiKeyListResponse,
 } from "../packages/core/src/services/apiKeys";
 
 type ApiKeyRow = Awaited<ReturnType<ApiKeyRepository["findById"]>> & {};
@@ -144,6 +148,77 @@ describe("api key service", () => {
         },
       ],
       hasMore: true,
+    });
+  });
+
+  it("parses create payloads without broadening permission or domain inputs", () => {
+    expect(
+      parseCreateApiKeyBody({
+        name: "Primary",
+        permission: "sending_access",
+        domain_id: "domain-1",
+      }),
+    ).toEqual({
+      name: "Primary",
+      permission: "sending_access",
+      domainId: "domain-1",
+    });
+
+    expect(
+      parseCreateApiKeyBody({
+        name: 123,
+        permission: "admin",
+        domain_id: 456,
+      }),
+    ).toEqual({
+      name: "",
+      permission: undefined,
+      domainId: undefined,
+    });
+  });
+
+  it("formats public API-key payloads with token visible only on create", () => {
+    const created = {
+      id: "created-key",
+      token: "re_created",
+      tokenHash: "hash-created",
+    };
+    const list = toApiKeyListResponse({
+      data: [apiKeyRow({ id: "key-list", name: "List key" })],
+      hasMore: false,
+    });
+    const detail = toApiKeyDetailResponse(
+      apiKeyRow({ id: "key-detail", name: "Detail key" }),
+    );
+
+    expect(toApiKeyCreateResponse(created)).toEqual({
+      id: "created-key",
+      token: "re_created",
+    });
+    expect(JSON.stringify(list)).not.toContain("token");
+    expect(JSON.stringify(detail)).not.toContain("token");
+    expect(list).toEqual({
+      object: "list",
+      data: [
+        {
+          id: "key-list",
+          name: "List key",
+          created_at: new Date("2026-05-02T00:00:00.000Z"),
+          last_used_at: null,
+          permission: "full_access",
+          domain: null,
+        },
+      ],
+      has_more: false,
+    });
+    expect(detail).toEqual({
+      object: "api_key",
+      id: "key-detail",
+      name: "Detail key",
+      created_at: new Date("2026-05-02T00:00:00.000Z"),
+      last_used_at: null,
+      permission: "full_access",
+      domain: null,
     });
   });
 

--- a/tests/cache-invalidation-routes.test.ts
+++ b/tests/cache-invalidation-routes.test.ts
@@ -33,6 +33,40 @@ vi.mock("@opensend/core", () => ({
     getApiKey: vi.fn(),
     listApiKeys: vi.fn(),
   }),
+  parseCreateApiKeyBody: (body: unknown) => {
+    const record =
+      body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+    return {
+      name: typeof record.name === "string" ? record.name : "",
+      permission:
+        record.permission === "full_access" ||
+        record.permission === "sending_access"
+          ? record.permission
+          : undefined,
+      domainId:
+        typeof record.domain_id === "string" ? record.domain_id : undefined,
+    };
+  },
+  toApiKeyCreateResponse: (created: { id: string; token: string }) => ({
+    id: created.id,
+    token: created.token,
+  }),
+  toApiKeyDetailResponse: (key: {
+    id: string;
+    name: string;
+    createdAt: Date | string;
+    lastUsedAt: Date | string | null;
+    permission: string;
+    domain: string | null;
+  }) => ({
+    object: "api_key",
+    id: key.id,
+    name: key.name,
+    created_at: key.createdAt,
+    last_used_at: key.lastUsedAt,
+    permission: key.permission,
+    domain: key.domain,
+  }),
   createDomainService: () => ({
     createDomain: mockCreateDomain,
   }),

--- a/tests/webhooks-api-keys-tenant-isolation.test.ts
+++ b/tests/webhooks-api-keys-tenant-isolation.test.ts
@@ -45,6 +45,62 @@ vi.mock("@opensend/core", () => ({
     getApiKey: mockGetApiKey,
     deleteApiKey: mockDeleteApiKey,
   }),
+  parseCreateApiKeyBody: (body: unknown) => {
+    const record =
+      body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+    return {
+      name: typeof record.name === "string" ? record.name : "",
+      permission:
+        record.permission === "full_access" ||
+        record.permission === "sending_access"
+          ? record.permission
+          : undefined,
+      domainId:
+        typeof record.domain_id === "string" ? record.domain_id : undefined,
+    };
+  },
+  toApiKeyCreateResponse: (created: { id: string; token: string }) => ({
+    id: created.id,
+    token: created.token,
+  }),
+  toApiKeyDetailResponse: (key: {
+    id: string;
+    name: string;
+    createdAt: Date | string;
+    lastUsedAt: Date | string | null;
+    permission: string;
+    domain: string | null;
+  }) => ({
+    object: "api_key",
+    id: key.id,
+    name: key.name,
+    created_at: key.createdAt,
+    last_used_at: key.lastUsedAt,
+    permission: key.permission,
+    domain: key.domain,
+  }),
+  toApiKeyListResponse: (result: {
+    data: Array<{
+      id: string;
+      name: string;
+      createdAt: Date | string;
+      lastUsedAt: Date | string | null;
+      permission: string;
+      domain: string | null;
+    }>;
+    hasMore: boolean;
+  }) => ({
+    object: "list",
+    data: result.data.map((key) => ({
+      id: key.id,
+      name: key.name,
+      created_at: key.createdAt,
+      last_used_at: key.lastUsedAt,
+      permission: key.permission,
+      domain: key.domain,
+    })),
+    has_more: result.hasMore,
+  }),
   createWebhookService: () => ({
     listWebhooks: mockListWebhooks,
     createWebhook: mockCreateWebhook,


### PR DESCRIPTION
## Summary
- Extracted shared API-key route auth/error handling into `src/app/api/api-keys/route-helpers.ts` while preserving dashboard-session and API-key caller support.
- Moved create-body normalization and public list/detail/create DTO mapping into `packages/core/src/services/apiKeys.ts` so token material is create-only by construction.
- Added focused API-key route coverage for list/create/detail/delete, token visibility, dashboard session callers, tenant not-found mapping, permission failures, quota failures, and cache invalidation injection.
- Captured the boundary pattern in `agent_docs/learnings/active/2026-05-10-issue-318-api-key-route-boundary.md`.

Closes #318

## Changed files
- `agent_docs/learnings/active/2026-05-10-issue-318-api-key-route-boundary.md`
- `packages/core/src/services/apiKeys.ts`
- `src/app/api/api-keys/[id]/route.ts`
- `src/app/api/api-keys/route-helpers.ts`
- `src/app/api/api-keys/route.ts`
- `tests/api-key-routes.test.ts`
- `tests/api-key-service.test.ts`
- `tests/cache-invalidation-routes.test.ts`
- `tests/webhooks-api-keys-tenant-isolation.test.ts`

## Checks run
- `bun run test tests/api-key-service.test.ts tests/api-key-routes.test.ts tests/webhooks-api-keys-tenant-isolation.test.ts tests/quota-routes.test.ts tests/cache-invalidation-routes.test.ts`
- `make check`
- push guardrails: `scripts/check-changed-files.mjs`, full-project typecheck, changed-file Biome lint

## Not run / residual risk
- Full `make test` was not run because the changed surface is limited to API-key routes/core mapping/tests and does not edit shared auth/cache internals.
- Playwright was not run because there are no dashboard UI changes.
