### PR TITLE
architecture: extract suppressions API service boundary

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export * from "./services/contact";
 export * from "./services/email";
 export * from "./services/emailRead";
 export * from "./services/logs";
+export * from "./services/suppressions";
 export * from "./services/emailProvider";
 export * from "./services/sandboxTestRecipients";
 export * from "./services/storage";

--- a/packages/core/src/services/suppressions.ts
+++ b/packages/core/src/services/suppressions.ts
@@ -1,0 +1,123 @@
+import { suppressionRepo } from "../db/repositories/suppressionRepo";
+import type {
+  SuppressionReason,
+  SuppressionSourceMetadata,
+  emailSuppressions,
+} from "../db/schema";
+
+type SuppressionRow = typeof emailSuppressions.$inferSelect;
+
+export type SuppressionPublicItem = {
+  id: string;
+  object: "suppression";
+  email: string;
+  reason: SuppressionReason;
+  scope: "user";
+  source_event_id: string | null;
+  source_email_id: string | null;
+  source_message_id: string | null;
+  metadata: SuppressionSourceMetadata | null;
+  suppressed_at: string;
+  updated_at: string;
+};
+
+export type SuppressionListResponse = {
+  object: "list";
+  scope: "user";
+  data: SuppressionPublicItem[];
+  has_more: boolean;
+};
+
+export type SuppressionDeleteResponse = {
+  object: "suppression";
+  deleted: true;
+};
+
+export type SuppressionRepository = {
+  list(options: {
+    userId: string;
+    limit: number;
+    after?: string;
+  }): Promise<{ data: SuppressionRow[]; hasMore: boolean }>;
+  removeForUser(userId: string, email: string): Promise<Array<{ id: string }>>;
+};
+
+export type SuppressionServiceErrorCode = "not_found";
+
+export class SuppressionServiceError extends Error {
+  constructor(
+    readonly code: SuppressionServiceErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "SuppressionServiceError";
+  }
+}
+
+export type SuppressionServiceDependencies = {
+  repository?: SuppressionRepository;
+};
+
+export type ListSuppressionsInput = {
+  userId: string;
+  limit?: number;
+  after?: string | null;
+};
+
+function normalizeLimit(limit: number | undefined): number {
+  return Math.min(Math.max(limit || 50, 1), 100);
+}
+
+function toPublicItem(row: SuppressionRow): SuppressionPublicItem {
+  return {
+    id: row.id,
+    object: "suppression",
+    email: row.email,
+    reason: row.reason,
+    scope: "user",
+    source_event_id: row.sourceEventId,
+    source_email_id: row.sourceEmailId,
+    source_message_id: row.sourceMessageId,
+    metadata: row.metadata ?? null,
+    suppressed_at: row.suppressedAt.toISOString(),
+    updated_at: row.updatedAt.toISOString(),
+  };
+}
+
+export function createSuppressionService({
+  repository = suppressionRepo,
+}: SuppressionServiceDependencies = {}) {
+  return {
+    async listSuppressions(
+      input: ListSuppressionsInput,
+    ): Promise<SuppressionListResponse> {
+      const result = await repository.list({
+        userId: input.userId,
+        limit: normalizeLimit(input.limit),
+        after: input.after || undefined,
+      });
+
+      return {
+        object: "list",
+        scope: "user",
+        data: result.data.map(toPublicItem),
+        has_more: result.hasMore,
+      };
+    },
+
+    async deleteSuppression(
+      userId: string,
+      email: string,
+    ): Promise<SuppressionDeleteResponse> {
+      const removed = await repository.removeForUser(userId, email);
+
+      if (removed.length === 0) {
+        throw new SuppressionServiceError("not_found", "Suppression not found");
+      }
+
+      return { object: "suppression", deleted: true };
+    },
+  };
+}
+
+export const suppressionService = createSuppressionService();

--- a/src/app/api/suppressions/[email]/route.ts
+++ b/src/app/api/suppressions/[email]/route.ts
@@ -4,8 +4,13 @@ import {
   unauthorizedResponse,
 } from "@/lib/api-auth";
 import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
-import { removeSuppression } from "@/lib/suppressions";
+import {
+  SuppressionServiceError,
+  createSuppressionService,
+} from "@opensend/core";
 import { NextResponse } from "next/server";
