### PR TITLE
Extract email read API service boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-322-email-read-delete-boundary.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-322-email-read-delete-boundary.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-11
+issue: "#322"
+type: decision
+promoted_to: null
+---
+
+## Email read boundary preserves collection delete success semantics
+
+Issue #322 moved public email list/detail/delete behavior into `packages/core/src/services/emailRead.ts`, with tenant scope enforced through `emailRepo.listForApi`, `findByIdForUser`, and `deleteForUser`.
+
+The delete service intentionally returns `{ success: true }` after a scoped delete without first checking row existence because the existing `DELETE /api/emails?id=...` route did not 404 missing rows. Future detail-style delete routes can add explicit not-found behavior, but the collection query-param delete adapter should keep this legacy success response unless a public API change is planned.

--- a/packages/core/src/db/repositories/emailRepo.ts
+++ b/packages/core/src/db/repositories/emailRepo.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gt, lt, lte } from "drizzle-orm";
+import { type SQL, and, desc, eq, gt, lt, lte } from "drizzle-orm";
 import { db } from "../client";
 import { emails } from "../schema";
 
@@ -8,6 +8,12 @@ export const emailRepo = {
       where: userId
         ? and(eq(emails.id, id), eq(emails.userId, userId))
         : eq(emails.id, id),
+    });
+  },
+
+  async findByIdForUser(id: string, userId: string) {
+    return await db.query.emails.findFirst({
+      where: and(eq(emails.id, id), eq(emails.userId, userId)),
     });
   },
 
