### PR TITLE
Extract logs API service boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-328-logs-service-boundary.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-328-logs-service-boundary.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-11
+issue: "#328"
+type: pattern
+promoted_to: null
+---
+
+## Public logs read APIs now use a core service boundary
+
+Issue #328 extracted `GET /api/logs` and `GET /api/logs/[id]` into `packages/core/src/services/logs.ts`, with `logRepo.listForApi` / `findByIdForUser` owning persistence, filters, cursor ordering, and tenant predicates. The Next adapters should stay limited to API-key auth, full-access permission checks, URL/param extraction, and HTTP error mapping.
+
+The core schema must mirror app schema for log fields such as `apiKeyId`; missing schema parity can make the service extraction typecheck fail even when the app route previously compiled against `src/lib/db/schema.ts`.

--- a/packages/core/src/db/repositories/logRepo.ts
+++ b/packages/core/src/db/repositories/logRepo.ts
@@ -1,4 +1,16 @@
-import { and, desc, eq, lt } from "drizzle-orm";
+import {
+  type SQL,
+  and,
+  desc,
+  eq,
+  gt,
+  gte,
+  ilike,
+  lt,
+  lte,
+  or,
+  sql,
+} from "drizzle-orm";
 import { db } from "../client";
 import { logs } from "../schema";
 
