### PR TITLE
architecture: extract broadcast CRUD service boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-10-issue-320-broadcast-crud-boundary.md
+++ b/agent_docs/learnings/active/2026-05-10-issue-320-broadcast-crud-boundary.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-10
+issue: "#320"
+type: pattern
+promoted_to: null
+---
+
+## Broadcast CRUD keeps auth and HTTP mapping in Next while core owns tenant-scoped orchestration
+
+Broadcast create/list/detail/update/delete now route through `packages/core/src/services/broadcast.ts`, with Next adapters limited to auth resolution, request/query parsing, service invocation, and status/body mapping.
+
+The reusable boundary should keep tenant scope in every repository method (`findByIdForUser`, `listForApi`, `updateForUser`, `deleteForUser`) instead of accepting unscoped CRUD calls from adapters. Preserve send and metrics as separate slices because they own fanout/status-transition and aggregation/cache behavior beyond CRUD.

--- a/packages/core/src/db/repositories/broadcastRepo.ts
+++ b/packages/core/src/db/repositories/broadcastRepo.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, ilike, lt } from "drizzle-orm";
+import { type SQL, and, desc, eq, ilike, lt } from "drizzle-orm";
 import { db } from "../client";
 import { broadcasts } from "../schema";
 
@@ -7,6 +7,22 @@ export const broadcastRepo = {
     return await db.query.broadcasts.findFirst({
       where: eq(broadcasts.id, id),
     });
+  },
+
+  async findByIdForUser(id: string, userId: string) {
+    return await db.query.broadcasts.findFirst({
+      where: and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)),
+    });
+  },
+
+  async findDeletionCandidateForUser(id: string, userId: string) {
+    const [broadcast] = await db
+      .select({ status: broadcasts.status })
+      .from(broadcasts)
+      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
+      .limit(1);
+
+    return broadcast;
   },
 
   async create(data: typeof broadcasts.$inferInsert) {
@@ -21,10 +37,29 @@ export const broadcastRepo = {
       .returning();
   },
 
+  async updateForUser(
+    id: string,
+    userId: string,
+    data: Record<string, unknown>,
+  ) {
+    return await db
+      .update(broadcasts)
+      .set(data)
+      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
+      .returning();
+  },
+
   async delete(id: string) {
     return await db
       .delete(broadcasts)
       .where(eq(broadcasts.id, id))
+      .returning({ id: broadcasts.id });
+  },
+
+  async deleteForUser(id: string, userId: string) {
+    return await db
+      .delete(broadcasts)
+      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
       .returning({ id: broadcasts.id });
   },
 
@@ -38,7 +73,7 @@ export const broadcastRepo = {
     } = {},
   ) {
     const { limit = 40, after, search, status, segmentId } = options;
-    const conditions = [];
+    const conditions: SQL[] = [];
 
     if (search) conditions.push(ilike(broadcasts.name, `%${search}%`));
     if (status) conditions.push(eq(broadcasts.status, status));
@@ -49,6 +84,43 @@ export const broadcastRepo = {
       .select()
       .from(broadcasts)
       .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(desc(broadcasts.id))
+      .limit(limit + 1);
+
+    const hasMore = results.length > limit;
+    const data = hasMore ? results.slice(0, limit) : results;
+
+    return { data, hasMore };
+  },
+
+  async listForApi(options: {
+    userId: string;
+    limit: number;
+    after?: string;
+    search?: string;
+    status?: string;
+    segmentId?: string;
+  }) {
+    const { userId, limit, after, search, status, segmentId } = options;
+    const conditions: SQL[] = [eq(broadcasts.userId, userId)];
+
+    if (search) conditions.push(ilike(broadcasts.name, `%${search}%`));
+    if (status) conditions.push(eq(broadcasts.status, status));
+    if (segmentId) conditions.push(eq(broadcasts.audienceId, segmentId));
+    if (after) conditions.push(lt(broadcasts.id, after));
+
+    const results = await db
+      .select({
+        id: broadcasts.id,
+        name: broadcasts.name,
+        status: broadcasts.status,
+        audienceId: broadcasts.audienceId,
+        topicId: broadcasts.topicId,
+        createdAt: broadcasts.createdAt,
+        scheduledAt: broadcasts.scheduledAt,
+      })
+      .from(broadcasts)
+      .where(and(...conditions))
       .orderBy(desc(broadcasts.id))
       .limit(limit + 1);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,7 @@ export * from "./services/emailProvider";
 export * from "./services/sandboxTestRecipients";
 export * from "./services/storage";
 export * from "./services/template";
+export * from "./services/broadcast";
 export * from "./services/audience-metadata";
 export * from "./jobs/background-jobs";
 export * from "./observability/telemetry";

--- a/packages/core/src/services/broadcast.ts
+++ b/packages/core/src/services/broadcast.ts
@@ -1,0 +1,291 @@
+import { broadcastRepo } from "../db/repositories/broadcastRepo";
+import type { broadcasts } from "../db/schema";
+
+type BroadcastRow = typeof broadcasts.$inferSelect;
+type BroadcastInsert = typeof broadcasts.$inferInsert;
+
+export type BroadcastListItem = Pick<
+  BroadcastRow,
+  | "id"
+  | "name"
+  | "status"
+  | "audienceId"
+  | "topicId"
+  | "createdAt"
+  | "scheduledAt"
+>;
+
+export type BroadcastDetail = Pick<
+  BroadcastRow,
+  | "id"
+  | "name"
+  | "status"
+  | "from"
+  | "subject"
+  | "html"
+  | "text"
+  | "replyTo"
+  | "previewText"
+  | "audienceId"
+  | "topicId"
+  | "scheduledAt"
+  | "createdAt"
+>;
+
+export type BroadcastCreateResult = Pick<
+  BroadcastRow,
+  "id" | "name" | "status" | "createdAt"
+>;
+
+export type BroadcastDeleteResult = {
+  id: string;
+};
+
+export type BroadcastListResult = {
+  data: BroadcastListItem[];
+  hasMore: boolean;
+};
+
+export type BroadcastServiceErrorCode =
+  | "invalid_input"
+  | "not_found"
+  | "delete_forbidden";
+
+export class BroadcastServiceError extends Error {
+  constructor(
+    readonly code: BroadcastServiceErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "BroadcastServiceError";
+  }
+}
+
+export type BroadcastRepository = {
+  findByIdForUser(
+    id: string,
+    userId: string,
+  ): Promise<BroadcastRow | undefined>;
+  create(data: BroadcastInsert): Promise<BroadcastRow[]>;
+  updateForUser(
+    id: string,
+    userId: string,
+    data: Record<string, unknown>,
+  ): Promise<BroadcastRow[]>;
+  deleteForUser(id: string, userId: string): Promise<BroadcastDeleteResult[]>;
+  findDeletionCandidateForUser(
+    id: string,
+    userId: string,
+  ): Promise<Pick<BroadcastRow, "status"> | undefined>;
+  listForApi(options: {
+    userId: string;
+    limit: number;
+    after?: string;
+    search?: string;
+    status?: string;
+    segmentId?: string;
+  }): Promise<BroadcastListResult>;
+};
+
+export type BroadcastServiceDependencies = {
+  repository?: BroadcastRepository;
+};
+
+export type ListBroadcastsInput = {
+  userId: string;
+  limit?: number;
+  after?: string;
+  search?: string;
+  status?: string;
+  segmentId?: string;
+};
+
+export type CreateBroadcastInput = {
+  userId: string;
+  body: unknown;
+};
+
+export type UpdateBroadcastInput = {
+  userId: string;
+  id: string;
+  body: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function trimString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function optionalStoredString(value: unknown): string | null {
+  return value ? String(value) : null;
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  return Math.min(120, Math.max(1, limit || 40));
+}
+
+function toDetail(row: BroadcastRow): BroadcastDetail {
+  return {
+    id: row.id,
+    name: row.name,
+    status: row.status,
+    from: row.from,
+    subject: row.subject,
+    html: row.html,
+    text: row.text,
+    replyTo: row.replyTo,
+    previewText: row.previewText,
+    audienceId: row.audienceId,
+    topicId: row.topicId,
+    scheduledAt: row.scheduledAt,
+    createdAt: row.createdAt,
+  };
+}
+
+function buildUpdateData(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  const updateData: Record<string, unknown> = {};
+  if (body.name !== undefined) updateData.name = body.name;
+  if (body.status !== undefined) updateData.status = body.status;
+  if (body.from !== undefined) updateData.from = body.from;
+  if (body.subject !== undefined) updateData.subject = body.subject;
+  if (body.html !== undefined) updateData.html = body.html;
+  if (body.text !== undefined) updateData.text = body.text;
+  if (body.reply_to !== undefined) updateData.replyTo = body.reply_to;
+  if (body.replyTo !== undefined) updateData.replyTo = body.replyTo;
+  if (body.preview_text !== undefined)
+    updateData.previewText = body.preview_text;
+  if (body.previewText !== undefined) updateData.previewText = body.previewText;
+  if (body.audience_id !== undefined) updateData.audienceId = body.audience_id;
+  if (body.audienceId !== undefined) updateData.audienceId = body.audienceId;
+  if (body.topic_id !== undefined) updateData.topicId = body.topic_id;
+  if (body.topicId !== undefined) updateData.topicId = body.topicId;
+  if (body.scheduled_at !== undefined)
+    updateData.scheduledAt = body.scheduled_at;
+  if (body.scheduledAt !== undefined) updateData.scheduledAt = body.scheduledAt;
+  return updateData;
+}
+
+export function createBroadcastService({
+  repository = broadcastRepo,
+}: BroadcastServiceDependencies = {}) {
+  return {
+    async listBroadcasts(
+      input: ListBroadcastsInput,
+    ): Promise<BroadcastListResult> {
+      return await repository.listForApi({
+        userId: input.userId,
+        limit: normalizeLimit(input.limit),
+        after: input.after?.trim() || undefined,
+        search: input.search?.trim() || undefined,
+        status: input.status?.trim() || undefined,
+        segmentId: input.segmentId?.trim() || undefined,
+      });
+    },
+
+    async createBroadcast(
+      input: CreateBroadcastInput,
+    ): Promise<BroadcastCreateResult> {
+      const body = asRecord(input.body);
+      const name = trimString(body.name) || "Untitled";
+      const from = trimString(body.from);
+      const subject = trimString(body.subject);
+      const audienceId = body.segment_id || body.audience_id || null;
+
+      if (!from || !subject || !audienceId) {
+        throw new BroadcastServiceError(
+          "invalid_input",
+          "from, subject, and segment_id are required",
+        );
+      }
+
+      const scheduledAt = body.scheduled_at
+        ? new Date(String(body.scheduled_at))
+        : null;
+      const shouldSend = body.send === true;
+      const [broadcast] = await repository.create({
+        name,
+        from,
+        subject,
+        audienceId: String(audienceId),
+        html: optionalStoredString(body.html),
+        text: optionalStoredString(body.text),
+        replyTo: optionalStoredString(body.reply_to),
+        previewText: optionalStoredString(body.preview_text),
+        topicId: optionalStoredString(body.topic_id),
+        status: shouldSend ? (scheduledAt ? "scheduled" : "queued") : "draft",
+        scheduledAt,
+        userId: input.userId,
+      });
+
+      return {
+        id: broadcast.id,
+        name: broadcast.name,
+        status: broadcast.status,
+        createdAt: broadcast.createdAt,
+      };
+    },
+
+    async getBroadcast(userId: string, id: string): Promise<BroadcastDetail> {
+      const broadcast = await repository.findByIdForUser(id, userId);
+      if (!broadcast) {
+        throw new BroadcastServiceError("not_found", "Broadcast not found");
+      }
+
+      return toDetail(broadcast);
+    },
+
+    async updateBroadcast(
+      input: UpdateBroadcastInput,
+    ): Promise<BroadcastDetail> {
+      const [updated] = await repository.updateForUser(
+        input.id,
+        input.userId,
+        buildUpdateData(asRecord(input.body)),
+      );
+
+      if (!updated) {
+        throw new BroadcastServiceError("not_found", "Broadcast not found");
+      }
+
+      return toDetail(updated);
+    },
+
+    async deleteBroadcast(
+      userId: string,
+      id: string,
+    ): Promise<BroadcastDeleteResult> {
+      const existing = await repository.findDeletionCandidateForUser(
+        id,
+        userId,
+      );
+
+      if (!existing) {
+        throw new BroadcastServiceError("not_found", "Broadcast not found");
+      }
+
+      if (existing.status !== "draft" && existing.status !== "scheduled") {
+        throw new BroadcastServiceError(
+          "delete_forbidden",
+          "Cannot delete a broadcast that is already sent or queued",
+        );
+      }
+
+      const [deleted] = await repository.deleteForUser(id, userId);
+
+      if (!deleted) {
+        throw new BroadcastServiceError("not_found", "Broadcast not found");
+      }
+
+      return deleted;
+    },
+  };
+}

--- a/src/app/api/broadcasts/[id]/route.ts
+++ b/src/app/api/broadcasts/[id]/route.ts
@@ -1,51 +1,62 @@
 import { unauthorizedResponse } from "@/lib/api-auth";
-import { db } from "@/lib/db";
-import { broadcasts } from "@/lib/db/schema";
-import { and, eq } from "drizzle-orm";
+import { BroadcastServiceError, createBroadcastService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 import { resolveBroadcastRouteUserId } from "../auth";
 
+const broadcastService = createBroadcastService();
+
+type BroadcastDetail = Awaited<
+  ReturnType<typeof broadcastService.getBroadcast>
+>;
+
+function broadcastDetailResponse(broadcast: BroadcastDetail) {
+  return NextResponse.json({
+    object: "broadcast",
+    id: broadcast.id,
+    name: broadcast.name,
+    status: broadcast.status,
+    from: broadcast.from,
+    subject: broadcast.subject,
+    html: broadcast.html,
+    text: broadcast.text,
+    reply_to: broadcast.replyTo,
+    preview_text: broadcast.previewText,
+    audience_id: broadcast.audienceId,
+    topic_id: broadcast.topicId,
+    scheduled_at: broadcast.scheduledAt,
+    created_at: broadcast.createdAt,
+  });
+}
+
+function notFoundResponse() {
+  return NextResponse.json({ error: "Broadcast not found" }, { status: 404 });
+}
+
+function deleteForbiddenResponse() {
+  return NextResponse.json(
+    { error: "Cannot delete a broadcast that is already sent or queued" },
+    { status: 400 },
+  );
+}
+
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const userId = await resolveBroadcastRouteUserId(
-    _request.headers.get("authorization"),
+    request.headers.get("authorization"),
   );
   if (!userId) return unauthorizedResponse();
 
   try {
     const { id } = await params;
-    const [broadcast] = await db
-      .select()
-      .from(broadcasts)
-      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
-      .limit(1);
-
-    if (!broadcast) {
-      return NextResponse.json(
-        { error: "Broadcast not found" },
-        { status: 404 },
-      );
+    const broadcast = await broadcastService.getBroadcast(userId, id);
+    return broadcastDetailResponse(broadcast);
+  } catch (error) {
+    if (error instanceof BroadcastServiceError && error.code === "not_found") {
+      return notFoundResponse();
     }
 
-    return NextResponse.json({
-      object: "broadcast",
-      id: broadcast.id,
-      name: broadcast.name,
-      status: broadcast.status,
-      from: broadcast.from,
-      subject: broadcast.subject,
-      html: broadcast.html,
-      text: broadcast.text,
-      reply_to: broadcast.replyTo,
-      preview_text: broadcast.previewText,
-      audience_id: broadcast.audienceId,
-      topic_id: broadcast.topicId,
-      scheduled_at: broadcast.scheduledAt,
-      created_at: broadcast.createdAt,
-    });
-  } catch (error) {
     console.error("Failed to fetch broadcast:", error);
     return NextResponse.json(
       { error: "Failed to fetch broadcast" },
@@ -66,60 +77,18 @@ export async function PATCH(
   try {
     const { id } = await params;
     const body = await request.json();
+    const updated = await broadcastService.updateBroadcast({
+      id,
+      userId,
+      body,
+    });
 
-    const updateData: Record<string, unknown> = {};
-    if (body.name !== undefined) updateData.name = body.name;
-    if (body.status !== undefined) updateData.status = body.status;
-    if (body.from !== undefined) updateData.from = body.from;
-    if (body.subject !== undefined) updateData.subject = body.subject;
-    if (body.html !== undefined) updateData.html = body.html;
-    if (body.text !== undefined) updateData.text = body.text;
-    if (body.reply_to !== undefined) updateData.replyTo = body.reply_to;
-    if (body.replyTo !== undefined) updateData.replyTo = body.replyTo;
-    if (body.preview_text !== undefined)
-      updateData.previewText = body.preview_text;
-    if (body.previewText !== undefined)
-      updateData.previewText = body.previewText;
-    if (body.audience_id !== undefined)
-      updateData.audienceId = body.audience_id;
-    if (body.audienceId !== undefined) updateData.audienceId = body.audienceId;
-    if (body.topic_id !== undefined) updateData.topicId = body.topic_id;
-    if (body.topicId !== undefined) updateData.topicId = body.topicId;
-    if (body.scheduled_at !== undefined)
-      updateData.scheduledAt = body.scheduled_at;
-    if (body.scheduledAt !== undefined)
-      updateData.scheduledAt = body.scheduledAt;
-
-    const [updated] = await db
-      .update(broadcasts)
-      .set(updateData)
-      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
-      .returning();
-
-    if (!updated) {
-      return NextResponse.json(
-        { error: "Broadcast not found" },
-        { status: 404 },
-      );
+    return broadcastDetailResponse(updated);
+  } catch (error) {
+    if (error instanceof BroadcastServiceError && error.code === "not_found") {
+      return notFoundResponse();
     }
 
-    return NextResponse.json({
-      object: "broadcast",
-      id: updated.id,
-      name: updated.name,
-      status: updated.status,
-      from: updated.from,
-      subject: updated.subject,
-      html: updated.html,
-      text: updated.text,
-      reply_to: updated.replyTo,
-      preview_text: updated.previewText,
-      audience_id: updated.audienceId,
-      topic_id: updated.topicId,
-      scheduled_at: updated.scheduledAt,
-      created_at: updated.createdAt,
-    });
-  } catch (error) {
     console.error("Failed to update broadcast:", error);
     return NextResponse.json(
       { error: "Failed to update broadcast" },
@@ -129,53 +98,17 @@ export async function PATCH(
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const userId = await resolveBroadcastRouteUserId(
-    _request.headers.get("authorization"),
+    request.headers.get("authorization"),
   );
   if (!userId) return unauthorizedResponse();
 
   try {
     const { id } = await params;
-
-    // Draft-guard logic
-    const results = await db
-      .select({ status: broadcasts.status })
-      .from(broadcasts)
-      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
-      .limit(1);
-
-    const existing = results ? results[0] : undefined;
-
-    if (!existing) {
-      return NextResponse.json(
-        { error: "Broadcast not found" },
-        { status: 404 },
-      );
-    }
-
-    if (existing.status !== "draft" && existing.status !== "scheduled") {
-      return NextResponse.json(
-        { error: "Cannot delete a broadcast that is already sent or queued" },
-        { status: 400 },
-      );
-    }
-
-    const deleteResults = await db
-      .delete(broadcasts)
-      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
-      .returning();
-
-    const deleted = deleteResults ? deleteResults[0] : undefined;
-
-    if (!deleted) {
-      return NextResponse.json(
-        { error: "Broadcast not found" },
-        { status: 404 },
-      );
-    }
+    const deleted = await broadcastService.deleteBroadcast(userId, id);
 
     return NextResponse.json({
       object: "broadcast",
@@ -183,6 +116,11 @@ export async function DELETE(
       deleted: true,
     });
   } catch (error) {
+    if (error instanceof BroadcastServiceError) {
+      if (error.code === "not_found") return notFoundResponse();
+      if (error.code === "delete_forbidden") return deleteForbiddenResponse();
+    }
+
     console.error("Failed to delete broadcast:", error);
     return NextResponse.json(
       { error: "Failed to delete broadcast" },

--- a/src/app/api/broadcasts/route.ts
+++ b/src/app/api/broadcasts/route.ts
@@ -1,9 +1,27 @@
 import { unauthorizedResponse } from "@/lib/api-auth";
-import { db } from "@/lib/db";
-import { broadcasts } from "@/lib/db/schema";
-import { type SQL, and, desc, eq, ilike, lt } from "drizzle-orm";
+import { BroadcastServiceError, createBroadcastService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 import { resolveBroadcastRouteUserId } from "./auth";
+
+const broadcastService = createBroadcastService();
+
+function broadcastListResponse(
+  result: Awaited<ReturnType<typeof broadcastService.listBroadcasts>>,
+) {
+  return NextResponse.json({
+    object: "list",
+    data: result.data.map((broadcast) => ({
+      id: broadcast.id,
+      name: broadcast.name,
+      status: broadcast.status,
+      audience_id: broadcast.audienceId,
+      topic_id: broadcast.topicId,
+      created_at: broadcast.createdAt,
+      scheduled_at: broadcast.scheduledAt,
+    })),
+    has_more: result.hasMore,
+  });
+}
 
 export async function GET(request: NextRequest) {
   const userId = await resolveBroadcastRouteUserId(
@@ -13,65 +31,17 @@ export async function GET(request: NextRequest) {
 
   try {
     const url = request.nextUrl;
-    const limit = Math.min(
-      120,
-      Math.max(1, Number(url.searchParams.get("limit")) || 40),
-    );
-    const search = url.searchParams.get("search")?.trim() || "";
-    const status = url.searchParams.get("status")?.trim() || "";
-    const segmentId = url.searchParams.get("segmentId")?.trim() || "";
-    const after = url.searchParams.get("after") || "";
-
-    const conditions: SQL[] = [eq(broadcasts.userId, userId)];
-    if (search) {
-      conditions.push(ilike(broadcasts.name, `%${search}%`));
-    }
-    if (status) {
-      conditions.push(
-        eq(
-          broadcasts.status,
-          status as "draft" | "scheduled" | "queued" | "sent" | "failed",
-        ),
-      );
-    }
-    if (segmentId) {
-      conditions.push(eq(broadcasts.audienceId, segmentId));
-    }
-    if (after) {
-      conditions.push(lt(broadcasts.id, after));
-    }
-
-    const rows = await db
-      .select({
-        id: broadcasts.id,
-        name: broadcasts.name,
-        status: broadcasts.status,
-        audienceId: broadcasts.audienceId,
-        topicId: broadcasts.topicId,
-        createdAt: broadcasts.createdAt,
-        scheduledAt: broadcasts.scheduledAt,
-      })
-      .from(broadcasts)
-      .where(and(...conditions))
-      .orderBy(desc(broadcasts.id))
-      .limit(limit + 1);
-
-    const hasMore = rows.length > limit;
-    const dataRows = hasMore ? rows.slice(0, limit) : rows;
-
-    return NextResponse.json({
-      object: "list",
-      data: dataRows.map((r) => ({
-        id: r.id,
-        name: r.name,
-        status: r.status,
-        audience_id: r.audienceId,
-        topic_id: r.topicId,
-        created_at: r.createdAt,
-        scheduled_at: r.scheduledAt,
-      })),
-      has_more: hasMore,
+    const limit = Number(url.searchParams.get("limit")) || 40;
+    const result = await broadcastService.listBroadcasts({
+      userId,
+      limit,
+      search: url.searchParams.get("search") ?? undefined,
+      status: url.searchParams.get("status") ?? undefined,
+      segmentId: url.searchParams.get("segmentId") ?? undefined,
+      after: url.searchParams.get("after") ?? undefined,
     });
+
+    return broadcastListResponse(result);
   } catch (error) {
     console.error("Failed to fetch broadcasts:", error);
     return NextResponse.json(
@@ -89,38 +59,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const name = body.name?.trim() || "Untitled";
-    const from = body.from?.trim();
-    const subject = body.subject?.trim();
-    const audienceId = body.segment_id || body.audience_id || null;
-
-    if (!from || !subject || !audienceId) {
-      return NextResponse.json(
-        { error: "from, subject, and segment_id are required" },
-        { status: 422 },
-      );
-    }
-
-    const scheduledAt = body.scheduled_at ? new Date(body.scheduled_at) : null;
-    const shouldSend = body.send === true;
-
-    const [broadcast] = await db
-      .insert(broadcasts)
-      .values({
-        name,
-        from,
-        subject,
-        audienceId,
-        html: body.html || null,
-        text: body.text || null,
-        replyTo: body.reply_to || null,
-        previewText: body.preview_text || null,
-        topicId: body.topic_id || null,
-        status: shouldSend ? (scheduledAt ? "scheduled" : "queued") : "draft",
-        scheduledAt,
-        userId,
-      })
-      .returning();
+    const broadcast = await broadcastService.createBroadcast({ userId, body });
 
     return NextResponse.json(
       {
@@ -133,6 +72,13 @@ export async function POST(request: NextRequest) {
       { status: 201 },
     );
   } catch (error) {
+    if (
+      error instanceof BroadcastServiceError &&
+      error.code === "invalid_input"
+    ) {
+      return NextResponse.json({ error: error.message }, { status: 422 });
+    }
+
     console.error("Failed to create broadcast:", error);
     return NextResponse.json(
       { error: "Failed to create broadcast" },

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -222,6 +222,15 @@ describe("route smoke coverage", () => {
           this.name = "ContactServiceError";
         }
       }
+      class BroadcastServiceError extends Error {
+        constructor(
+          readonly code: string,
+          message: string,
+        ) {
+          super(message);
+          this.name = "BroadcastServiceError";
+        }
+      }
       class AudienceMetadataServiceError extends Error {
         constructor(
           readonly code: string,
@@ -242,7 +251,75 @@ describe("route smoke coverage", () => {
         createWebhookService: mockCreateWebhookService,
         TemplateServiceError,
         ContactServiceError,
+        BroadcastServiceError,
         AudienceMetadataServiceError,
+        createBroadcastService: () => ({
+          async listBroadcasts() {
+            const rows = await mockSelect().from().where().orderBy().limit();
+            return { data: rows, hasMore: false };
+          },
+          async createBroadcast(input: { body: Record<string, unknown> }) {
+            const [broadcast] = await mockInsert()
+              .values(input.body)
+              .returning();
+            return broadcast;
+          },
+          async getBroadcast(_userId: string, id: string) {
+            const [broadcast] = await mockSelect()
+              .from()
+              .where({ id })
+              .limit(1);
+            if (!broadcast) {
+              throw new BroadcastServiceError(
+                "not_found",
+                "Broadcast not found",
+              );
+            }
+            return broadcast;
+          },
+          async updateBroadcast(input: {
+            id: string;
+            body: Record<string, unknown>;
+          }) {
+            const [broadcast] = await mockUpdate()
+              .set(input.body)
+              .where({ id: input.id })
+              .returning();
+            if (!broadcast) {
+              throw new BroadcastServiceError(
+                "not_found",
+                "Broadcast not found",
+              );
+            }
+            return broadcast;
+          },
+          async deleteBroadcast(_userId: string, id: string) {
+            const [existing] = await mockSelect().from().where({ id }).limit(1);
+            if (!existing) {
+              throw new BroadcastServiceError(
+                "not_found",
+                "Broadcast not found",
+              );
+            }
+            if (
+              existing.status !== "draft" &&
+              existing.status !== "scheduled"
+            ) {
+              throw new BroadcastServiceError(
+                "delete_forbidden",
+                "Cannot delete a broadcast that is already sent or queued",
+              );
+            }
+            const [broadcast] = await mockDelete().where({ id }).returning();
+            if (!broadcast) {
+              throw new BroadcastServiceError(
+                "not_found",
+                "Broadcast not found",
+              );
+            }
+            return broadcast;
+          },
+        }),
         createAudienceMetadataService: () => ({
           async listSegments() {
             const rows = await mockSelect().from().where().orderBy().limit();

--- a/tests/broadcast-service.test.ts
+++ b/tests/broadcast-service.test.ts
@@ -1,0 +1,228 @@
+import {
+  type BroadcastRepository,
+  BroadcastServiceError,
+  createBroadcastService,
+} from "@opensend/core";
+import { describe, expect, it } from "vitest";
+
+type BroadcastRow = NonNullable<
+  Awaited<ReturnType<BroadcastRepository["findByIdForUser"]>>
+>;
+type BroadcastInsert = Parameters<BroadcastRepository["create"]>[0];
+type BroadcastListOptions = Parameters<BroadcastRepository["listForApi"]>[0];
+type BroadcastUpdateData = Parameters<BroadcastRepository["updateForUser"]>[2];
+
+function makeBroadcast(overrides: Partial<BroadcastRow> = {}): BroadcastRow {
+  return {
+    id: "broadcast-1",
+    name: "Launch",
+    status: "draft",
+    from: "team@example.com",
+    subject: "Hello",
+    html: "<p>Hello</p>",
+    replyTo: null,
+    previewText: null,
+    audienceId: "segment-1",
+    topicId: null,
+    text: null,
+    scheduledAt: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    document: null,
+    userId: "user-1",
+    ...overrides,
+  };
+}
+
+function makeRepository(
+  overrides: Partial<BroadcastRepository> = {},
+): BroadcastRepository {
+  return {
+    async findByIdForUser() {
+      return makeBroadcast();
+    },
+    async create(data) {
+      return [makeBroadcast(data)];
+    },
+    async updateForUser() {
+      return [makeBroadcast({ name: "Updated" })];
+    },
+    async deleteForUser() {
+      return [{ id: "broadcast-1" }];
+    },
+    async findDeletionCandidateForUser() {
+      return { status: "draft" };
+    },
+    async listForApi() {
+      return { data: [makeBroadcast()], hasMore: false };
+    },
+    ...overrides,
+  };
+}
+
+describe("broadcast service boundary", () => {
+  it("normalizes list filters and requires caller tenant scope", async () => {
+    let capturedOptions: BroadcastListOptions | undefined;
+    const service = createBroadcastService({
+      repository: makeRepository({
+        async listForApi(options) {
+          capturedOptions = options;
+          return { data: [], hasMore: false };
+        },
+      }),
+    });
+
+    await service.listBroadcasts({
+      userId: "user-1",
+      limit: 500,
+      search: "  launch  ",
+      status: " draft ",
+      segmentId: " segment-1 ",
+      after: " b0 ",
+    });
+
+    expect(capturedOptions).toEqual({
+      userId: "user-1",
+      limit: 120,
+      search: "launch",
+      status: "draft",
+      segmentId: "segment-1",
+      after: "b0",
+    });
+  });
+
+  it("validates create input and stamps new broadcasts with the caller", async () => {
+    let capturedData: BroadcastInsert | undefined;
+    const createdAt = new Date("2026-02-01T00:00:00Z");
+    const service = createBroadcastService({
+      repository: makeRepository({
+        async create(data) {
+          capturedData = data;
+          return [
+            makeBroadcast({
+              id: "broadcast-2",
+              name: data.name,
+              status: data.status ?? "draft",
+              createdAt,
+              userId: data.userId,
+            }),
+          ];
+        },
+      }),
+    });
+
+    const result = await service.createBroadcast({
+      userId: "user-2",
+      body: {
+        name: " Launch ",
+        from: " team@example.com ",
+        subject: " Hello ",
+        segment_id: "segment-2",
+        send: true,
+        scheduled_at: "2026-03-01T00:00:00Z",
+      },
+    });
+
+    expect(capturedData).toMatchObject({
+      name: "Launch",
+      from: "team@example.com",
+      subject: "Hello",
+      audienceId: "segment-2",
+      status: "scheduled",
+      userId: "user-2",
+    });
+    expect(result).toEqual({
+      id: "broadcast-2",
+      name: "Launch",
+      status: "scheduled",
+      createdAt,
+    });
+
+    await expect(
+      service.createBroadcast({
+        userId: "user-2",
+        body: { from: "team@example.com", subject: "Hello" },
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_input",
+      message: "from, subject, and segment_id are required",
+    });
+  });
+
+  it("maps update aliases and scopes mutations by id plus user id", async () => {
+    let capturedId = "";
+    let capturedUserId = "";
+    let capturedData: BroadcastUpdateData | undefined;
+    const service = createBroadcastService({
+      repository: makeRepository({
+        async updateForUser(id, userId, data) {
+          capturedId = id;
+          capturedUserId = userId;
+          capturedData = data;
+          return [
+            makeBroadcast({
+              id,
+              userId,
+              replyTo: String(data.replyTo),
+              previewText: String(data.previewText),
+              audienceId: String(data.audienceId),
+            }),
+          ];
+        },
+      }),
+    });
+
+    const result = await service.updateBroadcast({
+      id: "broadcast-3",
+      userId: "user-3",
+      body: {
+        reply_to: "reply@example.com",
+        preview_text: "Preview",
+        audience_id: "segment-3",
+      },
+    });
+
+    expect(capturedId).toBe("broadcast-3");
+    expect(capturedUserId).toBe("user-3");
+    expect(capturedData).toEqual({
+      replyTo: "reply@example.com",
+      previewText: "Preview",
+      audienceId: "segment-3",
+    });
+    expect(result.replyTo).toBe("reply@example.com");
+  });
+
+  it("keeps delete preconditions in the service boundary", async () => {
+    const queuedService = createBroadcastService({
+      repository: makeRepository({
+        async findDeletionCandidateForUser() {
+          return { status: "queued" };
+        },
+      }),
+    });
+
+    await expect(
+      queuedService.deleteBroadcast("user-1", "broadcast-1"),
+    ).rejects.toBeInstanceOf(BroadcastServiceError);
+    await expect(
+      queuedService.deleteBroadcast("user-1", "broadcast-1"),
+    ).rejects.toMatchObject({
+      code: "delete_forbidden",
+      message: "Cannot delete a broadcast that is already sent or queued",
+    });
+
+    let deletedForUser: { id: string; userId: string } | undefined;
+    const draftService = createBroadcastService({
+      repository: makeRepository({
+        async deleteForUser(id, userId) {
+          deletedForUser = { id, userId };
+          return [{ id }];
+        },
+      }),
+    });
+
+    await expect(
+      draftService.deleteBroadcast("user-2", "broadcast-2"),
+    ).resolves.toEqual({ id: "broadcast-2" });
+    expect(deletedForUser).toEqual({ id: "broadcast-2", userId: "user-2" });
+  });
+});

--- a/tests/broadcast-tenant-routes.test.ts
+++ b/tests/broadcast-tenant-routes.test.ts
@@ -6,6 +6,25 @@ const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
 const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockReadDashboardAggregateCache = vi.hoisted(() => vi.fn());
 const mockWriteDashboardAggregateCache = vi.hoisted(() => vi.fn());
+const mockBroadcastService = vi.hoisted(() => ({
+  listBroadcasts: vi.fn(),
+  createBroadcast: vi.fn(),
+  getBroadcast: vi.fn(),
+  updateBroadcast: vi.fn(),
+  deleteBroadcast: vi.fn(),
+}));
+const MockBroadcastServiceError = vi.hoisted(
+  () =>
+    class BroadcastServiceError extends Error {
+      constructor(
+        readonly code: "invalid_input" | "not_found" | "delete_forbidden",
+        message: string,
+      ) {
+        super(message);
+        this.name = "BroadcastServiceError";
+      }
+    },
+);
 const mockDb = vi.hoisted(() => ({
   select: vi.fn(),
   insert: vi.fn(),
@@ -33,6 +52,11 @@ vi.mock("@/lib/cache/dashboard-aggregates", async () => {
 
 vi.mock("@/lib/db", () => ({
   db: mockDb,
+}));
+
+vi.mock("@opensend/core", () => ({
+  BroadcastServiceError: MockBroadcastServiceError,
+  createBroadcastService: () => mockBroadcastService,
 }));
 
 function deepValues(value: unknown, seen = new WeakSet<object>()): unknown[] {
@@ -91,13 +115,6 @@ function selectRows<T>(rows: T[], whereClauses: SQL<unknown>[]) {
   return chain;
 }
 
-function insertReturning<T>(rows: T[]) {
-  const returning = vi.fn().mockResolvedValue(rows);
-  const values = vi.fn(() => ({ returning }));
-  mockDb.insert.mockReturnValue({ values });
-  return { values, returning };
-}
-
 function updateReturning<T>(rows: T[], whereClauses: SQL<unknown>[]) {
   const returning = vi.fn().mockResolvedValue(rows);
   const where = vi.fn((clause: SQL<unknown>) => {
@@ -107,16 +124,6 @@ function updateReturning<T>(rows: T[], whereClauses: SQL<unknown>[]) {
   const set = vi.fn(() => ({ where }));
   mockDb.update.mockReturnValue({ set });
   return { set, where, returning };
-}
-
-function deleteReturning<T>(rows: T[], whereClauses: SQL<unknown>[]) {
-  const returning = vi.fn().mockResolvedValue(rows);
-  const where = vi.fn((clause: SQL<unknown>) => {
-    whereClauses.push(clause);
-    return { returning };
-  });
-  mockDb.delete.mockReturnValue({ where });
-  return { where, returning };
 }
 
 beforeEach(() => {
@@ -134,53 +141,97 @@ beforeEach(() => {
 });
 
 describe("broadcast tenant isolation", () => {
-  it("scopes broadcast list queries to the authenticated user", async () => {
-    const whereClauses: SQL<unknown>[] = [];
-    mockDb.select.mockReturnValue(selectRows([], whereClauses));
+  it("passes tenant and list filters to the broadcast service", async () => {
+    const createdAt = new Date("2026-01-01T00:00:00Z");
+    mockBroadcastService.listBroadcasts.mockResolvedValueOnce({
+      data: [
+        {
+          id: "broadcast-1",
+          name: "Launch",
+          status: "draft",
+          audienceId: "segment-1",
+          topicId: "topic-1",
+          createdAt,
+          scheduledAt: null,
+        },
+      ],
+      hasMore: true,
+    });
 
     const { GET } = await import("@/app/api/broadcasts/route");
     const response = await GET(
-      makeNextRequest("http://localhost:3015/api/broadcasts"),
+      makeNextRequest(
+        "http://localhost:3015/api/broadcasts?limit=10&search=Launch&status=draft&segmentId=segment-1&after=b0",
+      ),
     );
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data.data).toEqual([]);
-    expectTenantPredicate(whereClauses.at(-1));
+    expect(data).toEqual({
+      object: "list",
+      data: [
+        {
+          id: "broadcast-1",
+          name: "Launch",
+          status: "draft",
+          audience_id: "segment-1",
+          topic_id: "topic-1",
+          created_at: createdAt.toISOString(),
+          scheduled_at: null,
+        },
+      ],
+      has_more: true,
+    });
+    expect(mockBroadcastService.listBroadcasts).toHaveBeenCalledWith({
+      userId: "user-b",
+      limit: 10,
+      search: "Launch",
+      status: "draft",
+      segmentId: "segment-1",
+      after: "b0",
+    });
   });
 
-  it("stamps created broadcasts with the authenticated user id", async () => {
-    const insertChain = insertReturning([
-      {
-        id: "broadcast-1",
-        name: "Launch",
-        status: "draft",
-        createdAt: new Date("2026-01-01T00:00:00Z"),
-      },
-    ]);
+  it("passes created broadcast payloads with the authenticated user id", async () => {
+    const createdAt = new Date("2026-01-01T00:00:00Z");
+    mockBroadcastService.createBroadcast.mockResolvedValueOnce({
+      id: "broadcast-1",
+      name: "Launch",
+      status: "draft",
+      createdAt,
+    });
+
+    const body = {
+      name: "Launch",
+      from: "team@example.com",
+      subject: "Hello",
+      segment_id: "segment-1",
+    };
 
     const { POST } = await import("@/app/api/broadcasts/route");
     const response = await POST(
-      jsonRequest("http://localhost:3015/api/broadcasts", {
-        name: "Launch",
-        from: "team@example.com",
-        subject: "Hello",
-        segment_id: "segment-1",
-      }),
+      jsonRequest("http://localhost:3015/api/broadcasts", body),
     );
+    const data = await response.json();
 
     expect(response.status).toBe(201);
-    expect(insertChain.values).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "Launch",
-        userId: "user-b",
-      }),
-    );
+    expect(data).toEqual({
+      object: "broadcast",
+      id: "broadcast-1",
+      name: "Launch",
+      status: "draft",
+      created_at: createdAt.toISOString(),
+    });
+    expect(mockBroadcastService.createBroadcast).toHaveBeenCalledWith({
+      userId: "user-b",
+      body,
+    });
   });
 
   it("returns 404 for broadcast detail reads outside the tenant", async () => {
-    const whereClauses: SQL<unknown>[] = [];
-    mockDb.select.mockReturnValue(selectRows([], whereClauses));
+    mockBroadcastService.getBroadcast.mockRejectedValueOnce(
+      new MockBroadcastServiceError("not_found", "Broadcast not found"),
+    );
 
     const { GET } = await import("@/app/api/broadcasts/[id]/route");
     const response = await GET(
@@ -191,39 +242,51 @@ describe("broadcast tenant isolation", () => {
     );
 
     expect(response.status).toBe(404);
-    expectTenantPredicate(whereClauses.at(-1));
+    await expect(response.json()).resolves.toEqual({
+      error: "Broadcast not found",
+    });
+    expect(mockBroadcastService.getBroadcast).toHaveBeenCalledWith(
+      "user-b",
+      "broadcast-a",
+    );
   });
 
-  it("scopes broadcast updates and deletes by id plus user id", async () => {
-    const updateWheres: SQL<unknown>[] = [];
-    updateReturning(
-      [
-        {
-          id: "broadcast-1",
-          name: "Renamed",
-          status: "draft",
-        },
-      ],
-      updateWheres,
-    );
+  it("passes broadcast updates and deletes by id plus user id", async () => {
+    mockBroadcastService.updateBroadcast.mockResolvedValueOnce({
+      id: "broadcast-1",
+      name: "Renamed",
+      status: "draft",
+      from: null,
+      subject: null,
+      html: null,
+      text: null,
+      replyTo: null,
+      previewText: null,
+      audienceId: null,
+      topicId: null,
+      scheduledAt: null,
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+    });
+    mockBroadcastService.deleteBroadcast.mockResolvedValueOnce({
+      id: "broadcast-1",
+    });
 
     const { PATCH, DELETE } = await import("@/app/api/broadcasts/[id]/route");
+    const patchBody = { name: "Renamed" };
     const patchResponse = await PATCH(
-      jsonRequest("http://localhost:3015/api/broadcasts/broadcast-1", {
-        name: "Renamed",
-      }),
+      jsonRequest(
+        "http://localhost:3015/api/broadcasts/broadcast-1",
+        patchBody,
+      ),
       { params: Promise.resolve({ id: "broadcast-1" }) },
     );
 
     expect(patchResponse.status).toBe(200);
-    expectTenantPredicate(updateWheres.at(-1));
-
-    const selectWheres: SQL<unknown>[] = [];
-    const deleteWheres: SQL<unknown>[] = [];
-    mockDb.select.mockReturnValue(
-      selectRows([{ id: "broadcast-1", status: "draft" }], selectWheres),
-    );
-    deleteReturning([{ id: "broadcast-1" }], deleteWheres);
+    expect(mockBroadcastService.updateBroadcast).toHaveBeenCalledWith({
+      id: "broadcast-1",
+      userId: "user-b",
+      body: patchBody,
+    });
 
     const deleteResponse = await DELETE(
       makeNextRequest("http://localhost:3015/api/broadcasts/broadcast-1", {
@@ -234,8 +297,10 @@ describe("broadcast tenant isolation", () => {
     );
 
     expect(deleteResponse.status).toBe(200);
-    expectTenantPredicate(selectWheres.at(-1));
-    expectTenantPredicate(deleteWheres.at(-1));
+    expect(mockBroadcastService.deleteBroadcast).toHaveBeenCalledWith(
+      "user-b",
+      "broadcast-1",
+    );
   });
 
   it("scopes broadcast send ownership checks and status updates", async () => {


### PR DESCRIPTION
## Summary
- Extracted broadcast CRUD/list orchestration into `createBroadcastService` in `@opensend/core`.
- Added tenant-scoped broadcast repository methods for list/detail/update/delete and delete precondition lookup.
- Reduced Next broadcast CRUD routes to auth resolution, request/query/param parsing, service calls, and HTTP status/body mapping.
- Left send and metrics routes untouched for later slices.

## Adapter responsibilities intentionally left in Next
- Dashboard/API-key auth resolution via `resolveBroadcastRouteUserId`.
- Request JSON, URL query, and route-param parsing.
- HTTP status mapping and public snake_case response body mapping.

## Validation
- `make check`
- `bunx vitest run tests/broadcast-service.test.ts tests/broadcast-tenant-routes.test.ts tests/api-auth-date-range-routes.test.ts`
- `make test`

Playwright skipped because no dashboard UI changed.

Closes #320.
