### PR TITLE
Extract audience taxonomy service boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-324-segment-contacts-boundary.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-324-segment-contacts-boundary.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-11
+issue: "#324"
+type: pattern
+promoted_to: null
+---
+
+## Segment contact listing belongs with audience metadata, not contacts CRUD
+
+**What:** `/api/segments/[id]/contacts` is part of the public audience taxonomy family even though it returns contact rows. Its compatibility contract is API-key-only detail auth, full-access permission gating, tenant-scoped segment existence check before listing, and the legacy list shape `{ object, data, has_more }` with `firstName`/`lastName` camel-case fields.
+
+**Why:** Treating it as generic contacts CRUD risks broadening issue #324 into contact mutation/list refactors and can accidentally change dashboard-capable auth rules used by collection segment/topic/property routes.
+
+**Fix:** Keep the Next route as an API-key auth/parse/HTTP adapter and place the tenant-scoped segment-contact join under the audience metadata service/repository boundary. Future changes should preserve the route family's auth split: collection routes may use dashboard-or-API-key auth, while `[id]` detail-family routes remain API-key-only.

--- a/packages/core/src/db/repositories/segmentRepo.ts
+++ b/packages/core/src/db/repositories/segmentRepo.ts
@@ -1,6 +1,6 @@
 import { type SQL, and, count, desc, eq, ilike, lt } from "drizzle-orm";
 import { db } from "../client";
