### PR TITLE
Extract automation run route service boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-326-automation-run-boundary.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-326-automation-run-boundary.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-11
+issue: "#326"
+type: decision
+promoted_to: null
+---
+
+## Automation run read/cancel/metrics boundary keeps request parsing in Next
+
+**What:** The automation run list/detail/cancel/metrics routes now delegate automation ownership checks, run lookup, cancellation metadata mutation, and metrics aggregation to `packages/core/src/services/automationRuns.ts`. Next route handlers still own API-key auth, full-access enforcement, JSON/query parsing, and HTTP status mapping.
+
+**Why:** This preserves the existing public API contract and keeps Zod/Request parsing close to Next while making the tenant-scoped orchestration reusable for future adapters.
+
+**Pattern:** For future automation run adapters, pass the already-authenticated `userId` and parsed query/body values into `createAutomationRunService()`. Keep cancellation guarded by both the pre-read status check and repository update condition so races continue to return `run_not_cancellable` instead of resurrecting terminal runs.

--- a/packages/core/src/db/repositories/automationRepo.ts
+++ b/packages/core/src/db/repositories/automationRepo.ts
@@ -193,6 +193,15 @@ export const automationRepo = {
     });
   },
 
+  async findByIdForUser(id: string, userId?: string | null) {
+    const conditions = [eq(automations.id, id)];
+    if (userId) conditions.push(eq(automations.userId, userId));
+
+    return await db.query.automations.findFirst({
+      where: and(...conditions),
+    });
+  },
+
   async findEnabledByTriggerEventName(
     triggerEventName: string,
     userId?: string | null,

--- a/packages/core/src/db/repositories/automationRunRepo.ts
+++ b/packages/core/src/db/repositories/automationRunRepo.ts
@@ -1,4 +1,14 @@
-import { and, asc, desc, eq, inArray, lt, lte } from "drizzle-orm";
+import {
+  type SQL,
+  and,
+  asc,
+  desc,
+  eq,
+  gte,
+  inArray,
+  lt,
+  lte,
+} from "drizzle-orm";
 import { AutomationValidationError } from "../../dto/automations";
 import { db } from "../client";
 import { automationRuns, automations } from "../schema";
@@ -65,9 +75,31 @@ export const automationRunRepo = {
     automationId: string,
     options: { limit?: number; after?: string } = {},
   ) {
-    const { limit = 25, after } = options;
-    const conditions = [eq(automationRuns.automationId, automationId)];
-    if (after) conditions.push(lt(automationRuns.id, after));
+    return await this.listForApi({
+      automationId,
+      statuses: [],
+      limit: options.limit ?? 25,
+      after: options.after,
+    });
+  },
+
+  async listForApi(input: {
+    automationId: string;
+    statuses?: readonly string[];
+    limit?: number;
+    after?: string;
+  }) {
+    const limit = input.limit ?? 25;
+    const conditions: SQL[] = [
+      eq(automationRuns.automationId, input.automationId),
+    ];
+    const statuses = input.statuses ?? [];
+    if (statuses.length === 1) {
+      conditions.push(eq(automationRuns.status, statuses[0]));
+    } else if (statuses.length > 1) {
+      conditions.push(inArray(automationRuns.status, [...statuses]));
+    }
+    if (input.after) conditions.push(lt(automationRuns.id, input.after));
 
     const results = await db
       .select()
@@ -79,6 +111,62 @@ export const automationRunRepo = {
     const hasMore = results.length > limit;
     const data = hasMore ? results.slice(0, limit) : results;
     return { data, hasMore };
+  },
+
+  async findByIdForAutomation(runId: string, automationId: string) {
+    return await db.query.automationRuns.findFirst({
+      where: and(
+        eq(automationRuns.id, runId),
+        eq(automationRuns.automationId, automationId),
+      ),
+    });
+  },
+
+  async cancelForApi(input: {
+    runId: string;
+    automationId: string;
+    stepStates: NonNullable<(typeof automationRuns.$inferInsert)["stepStates"]>;
+    failureReason: string;
+    completedAt: Date;
+    cancellableStatuses: readonly string[];
+  }) {
+    const [updated] = await db
+      .update(automationRuns)
+      .set({
+        status: "cancelled",
+        stepStates: input.stepStates,
+        completedAt: input.completedAt,
+        nextStepAt: null,
+        failureReason: input.failureReason,
+        updatedAt: input.completedAt,
+      })
+      .where(
+        and(
+          eq(automationRuns.id, input.runId),
+          eq(automationRuns.automationId, input.automationId),
+          inArray(automationRuns.status, [...input.cancellableStatuses]),
+        ),
+      )
+      .returning();
+
+    return updated;
+  },
+
+  async listForMetrics(input: {
+    automationId: string;
+    from?: Date;
+    to?: Date;
+  }) {
+    const conditions: SQL[] = [
+      eq(automationRuns.automationId, input.automationId),
+    ];
+    if (input.from) conditions.push(gte(automationRuns.createdAt, input.from));
+    if (input.to) conditions.push(lte(automationRuns.createdAt, input.to));
+
+    return await db
+      .select()
+      .from(automationRuns)
+      .where(and(...conditions));
   },
 
   async listWaitingByContact(input: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,5 +44,6 @@ export * from "./services/storage";
 export * from "./services/template";
 export * from "./services/broadcast";
 export * from "./services/audience-metadata";
+export * from "./services/automationRuns";
 export * from "./jobs/background-jobs";
 export * from "./observability/telemetry";

--- a/packages/core/src/services/automationRuns.ts
+++ b/packages/core/src/services/automationRuns.ts
@@ -1,0 +1,388 @@
+import { automationRepo } from "../db/repositories/automationRepo";
+import { automationRunRepo } from "../db/repositories/automationRunRepo";
+import type {
+  AutomationStepStateEntry,
+  automationRuns,
+  automations,
+} from "../db/schema";
+
+type AutomationRow = typeof automations.$inferSelect;
+export type AutomationRunRow = typeof automationRuns.$inferSelect;
+type AutomationRunStatus =
+  | "queued"
+  | "running"
+  | "waiting"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "skipped";
+
+type RunMetricsStatus = AutomationRunStatus;
+type StepState = AutomationStepStateEntry;
+
+const RUN_METRIC_STATUSES: RunMetricsStatus[] = [
+  "queued",
+  "running",
+  "waiting",
+  "completed",
+  "failed",
+  "cancelled",
+  "skipped",
+];
+
+const CANCELLABLE_RUN_STATUSES = ["queued", "waiting"] as const;
+
+type CancellableRunStatus = (typeof CANCELLABLE_RUN_STATUSES)[number];
+
+export type AutomationRunServiceErrorCode =
+  | "automation_not_found"
+  | "run_not_found"
+  | "run_not_cancellable";
+
+export class AutomationRunServiceError extends Error {
+  constructor(
+    readonly code: AutomationRunServiceErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AutomationRunServiceError";
+  }
+}
+
+export type AutomationRunListItem = ReturnType<typeof toRunListItem>;
+export type AutomationRunDetailResponse = ReturnType<typeof toRunDetail>;
+export type AutomationRunMetricsResponse = ReturnType<typeof toRunMetrics>;
+
+export type AutomationRunListResponse = {
+  object: "list";
+  data: AutomationRunListItem[];
+  has_more: boolean;
+};
+
+export type AutomationRunBoundaryRepository = {
+  findAutomationById(
+    automationId: string,
+    userId?: string | null,
+  ): Promise<AutomationRow | undefined>;
+  listRuns(input: {
+    automationId: string;
+    statuses: string[];
+    limit: number;
+    after?: string;
+  }): Promise<{ data: AutomationRunRow[]; hasMore: boolean }>;
+  findRunByIdForAutomation(
+    runId: string,
+    automationId: string,
+  ): Promise<AutomationRunRow | undefined>;
+  cancelRun(input: {
+    runId: string;
+    automationId: string;
+    stepStates: NonNullable<AutomationRunRow["stepStates"]>;
+    failureReason: string;
+    completedAt: Date;
+    cancellableStatuses: readonly CancellableRunStatus[];
+  }): Promise<AutomationRunRow | undefined>;
+  listMetricRuns(input: {
+    automationId: string;
+    from?: Date;
+    to?: Date;
+  }): Promise<AutomationRunRow[]>;
+};
+
+export type AutomationRunServiceDependencies = {
+  repository?: AutomationRunBoundaryRepository;
+  now?: () => Date;
+};
+
+export type ListAutomationRunsInput = {
+  automationId: string;
+  userId?: string | null;
+  status?: string;
+  limit?: number;
+  after?: string;
+};
+
+export type GetAutomationRunInput = {
+  automationId: string;
+  runId: string;
+  userId?: string | null;
+};
+
+export type CancelAutomationRunInput = GetAutomationRunInput & {
+  reason?: string;
+};
+
+export type GetAutomationRunMetricsInput = {
+  automationId: string;
+  userId?: string | null;
+  from?: Date;
+  to?: Date;
+};
+
+function defaultRepository(): AutomationRunBoundaryRepository {
+  return {
+    findAutomationById: (automationId, userId) =>
+      automationRepo.findByIdForUser(automationId, userId),
+    listRuns: (input) => automationRunRepo.listForApi(input),
+    findRunByIdForAutomation: (runId, automationId) =>
+      automationRunRepo.findByIdForAutomation(runId, automationId),
+    cancelRun: (input) => automationRunRepo.cancelForApi(input),
+    listMetricRuns: (input) => automationRunRepo.listForMetrics(input),
+  };
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  return limit ?? 25;
+}
+
+export function parseRunStatusFilter(
+  value: string | null | undefined,
+): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+function findFailedStepKey(
+  stepStates: AutomationRunRow["stepStates"],
+): string | null {
+  if (!stepStates) return null;
+  for (const [key, state] of Object.entries(stepStates) as Array<
+    [string, StepState]
+  >) {
+    if (state.status === "failed") return key;
+  }
+  return null;
+}
+
+function durationMs(run: AutomationRunRow): number | null {
+  if (!run.startedAt || !run.completedAt) return null;
+  return Math.max(0, run.completedAt.getTime() - run.startedAt.getTime());
+}
+
+function toRunListItem(run: AutomationRunRow) {
+  return {
+    object: "automation_run" as const,
+    id: run.id,
+    automation_id: run.automationId,
+    status: run.status,
+    started_at: run.startedAt,
+    completed_at: run.completedAt,
+    duration_ms: durationMs(run),
+    current_step_key: run.currentStepKey,
+    failed_step_key: findFailedStepKey(run.stepStates),
+    failure_reason: run.failureReason,
+    next_step_at: run.nextStepAt,
+    created_at: run.createdAt,
+    updated_at: run.updatedAt,
+  };
+}
+
+function toRunDetail(run: AutomationRunRow) {
+  return {
+    object: "automation_run" as const,
+    id: run.id,
+    automation_id: run.automationId,
+    trigger_event_id: run.triggerEventId,
+    contact_id: run.contactId,
+    status: run.status,
+    current_step_key: run.currentStepKey,
+    failed_step_key: findFailedStepKey(run.stepStates),
+    failure_reason: run.failureReason,
+    step_states: run.stepStates ?? {},
+    started_at: run.startedAt,
+    completed_at: run.completedAt,
+    next_step_at: run.nextStepAt,
+    duration_ms: durationMs(run),
+    created_at: run.createdAt,
+    updated_at: run.updatedAt,
+  };
+}
+
+function emptyStatusCounts(): Record<RunMetricsStatus, number> {
+  return Object.fromEntries(
+    RUN_METRIC_STATUSES.map((status) => [status, 0]),
+  ) as Record<RunMetricsStatus, number>;
+}
+
+function toRunMetrics(
+  automationId: string,
+  runs: AutomationRunRow[],
+  range: { from?: Date; to?: Date } = {},
+) {
+  const byStatus = emptyStatusCounts();
+  const failedSteps = new Map<string, number>();
+  let durationTotal = 0;
+  let durationCount = 0;
+
+  for (const run of runs) {
+    if (RUN_METRIC_STATUSES.includes(run.status as RunMetricsStatus)) {
+      byStatus[run.status as RunMetricsStatus] += 1;
+    }
+
+    const duration = durationMs(run);
+    if (duration !== null) {
+      durationTotal += duration;
+      durationCount += 1;
+    }
+
+    const failedStepKey = findFailedStepKey(run.stepStates);
+    if (failedStepKey) {
+      failedSteps.set(failedStepKey, (failedSteps.get(failedStepKey) ?? 0) + 1);
+    }
+  }
+
+  const totalRuns = runs.length;
+  const failedStepSummary = [...failedSteps.entries()]
+    .map(([stepKey, count]) => ({ step_key: stepKey, count }))
+    .sort((a, b) => b.count - a.count || a.step_key.localeCompare(b.step_key))
+    .slice(0, 10);
+
+  return {
+    object: "automation_run_metrics" as const,
+    automation_id: automationId,
+    total_runs: totalRuns,
+    by_status: byStatus,
+    completion_rate: totalRuns > 0 ? byStatus.completed / totalRuns : 0,
+    failure_rate: totalRuns > 0 ? byStatus.failed / totalRuns : 0,
+    average_duration_ms:
+      durationCount > 0 ? Math.round(durationTotal / durationCount) : null,
+    waiting_count: byStatus.waiting,
+    failed_steps: failedStepSummary,
+    range: {
+      from: range.from?.toISOString() ?? null,
+      to: range.to?.toISOString() ?? null,
+    },
+  };
+}
+
+function isCancellableStatus(status: string): status is CancellableRunStatus {
+  return CANCELLABLE_RUN_STATUSES.includes(status as CancellableRunStatus);
+}
+
+function cancellableError(): AutomationRunServiceError {
+  return new AutomationRunServiceError(
+    "run_not_cancellable",
+    "Run is not cancellable",
+  );
+}
+
+export function createAutomationRunService({
+  repository = defaultRepository(),
+  now = () => new Date(),
+}: AutomationRunServiceDependencies = {}) {
+  async function requireAutomation(input: {
+    automationId: string;
+    userId?: string | null;
+  }): Promise<AutomationRow> {
+    const automation = await repository.findAutomationById(
+      input.automationId,
+      input.userId,
+    );
+    if (!automation) {
+      throw new AutomationRunServiceError(
+        "automation_not_found",
+        "Automation not found",
+      );
+    }
+    return automation;
+  }
+
+  return {
+    async listRuns(
+      input: ListAutomationRunsInput,
+    ): Promise<AutomationRunListResponse> {
+      const automation = await requireAutomation(input);
+      const result = await repository.listRuns({
+        automationId: automation.id,
+        statuses: parseRunStatusFilter(input.status),
+        limit: normalizeLimit(input.limit),
+        after: input.after || undefined,
+      });
+
+      return {
+        object: "list",
+        data: result.data.map(toRunListItem),
+        has_more: result.hasMore,
+      };
+    },
+
+    async getRun(
+      input: GetAutomationRunInput,
+    ): Promise<AutomationRunDetailResponse> {
+      const automation = await requireAutomation(input);
+      const run = await repository.findRunByIdForAutomation(
+        input.runId,
+        automation.id,
+      );
+      if (!run) {
+        throw new AutomationRunServiceError("run_not_found", "Run not found");
+      }
+      return toRunDetail(run);
+    },
+
+    async cancelRun(
+      input: CancelAutomationRunInput,
+    ): Promise<AutomationRunDetailResponse> {
+      const automation = await requireAutomation(input);
+      const run = await repository.findRunByIdForAutomation(
+        input.runId,
+        automation.id,
+      );
+      if (!run) {
+        throw new AutomationRunServiceError("run_not_found", "Run not found");
+      }
+      if (!isCancellableStatus(run.status)) throw cancellableError();
+
+      const completedAt = now();
+      const reason = input.reason ?? "cancelled_by_api";
+      const stepStates = { ...(run.stepStates ?? {}) };
+      if (run.currentStepKey) {
+        const currentState: StepState = stepStates[run.currentStepKey] ?? {
+          status: "pending",
+        };
+        stepStates[run.currentStepKey] = {
+          ...currentState,
+          status: "cancelled",
+          completedAt: completedAt.toISOString(),
+          output: {
+            ...(currentState.output ?? {}),
+            cancellation_reason: reason,
+          },
+        };
+      }
+
+      const updated = await repository.cancelRun({
+        runId: run.id,
+        automationId: automation.id,
+        stepStates,
+        failureReason: reason,
+        completedAt,
+        cancellableStatuses: CANCELLABLE_RUN_STATUSES,
+      });
+      if (!updated) throw cancellableError();
+
+      return toRunDetail(updated);
+    },
+
+    async getMetrics(
+      input: GetAutomationRunMetricsInput,
+    ): Promise<AutomationRunMetricsResponse> {
+      const automation = await requireAutomation(input);
+      const runs = await repository.listMetricRuns({
+        automationId: automation.id,
+        from: input.from,
+        to: input.to,
+      });
+
+      return toRunMetrics(automation.id, runs, {
+        from: input.from,
+        to: input.to,
+      });
+    },
+  };
+}
+
+export const automationRunService = createAutomationRunService();

--- a/src/app/api/automations/[id]/runs/[runId]/cancel/route.ts
+++ b/src/app/api/automations/[id]/runs/[runId]/cancel/route.ts
@@ -1,12 +1,9 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { formatRunDetail } from "@/lib/automations";
-import { db } from "@/lib/db";
-import { automationRuns, automations } from "@/lib/db/schema";
 import { cancelAutomationRunSchema } from "@/lib/validation/automations";
-import { and, eq, inArray } from "drizzle-orm";
-
-const CANCELLABLE_RUN_STATUSES = ["queued", "waiting"] as const;
+import {
+  authorizeAutomationRunRoute,
+  automationRunService,
+  mapAutomationRunServiceError,
+} from "../../route-helpers";
 
 async function readJsonBody(request: Request): Promise<unknown> {
   const body = await request.text();
@@ -18,10 +15,8 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string; runId: string }> },
 ): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
+  const auth = await authorizeAutomationRunRoute(request);
+  if ("response" in auth) return auth.response;
 
   let body: unknown;
   try {
@@ -40,83 +35,15 @@ export async function POST(
 
   const { id, runId } = await params;
   try {
-    const ownerConditions = [eq(automations.id, id)];
-    if (auth.userId) ownerConditions.push(eq(automations.userId, auth.userId));
-    const automation = await db.query.automations.findFirst({
-      where: and(...ownerConditions),
+    const run = await automationRunService.cancelRun({
+      automationId: id,
+      runId,
+      userId: auth.userId,
+      reason: parsed.data.reason,
     });
-    if (!automation) {
-      return Response.json({ error: "Automation not found" }, { status: 404 });
-    }
 
-    const run = await db.query.automationRuns.findFirst({
-      where: and(
-        eq(automationRuns.id, runId),
-        eq(automationRuns.automationId, automation.id),
-      ),
-    });
-    if (!run) return Response.json({ error: "Run not found" }, { status: 404 });
-
-    if (
-      !CANCELLABLE_RUN_STATUSES.includes(run.status as "queued" | "waiting")
-    ) {
-      return Response.json(
-        {
-          error: "Run is not cancellable",
-          code: "run_not_cancellable",
-        },
-        { status: 409 },
-      );
-    }
-
-    const now = new Date();
-    const reason = parsed.data.reason ?? "cancelled_by_api";
-    const stepStates = { ...(run.stepStates ?? {}) };
-    if (run.currentStepKey) {
-      stepStates[run.currentStepKey] = {
-        ...(stepStates[run.currentStepKey] ?? { status: "pending" }),
-        status: "cancelled",
-        completedAt: now.toISOString(),
-        output: {
-          ...(stepStates[run.currentStepKey]?.output ?? {}),
-          cancellation_reason: reason,
-        },
-      };
-    }
-
-    const [updated] = await db
-      .update(automationRuns)
-      .set({
-        status: "cancelled",
-        stepStates,
-        completedAt: now,
-        nextStepAt: null,
-        failureReason: reason,
-        updatedAt: now,
-      })
-      .where(
-        and(
-          eq(automationRuns.id, run.id),
-          eq(automationRuns.automationId, automation.id),
-          inArray(automationRuns.status, [...CANCELLABLE_RUN_STATUSES]),
-        ),
-      )
-      .returning();
-
-    if (!updated) {
-      return Response.json(
-        {
-          error: "Run is not cancellable",
-          code: "run_not_cancellable",
-        },
-        { status: 409 },
-      );
-    }
-
-    return Response.json(formatRunDetail(updated));
+    return Response.json(run);
   } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to cancel automation run";
-    return Response.json({ error: message }, { status: 500 });
+    return mapAutomationRunServiceError(err, "Failed to cancel automation run");
   }
 }

--- a/src/app/api/automations/[id]/runs/[runId]/route.ts
+++ b/src/app/api/automations/[id]/runs/[runId]/route.ts
@@ -1,42 +1,28 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { formatRunDetail } from "@/lib/automations";
-import { db } from "@/lib/db";
-import { automationRuns, automations } from "@/lib/db/schema";
-import { and, eq } from "drizzle-orm";
+import {
+  authorizeAutomationRunRoute,
+  automationRunService,
+  mapAutomationRunServiceError,
+} from "../route-helpers";
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string; runId: string }> },
 ): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