@@ -46,6 +52,61 @@ export const emailRepo = {
       .from(emails)
       .where(and(eq(emails.status, "scheduled"), lte(emails.scheduledAt, now)))
       .limit(limit);
+  },
+
+  async deleteForUser(id: string, userId: string) {
+    await db
+      .delete(emails)
+      .where(and(eq(emails.id, id), eq(emails.userId, userId)));
+  },
+
+  async listForApi(options: {
+    userId: string;
+    limit: number;
+    after?: string;
+    before?: string;
+    status?: string;
+  }) {
+    const conditions: SQL[] = [eq(emails.userId, options.userId)];
+
+    if (options.status && options.status !== "all") {
+      conditions.push(eq(emails.status, options.status));
+    }
+    if (options.after) {
+      conditions.push(gt(emails.id, options.after));
+    } else if (options.before) {
+      conditions.push(lt(emails.id, options.before));
+    }
+
+    const results = await db
+      .select({
+        id: emails.id,
+        from: emails.from,
+        to: emails.to,
+        subject: emails.subject,
+        cc: emails.cc,
+        bcc: emails.bcc,
+        replyTo: emails.replyTo,
+        status: emails.status,
+        providerRetryCount: emails.providerRetryCount,
+        providerLastAttemptedAt: emails.providerLastAttemptedAt,
+        providerNextRetryAt: emails.providerNextRetryAt,
+        providerLastErrorCode: emails.providerLastErrorCode,
+        providerLastErrorMessage: emails.providerLastErrorMessage,
+        providerDeadLetteredAt: emails.providerDeadLetteredAt,
+        scheduledAt: emails.scheduledAt,
+        sentAt: emails.sentAt,
+        createdAt: emails.createdAt,
+      })
+      .from(emails)
+      .where(and(...conditions))
+      .orderBy(desc(emails.createdAt))
+      .limit(options.limit + 1);
+
+    const hasMore = results.length > options.limit;
+    const data = hasMore ? results.slice(0, options.limit) : results;
+
+    return { data, hasMore };
   },
 
   async list(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,6 +37,7 @@ export * from "./services/webhook";
 export * from "./services/apiKeys";
 export * from "./services/contact";
 export * from "./services/email";
+export * from "./services/emailRead";
 export * from "./services/emailProvider";
 export * from "./services/sandboxTestRecipients";
 export * from "./services/storage";

--- a/packages/core/src/services/emailRead.ts
+++ b/packages/core/src/services/emailRead.ts
@@ -1,0 +1,202 @@
+import { emailRepo } from "../db/repositories/emailRepo";
+import type { emails } from "../db/schema";
+
+type EmailRow = typeof emails.$inferSelect;
+type ProviderRetryRow = Pick<
+  EmailRow,
+  | "providerRetryCount"
+  | "providerLastAttemptedAt"
+  | "providerNextRetryAt"
+  | "providerLastErrorCode"
+  | "providerLastErrorMessage"
+  | "providerDeadLetteredAt"
+>;
+
+export type EmailReadListRow = Pick<
+  EmailRow,
+  | "id"
+  | "from"
+  | "to"
+  | "subject"
+  | "cc"
+  | "bcc"
+  | "replyTo"
+  | "status"
+  | "scheduledAt"
+  | "sentAt"
+  | "createdAt"
+> &
+  ProviderRetryRow;
+
+export type EmailReadListItem = {
+  id: string;
+  from: string;
+  to: string[];
+  subject: string;
+  cc: string[] | null;
+  bcc: string[] | null;
+  reply_to: string[] | null;
+  last_event: string;
+  provider_retry_count: number;
+  provider_last_attempted_at: Date | null;
+  provider_next_retry_at: Date | null;
+  provider_last_error: {
+    code: string;
+    message: string;
+  } | null;
+  provider_dead_lettered_at: Date | null;
+  scheduled_at: Date | null;
+  sent_at: Date | null;
+  created_at: Date;
+};
+
+export type EmailReadListResponse = {
+  object: "list";
+  has_more: boolean;
+  data: EmailReadListItem[];
+};
+
+export type EmailReadDetailResponse = EmailReadListItem & {
+  object: "email";
+  html: string | null;
+  text: string | null;
+  tags: Array<{ name: string; value: string }> | null;
+};
+
+export type EmailReadDeleteResponse = {
+  success: true;
+};
+
+export type EmailReadRepository = {
+  listForApi(options: {
+    userId: string;
+    limit: number;
+    after?: string;
+    before?: string;
+    status?: string;
+  }): Promise<{ data: EmailReadListRow[]; hasMore: boolean }>;
+  findByIdForUser(id: string, userId: string): Promise<EmailRow | undefined>;
+  deleteForUser(id: string, userId: string): Promise<void>;
+};
+
+export type EmailReadServiceErrorCode = "not_found";
+
+export class EmailReadServiceError extends Error {
+  constructor(
+    readonly code: EmailReadServiceErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "EmailReadServiceError";
+  }
+}
+
+export type EmailReadServiceDependencies = {
+  repository?: EmailReadRepository;
+};
+
+export type ListEmailsInput = {
+  userId: string;
+  limit?: number;
+  after?: string;
+  before?: string;
+  status?: string;
+};
+
+function normalizeLimit(limit: number | undefined): number {
+  if (limit === undefined || !Number.isFinite(limit) || limit === 0) {
+    return 20;
+  }
+
+  return Math.min(Math.max(limit, 1), 100);
+}
+
+function normalizeStatus(status: string | undefined): string | undefined {
+  const normalized = status?.trim();
+  return normalized && normalized !== "all" ? normalized : undefined;
+}
+
+function providerLastError(row: ProviderRetryRow) {
+  return row.providerLastErrorCode
+    ? {
+        code: row.providerLastErrorCode,
+        message: row.providerLastErrorMessage ?? "Provider send failed.",
+      }
+    : null;
+}
+
+function toListItem(row: EmailReadListRow): EmailReadListItem {
+  return {
+    id: row.id,
+    from: row.from,
+    to: row.to,
+    subject: row.subject,
+    cc: row.cc,
+    bcc: row.bcc,
+    reply_to: row.replyTo,
+    last_event: row.status,
+    provider_retry_count: row.providerRetryCount,
+    provider_last_attempted_at: row.providerLastAttemptedAt,
+    provider_next_retry_at: row.providerNextRetryAt,
+    provider_last_error: providerLastError(row),
+    provider_dead_lettered_at: row.providerDeadLetteredAt,
+    scheduled_at: row.scheduledAt,
+    sent_at: row.sentAt,
+    created_at: row.createdAt,
+  };
+}
+
+function toDetail(row: EmailRow): EmailReadDetailResponse {
+  return {
+    object: "email",
+    ...toListItem(row),
+    html: row.html,
+    text: row.text,
+    tags: row.tags,
+  };
+}
+
+export function createEmailReadService({
+  repository = emailRepo,
+}: EmailReadServiceDependencies = {}) {
+  return {
+    async listEmails(input: ListEmailsInput): Promise<EmailReadListResponse> {
+      const result = await repository.listForApi({
+        userId: input.userId,
+        limit: normalizeLimit(input.limit),
+        after: input.after ?? undefined,
+        before: input.before ?? undefined,
+        status: normalizeStatus(input.status),
+      });
+
+      return {
+        object: "list",
+        has_more: result.hasMore,
+        data: result.data.map(toListItem),
+      };
+    },
+
+    async getEmail(
+      userId: string,
+      id: string,
+    ): Promise<EmailReadDetailResponse> {
+      const email = await repository.findByIdForUser(id, userId);
+
+      if (!email) {
+        throw new EmailReadServiceError("not_found", "Email not found");
+      }
+
+      return toDetail(email);
+    },
+
+    async deleteEmail(
+      userId: string,
+      id: string,
+    ): Promise<EmailReadDeleteResponse> {
+      await repository.deleteForUser(id, userId);
+      return { success: true };
+    },
+  };
+}
+
+export const emailReadService = createEmailReadService();

--- a/src/app/api/emails/[id]/route.ts
+++ b/src/app/api/emails/[id]/route.ts
@@ -7,7 +7,10 @@ import {
   parseScheduledAt,
   scheduledAtValidationMessage,
 } from "@/lib/validation/emails";
+import { EmailReadServiceError, createEmailReadService } from "@opensend/core";
 import { and, eq } from "drizzle-orm";
+
+const emailReadService = createEmailReadService();
 
 export async function GET(
   request: Request,
@@ -21,42 +24,13 @@ export async function GET(
   const { id } = await params;
 
   try {
-    const email = await db.query.emails.findFirst({
-      where: and(eq(emails.id, id), eq(emails.userId, auth.userId)),
-    });
-
-    if (!email) {
+    const email = await emailReadService.getEmail(auth.userId, id);
+    return Response.json(email);
+  } catch (err) {
+    if (err instanceof EmailReadServiceError && err.code === "not_found") {
       return Response.json({ error: "Email not found" }, { status: 404 });
     }
 
-    return Response.json({
-      object: "email",
-      id: email.id,
-      from: email.from,
-      to: email.to,
-      subject: email.subject,
-      html: email.html,
-      text: email.text,
-      cc: email.cc,
-      bcc: email.bcc,
-      reply_to: email.replyTo,
-      last_event: email.status,
-      provider_retry_count: email.providerRetryCount,
-      provider_last_attempted_at: email.providerLastAttemptedAt,
-      provider_next_retry_at: email.providerNextRetryAt,
-      provider_last_error: email.providerLastErrorCode
-        ? {
-            code: email.providerLastErrorCode,
-            message: email.providerLastErrorMessage ?? "Provider send failed.",
-          }
-        : null,
-      provider_dead_lettered_at: email.providerDeadLetteredAt,
-      scheduled_at: email.scheduledAt,
-      sent_at: email.sentAt,
-      tags: email.tags,
-      created_at: email.createdAt,
-    });
-  } catch (err) {
     const message =
       err instanceof Error ? err.message : "Failed to retrieve email";
     return Response.json({ error: message }, { status: 500 });

--- a/src/app/api/emails/route.ts
+++ b/src/app/api/emails/route.ts
@@ -2,10 +2,10 @@ import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { zodValidationDetails } from "@/lib/api-errors";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { handlePostEmailRequest } from "@/lib/api/emails/send";
-import { db } from "@/lib/db";
-import { emails } from "@/lib/db/schema";
-import { type SQL, and, desc, eq, gt, lt } from "drizzle-orm";
+import { createEmailReadService } from "@opensend/core";
 import type { ZodError } from "zod";
+
+const emailReadService = createEmailReadService();
 
 // ── POST /api/emails ──────────────────────────────────────────────
 
@@ -20,10 +20,7 @@ export async function GET(request: Request): Promise<Response> {
   if (permissionError) return permissionError;
 
   const url = new URL(request.url);
-  const limit = Math.min(
-    Math.max(Number(url.searchParams.get("limit")) || 20, 1),
-    100,
-  );
+  const limit = Number(url.searchParams.get("limit")) || 20;
   const after = url.searchParams.get("after");
   const before = url.searchParams.get("before");
   const status = (
@@ -33,73 +30,14 @@ export async function GET(request: Request): Promise<Response> {
   ).trim();
 
   try {
-    let query = db
-      .select({
-        id: emails.id,
-        from: emails.from,
-        to: emails.to,
-        subject: emails.subject,
-        cc: emails.cc,
-        bcc: emails.bcc,
-        replyTo: emails.replyTo,
-        status: emails.status,
-        providerRetryCount: emails.providerRetryCount,
-        providerLastAttemptedAt: emails.providerLastAttemptedAt,
-        providerNextRetryAt: emails.providerNextRetryAt,
-        providerLastErrorCode: emails.providerLastErrorCode,
-        providerLastErrorMessage: emails.providerLastErrorMessage,
-        providerDeadLetteredAt: emails.providerDeadLetteredAt,
-        scheduledAt: emails.scheduledAt,
-        sentAt: emails.sentAt,
-        createdAt: emails.createdAt,
-      })
-      .from(emails);
-
-    const conditions: SQL[] = [eq(emails.userId, auth.userId)];
-    if (status && status !== "all") {
-      conditions.push(eq(emails.status, status));
-    }
-    if (after) {
-      conditions.push(gt(emails.id, after));
-    } else if (before) {
-      conditions.push(lt(emails.id, before));
-    }
-    query = query.where(and(...conditions)) as typeof query;
-
-    const results = await query
-      .orderBy(desc(emails.createdAt))
-      .limit(limit + 1);
-
-    const hasMore = results.length > limit;
-    const data = hasMore ? results.slice(0, limit) : results;
-
-    return Response.json({
-      object: "list",
-      has_more: hasMore,
-      data: data.map((e) => ({
-        id: e.id,
-        from: e.from,
-        to: e.to,
-        subject: e.subject,
-        cc: e.cc,
-        bcc: e.bcc,
-        reply_to: e.replyTo,
-        last_event: e.status,
-        provider_retry_count: e.providerRetryCount,
-        provider_last_attempted_at: e.providerLastAttemptedAt,
-        provider_next_retry_at: e.providerNextRetryAt,
-        provider_last_error: e.providerLastErrorCode
-          ? {
-              code: e.providerLastErrorCode,
-              message: e.providerLastErrorMessage ?? "Provider send failed.",
-            }
-          : null,
-        provider_dead_lettered_at: e.providerDeadLetteredAt,
-        scheduled_at: e.scheduledAt,
-        sent_at: e.sentAt,
-        created_at: e.createdAt,
-      })),
+    const result = await emailReadService.listEmails({
+      userId: auth.userId,
+      limit,
+      after: after ?? undefined,
+      before: before ?? undefined,
+      status,
     });
+    return Response.json(result);
   } catch (err) {
     const message =
       err instanceof Error ? err.message : "Failed to list emails";
@@ -123,10 +61,8 @@ export async function DELETE(request: Request): Promise<Response> {
   }
 
   try {
-    await db
-      .delete(emails)
-      .where(and(eq(emails.id, id), eq(emails.userId, auth.userId)));
-    return Response.json({ success: true });
+    const result = await emailReadService.deleteEmail(auth.userId, id);
+    return Response.json(result);
   } catch (err) {
     const message =
       err instanceof Error ? err.message : "Failed to delete email";

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -11,6 +11,23 @@ const mockLogTelemetry = vi.hoisted(() => vi.fn());
 const mockRecordTelemetryError = vi.hoisted(() => vi.fn());
 const mockReserveEmailQuota = vi.hoisted(() => vi.fn());
 const mockReleaseEmailQuota = vi.hoisted(() => vi.fn());
+const mockEmailReadService = vi.hoisted(() => ({
+  listEmails: vi.fn(),
+  getEmail: vi.fn(),
+  deleteEmail: vi.fn(),
+}));
+const MockEmailReadServiceError = vi.hoisted(
+  () =>
+    class EmailReadServiceError extends Error {
+      constructor(
+        readonly code: string,
+        message: string,
+      ) {
+        super(message);
+        this.name = "EmailReadServiceError";
+      }
+    },
+);
 const mockDb = vi.hoisted(() => ({
   insert: vi.fn(),
   select: vi.fn(),
@@ -44,10 +61,12 @@ vi.mock("@opensend/core", () => {
   };
 
   return {
+    EmailReadServiceError: MockEmailReadServiceError,
     createBackgroundJob: (job: Record<string, unknown>) => ({
       ...job,
       requestedAt: "2026-04-28T00:00:00.000Z",
     }),
+    createEmailReadService: () => mockEmailReadService,
     detectSandboxTestRecipient: (recipient: string) => {
       const normalized = recipient.trim().toLowerCase();
       const [local, domain] = normalized.split("@");
@@ -2154,34 +2173,35 @@ describe("services/api transactional email routes", () => {
 describe("GET /api/emails", () => {
   beforeEach(() => {
     vi.resetModules();
+    mockEmailReadService.listEmails.mockReset();
     mockValidateApiKey.mockResolvedValue(AUTH_RESULT);
   });
 
   it("returns paginated list of emails", async () => {
-    const mockEmails = [
-      {
-        id: "email-1",
-        from: "sender@domain.com",
-        to: ["user@test.com"],
-        subject: "Test",
-        createdAt: new Date("2024-01-01"),
-        status: "delivered",
-        cc: null,
-        bcc: null,
-        replyTo: null,
-        scheduledAt: null,
-        sentAt: new Date("2024-01-01T00:00:05Z"),
-      },
-    ];
-
-    const mockLimit = vi.fn().mockResolvedValue(mockEmails);
-    const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
-    const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
-    const mockFrom = vi.fn().mockReturnValue({
-      orderBy: mockOrderBy,
-      where: mockWhere,
+    mockEmailReadService.listEmails.mockResolvedValueOnce({
+      object: "list",
+      has_more: false,
+      data: [
+        {
+          id: "email-1",
+          from: "sender@domain.com",
+          to: ["user@test.com"],
+          subject: "Test",
+          created_at: new Date("2024-01-01"),
+          last_event: "delivered",
+          cc: null,
+          bcc: null,
+          reply_to: null,
+          provider_retry_count: 0,
+          provider_last_attempted_at: null,
+          provider_next_retry_at: null,
+          provider_last_error: null,
+          provider_dead_lettered_at: null,
+          scheduled_at: null,
+          sent_at: new Date("2024-01-01T00:00:05Z"),
+        },
+      ],
     });
-    mockDb.select = vi.fn().mockReturnValue({ from: mockFrom });
 
     const { GET } = await import("@/app/api/emails/route");
     const req = new Request("http://localhost:3015/api/emails?limit=20", {
@@ -2194,28 +2214,40 @@ describe("GET /api/emails", () => {
     expect(json).toHaveProperty("data");
     expect(Array.isArray(json.data)).toBe(true);
     expect(json.data[0]).toHaveProperty("sent_at", "2024-01-01T00:00:05.000Z");
-    expect(mockWhere).toHaveBeenCalledWith(
-      expect.objectContaining({
-        op: "and",
-        args: [
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining([AUTH_RESULT.userId]),
-          }),
-        ],
-      }),
-    );
+    expect(mockEmailReadService.listEmails).toHaveBeenCalledWith({
+      userId: AUTH_RESULT.userId,
+      limit: 20,
+      after: undefined,
+      before: undefined,
+      status: "",
+    });
   });
 
-  it("applies status filter so queued dashboard/API views return queued rows", async () => {
-    const mockLimit = vi.fn().mockResolvedValue([]);
-    const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
-    const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
-    const mockFrom = vi.fn().mockReturnValue({
-      orderBy: mockOrderBy,
-      where: mockWhere,
+  it("passes status filter so queued dashboard/API views return queued rows", async () => {
+    mockEmailReadService.listEmails.mockResolvedValueOnce({
+      object: "list",
+      has_more: false,
+      data: [
+        {
+          id: "email-1",
+          from: "sender@domain.com",
+          to: ["user@test.com"],
+          subject: "Test",
+          created_at: new Date("2024-01-01"),
+          last_event: "queued",
+          cc: null,
+          bcc: null,
+          reply_to: null,
+          provider_retry_count: 0,
+          provider_last_attempted_at: null,
+          provider_next_retry_at: null,
+          provider_last_error: null,
+          provider_dead_lettered_at: null,
+          sent_at: null,
+          scheduled_at: null,
+        },
+      ],
     });
-    mockDb.select = vi.fn().mockReturnValue({ from: mockFrom });
 
     const { GET } = await import("@/app/api/emails/route");
     const req = new Request("http://localhost:3015/api/emails?status=queued", {
@@ -2225,21 +2257,16 @@ describe("GET /api/emails", () => {
     const res = await GET(req);
 
     expect(res.status).toBe(200);
-    expect(mockWhere).toHaveBeenCalledWith(
-      expect.objectContaining({
-        op: "and",
-        args: [
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining([AUTH_RESULT.userId]),
-          }),
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining(["queued"]),
-          }),
-        ],
-      }),
-    );
+    await expect(res.json()).resolves.toMatchObject({
+      data: [{ last_event: "queued" }],
+    });
+    expect(mockEmailReadService.listEmails).toHaveBeenCalledWith({
+      userId: AUTH_RESULT.userId,
+      limit: 20,
+      after: undefined,
+      before: undefined,
+      status: "queued",
+    });
   });
 });
 
@@ -2248,11 +2275,13 @@ describe("GET /api/emails", () => {
 describe("GET /api/emails/:id", () => {
   beforeEach(() => {
     vi.resetModules();
+    mockEmailReadService.getEmail.mockReset();
     mockValidateApiKey.mockResolvedValue(AUTH_RESULT);
   });
 
-  it("returns email with events", async () => {
-    const mockEmail = {
+  it("returns email detail from the read service", async () => {
+    mockEmailReadService.getEmail.mockResolvedValueOnce({
+      object: "email",
       id: "email-uuid",
       from: "sender@domain.com",
       to: ["user@test.com"],
@@ -2261,27 +2290,18 @@ describe("GET /api/emails/:id", () => {
       text: null,
       cc: null,
       bcc: null,
-      replyTo: null,
-      status: "delivered",
-      scheduledAt: null,
-      sentAt: new Date("2024-01-01T00:00:05Z"),
+      reply_to: null,
+      last_event: "delivered",
+      provider_retry_count: 0,
+      provider_last_attempted_at: null,
+      provider_next_retry_at: null,
+      provider_last_error: null,
+      provider_dead_lettered_at: null,
+      scheduled_at: null,
+      sent_at: new Date("2024-01-01T00:00:05Z"),
       tags: null,
-      createdAt: new Date("2024-01-01"),
-      events: [
-        {
-          type: "sent",
-          timestamp: new Date("2024-01-01"),
-          data: null,
-        },
-      ],
-    };
-
-    const findFirst = vi.fn().mockResolvedValue(mockEmail);
-    mockDb.query = {
-      emails: {
-        findFirst,
-      },
-    } as unknown as ReturnType<typeof vi.fn>;
+      created_at: new Date("2024-01-01"),
+    });
 
     const { GET } = await import("@/app/api/emails/[id]/route");
     const req = new Request("http://localhost:3015/api/emails/email-uuid", {
@@ -2296,30 +2316,16 @@ describe("GET /api/emails/:id", () => {
     expect(json).toHaveProperty("id", "email-uuid");
     expect(json).toHaveProperty("last_event", "delivered");
     expect(json).toHaveProperty("sent_at", "2024-01-01T00:00:05.000Z");
-    expect(findFirst).toHaveBeenCalledWith({
-      where: expect.objectContaining({
-        op: "and",
-        args: [
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining(["email-uuid"]),
-          }),
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining([AUTH_RESULT.userId]),
-          }),
-        ],
-      }),
-    });
+    expect(mockEmailReadService.getEmail).toHaveBeenCalledWith(
+      AUTH_RESULT.userId,
+      "email-uuid",
+    );
   });
 
   it("returns 404 for non-existent email", async () => {
-    const findFirst = vi.fn().mockResolvedValue(null);
-    mockDb.query = {
-      emails: {
-        findFirst,
-      },
-    } as unknown as ReturnType<typeof vi.fn>;
+    mockEmailReadService.getEmail.mockRejectedValueOnce(
+      new MockEmailReadServiceError("not_found", "Email not found"),
+    );
 
     const { GET } = await import("@/app/api/emails/[id]/route");
     const req = new Request("http://localhost:3015/api/emails/nonexistent", {
@@ -2329,21 +2335,11 @@ describe("GET /api/emails/:id", () => {
       params: Promise.resolve({ id: "nonexistent" }),
     });
     expect(res.status).toBe(404);
-    expect(findFirst).toHaveBeenCalledWith({
-      where: expect.objectContaining({
-        op: "and",
-        args: [
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining(["nonexistent"]),
-          }),
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining([AUTH_RESULT.userId]),
-          }),
-        ],
-      }),
-    });
+    await expect(res.json()).resolves.toEqual({ error: "Email not found" });
+    expect(mockEmailReadService.getEmail).toHaveBeenCalledWith(
+      AUTH_RESULT.userId,
+      "nonexistent",
+    );
   });
 });
 
@@ -2514,12 +2510,12 @@ describe("PATCH /api/emails/:id", () => {
 describe("DELETE /api/emails", () => {
   beforeEach(() => {
     vi.resetModules();
+    mockEmailReadService.deleteEmail.mockReset();
     mockValidateApiKey.mockResolvedValue(AUTH_RESULT);
   });
 
   it("scopes deletes to the authenticated user", async () => {
-    const where = vi.fn().mockResolvedValue(undefined);
-    mockDb.delete = vi.fn().mockReturnValue({ where });
+    mockEmailReadService.deleteEmail.mockResolvedValueOnce({ success: true });
 
     const { DELETE } = await import("@/app/api/emails/route");
     const res = await DELETE(
@@ -2530,20 +2526,10 @@ describe("DELETE /api/emails", () => {
     );
 
     expect(res.status).toBe(200);
-    expect(where).toHaveBeenCalledWith(
-      expect.objectContaining({
-        op: "and",
-        args: expect.arrayContaining([
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining(["email-uuid"]),
-          }),
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining([AUTH_RESULT.userId]),
-          }),
-        ]),
-      }),
+    await expect(res.json()).resolves.toEqual({ success: true });
+    expect(mockEmailReadService.deleteEmail).toHaveBeenCalledWith(
+      AUTH_RESULT.userId,
+      "email-uuid",
     );
   });
 });

--- a/tests/email-read-service.test.ts
+++ b/tests/email-read-service.test.ts
@@ -1,0 +1,176 @@
+import {
+  type EmailReadRepository,
+  EmailReadServiceError,
+  createEmailReadService,
+} from "@opensend/core";
+import { describe, expect, it } from "vitest";
+
+type EmailRow = NonNullable<
+  Awaited<ReturnType<EmailReadRepository["findByIdForUser"]>>
+>;
+type ListOptions = Parameters<EmailReadRepository["listForApi"]>[0];
+
+function makeEmail(overrides: Partial<EmailRow> = {}): EmailRow {
+  return {
+    id: "email-1",
+    from: "sender@example.com",
+    to: ["user@example.com"],
+    cc: null,
+    bcc: null,
+    replyTo: null,
+    subject: "Hello",
+    html: "<p>Hello</p>",
+    text: null,
+    status: "delivered",
+    providerRetryCount: 0,
+    providerLastAttemptedAt: null,
+    providerNextRetryAt: null,
+    providerLastErrorCode: null,
+    providerLastErrorMessage: null,
+    providerDeadLetteredAt: null,
+    tags: null,
+    headers: null,
+    attachments: null,
+    scheduledAt: null,
+    sentAt: new Date("2026-01-01T00:00:05Z"),
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    document: null,
+    userId: "user-1",
+    topicId: null,
+    idempotencyKey: null,
+    ...overrides,
+  };
+}
+
+function makeRepository(
+  overrides: Partial<EmailReadRepository> = {},
+): EmailReadRepository {
+  return {
+    async listForApi() {
+      return { data: [], hasMore: false };
+    },
+    async findByIdForUser() {
+      return makeEmail();
+    },
+    async deleteForUser() {},
+    ...overrides,
+  };
+}
+
+describe("email read service boundary", () => {
+  it("normalizes list inputs, requires tenant scope, and maps retry visibility", async () => {
+    let capturedOptions: ListOptions | undefined;
+    const service = createEmailReadService({
+      repository: makeRepository({
+        async listForApi(options) {
+          capturedOptions = options;
+          return {
+            hasMore: true,
+            data: [
+              makeEmail({
+                providerRetryCount: 2,
+                providerLastErrorCode: "Throttling",
+                providerLastErrorMessage: null,
+              }),
+            ],
+          };
+        },
+      }),
+    });
+
+    const result = await service.listEmails({
+      userId: "user-1",
+      limit: 500,
+      after: "email-0",
+      before: "ignored-before",
+      status: " all ",
+    });
+
+    expect(capturedOptions).toEqual({
+      userId: "user-1",
+      limit: 100,
+      after: "email-0",
+      before: "ignored-before",
+      status: undefined,
+    });
+    expect(result).toEqual({
+      object: "list",
+      has_more: true,
+      data: [
+        expect.objectContaining({
+          id: "email-1",
+          last_event: "delivered",
+          reply_to: null,
+          provider_retry_count: 2,
+          provider_last_error: {
+            code: "Throttling",
+            message: "Provider send failed.",
+          },
+          sent_at: new Date("2026-01-01T00:00:05Z"),
+        }),
+      ],
+    });
+  });
+
+  it("scopes detail reads and maps public detail fields", async () => {
+    let capturedScope: { id: string; userId: string } | undefined;
+    const service = createEmailReadService({
+      repository: makeRepository({
+        async findByIdForUser(id, userId) {
+          capturedScope = { id, userId };
+          return makeEmail({
+            id,
+            userId,
+            tags: [{ name: "campaign", value: "launch" }],
+          });
+        },
+      }),
+    });
+
+    const result = await service.getEmail("user-2", "email-2");
+
+    expect(capturedScope).toEqual({ id: "email-2", userId: "user-2" });
+    expect(result).toMatchObject({
+      object: "email",
+      id: "email-2",
+      html: "<p>Hello</p>",
+      text: null,
+      tags: [{ name: "campaign", value: "launch" }],
+      created_at: new Date("2026-01-01T00:00:00Z"),
+    });
+  });
+
+  it("raises not_found for missing detail rows", async () => {
+    const service = createEmailReadService({
+      repository: makeRepository({
+        async findByIdForUser() {
+          return undefined;
+        },
+      }),
+    });
+
+    await expect(service.getEmail("user-1", "missing")).rejects.toBeInstanceOf(
+      EmailReadServiceError,
+    );
+    await expect(service.getEmail("user-1", "missing")).rejects.toMatchObject({
+      code: "not_found",
+      message: "Email not found",
+    });
+  });
+
+  it("scopes deletes while preserving collection delete success semantics", async () => {
+    let capturedScope: { id: string; userId: string } | undefined;
+    const service = createEmailReadService({
+      repository: makeRepository({
+        async deleteForUser(id, userId) {
+          capturedScope = { id, userId };
+        },
+      }),
+    });
+
+    await expect(service.deleteEmail("user-3", "email-3")).resolves.toEqual({
+      success: true,
+    });
+    expect(capturedScope).toEqual({ id: "email-3", userId: "user-3" });
+  });
+});

--- a/tests/sdk-client.test.tsx
+++ b/tests/sdk-client.test.tsx
@@ -216,6 +216,57 @@ describe("Opensend SDK", () => {
     );
   });
 
+  it("fetches email details from the public detail endpoint", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          object: "email",
+          id: "email_123",
+          from: "sender@example.com",
+          to: ["user@example.com"],
+          subject: "Hello",
+          html: "<p>Hello</p>",
+          text: null,
+          cc: null,
+          bcc: null,
+          reply_to: null,
+          last_event: "delivered",
+          provider_retry_count: 0,
+          provider_last_attempted_at: null,
+          provider_next_retry_at: null,
+          provider_last_error: null,
+          provider_dead_lettered_at: null,
+          scheduled_at: null,
+          sent_at: "2026-01-01T00:00:05.000Z",
+          tags: null,
+          created_at: "2026-01-01T00:00:00.000Z",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new Opensend("re_test", {
+      baseUrl: "https://api.example.com",
+    });
+
+    const response = await client.emails.get("email_123");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/api/emails/email_123",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(response.data).toMatchObject({
+      object: "email",
+      id: "email_123",
+      last_event: "delivered",
+    });
+  });
+
   it("uses Resend-compatible root contacts endpoints for CRUD", async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(JSON.stringify({ object: "contact", id: "contact_123" }), {


### PR DESCRIPTION
## Summary

Closes #322.

- Extracts email list/detail/query-param delete behavior into `packages/core/src/services/emailRead.ts`.
- Adds tenant-scoped core repository methods for list/detail/delete (`listForApi`, `findByIdForUser`, `deleteForUser`).
- Keeps Next email adapters focused on API-key auth, permission checks, query/param parsing, service calls, and HTTP error mapping.
- Preserves existing public response shapes, including collection delete returning `{ "success": true }` even when no row is deleted.

## Changed files

- `src/app/api/emails/route.ts`
- `src/app/api/emails/[id]/route.ts`
- `packages/core/src/db/repositories/emailRepo.ts`
- `packages/core/src/services/emailRead.ts`
- `packages/core/src/index.ts`
- `tests/api-emails.test.ts`
- `tests/email-read-service.test.ts`
- `tests/sdk-client.test.tsx`
- `agent_docs/learnings/active/2026-05-11-issue-322-email-read-delete-boundary.md`

## Validation

- `bun run test -- tests/email-read-service.test.ts tests/api-emails.test.ts tests/sdk-client.test.tsx`
- `make check`
- `make test`
- Push guardrails: `scripts/check-changed-files.mjs`, full-project typecheck, changed-file Biome lint

## Residual risk

- Playwright E2E was not run; this is a read-side API/core extraction with unit/route/SDK coverage and no dashboard UI changes.