-import { segments } from "../schema";
+import { contacts, contactsToSegments, segments } from "../schema";
 
 export const segmentRepo = {
   async findById(id: string) {
@@ -92,5 +92,42 @@ export const segmentRepo = {
       .delete(segments)
       .where(and(eq(segments.id, id), eq(segments.userId, userId)))
       .returning();
+  },
+
+  async listContactsForApi(options: {
+    userId: string;
+    segmentId: string;
+    limit: number;
+    after?: string;
+  }) {
+    const conditions: SQL[] = [
+      eq(contactsToSegments.segmentId, options.segmentId),
+      eq(contacts.userId, options.userId),
+    ];
+
+    if (options.after) conditions.push(lt(contacts.id, options.after));
+
+    const rows = await db
+      .select({
+        id: contacts.id,
+        email: contacts.email,
+        firstName: contacts.firstName,
+        lastName: contacts.lastName,
+        unsubscribed: contacts.unsubscribed,
+        createdAt: contacts.createdAt,
+      })
+      .from(contacts)
+      .innerJoin(
+        contactsToSegments,
+        eq(contacts.id, contactsToSegments.contactId),
+      )
+      .where(and(...conditions))
+      .orderBy(desc(contacts.id))
+      .limit(options.limit + 1);
+
+    const hasMore = rows.length > options.limit;
+    const data = hasMore ? rows.slice(0, options.limit) : rows;
+
+    return { data, hasMore };
   },
 };

--- a/packages/core/src/services/audience-metadata.ts
+++ b/packages/core/src/services/audience-metadata.ts
@@ -1,7 +1,12 @@
 import { propertyRepo } from "../db/repositories/propertyRepo";
 import { segmentRepo } from "../db/repositories/segmentRepo";
 import { topicRepo } from "../db/repositories/topicRepo";
-import type { contactProperties, segments, topics } from "../db/schema";
+import type {
+  contactProperties,
+  contacts,
+  segments,
+  topics,
+} from "../db/schema";
 
 type SegmentRow = typeof segments.$inferSelect;
 type SegmentInsert = typeof segments.$inferInsert;
@@ -9,8 +14,13 @@ type TopicRow = typeof topics.$inferSelect;
 type TopicInsert = typeof topics.$inferInsert;
 type PropertyRow = typeof contactProperties.$inferSelect;
 type PropertyInsert = typeof contactProperties.$inferInsert;
+type ContactRow = typeof contacts.$inferSelect;
 
 type SegmentListRow = Pick<SegmentRow, "id" | "name" | "createdAt">;
+type SegmentContactListRow = Pick<
+  ContactRow,
+  "id" | "email" | "firstName" | "lastName" | "unsubscribed" | "createdAt"
+>;
 type TopicListRow = Pick<
   TopicRow,
   | "id"
@@ -38,6 +48,12 @@ export type AudienceMetadataRepository = {
     userId: string,
   ): Promise<SegmentRow | undefined>;
   deleteSegmentForUser(id: string, userId: string): Promise<SegmentRow[]>;
+  listSegmentContactsForApi(options: {
+    userId: string;
+    segmentId: string;
+    limit: number;
+    after?: string;
+  }): Promise<{ data: SegmentContactListRow[]; hasMore: boolean }>;
 
   listTopicsForApi(options: {
     userId: string;
@@ -100,6 +116,8 @@ function defaultRepository(): AudienceMetadataRepository {
     findSegmentByIdForUser: (id, userId) =>
       segmentRepo.findByIdForUser(id, userId),
     deleteSegmentForUser: (id, userId) => segmentRepo.deleteForUser(id, userId),
+    listSegmentContactsForApi: (options) =>
+      segmentRepo.listContactsForApi(options),
 
     listTopicsForApi: (options) => topicRepo.listForApi(options),
     createTopic: (data) => topicRepo.create(data),
@@ -174,6 +192,17 @@ function toSegmentDetail(row: SegmentRow) {
     object: "segment" as const,
     id: row.id,
     name: row.name,
+    created_at: row.createdAt,
+  };
+}
+
+function toSegmentContactListItem(row: SegmentContactListRow) {
+  return {
+    id: row.id,
+    email: row.email,
+    firstName: row.firstName,
+    lastName: row.lastName,
+    status: row.unsubscribed ? "unsubscribed" : "subscribed",
     created_at: row.createdAt,
   };
 }
@@ -282,6 +311,32 @@ export function createAudienceMetadataService({
         input.userId,
       );
       if (!deleted) throw notFound("Segment not found");
+    },
+
+    async listSegmentContacts(input: {
+      userId: string;
+      segmentId: string;
+      limit?: number;
+      after?: string;
+    }) {
+      const segment = await repository.findSegmentByIdForUser(
+        input.segmentId,
+        input.userId,
+      );
+      if (!segment) throw notFound("Segment not found");
+
+      const result = await repository.listSegmentContactsForApi({
+        userId: input.userId,
+        segmentId: input.segmentId,
+        limit: normalizeLimit(input.limit, 20),
+        after: input.after || undefined,
+      });
+
+      return {
+        object: "list" as const,
+        data: result.data.map(toSegmentContactListItem),
+        has_more: result.hasMore,
+      };
     },
 
     async listTopics(input: {

--- a/src/app/api/segments/[id]/contacts/route.ts
+++ b/src/app/api/segments/[id]/contacts/route.ts
@@ -1,9 +1,29 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { contacts, contactsToSegments, segments } from "@/lib/db/schema";
-import { and, desc, eq, sql } from "drizzle-orm";
+import {
+  AudienceMetadataServiceError,
+  createAudienceMetadataService,
+} from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
+
+function audienceMetadataService() {
+  return createAudienceMetadataService();
+}
+
+function mapServiceError(error: unknown) {
+  if (error instanceof AudienceMetadataServiceError) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: error.status },
+    );
+  }
+
+  console.error("Failed to fetch segment contacts:", error);
+  return NextResponse.json(
+    { error: "Failed to fetch segment contacts" },
+    { status: 500 },
+  );
+}
 
 export async function GET(
   request: NextRequest,
@@ -18,70 +38,16 @@ export async function GET(
 
   try {
     const { id: segmentId } = await params;
-
-    // Check if segment exists
-    const [segment] = await db
-      .select({ id: segments.id, name: segments.name })
-      .from(segments)
-      .where(and(eq(segments.id, segmentId), eq(segments.userId, userId)));
-
-    if (!segment) {
-      return NextResponse.json({ error: "Segment not found" }, { status: 404 });
-    }
-
     const url = request.nextUrl;
-    const limit = Math.min(
-      100,
-      Math.max(1, Number(url.searchParams.get("limit")) || 20),
-    );
-    const after = url.searchParams.get("after") || "";
-
-    // Join with join table
-    const query = db
-      .select({
-        id: contacts.id,
-        email: contacts.email,
-        firstName: contacts.firstName,
-        lastName: contacts.lastName,
-        unsubscribed: contacts.unsubscribed,
-        createdAt: contacts.createdAt,
-      })
-      .from(contacts)
-      .innerJoin(
-        contactsToSegments,
-        eq(contacts.id, contactsToSegments.contactId),
-      )
-      .where(
-        and(
-          eq(contactsToSegments.segmentId, segmentId),
-          eq(contacts.userId, userId),
-        ),
-      );
-
-    const rows = await query.orderBy(desc(contacts.id)).limit(limit + 1);
-
-    const hasMore = rows.length > limit;
-    const dataRows = hasMore ? rows.slice(0, limit) : rows;
-
-    const data = dataRows.map((c) => ({
-      id: c.id,
-      email: c.email,
-      firstName: c.firstName,
-      lastName: c.lastName,
-      status: c.unsubscribed ? "unsubscribed" : "subscribed",
-      created_at: c.createdAt,
-    }));
-
-    return NextResponse.json({
-      object: "list",
-      data,
-      has_more: hasMore,
+    const result = await audienceMetadataService().listSegmentContacts({
+      userId,
+      segmentId,
+      limit: Number(url.searchParams.get("limit")) || undefined,
+      after: url.searchParams.get("after") || undefined,
     });
+
+    return NextResponse.json(result);
   } catch (error) {
-    console.error("Failed to fetch segment contacts:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch segment contacts" },
-      { status: 500 },
-    );
+    return mapServiceError(error);
   }
 }

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -356,6 +356,28 @@ describe("route smoke coverage", () => {
             const [deleted] = await mockDelete().where().returning();
             if (!deleted) throw notFound("Segment not found");
           },
+          async listSegmentContacts() {
+            const [segment] = await mockSelect().from().where();
+            if (!segment) throw notFound("Segment not found");
+            const rows = await mockSelect()
+              .from()
+              .innerJoin()
+              .where()
+              .orderBy()
+              .limit();
+            return {
+              object: "list",
+              data: rows.map((row: Record<string, unknown>) => ({
+                id: row.id,
+                email: row.email,
+                firstName: row.firstName,
+                lastName: row.lastName,
+                status: row.unsubscribed ? "unsubscribed" : "subscribed",
+                created_at: row.createdAt,
+              })),
+              has_more: false,
+            };
+          },
           async listTopics() {
             const rows = await mockSelect().from().where().orderBy().limit();
             const total = await mockCountFn();

--- a/tests/audience-metadata-routes.test.ts
+++ b/tests/audience-metadata-routes.test.ts
@@ -4,6 +4,7 @@ const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
 const mockValidateApiKey = vi.hoisted(() => vi.fn());
 const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockListSegments = vi.hoisted(() => vi.fn());
+const mockListSegmentContacts = vi.hoisted(() => vi.fn());
 const mockCreateTopic = vi.hoisted(() => vi.fn());
 const mockGetProperty = vi.hoisted(() => vi.fn());
 const mockUpdateTopic = vi.hoisted(() => vi.fn());
@@ -31,6 +32,7 @@ vi.mock("@opensend/core", () => ({
   AudienceMetadataServiceError: TestAudienceMetadataServiceError,
   createAudienceMetadataService: () => ({
     listSegments: mockListSegments,
+    listSegmentContacts: mockListSegmentContacts,
     createTopic: mockCreateTopic,
     getProperty: mockGetProperty,
     updateTopic: mockUpdateTopic,
@@ -141,6 +143,43 @@ describe("audience metadata route adapters", () => {
     expect(mockGetProperty).toHaveBeenCalledWith({
       userId: "user-1",
       id: "prop-1",
+    });
+    expect(mockAuthorizeDashboardOrApiKey).not.toHaveBeenCalled();
+  });
+
+  it("keeps segment contacts as an API-key-only thin service adapter", async () => {
+    mockListSegmentContacts.mockResolvedValueOnce({
+      object: "list",
+      data: [
+        {
+          id: "contact-1",
+          email: "user@example.com",
+          firstName: "User",
+          lastName: "One",
+          status: "subscribed",
+          created_at: "2026-05-10T00:00:00.000Z",
+        },
+      ],
+      has_more: false,
+    });
+    const { GET } = await import("@/app/api/segments/[id]/contacts/route");
+
+    const response = await GET(
+      makeNextRequest(
+        "http://localhost/api/segments/seg-1/contacts?limit=10&after=contact-9",
+        {
+          headers: { authorization: "Bearer re_test" },
+        },
+      ) as never,
+      { params: Promise.resolve({ id: "seg-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockListSegmentContacts).toHaveBeenCalledWith({
+      userId: "user-1",
+      segmentId: "seg-1",
+      limit: 10,
+      after: "contact-9",
     });
     expect(mockAuthorizeDashboardOrApiKey).not.toHaveBeenCalled();
   });

--- a/tests/audience-metadata-service.test.ts
+++ b/tests/audience-metadata-service.test.ts
@@ -14,16 +14,21 @@ type TopicRow = NonNullable<
 type PropertyRow = NonNullable<
   Awaited<ReturnType<AudienceMetadataRepository["findPropertyByIdForUser"]>>
 >;
+type SegmentContactRow = Awaited<
+  ReturnType<AudienceMetadataRepository["listSegmentContactsForApi"]>
+>["data"][number] & { segmentId: string; userId: string };
 
 const baseDate = new Date("2026-05-10T00:00:00.000Z");
 const updatedDate = new Date("2026-05-10T01:00:00.000Z");
 
 function makeRepository(seed?: {
   segments?: SegmentRow[];
+  segmentContacts?: SegmentContactRow[];
   topics?: TopicRow[];
   properties?: PropertyRow[];
 }): AudienceMetadataRepository {
   const segments = [...(seed?.segments ?? [])];
+  const segmentContacts = [...(seed?.segmentContacts ?? [])];
   const topics = [...(seed?.topics ?? [])];
   const properties = [...(seed?.properties ?? [])];
 
@@ -70,6 +75,22 @@ function makeRepository(seed?: {
       );
       if (index === -1) return [];
       return segments.splice(index, 1);
+    },
+    async listSegmentContactsForApi(options) {
+      const filtered = segmentContacts
+        .filter(
+          (contact) =>
+            contact.userId === options.userId &&
+            contact.segmentId === options.segmentId,
+        )
+        .filter((contact) =>
+          options.after ? contact.id < options.after : true,
+        )
+        .sort((a, b) => b.id.localeCompare(a.id));
+      return {
+        data: filtered.slice(0, options.limit),
+        hasMore: filtered.length > options.limit,
+      };
     },
 
     async listTopicsForApi(options) {
@@ -208,6 +229,25 @@ function property(id: string, key: string, userId: string): PropertyRow {
   };
 }
 
+function segmentContact(
+  id: string,
+  email: string,
+  userId: string,
+  segmentId: string,
+  unsubscribed = false,
+): SegmentContactRow {
+  return {
+    id,
+    email,
+    firstName: "First",
+    lastName: "Last",
+    unsubscribed,
+    createdAt: baseDate,
+    segmentId,
+    userId,
+  };
+}
+
 describe("audience metadata service", () => {
   it("lists segments with tenant isolation, search, pagination, and response shape", async () => {
     const service = createAudienceMetadataService({
@@ -286,6 +326,49 @@ describe("audience metadata service", () => {
     await expect(
       service.deleteTopic({ userId: "user-2", id: "topic-1" }),
     ).rejects.toMatchObject({ message: "Topic not found", status: 404 });
+  });
+
+  it("lists segment contacts with segment tenant check, cursor pagination, and response shape", async () => {
+    const service = createAudienceMetadataService({
+      repository: makeRepository({
+        segments: [segment("seg-1", "VIP", "user-1")],
+        segmentContacts: [
+          segmentContact("contact-c", "c@example.com", "user-1", "seg-1"),
+          segmentContact("contact-b", "b@example.com", "user-1", "seg-1", true),
+          segmentContact("contact-a", "a@example.com", "user-1", "seg-1"),
+          segmentContact("contact-z", "z@example.com", "user-2", "seg-1"),
+        ],
+      }),
+    });
+
+    await expect(
+      service.listSegmentContacts({
+        userId: "user-1",
+        segmentId: "seg-1",
+        after: "contact-c",
+        limit: 1,
+      }),
+    ).resolves.toEqual({
+      object: "list",
+      data: [
+        {
+          id: "contact-b",
+          email: "b@example.com",
+          firstName: "First",
+          lastName: "Last",
+          status: "unsubscribed",
+          created_at: baseDate,
+        },
+      ],
+      has_more: true,
+    });
+
+    await expect(
+      service.listSegmentContacts({
+        userId: "user-2",
+        segmentId: "seg-1",
+      }),
+    ).rejects.toMatchObject({ message: "Segment not found", status: 404 });
   });
 
   it("lists and creates properties with tenant isolation, key generation, and page metadata", async () => {


### PR DESCRIPTION
## Summary
- Moved the remaining `/api/segments/[id]/contacts` data orchestration behind the existing `packages/core` audience metadata service boundary.
- Added a tenant-scoped segment-contact repository helper and service method while preserving API-key-only detail auth, full-access gating, and the public list response shape.
- Added focused service/route tests plus a learning note for the segment-contact ownership/auth split.

Closes #324

## Validation
- `bun run test -- tests/audience-metadata-service.test.ts tests/audience-metadata-routes.test.ts tests/api-auth-date-range-routes.test.ts` — 27 tests passed across 3 files.
- `bun run typecheck` — passed.
- `make check` — TypeCheck passed; Biome lint/format passed.
- `make test` — 113 test files passed; 955 tests passed.
- Push guardrails — full-project typecheck passed; changed-file Biome lint passed.

## Playwright
- Not run. This is a server route/service-boundary extraction with no dashboard UI or browser flow changes; Vitest route/service coverage plus the full unit suite covers the changed behavior.

## Residual risk
- Low: `/api/segments/[id]/contacts` now delegates through core, so regressions would most likely be limited to segment-contact listing. Existing and added tests cover auth mode, tenant scoping, pagination inputs, not-found mapping, and response shape.