+  const auth = await authorizeAutomationRunRoute(request);
+  if ("response" in auth) return auth.response;
 
   const { id, runId } = await params;
   try {
-    const ownerConditions = [eq(automations.id, id)];
-    if (auth.userId) ownerConditions.push(eq(automations.userId, auth.userId));
-    const automation = await db.query.automations.findFirst({
-      where: and(...ownerConditions),
+    const run = await automationRunService.getRun({
+      automationId: id,
+      runId,
+      userId: auth.userId,
     });
-    if (!automation) {
-      return Response.json({ error: "Automation not found" }, { status: 404 });
-    }
-
-    const run = await db.query.automationRuns.findFirst({
-      where: and(
-        eq(automationRuns.id, runId),
-        eq(automationRuns.automationId, id),
-      ),
-    });
-    if (!run) return Response.json({ error: "Run not found" }, { status: 404 });
-
-    return Response.json(formatRunDetail(run));
+    return Response.json(run);
   } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to retrieve automation run";
-    return Response.json({ error: message }, { status: 500 });
+    return mapAutomationRunServiceError(
+      err,
+      "Failed to retrieve automation run",
+    );
   }
 }

--- a/src/app/api/automations/[id]/runs/metrics/route.ts
+++ b/src/app/api/automations/[id]/runs/metrics/route.ts
@@ -1,19 +1,16 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { formatRunMetrics } from "@/lib/automations";
-import { db } from "@/lib/db";
-import { automationRuns, automations } from "@/lib/db/schema";
 import { automationRunMetricsQuerySchema } from "@/lib/validation/automations";