+
+const suppressionService = createSuppressionService();
 
 export async function DELETE(
   request: Request,
@@ -23,17 +28,20 @@ export async function DELETE(
 
   const { email } = await params;
   const decodedEmail = decodeURIComponent(email);
-  const removed = await removeSuppression({
-    userId,
-    email: decodedEmail,
-  });
 
-  if (!removed) {
-    return NextResponse.json(
-      { error: "Suppression not found", code: "not_found" },
-      { status: 404 },
+  try {
+    const deleted = await suppressionService.deleteSuppression(
+      userId,
+      decodedEmail,
     );
+    return NextResponse.json(deleted);
+  } catch (err) {
+    if (err instanceof SuppressionServiceError && err.code === "not_found") {
+      return NextResponse.json(
+        { error: "Suppression not found", code: "not_found" },
+        { status: 404 },
+      );
+    }
+    throw err;
   }
-
-  return NextResponse.json({ object: "suppression", deleted: true });
 }

--- a/src/app/api/suppressions/route.ts
+++ b/src/app/api/suppressions/route.ts
@@ -4,8 +4,10 @@ import {
   unauthorizedResponse,
 } from "@/lib/api-auth";
 import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
-import { listSuppressions, serializeSuppression } from "@/lib/suppressions";
+import { createSuppressionService } from "@opensend/core";
 import { NextResponse } from "next/server";
+
+const suppressionService = createSuppressionService();
 
 export async function GET(request: Request) {
   const auth = await authorizeDashboardOrApiKey(
@@ -19,18 +21,14 @@ export async function GET(request: Request) {
   if (!userId) return unauthorizedResponse();
 
   const url = new URL(request.url);
-  const limit = Math.min(
-    100,
-    Math.max(1, Number(url.searchParams.get("limit")) || 50),
-  );
+  const limit = Number(url.searchParams.get("limit"));
   const after = url.searchParams.get("after") || undefined;
 
-  const result = await listSuppressions({ userId, limit, after });
-
-  return NextResponse.json({
-    object: "list",
-    scope: "user",
-    data: result.data.map(serializeSuppression),
-    has_more: result.hasMore,
+  const result = await suppressionService.listSuppressions({
+    userId,
+    limit,
+    after,
   });
+
+  return NextResponse.json(result);
 }

--- a/tests/suppressions-route.test.ts
+++ b/tests/suppressions-route.test.ts
@@ -1,9 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { emailSuppressions } from "../packages/core/src/db/schema";
+import {
+  SuppressionServiceError as ActualSuppressionServiceError,
+  type SuppressionRepository,
+  createSuppressionService as createActualSuppressionService,
+} from "../packages/core/src/services/suppressions";
 
 const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
 const mockGetServerSession = vi.hoisted(() => vi.fn());
-const mockRemoveSuppression = vi.hoisted(() => vi.fn());
+const mockCreateSuppressionService = vi.hoisted(() => vi.fn());
 const mockListSuppressions = vi.hoisted(() => vi.fn());
+const mockDeleteSuppression = vi.hoisted(() => vi.fn());
+const MockSuppressionServiceError = vi.hoisted(
+  () =>
+    class SuppressionServiceError extends Error {
+      constructor(
+        readonly code: "not_found",
+        message: string,
+      ) {
+        super(message);
+        this.name = "SuppressionServiceError";
+      }
+    },
+);
 
 vi.mock("@/lib/api-auth", () => ({
   authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
@@ -12,26 +31,131 @@ vi.mock("@/lib/api-auth", () => ({
     Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
 }));
 
-vi.mock("@/lib/suppressions", () => ({
-  listSuppressions: mockListSuppressions,
-  removeSuppression: mockRemoveSuppression,
-  serializeSuppression: (row: {
-    id: string;
-    email: string;
-    reason: string;
-  }) => ({
-    id: row.id,
-    object: "suppression",
-    email: row.email,
-    reason: row.reason,
-    scope: "user",
-  }),
+vi.mock("@opensend/core", () => ({
+  createSuppressionService: mockCreateSuppressionService,
+  SuppressionServiceError: MockSuppressionServiceError,
 }));
+
+const suppressedAt = new Date("2026-05-05T12:00:00.000Z");
+const updatedAt = new Date("2026-05-05T12:30:00.000Z");
+
+type SuppressionRow = typeof emailSuppressions.$inferSelect;
+
+function suppressionRow(
+  overrides: Partial<SuppressionRow> = {},
+): SuppressionRow {
+  return {
+    id: "supp-1",
+    userId: "user-1",
+    email: "blocked@test.com",
+    reason: "bounced",
+    sourceEventId: "evt-1",
+    sourceEmailId: "email-1",
+    sourceMessageId: "msg-1",
+    metadata: { source: "ses", bounceType: "Permanent" },
+    suppressedAt,
+    updatedAt,
+    ...overrides,
+  };
+}
+
+describe("suppression service", () => {
+  it("lists user-scoped suppressions with public DTO shape and clamps limits", async () => {
+    const calls: Parameters<SuppressionRepository["list"]>[0][] = [];
+    const repository: SuppressionRepository = {
+      async list(options) {
+        calls.push(options);
+        return {
+          data: [suppressionRow()],
+          hasMore: true,
+        };
+      },
+      async removeForUser() {
+        return [];
+      },
+    };
+
+    const service = createActualSuppressionService({ repository });
+    const response = await service.listSuppressions({
+      userId: "user-1",
+      limit: 500,
+      after: "supp-0",
+    });
+
+    expect(calls).toEqual([{ userId: "user-1", limit: 100, after: "supp-0" }]);
+    expect(response).toEqual({
+      object: "list",
+      scope: "user",
+      data: [
+        {
+          id: "supp-1",
+          object: "suppression",
+          email: "blocked@test.com",
+          reason: "bounced",
+          scope: "user",
+          source_event_id: "evt-1",
+          source_email_id: "email-1",
+          source_message_id: "msg-1",
+          metadata: { source: "ses", bounceType: "Permanent" },
+          suppressed_at: "2026-05-05T12:00:00.000Z",
+          updated_at: "2026-05-05T12:30:00.000Z",
+        },
+      ],
+      has_more: true,
+    });
+
+    await service.listSuppressions({ userId: "user-1", limit: -1 });
+    await service.listSuppressions({ userId: "user-1", limit: Number.NaN });
+
+    expect(calls.slice(1)).toEqual([
+      { userId: "user-1", limit: 1, after: undefined },
+      { userId: "user-1", limit: 50, after: undefined },
+    ]);
+  });
+
+  it("deletes within caller scope and reports not_found when no row is removed", async () => {
+    const calls: Array<{ userId: string; email: string }> = [];
+    const repository: SuppressionRepository = {
+      async list() {
+        return { data: [], hasMore: false };
+      },
+      async removeForUser(userId, email) {
+        calls.push({ userId, email });
+        return calls.length === 1 ? [{ id: "supp-1" }] : [];
+      },
+    };
+
+    const service = createActualSuppressionService({ repository });
+
+    await expect(
+      service.deleteSuppression("user-1", "Blocked@Test.com"),
+    ).resolves.toEqual({ object: "suppression", deleted: true });
+
+    let error: unknown;
+    try {
+      await service.deleteSuppression("user-2", "blocked@test.com");
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(ActualSuppressionServiceError);
+    expect(error).toMatchObject({ code: "not_found" });
+
+    expect(calls).toEqual([
+      { userId: "user-1", email: "Blocked@Test.com" },
+      { userId: "user-2", email: "blocked@test.com" },
+    ]);
+  });
+});
 
 describe("suppression management routes", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockCreateSuppressionService.mockReturnValue({
+      listSuppressions: mockListSuppressions,
+      deleteSuppression: mockDeleteSuppression,
+    });
     mockAuthorizeDashboardOrApiKey.mockResolvedValue({
       apiKeyId: "key-1",
       permission: "full_access",
@@ -40,17 +164,30 @@ describe("suppression management routes", () => {
     });
   });
 
-  it("lists user-scoped suppression records", async () => {
+  it("lists user-scoped suppression records through the core service", async () => {
     mockListSuppressions.mockResolvedValue({
-      data: [{ id: "supp-1", email: "blocked@test.com", reason: "bounced" }],
-      hasMore: false,
+      object: "list",
+      scope: "user",
+      data: [
+        {
+          id: "supp-1",
+          object: "suppression",
+          email: "blocked@test.com",
+          reason: "bounced",
+          scope: "user",
+        },
+      ],
+      has_more: false,
     });
 
     const { GET } = await import("@/app/api/suppressions/route");
     const res = await GET(
-      new Request("http://localhost:3015/api/suppressions?limit=10", {
-        headers: { Authorization: "Bearer re_test" },
-      }),
+      new Request(
+        "http://localhost:3015/api/suppressions?limit=10&after=supp-0",
+        {
+          headers: { Authorization: "Bearer re_test" },
+        },
+      ),
     );
 
     expect(res.status).toBe(200);
@@ -71,12 +208,73 @@ describe("suppression management routes", () => {
     expect(mockListSuppressions).toHaveBeenCalledWith({
       userId: "user-1",
       limit: 10,
+      after: "supp-0",
+    });
+  });
+
+  it("resolves dashboard session users before listing suppressions", async () => {
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue({ dashboard: true });
+    mockGetServerSession.mockResolvedValue({ user: { id: "dashboard-user" } });
+    mockListSuppressions.mockResolvedValue({
+      object: "list",
+      scope: "user",
+      data: [],
+      has_more: false,
+    });
+
+    const { GET } = await import("@/app/api/suppressions/route");
+    const res = await GET(
+      new Request("http://localhost:3015/api/suppressions?limit=abc"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockListSuppressions).toHaveBeenCalledWith({
+      userId: "dashboard-user",
+      limit: Number.NaN,
       after: undefined,
     });
   });
 
+  it("keeps unauthorized and API-key permission responses route-local", async () => {
+    mockAuthorizeDashboardOrApiKey.mockResolvedValueOnce(null);
+
+    const { GET } = await import("@/app/api/suppressions/route");
+    const unauthorized = await GET(
+      new Request("http://localhost:3015/api/suppressions"),
+    );
+
+    expect(unauthorized.status).toBe(401);
+    await expect(unauthorized.json()).resolves.toEqual({
+      error: "Missing or invalid API key",
+    });
+    expect(mockListSuppressions).not.toHaveBeenCalled();
+
+    mockAuthorizeDashboardOrApiKey.mockResolvedValueOnce({
+      apiKeyId: "key-1",
+      permission: "sending_access",
+      domain: null,
+      userId: "user-1",
+    });
+
+    const forbidden = await GET(
+      new Request("http://localhost:3015/api/suppressions", {
+        headers: { Authorization: "Bearer re_test" },
+      }),
+    );
+
+    expect(forbidden.status).toBe(403);
+    await expect(forbidden.json()).resolves.toMatchObject({
+      code: "insufficient_api_key_permission",
+      statusCode: 403,
+    });
+    expect(mockListSuppressions).not.toHaveBeenCalled();
+  });
+
   it("removes a suppression for the authenticated user", async () => {
-    mockRemoveSuppression.mockResolvedValue({ id: "supp-1" });
+    mockDeleteSuppression.mockResolvedValue({
+      object: "suppression",
+      deleted: true,
+    });
 
     const { DELETE } = await import("@/app/api/suppressions/[email]/route");
     const res = await DELETE(
@@ -92,9 +290,30 @@ describe("suppression management routes", () => {
       object: "suppression",
       deleted: true,
     });
-    expect(mockRemoveSuppression).toHaveBeenCalledWith({
-      userId: "user-1",
-      email: "blocked@test.com",
+    expect(mockDeleteSuppression).toHaveBeenCalledWith(
+      "user-1",
+      "blocked@test.com",
+    );
+  });
+
+  it("preserves the not-found delete response when the core service misses", async () => {
+    mockDeleteSuppression.mockRejectedValue(
+      new MockSuppressionServiceError("not_found", "Suppression not found"),
+    );
+
+    const { DELETE } = await import("@/app/api/suppressions/[email]/route");
+    const res = await DELETE(
+      new Request("http://localhost:3015/api/suppressions/absent%40test.com", {
+        method: "DELETE",
+        headers: { Authorization: "Bearer re_test" },
+      }),
+      { params: Promise.resolve({ email: "absent%40test.com" }) },
+    );
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({
+      error: "Suppression not found",
+      code: "not_found",
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add a reusable @opensend/core suppression service for list/delete DTO shaping and not-found behavior
- Keep Next suppression routes as thin auth/permission/parse/service/HTTP adapters
- Expand focused suppression route tests with service-boundary coverage, dashboard auth scoping, permission preservation, and delete 404 mapping

## Validation
- make check
- bun run test -- tests/suppressions-route.test.ts
- make test

Closes #330