@@ -6,6 +18,12 @@ export const logRepo = {
   async findById(id: string) {
     return await db.query.logs.findFirst({
       where: eq(logs.id, id),
+    });
+  },
+
+  async findByIdForUser(id: string, userId: string) {
+    return await db.query.logs.findFirst({
+      where: and(eq(logs.id, id), eq(logs.userId, userId)),
     });
   },
 
@@ -37,6 +55,85 @@ export const logRepo = {
 
     const hasMore = results.length > limit;
     const data = hasMore ? results.slice(0, limit) : results;
+
+    return { data, hasMore };
+  },
+
+  async listForApi(options: {
+    userId: string;
+    limit: number;
+    status?: number;
+    method?: string;
+    apiKeyId?: string;
+    after?: string;
+    before?: string;
+    dateFrom?: Date;
+    dateTo?: Date;
+    userAgent?: string;
+    search?: string;
+  }) {
+    const conditions: SQL[] = [eq(logs.userId, options.userId)];
+
+    if (options.status !== undefined) {
+      conditions.push(eq(logs.status, options.status));
+    }
+    if (options.method) {
+      conditions.push(eq(logs.method, options.method));
+    }
+    if (options.apiKeyId) {
+      conditions.push(eq(logs.apiKeyId, options.apiKeyId));
+    }
+    if (options.after) {
+      conditions.push(lt(logs.id, options.after));
+    }
+    if (options.before) {
+      conditions.push(gt(logs.id, options.before));
+    }
+    if (options.dateFrom) {
+      conditions.push(gte(logs.createdAt, options.dateFrom));
+    }
+    if (options.dateTo) {
+      conditions.push(lte(logs.createdAt, options.dateTo));
+    }
+    if (options.userAgent) {
+      conditions.push(ilike(logs.userAgent, `%${options.userAgent}%`));
+    }
+    if (options.search) {
+      conditions.push(
+        or(
+          sql`${logs.id}::text ILIKE ${`%${options.search}%`}`,
+          ilike(logs.endpoint, `%${options.search}%`),
+          ilike(logs.userAgent, `%${options.search}%`),
+          sql`${logs.status}::text ILIKE ${`%${options.search}%`}`,
+          sql`${logs.requestBody}::text ILIKE ${`%${options.search}%`}`,
+          sql`${logs.responseBody}::text ILIKE ${`%${options.search}%`}`,
+          sql`${logs.document}::text ILIKE ${`%${options.search}%`}`,
+        ) as SQL,
+      );
+    }
+
+    const query = db
+      .select({
+        id: logs.id,
+        method: logs.method,
+        endpoint: logs.endpoint,
+        status: logs.status,
+        userAgent: logs.userAgent,
+        apiKeyId: logs.apiKeyId,
+        createdAt: logs.createdAt,
+      })
+      .from(logs)
+      .where(and(...conditions));
+
+    const results = await (options.before
+      ? query.orderBy(logs.id).limit(options.limit + 1)
+      : query.orderBy(desc(logs.id)).limit(options.limit + 1));
+
+    let data = results.slice(0, options.limit);
+    if (options.before) {
+      data = data.reverse();
+    }
+    const hasMore = results.length > options.limit;
 
     return { data, hasMore };
   },

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -361,6 +361,7 @@ export const logs = pgTable("logs", {
     .defaultNow(),
   document: jsonb("document"),
   userId: text("user_id"),
+  apiKeyId: uuid("api_key_id"),
 });
 
 export const contactProperties = pgTable(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,7 @@ export * from "./services/apiKeys";
 export * from "./services/contact";
 export * from "./services/email";
 export * from "./services/emailRead";
+export * from "./services/logs";
 export * from "./services/emailProvider";
 export * from "./services/sandboxTestRecipients";
 export * from "./services/storage";

--- a/packages/core/src/services/logs.ts
+++ b/packages/core/src/services/logs.ts
@@ -1,0 +1,184 @@
+import { logRepo } from "../db/repositories/logRepo";
+import type { logs } from "../db/schema";
+
+type LogRow = typeof logs.$inferSelect;
+
+export type LogListRow = Pick<
+  LogRow,
+  | "id"
+  | "method"
+  | "endpoint"
+  | "status"
+  | "userAgent"
+  | "apiKeyId"
+  | "createdAt"
+>;
+
+export type LogPublicListItem = {
+  id: string;
+  method: string | null;
+  endpoint: string | null;
+  response_status: number | null;
+  user_agent: string | null;
+  api_key_id: string | null;
+  created_at: Date;
+};
+
+export type LogPublicListResponse = {
+  object: "list";
+  data: LogPublicListItem[];
+  has_more: boolean;
+};
+
+export type LogPublicDetailResponse = {
+  object: "log";
+  id: string;
+  method: string | null;
+  endpoint: string | null;
+  status: number | null;
+  user_agent: string | null;
+  api_key_id: string | null;
+  request_body: unknown;
+  response_body: unknown;
+  created_at: Date;
+};
+
+export type LogRepository = {
+  listForApi(options: {
+    userId: string;
+    limit: number;
+    status?: number;
+    method?: string;
+    apiKeyId?: string;
+    after?: string;
+    before?: string;
+    dateFrom?: Date;
+    dateTo?: Date;
+    userAgent?: string;
+    search?: string;
+  }): Promise<{ data: LogListRow[]; hasMore: boolean }>;
+  findByIdForUser(id: string, userId: string): Promise<LogRow | undefined>;
+};
+
+export type LogReadServiceErrorCode = "not_found";
+
+export class LogReadServiceError extends Error {
+  constructor(
+    readonly code: LogReadServiceErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "LogReadServiceError";
+  }
+}
+
+export type LogReadServiceDependencies = {
+  repository?: LogRepository;
+};
+
+export type ListLogsInput = {
+  userId: string;
+  limit?: number;
+  status?: string | null;
+  method?: string | null;
+  apiKeyId?: string | null;
+  after?: string | null;
+  before?: string | null;
+  dateFrom?: string | null;
+  dateTo?: string | null;
+  userAgent?: string | null;
+  search?: string | null;
+};
+
+function normalizeLimit(limit: number | undefined): number {
+  return Math.min(Math.max(limit || 20, 1), 100);
+}
+
+function parseDate(value: string | null | undefined, endOfDay = false) {
+  if (!value) return undefined;
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return undefined;
+
+  if (endOfDay && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    date.setHours(23, 59, 59, 999);
+  }
+
+  return date;
+}
+
+function normalizeOptionalString(value: string | null | undefined) {
+  return value || undefined;
+}
+
+function normalizeSearch(value: string | null | undefined) {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function toListItem(row: LogListRow): LogPublicListItem {
+  return {
+    id: row.id,
+    method: row.method,
+    endpoint: row.endpoint,
+    response_status: row.status,
+    user_agent: row.userAgent,
+    api_key_id: row.apiKeyId,
+    created_at: row.createdAt,
+  };
+}
+
+function toDetail(row: LogRow): LogPublicDetailResponse {
+  return {
+    object: "log",
+    id: row.id,
+    method: row.method,
+    endpoint: row.endpoint,
+    status: row.status,
+    user_agent: row.userAgent,
+    api_key_id: row.apiKeyId,
+    request_body: row.requestBody,
+    response_body: row.responseBody,
+    created_at: row.createdAt,
+  };
+}
+
+export function createLogReadService({
+  repository = logRepo,
+}: LogReadServiceDependencies = {}) {
+  return {
+    async listLogs(input: ListLogsInput): Promise<LogPublicListResponse> {
+      const result = await repository.listForApi({
+        userId: input.userId,
+        limit: normalizeLimit(input.limit),
+        status: input.status ? Number(input.status) : undefined,
+        method: input.method ? input.method.toUpperCase() : undefined,
+        apiKeyId: normalizeOptionalString(input.apiKeyId),
+        after: normalizeOptionalString(input.after),
+        before: normalizeOptionalString(input.before),
+        dateFrom: parseDate(input.dateFrom),
+        dateTo: parseDate(input.dateTo, true),
+        userAgent: normalizeOptionalString(input.userAgent),
+        search: normalizeSearch(input.search),
+      });
+
+      return {
+        object: "list",
+        data: result.data.map(toListItem),
+        has_more: result.hasMore,
+      };
+    },
+
+    async getLog(userId: string, id: string): Promise<LogPublicDetailResponse> {
+      const log = await repository.findByIdForUser(id, userId);
+
+      if (!log) {
+        throw new LogReadServiceError("not_found", "Log not found");
+      }
+
+      return toDetail(log);
+    },
+  };
+}
+
+export const logReadService = createLogReadService();

--- a/src/app/api/logs/[id]/route.ts
+++ b/src/app/api/logs/[id]/route.ts
@@ -1,8 +1,8 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { logs } from "@/lib/db/schema";
-import { and, eq } from "drizzle-orm";
+import { LogReadServiceError, createLogReadService } from "@opensend/core";
+
+const logReadService = createLogReadService();
 
 export async function GET(
   request: Request,
@@ -16,27 +16,13 @@ export async function GET(
   const { id } = await params;
 
   try {
-    const log = await db.query.logs.findFirst({
-      where: and(eq(logs.id, id), eq(logs.userId, auth.userId)),
-    });
-
-    if (!log) {
+    const log = await logReadService.getLog(auth.userId, id);
+    return Response.json(log);
+  } catch (err) {
+    if (err instanceof LogReadServiceError && err.code === "not_found") {
       return Response.json({ error: "Log not found" }, { status: 404 });
     }
 
-    return Response.json({
-      object: "log",
-      id: log.id,
-      method: log.method,
-      endpoint: log.endpoint,
-      status: log.status,
-      user_agent: log.userAgent,
-      api_key_id: log.apiKeyId,
-      request_body: log.requestBody,
-      response_body: log.responseBody,
-      created_at: log.createdAt,
-    });
-  } catch (err) {
     const message =
       err instanceof Error ? err.message : "Failed to retrieve log";
     return Response.json({ error: message }, { status: 500 });

--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -1,30 +1,8 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { logs } from "@/lib/db/schema";
-import {
-  type SQL,
-  and,
-  desc,
-  eq,
-  gt,
-  gte,
-  ilike,
-  lt,
-  lte,
-  or,
-  sql,
-} from "drizzle-orm";
+import { createLogReadService } from "@opensend/core";
 
-function parseDate(value: string | null, endOfDay = false): Date | null {
-  if (!value) return null;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  if (endOfDay && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
-    date.setHours(23, 59, 59, 999);
-  }
-  return date;
-}
+const logReadService = createLogReadService();
 
 export async function GET(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
@@ -33,109 +11,29 @@ export async function GET(request: Request): Promise<Response> {
   if (permissionError) return permissionError;
 
   const url = new URL(request.url);
-  const limit = Math.min(
-    Math.max(Number(url.searchParams.get("limit")) || 20, 1),
-    100,
-  );
-
-  const status = url.searchParams.get("status");
-  const method = url.searchParams.get("method");
-  const apiKeyId =
-    url.searchParams.get("api_key_id") || url.searchParams.get("apiKeyId");
-  const after = url.searchParams.get("after");
-  const before = url.searchParams.get("before");
-  const dateFrom = parseDate(
-    url.searchParams.get("date_from") || url.searchParams.get("created_after"),
-  );
-  const dateTo = parseDate(
-    url.searchParams.get("date_to") || url.searchParams.get("created_before"),
-    true,
-  );
-  const userAgent =
-    url.searchParams.get("user_agent") || url.searchParams.get("userAgent");
-  const search = (
-    url.searchParams.get("q") ||
-    url.searchParams.get("search") ||
-    ""
-  ).trim();
 
   try {
-    const conditions: SQL[] = [eq(logs.userId, auth.userId)];
-
-    if (status) {
-      conditions.push(eq(logs.status, Number(status)));
-    }
-    if (method) {
-      conditions.push(eq(logs.method, method.toUpperCase()));
-    }
-    if (apiKeyId) {
-      conditions.push(eq(logs.apiKeyId, apiKeyId));
-    }
-    if (after) {
-      conditions.push(lt(logs.id, after));
-    }
-    if (before) {
-      conditions.push(gt(logs.id, before));
-    }
-    if (dateFrom) {
-      conditions.push(gte(logs.createdAt, dateFrom));
-    }
-    if (dateTo) {
-      conditions.push(lte(logs.createdAt, dateTo));
-    }
-    if (userAgent) {
-      conditions.push(ilike(logs.userAgent, `%${userAgent}%`));
-    }
-    if (search) {
-      conditions.push(
-        or(
-          sql`${logs.id}::text ILIKE ${`%${search}%`}`,
-          ilike(logs.endpoint, `%${search}%`),
-          ilike(logs.userAgent, `%${search}%`),
-          sql`${logs.status}::text ILIKE ${`%${search}%`}`,
-          sql`${logs.requestBody}::text ILIKE ${`%${search}%`}`,
-          sql`${logs.responseBody}::text ILIKE ${`%${search}%`}`,
-          sql`${logs.document}::text ILIKE ${`%${search}%`}`,
-        ) as SQL,
-      );
-    }
-
-    const query = db
-      .select({
-        id: logs.id,
-        method: logs.method,
-        endpoint: logs.endpoint,
-        status: logs.status,
-        userAgent: logs.userAgent,
-        apiKeyId: logs.apiKeyId,
-        createdAt: logs.createdAt,
-      })
-      .from(logs)
-      .where(and(...conditions));
-
-    const results = await (before
-      ? query.orderBy(logs.id).limit(limit + 1)
-      : query.orderBy(desc(logs.id)).limit(limit + 1));
-
-    let dataRows = results.slice(0, limit);
-    if (before) {
-      dataRows = dataRows.reverse();
-    }
-    const hasMore = results.length > limit;
-
-    return Response.json({
-      object: "list",
-      data: dataRows.map((l) => ({
-        id: l.id,
-        method: l.method,
-        endpoint: l.endpoint,
-        response_status: l.status,
-        user_agent: l.userAgent,
-        api_key_id: l.apiKeyId,
-        created_at: l.createdAt,
-      })),
-      has_more: hasMore,
+    const result = await logReadService.listLogs({
+      userId: auth.userId,
+      limit: Number(url.searchParams.get("limit")) || 20,
+      status: url.searchParams.get("status"),
+      method: url.searchParams.get("method"),
+      apiKeyId:
+        url.searchParams.get("api_key_id") || url.searchParams.get("apiKeyId"),
+      after: url.searchParams.get("after"),
+      before: url.searchParams.get("before"),
+      dateFrom:
+        url.searchParams.get("date_from") ||
+        url.searchParams.get("created_after"),
+      dateTo:
+        url.searchParams.get("date_to") ||
+        url.searchParams.get("created_before"),
+      userAgent:
+        url.searchParams.get("user_agent") || url.searchParams.get("userAgent"),
+      search: url.searchParams.get("q") || url.searchParams.get("search"),
     });
+
+    return Response.json(result);
   } catch (err) {
     const message = err instanceof Error ? err.message : "Failed to list logs";
     return Response.json({ error: message }, { status: 500 });

--- a/tests/api-logs.test.ts
+++ b/tests/api-logs.test.ts
@@ -1,28 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  LogReadServiceError as ActualLogReadServiceError,
+  type LogRepository,
+  createLogReadService as createActualLogReadService,
+} from "../packages/core/src/services/logs";
 
 const mockValidateApiKey = vi.hoisted(() => vi.fn());
-const mockFindFirst = vi.hoisted(() => vi.fn());
-const mockSelect = vi.hoisted(() => vi.fn());
-const recordedWhere = vi.hoisted(() => [] as unknown[]);
-const mockEq = vi.hoisted(() =>
-  vi.fn((left, right) => ({ op: "eq", args: [left, right] })),
-);
-const mockAnd = vi.hoisted(() => vi.fn((...args) => ({ op: "and", args })));
-const mockOr = vi.hoisted(() => vi.fn((...args) => ({ op: "or", args })));
-const mockIlike = vi.hoisted(() =>
-  vi.fn((left, right) => ({ op: "ilike", args: [left, right] })),
-);
-const mockGte = vi.hoisted(() =>
-  vi.fn((left, right) => ({ op: "gte", args: [left, right] })),
-);
-const mockLte = vi.hoisted(() =>
-  vi.fn((left, right) => ({ op: "lte", args: [left, right] })),
-);
-const mockGt = vi.hoisted(() =>
-  vi.fn((left, right) => ({ op: "gt", args: [left, right] })),
-);
-const mockLt = vi.hoisted(() =>
-  vi.fn((left, right) => ({ op: "lt", args: [left, right] })),
+const mockCreateLogReadService = vi.hoisted(() => vi.fn());
+const mockListLogs = vi.hoisted(() => vi.fn());
+const mockGetLog = vi.hoisted(() => vi.fn());
+const MockLogReadServiceError = vi.hoisted(
+  () =>
+    class LogReadServiceError extends Error {
+      constructor(
+        readonly code: "not_found",
+        message: string,
+      ) {
+        super(message);
+        this.name = "LogReadServiceError";
+      }
+    },
 );
 
 vi.mock("@/lib/api-auth", async () => {
@@ -34,132 +31,280 @@ vi.mock("@/lib/api-auth", async () => {
   };
 });
 
-vi.mock("@/lib/db", () => ({
-  db: {
-    query: { logs: { findFirst: mockFindFirst } },
-    select: mockSelect,
-  },
+vi.mock("@opensend/core", () => ({
+  createLogReadService: mockCreateLogReadService,
+  LogReadServiceError: MockLogReadServiceError,
 }));
 
-vi.mock("drizzle-orm", async () => {
-  const actual = await vi.importActual("drizzle-orm");
-  return {
-    ...actual,
-    and: mockAnd,
-    or: mockOr,
-    eq: mockEq,
-    gt: mockGt,
-    gte: mockGte,
-    lt: mockLt,
-    lte: mockLte,
-    ilike: mockIlike,
-    desc: vi.fn((column) => ({ op: "desc", column })),
-    sql: vi.fn((parts: TemplateStringsArray, ...values: unknown[]) => ({
-      op: "sql",
-      text: Array.from(parts).join("?"),
-      values,
-    })),
-  };
-});
+const createdAt = new Date("2026-05-06T00:00:00.000Z");
+const detailCreatedAt = new Date("2026-05-06T01:00:00.000Z");
 
-function makeQuery<T>(rows: T[]) {
-  const chain = {
-    from: vi.fn(() => chain),
-    where: vi.fn((condition: unknown) => {
-      recordedWhere.push(condition);
-      return chain;
-    }),
-    orderBy: vi.fn(() => chain),
-    limit: vi.fn(() => Promise.resolve(rows)),
-  };
-  return chain;
+function request(url: string) {
+  return new Request(url, {
+    headers: { Authorization: "Bearer re_test" },
+  });
 }
 
-describe("/api/logs", () => {
-  beforeEach(() => {
-    vi.resetModules();
-    vi.clearAllMocks();
-    recordedWhere.length = 0;
-    mockValidateApiKey.mockResolvedValue({
-      apiKeyId: "api-key-a",
-      permission: "full_access",
-      domain: null,
+function fullAccessAuth() {
+  return {
+    apiKeyId: "api-key-a",
+    permission: "full_access",
+    domain: null,
+    userId: "user-a",
+  };
+}
+
+describe("log read service", () => {
+  it("normalizes filters, preserves cursor aliases, and scopes list queries to the caller", async () => {
+    const calls: Parameters<LogRepository["listForApi"]>[0][] = [];
+    const repository: LogRepository = {
+      async listForApi(options) {
+        calls.push(options);
+        return {
+          data: [
+            {
+              id: "log-1",
+              method: "POST",
+              endpoint: "/api/emails",
+              status: 200,
+              userAgent: "opensend-test",
+              apiKeyId: "api-key-a",
+              createdAt,
+            },
+          ],
+          hasMore: true,
+        };
+      },
+      async findByIdForUser() {
+        return undefined;
+      },
+    };
+    const service = createActualLogReadService({ repository });
+
+    const response = await service.listLogs({
       userId: "user-a",
+      limit: 500,
+      status: "200",
+      method: "post",
+      apiKeyId: "api-key-a",
+      after: "log-z",
+      before: "log-0",
+      dateFrom: "2026-05-01",
+      dateTo: "2026-05-06",
+      userAgent: "test",
+      search: "  email-1  ",
     });
-  });
 
-  it("lists only caller-owned logs and applies search/date/user-agent filters", async () => {
-    mockSelect.mockReturnValue(
-      makeQuery([
-        {
-          id: "log-1",
-          method: "POST",
-          endpoint: "/api/emails",
-          status: 200,
-          userAgent: "opensend-test",
-          apiKeyId: "api-key-a",
-          createdAt: new Date("2026-05-06T00:00:00Z"),
-        },
-      ]),
-    );
-
-    const { GET } = await import("@/app/api/logs/route");
-    const res = await GET(
-      new Request(
-        "http://localhost:3015/api/logs?q=email-1&user_agent=test&date_from=2026-05-01&date_to=2026-05-06&api_key_id=api-key-a",
-        { headers: { Authorization: "Bearer re_test" } },
-      ),
-    );
-
-    expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toMatchObject({
+    expect(response).toEqual({
       object: "list",
       data: [
         {
           id: "log-1",
+          method: "POST",
           endpoint: "/api/emails",
+          response_status: 200,
+          user_agent: "opensend-test",
           api_key_id: "api-key-a",
+          created_at: createdAt,
         },
       ],
+      has_more: true,
     });
-    expect(mockEq.mock.calls.some(([, right]) => right === "user-a")).toBe(
-      true,
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      userId: "user-a",
+      limit: 100,
+      status: 200,
+      method: "POST",
+      apiKeyId: "api-key-a",
+      after: "log-z",
+      before: "log-0",
+      userAgent: "test",
+      search: "email-1",
+    });
+    expect(calls[0].dateFrom).toBeInstanceOf(Date);
+    expect(calls[0].dateTo).toBeInstanceOf(Date);
+    expect(calls[0].dateTo?.getHours()).toBe(23);
+    expect(calls[0].dateTo?.getMinutes()).toBe(59);
+  });
+
+  it("returns log detail DTOs with request and response bodies", async () => {
+    const repository: LogRepository = {
+      async listForApi() {
+        return { data: [], hasMore: false };
+      },
+      async findByIdForUser(id, userId) {
+        expect(id).toBe("log-1");
+        expect(userId).toBe("user-a");
+        return {
+          id: "log-1",
+          method: "GET",
+          endpoint: "/api/logs/log-1",
+          status: 200,
+          userAgent: "opensend-test",
+          requestBody: { query: "test" },
+          responseBody: { ok: true },
+          createdAt: detailCreatedAt,
+          document: { trace: "trace-1" },
+          userId: "user-a",
+          apiKeyId: "api-key-a",
+        };
+      },
+    };
+    const service = createActualLogReadService({ repository });
+
+    await expect(service.getLog("user-a", "log-1")).resolves.toEqual({
+      object: "log",
+      id: "log-1",
+      method: "GET",
+      endpoint: "/api/logs/log-1",
+      status: 200,
+      user_agent: "opensend-test",
+      api_key_id: "api-key-a",
+      request_body: { query: "test" },
+      response_body: { ok: true },
+      created_at: detailCreatedAt,
+    });
+  });
+
+  it("raises a typed not-found error for cross-tenant or missing log detail", async () => {
+    const repository: LogRepository = {
+      async listForApi() {
+        return { data: [], hasMore: false };
+      },
+      async findByIdForUser() {
+        return undefined;
+      },
+    };
+    const service = createActualLogReadService({ repository });
+
+    await expect(service.getLog("user-a", "log-b")).rejects.toMatchObject({
+      code: "not_found",
+      message: "Log not found",
+    });
+    await expect(service.getLog("user-a", "log-b")).rejects.toBeInstanceOf(
+      ActualLogReadServiceError,
     );
-    expect(mockEq.mock.calls.some(([, right]) => right === "api-key-a")).toBe(
-      true,
+  });
+});
+
+describe("/api/logs routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue(fullAccessAuth());
+    mockCreateLogReadService.mockReturnValue({
+      listLogs: mockListLogs,
+      getLog: mockGetLog,
+    });
+  });
+
+  it("lists logs through the service with compatible aliases", async () => {
+    mockListLogs.mockResolvedValue({
+      object: "list",
+      data: [
+        {
+          id: "log-1",
+          method: "POST",
+          endpoint: "/api/emails",
+          response_status: 200,
+          user_agent: "opensend-test",
+          api_key_id: "api-key-a",
+          created_at: createdAt,
+        },
+      ],
+      has_more: false,
+    });
+
+    const { GET } = await import("@/app/api/logs/route");
+    const res = await GET(
+      request(
+        "http://localhost:3015/api/logs?q=email-1&user_agent=test&date_from=2026-05-01&date_to=2026-05-06&api_key_id=api-key-a&after=log-z&before=log-0&method=post&status=200&limit=50",
+      ),
     );
-    expect(mockIlike).toHaveBeenCalledWith(expect.anything(), "%test%");
-    expect(mockGte).toHaveBeenCalled();
-    expect(mockLte).toHaveBeenCalled();
-    expect(mockOr).toHaveBeenCalled();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      object: "list",
+      data: [
+        {
+          id: "log-1",
+          method: "POST",
+          endpoint: "/api/emails",
+          response_status: 200,
+          user_agent: "opensend-test",
+          api_key_id: "api-key-a",
+          created_at: createdAt.toISOString(),
+        },
+      ],
+      has_more: false,
+    });
+    expect(mockListLogs).toHaveBeenCalledWith({
+      userId: "user-a",
+      limit: 50,
+      status: "200",
+      method: "post",
+      apiKeyId: "api-key-a",
+      after: "log-z",
+      before: "log-0",
+      dateFrom: "2026-05-01",
+      dateTo: "2026-05-06",
+      userAgent: "test",
+      search: "email-1",
+    });
+  });
+
+  it("supports camelCase and created date aliases", async () => {
+    mockListLogs.mockResolvedValue({
+      object: "list",
+      data: [],
+      has_more: false,
+    });
+
+    const { GET } = await import("@/app/api/logs/route");
+    const res = await GET(
+      request(
+        "http://localhost:3015/api/logs?apiKeyId=api-key-a&userAgent=agent&search=needle&created_after=2026-05-01&created_before=2026-05-06",
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockListLogs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKeyId: "api-key-a",
+        userAgent: "agent",
+        search: "needle",
+        dateFrom: "2026-05-01",
+        dateTo: "2026-05-06",
+      }),
+    );
+  });
+
+  it("requires full-access API keys for log reads", async () => {
+    mockValidateApiKey.mockResolvedValue({
+      ...fullAccessAuth(),
+      permission: "sending_access",
+    });
+
+    const { GET } = await import("@/app/api/logs/route");
+    const res = await GET(request("http://localhost:3015/api/logs"));
+
+    expect(res.status).toBe(403);
+    expect(mockListLogs).not.toHaveBeenCalled();
   });
 
   it("returns 404 for another tenant's log detail", async () => {
-    mockFindFirst.mockResolvedValue(null);
-
-    const { GET } = await import("@/app/api/logs/[id]/route");
-    const res = await GET(
-      new Request("http://localhost:3015/api/logs/log-b", {
-        headers: { Authorization: "Bearer re_test" },
-      }),
-      { params: Promise.resolve({ id: "log-b" }) },
+    mockGetLog.mockRejectedValue(
+      new MockLogReadServiceError("not_found", "Log not found"),
     );
 
-    expect(res.status).toBe(404);
-    expect(mockFindFirst).toHaveBeenCalledWith({
-      where: expect.objectContaining({
-        op: "and",
-        args: expect.arrayContaining([
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining(["log-b"]),
-          }),
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining(["user-a"]),
-          }),
-        ]),
-      }),
+    const { GET } = await import("@/app/api/logs/[id]/route");
+    const res = await GET(request("http://localhost:3015/api/logs/log-b"), {
+      params: Promise.resolve({ id: "log-b" }),
     });
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Log not found" });
+    expect(mockGetLog).toHaveBeenCalledWith("user-a", "log-b");
   });
 });

--- a/tests/issue-200-missed-tenant-scope.test.tsx
+++ b/tests/issue-200-missed-tenant-scope.test.tsx
@@ -8,6 +8,21 @@ const mockFindLog = vi.hoisted(() => vi.fn());
 const mockSelect = vi.hoisted(() => vi.fn());
 const mockUpdate = vi.hoisted(() => vi.fn());
 const mockGetPresignedUrl = vi.hoisted(() => vi.fn());
+const mockCreateLogReadService = vi.hoisted(() => vi.fn());
+const mockListLogs = vi.hoisted(() => vi.fn());
+const mockGetLog = vi.hoisted(() => vi.fn());
+const MockLogReadServiceError = vi.hoisted(
+  () =>
+    class LogReadServiceError extends Error {
+      constructor(
+        readonly code: "not_found",
+        message: string,
+      ) {
+        super(message);
+        this.name = "LogReadServiceError";
+      }
+    },
+);
 const mockRedirect = vi.hoisted(() =>
   vi.fn(() => {
     throw new Error("NEXT_REDIRECT");
@@ -55,6 +70,11 @@ vi.mock("@/lib/db", () => ({
 
 vi.mock("@/lib/s3", () => ({
   getPresignedUrl: mockGetPresignedUrl,
+}));
+
+vi.mock("@opensend/core", () => ({
+  createLogReadService: mockCreateLogReadService,
+  LogReadServiceError: MockLogReadServiceError,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -131,6 +151,18 @@ describe("issue #200 missed tenant isolation gaps", () => {
     mockFindEmail.mockResolvedValue(null);
     mockFindLog.mockResolvedValue(null);
     mockGetPresignedUrl.mockResolvedValue("https://download.example/att-1");
+    mockCreateLogReadService.mockReturnValue({
+      listLogs: mockListLogs,
+      getLog: mockGetLog,
+    });
+    mockListLogs.mockResolvedValue({
+      object: "list",
+      data: [],
+      has_more: false,
+    });
+    mockGetLog.mockRejectedValue(
+      new MockLogReadServiceError("not_found", "Log not found"),
+    );
   });
 
   it("404s email cancel for another tenant and does not update", async () => {
@@ -184,7 +216,6 @@ describe("issue #200 missed tenant isolation gaps", () => {
   });
 
   it("returns an empty public logs list when user-scoped predicates find no owned rows", async () => {
-    queueSelectRows([]);
     const { GET } = await import("@/app/api/logs/route");
 
     const response = await GET(
@@ -197,9 +228,12 @@ describe("issue #200 missed tenant isolation gaps", () => {
       data: [],
       has_more: false,
     });
-    expect(recordedWhere).toHaveLength(1);
-    expectConditionIncludes(AUTH_RESULT.userId);
-    expectConditionIncludes("key-a");
+    expect(mockListLogs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: AUTH_RESULT.userId,
+        apiKeyId: "key-a",
+      }),
+    );
   });
 
   it("404s public log detail for another tenant", async () => {
@@ -212,8 +246,7 @@ describe("issue #200 missed tenant isolation gaps", () => {
 
     expect(response.status).toBe(404);
     expect(await response.json()).toEqual({ error: "Log not found" });
-    expectConditionIncludes("log-a");
-    expectConditionIncludes(AUTH_RESULT.userId);
+    expect(mockGetLog).toHaveBeenCalledWith(AUTH_RESULT.userId, "log-a");
   });
 
   it("redirects unauthenticated contact detail dashboard access before querying", async () => {


### PR DESCRIPTION
## Summary
- Extracted public logs list/detail read behavior into `packages/core/src/services/logs.ts` with `logRepo.listForApi` and `findByIdForUser` owning persistence, filters, cursor behavior, DTO shaping, and tenant predicates.
- Kept `GET /api/logs` and `GET /api/logs/[id]` as thin adapters: API-key auth/full-access permission -> query/param extraction -> service call -> HTTP response mapping.
- Added compatibility coverage for tenant/user scoping, full-access gating, alias parsing, representative filters, detail request/response body fields, and service not-found behavior.

Closes #328

## Changed files
- `packages/core/src/services/logs.ts`
- `packages/core/src/db/repositories/logRepo.ts`
- `packages/core/src/db/schema.ts`
- `packages/core/src/index.ts`
- `src/app/api/logs/route.ts`
- `src/app/api/logs/[id]/route.ts`
- `tests/api-logs.test.ts`
- `tests/issue-200-missed-tenant-scope.test.tsx`
- `agent_docs/learnings/active/2026-05-11-issue-328-logs-service-boundary.md`

## Validation
- `make check` ✅
- `bun run test -- tests/api-logs.test.ts tests/issue-200-missed-tenant-scope.test.tsx` ✅ — 2 files / 14 tests passed
- `make test` ✅ — 114 files / 969 tests passed
- Push guardrails ✅ — typecheck + changed-file Biome lint passed

## Residual risk
- No Hono/control-plane route parity was added by design to keep scope narrow.
- Playwright e2e was not run because no dashboard UI or browser behavior changed.