-import { type SQL, and, eq, gte, lte } from "drizzle-orm";
+import {
+  authorizeAutomationRunRoute,
+  automationRunService,
+  mapAutomationRunServiceError,
+} from "../route-helpers";
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
+  const auth = await authorizeAutomationRunRoute(request);
+  if ("response" in auth) return auth.response;
 
   const url = new URL(request.url);
   const parsed = automationRunMetricsQuerySchema.safeParse({
@@ -29,32 +26,20 @@ export async function GET(
 
   const { id } = await params;
   try {
-    const ownerConditions = [eq(automations.id, id)];
-    if (auth.userId) ownerConditions.push(eq(automations.userId, auth.userId));
-    const automation = await db.query.automations.findFirst({
-      where: and(...ownerConditions),
-    });
-    if (!automation) {
-      return Response.json({ error: "Automation not found" }, { status: 404 });
-    }
-
     const from = parsed.data.from ? new Date(parsed.data.from) : undefined;
     const to = parsed.data.to ? new Date(parsed.data.to) : undefined;
-    const conditions: SQL[] = [eq(automationRuns.automationId, automation.id)];
-    if (from) conditions.push(gte(automationRuns.createdAt, from));
-    if (to) conditions.push(lte(automationRuns.createdAt, to));
+    const metrics = await automationRunService.getMetrics({
+      automationId: id,
+      userId: auth.userId,
+      from,
+      to,
+    });
 
-    const runs = await db
-      .select()
-      .from(automationRuns)
-      .where(and(...conditions));
-
-    return Response.json(formatRunMetrics(automation.id, runs, { from, to }));
+    return Response.json(metrics);
   } catch (err) {
-    const message =
-      err instanceof Error
-        ? err.message
-        : "Failed to retrieve automation run metrics";
-    return Response.json({ error: message }, { status: 500 });
+    return mapAutomationRunServiceError(
+      err,
+      "Failed to retrieve automation run metrics",
+    );
   }
 }

--- a/src/app/api/automations/[id]/runs/route-helpers.ts
+++ b/src/app/api/automations/[id]/runs/route-helpers.ts
@@ -1,0 +1,39 @@
+import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
+import {
+  AutomationRunServiceError,
+  createAutomationRunService,
+} from "@opensend/core";
+
+export const automationRunService = createAutomationRunService();
+
+export async function authorizeAutomationRunRoute(
+  request: Request,
+): Promise<{ userId?: string | null } | { response: Response }> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return { response: unauthorizedResponse() };
+
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return { response: permissionError };
+
+  return { userId: auth.userId };
+}
+
+export function mapAutomationRunServiceError(
+  err: unknown,
+  fallback: string,
+): Response {
+  if (err instanceof AutomationRunServiceError) {
+    if (err.code === "run_not_cancellable") {
+      return Response.json(
+        { error: err.message, code: err.code },
+        { status: 409 },
+      );
+    }
+
+    return Response.json({ error: err.message }, { status: 404 });
+  }
+
+  const message = err instanceof Error ? err.message : fallback;
+  return Response.json({ error: message }, { status: 500 });
+}

--- a/src/app/api/automations/[id]/runs/route.ts
+++ b/src/app/api/automations/[id]/runs/route.ts
@@ -1,19 +1,16 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { formatRunListItem, parseRunStatusFilter } from "@/lib/automations";
-import { db } from "@/lib/db";
-import { automationRuns, automations } from "@/lib/db/schema";
 import { listRunsQuerySchema } from "@/lib/validation/automations";
-import { type SQL, and, desc, eq, inArray, lt } from "drizzle-orm";
+import {
+  authorizeAutomationRunRoute,
+  automationRunService,
+  mapAutomationRunServiceError,
+} from "./route-helpers";
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
+  const auth = await authorizeAutomationRunRoute(request);
+  if ("response" in auth) return auth.response;
 
   const url = new URL(request.url);
   const parsed = listRunsQuerySchema.safeParse({
@@ -30,44 +27,14 @@ export async function GET(
 
   const { id } = await params;
   try {
-    const ownerConditions = [eq(automations.id, id)];
-    if (auth.userId) ownerConditions.push(eq(automations.userId, auth.userId));
-    const automation = await db.query.automations.findFirst({
-      where: and(...ownerConditions),
+    const result = await automationRunService.listRuns({
+      automationId: id,
+      userId: auth.userId,
+      ...parsed.data,
     });
-    if (!automation) {
-      return Response.json({ error: "Automation not found" }, { status: 404 });
-    }
 
-    const conditions: SQL[] = [eq(automationRuns.automationId, automation.id)];
-    const statuses = parseRunStatusFilter(parsed.data.status ?? null);
-    if (statuses.length === 1) {
-      conditions.push(eq(automationRuns.status, statuses[0]));
-    } else if (statuses.length > 1) {
-      conditions.push(inArray(automationRuns.status, statuses));
-    }
-    if (parsed.data.after)
-      conditions.push(lt(automationRuns.id, parsed.data.after));
-
-    const limit = parsed.data.limit ?? 25;
-    const rows = await db
-      .select()
-      .from(automationRuns)
-      .where(and(...conditions))
-      .orderBy(desc(automationRuns.createdAt))
-      .limit(limit + 1);
-
-    const hasMore = rows.length > limit;
-    const data = hasMore ? rows.slice(0, limit) : rows;
-
-    return Response.json({
-      object: "list",
-      data: data.map(formatRunListItem),
-      has_more: hasMore,
-    });
+    return Response.json(result);
   } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to list automation runs";
-    return Response.json({ error: message }, { status: 500 });
+    return mapAutomationRunServiceError(err, "Failed to list automation runs");
   }
 }

--- a/tests/api-automations-events.test.ts
+++ b/tests/api-automations-events.test.ts
@@ -11,6 +11,10 @@ const mockCustomEventFindByName = vi.hoisted(() => vi.fn());
 const mockCustomEventList = vi.hoisted(() => vi.fn());
 const mockDeliveryRecord = vi.hoisted(() => vi.fn());
 const mockRunCreateFromTrigger = vi.hoisted(() => vi.fn());
+const mockListRuns = vi.hoisted(() => vi.fn());
+const mockGetRun = vi.hoisted(() => vi.fn());
+const mockCancelRun = vi.hoisted(() => vi.fn());
+const mockGetMetrics = vi.hoisted(() => vi.fn());
 const mockResumeWaitingRunsForEvent = vi.hoisted(() => vi.fn());
 const mockDbSelect = vi.hoisted(() => vi.fn());
 const mockDbInsert = vi.hoisted(() => vi.fn());
@@ -31,6 +35,16 @@ class TestAutomationValidationError extends Error {
   }
 }
 
+class TestAutomationRunServiceError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "AutomationRunServiceError";
+    this.code = code;
+  }
+}
+
 function queryRows<T>(rows: T[]) {
   return {
     from: vi.fn().mockReturnThis(),
@@ -47,22 +61,6 @@ function insertRows<T>(rows: T[]) {
   return {
     values: vi.fn().mockReturnValue({
       returning: vi.fn().mockResolvedValue(rows),
-    }),
-  };
-}
-
-function updateRows<T>(
-  rows: T[],
-  setCalls: Array<Record<string, unknown>> = [],
-) {
-  return {
-    set: vi.fn((data: Record<string, unknown>) => {
-      setCalls.push(data);
-      return {
-        where: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue(rows),
-        }),
-      };
     }),
   };
 }
@@ -94,6 +92,13 @@ vi.mock("@/lib/db", () => ({
 
 vi.mock("@opensend/core", () => ({
   AutomationValidationError: TestAutomationValidationError,
+  AutomationRunServiceError: TestAutomationRunServiceError,
+  createAutomationRunService: () => ({
+    listRuns: mockListRuns,
+    getRun: mockGetRun,
+    cancelRun: mockCancelRun,
+    getMetrics: mockGetMetrics,
+  }),
   automationRepo: {
     create: mockAutomationCreate,
     list: mockAutomationList,
@@ -640,13 +645,69 @@ describe("automation API routes", () => {
     });
   });
 
-  it("cancels a queued run with reason metadata and no history loss", async () => {
-    const setCalls: Array<Record<string, unknown>> = [];
-    mockAutomationFindFirst.mockResolvedValue(automation);
-    mockRunFindFirst.mockResolvedValue(queuedRun);
-    mockDbUpdate.mockReturnValue(
-      updateRows([{ ...queuedRun, status: "cancelled" }], setCalls),
+  it("lists automation runs through the service boundary", async () => {
+    mockListRuns.mockResolvedValue({
+      object: "list",
+      data: [{ object: "automation_run", id: "run_1", status: "queued" }],
+      has_more: false,
+    });
+    const { GET } = await import("@/app/api/automations/[id]/runs/route");
+
+    const response = await GET(
+      new Request(
+        "http://localhost/api/automations/auto_1/runs?status=queued,waiting&limit=10",
+        { headers: { Authorization: "Bearer re_test" } },
+      ),
+      { params: Promise.resolve({ id: "auto_1" }) },
     );
+
+    expect(response.status).toBe(200);
+    expect(mockListRuns).toHaveBeenCalledWith({
+      automationId: "auto_1",
+      userId: "user_1",
+      status: "queued,waiting",
+      limit: 10,
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      object: "list",
+      data: [{ id: "run_1" }],
+    });
+  });
+
+  it("retrieves an automation run through the service boundary", async () => {
+    mockGetRun.mockResolvedValue({
+      object: "automation_run",
+      id: "run_1",
+      automation_id: "auto_1",
+      status: "queued",
+    });
+    const { GET } = await import(
+      "@/app/api/automations/[id]/runs/[runId]/route"
+    );
+
+    const response = await GET(
+      new Request("http://localhost/api/automations/auto_1/runs/run_1", {
+        headers: { Authorization: "Bearer re_test" },
+      }),
+      { params: Promise.resolve({ id: "auto_1", runId: "run_1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockGetRun).toHaveBeenCalledWith({
+      automationId: "auto_1",
+      runId: "run_1",
+      userId: "user_1",
+    });
+    await expect(response.json()).resolves.toMatchObject({ id: "run_1" });
+  });
+
+  it("cancels a queued run through the service boundary", async () => {
+    mockCancelRun.mockResolvedValue({
+      object: "automation_run",
+      id: "run_1",
+      automation_id: "auto_1",
+      status: "cancelled",
+    });
     const { POST } = await import(
       "@/app/api/automations/[id]/runs/[runId]/cancel/route"
     );
@@ -659,19 +720,11 @@ describe("automation API routes", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(setCalls[0]).toMatchObject({
-      status: "cancelled",
-      nextStepAt: null,
-      failureReason: "customer requested stop",
-    });
-    expect(setCalls[0]?.stepStates).toMatchObject({
-      wait: {
-        status: "cancelled",
-        output: {
-          waiting_for_event: "invoice.paid",
-          cancellation_reason: "customer requested stop",
-        },
-      },
+    expect(mockCancelRun).toHaveBeenCalledWith({
+      automationId: "auto_1",
+      runId: "run_1",
+      userId: "user_1",
+      reason: "customer requested stop",
     });
     await expect(response.json()).resolves.toMatchObject({
       object: "automation_run",
@@ -681,13 +734,12 @@ describe("automation API routes", () => {
   });
 
   it("rejects cancellation for terminal runs deterministically", async () => {
-    mockAutomationFindFirst.mockResolvedValue(automation);
-    mockRunFindFirst.mockResolvedValue({
-      ...queuedRun,
-      status: "completed",
-      completedAt: now,
-      nextStepAt: null,
-    });
+    mockCancelRun.mockRejectedValue(
+      new TestAutomationRunServiceError(
+        "run_not_cancellable",
+        "Run is not cancellable",
+      ),
+    );
     const { POST } = await import(
       "@/app/api/automations/[id]/runs/[runId]/cancel/route"
     );
@@ -703,44 +755,38 @@ describe("automation API routes", () => {
     await expect(response.json()).resolves.toMatchObject({
       code: "run_not_cancellable",
     });
-    expect(mockDbUpdate).not.toHaveBeenCalled();
+    expect(mockCancelRun).toHaveBeenCalledWith({
+      automationId: "auto_1",
+      runId: "run_1",
+      userId: "user_1",
+      reason: "too late",
+    });
   });
 
   it("aggregates tenant-scoped automation run metrics", async () => {
-    mockAutomationFindFirst.mockResolvedValue(automation);
-    mockDbSelect.mockReturnValue(
-      queryRows([
-        {
-          ...queuedRun,
-          id: "run_completed",
-          status: "completed",
-          currentStepKey: null,
-          completedAt: new Date("2026-05-02T00:00:10.000Z"),
-        },
-        {
-          ...queuedRun,
-          id: "run_failed",
-          status: "failed",
-          currentStepKey: "send",
-          completedAt: new Date("2026-05-02T00:00:30.000Z"),
-          failureReason: "send_email template is missing or unpublished",
-          stepStates: {
-            send: {
-              status: "failed",
-              error: "send_email template is missing or unpublished",
-            },
-          },
-        },
-        {
-          ...queuedRun,
-          id: "run_waiting",
-          status: "waiting",
-          currentStepKey: "wait",
-          startedAt: null,
-          completedAt: null,
-        },
-      ]),
-    );
+    mockGetMetrics.mockResolvedValue({
+      object: "automation_run_metrics",
+      automation_id: "auto_1",
+      total_runs: 3,
+      by_status: {
+        queued: 0,
+        running: 0,
+        waiting: 1,
+        completed: 1,
+        failed: 1,
+        cancelled: 0,
+        skipped: 0,
+      },
+      completion_rate: 1 / 3,
+      failure_rate: 1 / 3,
+      average_duration_ms: 20000,
+      waiting_count: 1,
+      failed_steps: [{ step_key: "send", count: 1 }],
+      range: {
+        from: "2026-05-02T00:00:00.000Z",
+        to: "2026-05-03T00:00:00.000Z",
+      },
+    });
     const { GET } = await import(
       "@/app/api/automations/[id]/runs/metrics/route"
     );
@@ -754,6 +800,12 @@ describe("automation API routes", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(mockGetMetrics).toHaveBeenCalledWith({
+      automationId: "auto_1",
+      userId: "user_1",
+      from: new Date("2026-05-02T00:00:00.000Z"),
+      to: new Date("2026-05-03T00:00:00.000Z"),
+    });
     await expect(response.json()).resolves.toMatchObject({
       object: "automation_run_metrics",
       automation_id: "auto_1",
@@ -773,6 +825,25 @@ describe("automation API routes", () => {
         to: "2026-05-03T00:00:00.000Z",
       },
     });
+  });
+
+  it("maps missing automation run service errors to 404", async () => {
+    mockGetRun.mockRejectedValue(
+      new TestAutomationRunServiceError("run_not_found", "Run not found"),
+    );
+    const { GET } = await import(
+      "@/app/api/automations/[id]/runs/[runId]/route"
+    );
+
+    const response = await GET(
+      new Request("http://localhost/api/automations/auto_1/runs/missing", {
+        headers: { Authorization: "Bearer re_test" },
+      }),
+      { params: Promise.resolve({ id: "auto_1", runId: "missing" }) },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Run not found" });
   });
 });
 

--- a/tests/automation-run-service.test.ts
+++ b/tests/automation-run-service.test.ts
@@ -1,0 +1,301 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type AutomationRunBoundaryRepository,
+  type AutomationRunRow,
+  createAutomationRunService,
+} from "../packages/core/src/services/automationRuns";
+
+const now = new Date("2026-05-02T00:00:00.000Z");
+type AutomationRow = NonNullable<
+  Awaited<ReturnType<AutomationRunBoundaryRepository["findAutomationById"]>>
+>;
+
+const automation: AutomationRow = {
+  id: "auto_1",
+  name: "Welcome",
+  status: "enabled",
+  triggerEventName: "user.signed_up",
+  connections: [],
+  createdAt: now,
+  updatedAt: now,
+  userId: "user_1",
+  document: null,
+};
+
+const queuedRun: AutomationRunRow = {
+  id: "run_1",
+  automationId: "auto_1",
+  triggerEventId: "delivery_1",
+  contactId: "contact_1",
+  status: "queued",
+  currentStepKey: "wait",
+  stepStates: {
+    wait: {
+      status: "waiting",
+      output: { waiting_for_event: "invoice.paid" },
+    },
+  },
+  startedAt: now,
+  completedAt: null,
+  nextStepAt: now,
+  failureReason: null,
+  createdAt: now,
+  updatedAt: now,
+  userId: "user_1",
+};
+
+function createRepository(
+  overrides: Partial<AutomationRunBoundaryRepository> = {},
+) {
+  const metricRuns: AutomationRunRow[] = [
+    {
+      ...queuedRun,
+      id: "run_completed",
+      status: "completed",
+      currentStepKey: null,
+      completedAt: new Date("2026-05-02T00:00:10.000Z"),
+    },
+    {
+      ...queuedRun,
+      id: "run_failed",
+      status: "failed",
+      currentStepKey: "send",
+      completedAt: new Date("2026-05-02T00:00:30.000Z"),
+      failureReason: "send failed",
+      stepStates: { send: { status: "failed", error: "send failed" } },
+    },
+    {
+      ...queuedRun,
+      id: "run_waiting",
+      status: "waiting",
+      startedAt: null,
+      completedAt: null,
+    },
+  ];
+  const repository: AutomationRunBoundaryRepository = {
+    findAutomationById: vi.fn(async (automationId, userId) => {
+      if (automationId !== automation.id) return undefined;
+      if (userId && userId !== automation.userId) return undefined;
+      return automation;
+    }),
+    listRuns: vi.fn(async () => ({ data: [queuedRun], hasMore: false })),
+    findRunByIdForAutomation: vi.fn(async (runId, automationId) => {
+      if (runId === queuedRun.id && automationId === queuedRun.automationId) {
+        return queuedRun;
+      }
+      return undefined;
+    }),
+    cancelRun: vi.fn(async (input) => ({
+      ...queuedRun,
+      status: "cancelled",
+      completedAt: input.completedAt,
+      nextStepAt: null,
+      failureReason: input.failureReason,
+      stepStates: input.stepStates,
+      updatedAt: input.completedAt,
+    })),
+    listMetricRuns: vi.fn(async () => metricRuns),
+  };
+
+  return { ...repository, ...overrides };
+}
+
+describe("automation run service boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists tenant-scoped runs with status cursor options and preserves response shape", async () => {
+    const repository = createRepository({
+      listRuns: vi.fn(async () => ({
+        data: [queuedRun, { ...queuedRun, id: "run_2", status: "waiting" }],
+        hasMore: true,
+      })),
+    });
+    const service = createAutomationRunService({ repository });
+
+    const result = await service.listRuns({
+      automationId: "auto_1",
+      userId: "user_1",
+      status: "queued, waiting",
+      limit: 1,
+      after: "run_3",
+    });
+
+    expect(repository.findAutomationById).toHaveBeenCalledWith(
+      "auto_1",
+      "user_1",
+    );
+    expect(repository.listRuns).toHaveBeenCalledWith({
+      automationId: "auto_1",
+      statuses: ["queued", "waiting"],
+      limit: 1,
+      after: "run_3",
+    });
+    expect(result).toMatchObject({
+      object: "list",
+      has_more: true,
+    });
+    expect(result.data[0]).toMatchObject({
+      object: "automation_run",
+      id: "run_1",
+      automation_id: "auto_1",
+      status: "queued",
+      duration_ms: null,
+    });
+  });
+
+  it("retrieves detail and reports missing runs without leaking across automations", async () => {
+    const repository = createRepository();
+    const service = createAutomationRunService({ repository });
+
+    await expect(
+      service.getRun({
+        automationId: "auto_1",
+        runId: "run_1",
+        userId: "user_1",
+      }),
+    ).resolves.toMatchObject({
+      object: "automation_run",
+      id: "run_1",
+      step_states: { wait: { status: "waiting" } },
+    });
+
+    await expect(
+      service.getRun({
+        automationId: "auto_1",
+        runId: "missing",
+        userId: "user_1",
+      }),
+    ).rejects.toMatchObject({ code: "run_not_found" });
+  });
+
+  it("treats missing or different-tenant automations as not found before run queries", async () => {
+    const repository = createRepository();
+    const service = createAutomationRunService({ repository });
+
+    await expect(
+      service.listRuns({ automationId: "auto_1", userId: "user_2" }),
+    ).rejects.toMatchObject({
+      code: "automation_not_found",
+      message: "Automation not found",
+    });
+    expect(repository.listRuns).not.toHaveBeenCalled();
+    expect(repository.findRunByIdForAutomation).not.toHaveBeenCalled();
+  });
+
+  it("cancels only queued or waiting runs and preserves cancellation metadata", async () => {
+    const cancellationTime = new Date("2026-05-02T01:02:03.000Z");
+    const repository = createRepository();
+    const service = createAutomationRunService({
+      repository,
+      now: () => cancellationTime,
+    });
+
+    const result = await service.cancelRun({
+      automationId: "auto_1",
+      runId: "run_1",
+      userId: "user_1",
+      reason: "customer requested stop",
+    });
+
+    expect(repository.cancelRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run_1",
+        automationId: "auto_1",
+        failureReason: "customer requested stop",
+        completedAt: cancellationTime,
+        cancellableStatuses: ["queued", "waiting"],
+      }),
+    );
+    expect(result).toMatchObject({
+      status: "cancelled",
+      failure_reason: "customer requested stop",
+      completed_at: cancellationTime,
+      next_step_at: null,
+      step_states: {
+        wait: {
+          status: "cancelled",
+          completedAt: cancellationTime.toISOString(),
+          output: {
+            waiting_for_event: "invoice.paid",
+            cancellation_reason: "customer requested stop",
+          },
+        },
+      },
+    });
+  });
+
+  it("rejects cancellation when the run is already terminal or the guarded update loses the race", async () => {
+    const completedRun = {
+      ...queuedRun,
+      status: "completed",
+      completedAt: now,
+      nextStepAt: null,
+    };
+    const terminalRepository = createRepository({
+      findRunByIdForAutomation: vi.fn(async () => completedRun),
+    });
+    const terminalService = createAutomationRunService({
+      repository: terminalRepository,
+    });
+
+    await expect(
+      terminalService.cancelRun({ automationId: "auto_1", runId: "run_1" }),
+    ).rejects.toMatchObject({ code: "run_not_cancellable" });
+    expect(terminalRepository.cancelRun).not.toHaveBeenCalled();
+
+    const raceRepository = createRepository({
+      cancelRun: vi.fn(async () => undefined),
+    });
+    const raceService = createAutomationRunService({
+      repository: raceRepository,
+    });
+    await expect(
+      raceService.cancelRun({ automationId: "auto_1", runId: "run_1" }),
+    ).rejects.toMatchObject({ code: "run_not_cancellable" });
+  });
+
+  it("aggregates metrics with the parsed date range delegated to the repository", async () => {
+    const repository = createRepository();
+    const service = createAutomationRunService({ repository });
+    const from = new Date("2026-05-02T00:00:00.000Z");
+    const to = new Date("2026-05-03T00:00:00.000Z");
+
+    const metrics = await service.getMetrics({
+      automationId: "auto_1",
+      userId: "user_1",
+      from,
+      to,
+    });
+
+    expect(repository.listMetricRuns).toHaveBeenCalledWith({
+      automationId: "auto_1",
+      from,
+      to,
+    });
+    expect(metrics).toMatchObject({
+      object: "automation_run_metrics",
+      automation_id: "auto_1",
+      total_runs: 3,
+      by_status: {
+        queued: 0,
+        running: 0,
+        waiting: 1,
+        completed: 1,
+        failed: 1,
+        cancelled: 0,
+        skipped: 0,
+      },
+      completion_rate: 1 / 3,
+      failure_rate: 1 / 3,
+      average_duration_ms: 20000,
+      waiting_count: 1,
+      failed_steps: [{ step_key: "send", count: 1 }],
+      range: {
+        from: from.toISOString(),
+        to: to.toISOString(),
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extracted automation run list/detail/cancel/metrics orchestration into `packages/core/src/services/automationRuns.ts`.
- Added repository seams for tenant-scoped automation lookup, run listing/detail lookup, guarded cancellation, and metrics date-range queries.
- Kept Next route handlers thin: auth/full-access + request parsing + service call + HTTP error mapping.
- Added focused service-boundary tests and updated route tests to assert adapter-to-service behavior.

Closes #326

## Changed files
- `packages/core/src/services/automationRuns.ts`
- `packages/core/src/db/repositories/automationRepo.ts`
- `packages/core/src/db/repositories/automationRunRepo.ts`
- `packages/core/src/index.ts`
- `src/app/api/automations/[id]/runs/route.ts`
- `src/app/api/automations/[id]/runs/[runId]/route.ts`
- `src/app/api/automations/[id]/runs/[runId]/cancel/route.ts`
- `src/app/api/automations/[id]/runs/metrics/route.ts`
- `src/app/api/automations/[id]/runs/route-helpers.ts`
- `tests/api-automations-events.test.ts`
- `tests/automation-run-service.test.ts`
- `agent_docs/learnings/active/2026-05-11-issue-326-automation-run-boundary.md`

## Validation
- `make check` ✅
- `bun run test -- tests/api-automations-events.test.ts tests/automation-runner.test.ts tests/core-automation-repo.test.ts` ✅
- `bun run test -- tests/automation-run-service.test.ts` ✅
- `make test` ✅ — 114 files / 964 tests passed

## Residual risk
- Playwright E2E was not run; coverage here is focused on route/service behavior and full Vitest suite passed.
