### PR TITLE
Extract automation CRUD service boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-332-automations-crud-boundary.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-332-automations-crud-boundary.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-11
+issue: "#332"
+type: pattern
+promoted_to: null
+---
+
+## Automation CRUD routes keep HTTP/auth/Zod in Next while core owns orchestration and response DTOs
+
+Public automation create/list/detail/update/delete now route through `packages/core/src/services/automations.ts`. The Next adapters still own API-key auth, full-access gating, JSON/query parsing, Zod error envelopes, and HTTP status mapping; the core service owns tenant-scoped lookup/list orchestration, step replacement transactions, connection validation handoff, list enrichment, delete preconditions, and public automation response formatting.
+
+Preserve the existing split for future adapters: pass the authenticated `userId` and already-parsed request data into `createAutomationService()`. Do not move automation run routes or custom event ingestion into this CRUD boundary; runs remain in `automationRuns.ts` and event ingestion remains separate.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,7 @@ export * from "./services/storage";
 export * from "./services/template";
 export * from "./services/broadcast";
 export * from "./services/audience-metadata";
+export * from "./services/automations";
 export * from "./services/automationRuns";
 export * from "./jobs/background-jobs";
 export * from "./observability/telemetry";

--- a/packages/core/src/services/automations.ts
+++ b/packages/core/src/services/automations.ts
@@ -1,0 +1,429 @@
+import { count, desc, eq, inArray } from "drizzle-orm";
+import { db } from "../db/client";
+import {
+  type CreatedAutomation,
+  automationRepo,
+} from "../db/repositories/automationRepo";
+import {
+  type AutomationConnection,
+  automationRuns,
+  automationSteps,
+  automations,
+} from "../db/schema";
+import type {
+  AutomationConnectionDTO,
+  AutomationStatus,
+  AutomationStepInput,
+  CreateAutomationInput,
+} from "../dto/automations";
+
+export type AutomationRow = typeof automations.$inferSelect;
+export type AutomationStepRow = typeof automationSteps.$inferSelect;
+type AutomationInsert = typeof automations.$inferInsert;
+
+type AutomationStepPayload = {
+  key: string;
+  type: AutomationStepInput["type"];
+  config?: Record<string, unknown>;
+  position?: number;
+};
+
+type AutomationMutationPayload = {
+  name?: string;
+  status?: AutomationStatus;
+  trigger_event_name?: string;
+  triggerEventName?: string;
+  steps?: AutomationStepPayload[];
+  connections?: AutomationConnectionDTO[];
+};
+
+export type CreateAutomationServiceInput = {
+  userId: string | null;
+  data: AutomationMutationPayload & { steps: AutomationStepPayload[] };
+};
+
+export type ListAutomationsServiceInput = {
+  userId: string | null;
+  limit?: number;
+  after?: string;
+  status?: AutomationStatus;
+  search?: string;
+};
+
+export type UpdateAutomationServiceInput = {
+  userId: string | null;
+  id: string;
+  data: AutomationMutationPayload;
+};
+
+export type AutomationServiceErrorCode = "not_found" | "delete_forbidden";
+
+export class AutomationServiceError extends Error {
+  constructor(
+    readonly code: AutomationServiceErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AutomationServiceError";
+  }
+}
+
+export type AutomationDetailResponse = ReturnType<typeof formatAutomation>;
+export type AutomationListItemResponse = ReturnType<
+  typeof formatAutomationListItem
+> & {
+  step_count: number;
+  last_run: AutomationLastRun | null;
+};
+export type AutomationListResponse = {
+  object: "list";
+  data: AutomationListItemResponse[];
+  has_more: boolean;
+};
+export type AutomationDeleteResponse = {
+  object: "automation";
+  id: string;
+  deleted: true;
+};
+
+type AutomationLastRun = {
+  status: string;
+  created_at: Date;
+};
+
+export type AutomationServiceRepository = {
+  create(input: CreateAutomationInput): Promise<CreatedAutomation>;
+  list(input: {
+    limit: number;
+    after?: string;
+    status?: string;
+    search?: string;
+    userId?: string | null;
+  }): Promise<{ data: AutomationRow[]; hasMore: boolean }>;
+  findByIdForUser(
+    id: string,
+    userId?: string | null,
+  ): Promise<AutomationRow | undefined>;
+  listSteps(automationId: string): Promise<AutomationStepRow[]>;
+  validate(input: CreateAutomationInput): {
+    triggerEventName: string;
+    steps: Array<AutomationStepInput & { config: Record<string, unknown> }>;
+    connections: AutomationConnectionDTO[];
+  };
+  update(id: string, data: Partial<AutomationInsert>): Promise<AutomationRow[]>;
+  replaceStepsAndUpdate(input: {
+    automationId: string;
+    steps: Array<AutomationStepInput & { config: Record<string, unknown> }>;
+    update: Partial<AutomationInsert>;
+  }): Promise<void>;
+  delete(id: string): Promise<Array<{ id: string }>>;
+  countStepsByAutomationIds(
+    automationIds: string[],
+  ): Promise<Map<string, number>>;
+  findLastRunsByAutomationIds(
+    automationIds: string[],
+  ): Promise<Map<string, AutomationLastRun>>;
+};
+
+export type AutomationServiceDependencies = {
+  repository?: AutomationServiceRepository;
+};
+
+function defaultRepository(): AutomationServiceRepository {
+  return {
+    create: (input) => automationRepo.create(input),
+    list: (input) => automationRepo.list(input),
+    findByIdForUser: (id, userId) => automationRepo.findByIdForUser(id, userId),
+    listSteps: (automationId) => automationRepo.listSteps(automationId),
+    validate: (input) => automationRepo.validate(input),
+    update: (id, data) => automationRepo.update(id, data),
+    delete: (id) => automationRepo.delete(id),
+    replaceStepsAndUpdate: async ({ automationId, steps, update }) => {
+      await db.transaction(async (tx) => {
+        await tx
+          .delete(automationSteps)
+          .where(eq(automationSteps.automationId, automationId));
+        await tx.insert(automationSteps).values(
+          steps.map((step) => ({
+            automationId,
+            key: step.key,
+            type: step.type,
+            config: step.config,
+            position: step.position ?? 0,
+          })),
+        );
+        await tx
+          .update(automations)
+          .set({ ...update, updatedAt: new Date() })
+          .where(eq(automations.id, automationId));
+      });
+    },
+    countStepsByAutomationIds: async (automationIds) => {
+      const countsByAutomationId = new Map<string, number>();
+      if (automationIds.length === 0) return countsByAutomationId;
+
+      const rows = await db
+        .select({
+          automationId: automationSteps.automationId,
+          total: count(),
+        })
+        .from(automationSteps)
+        .where(inArray(automationSteps.automationId, automationIds))
+        .groupBy(automationSteps.automationId);
+
+      for (const row of rows) {
+        countsByAutomationId.set(row.automationId, Number(row.total));
+      }
+
+      return countsByAutomationId;
+    },
+    findLastRunsByAutomationIds: async (automationIds) => {
+      const lastRunByAutomationId = new Map<string, AutomationLastRun>();
+      if (automationIds.length === 0) return lastRunByAutomationId;
+
+      const runs = await db
+        .select({
+          automationId: automationRuns.automationId,
+          status: automationRuns.status,
+          createdAt: automationRuns.createdAt,
+        })
+        .from(automationRuns)
+        .where(inArray(automationRuns.automationId, automationIds))
+        .orderBy(desc(automationRuns.createdAt));
+
+      for (const run of runs) {
+        if (!lastRunByAutomationId.has(run.automationId)) {
+          lastRunByAutomationId.set(run.automationId, {
+            status: run.status,
+            created_at: run.createdAt,
+          });
+        }
+      }
+
+      return lastRunByAutomationId;
+    },
+  };
+}
+
+function toStepInputs(steps: AutomationStepPayload[]): AutomationStepInput[] {
+  return steps.map((step) => ({
+    key: step.key,
+    type: step.type,
+    config: step.config ?? {},
+    position: step.position,
+  }));
+}
+
+function toCreateInput(
+  input: CreateAutomationServiceInput,
+): CreateAutomationInput {
+  return {
+    name: input.data.name,
+    status: input.data.status,
+    triggerEventName:
+      input.data.trigger_event_name ?? input.data.triggerEventName,
+    steps: toStepInputs(input.data.steps),
+    connections: input.data.connections,
+    userId: input.userId,
+  };
+}
+
+function formatStep(step: AutomationStepRow) {
+  return {
+    id: step.id,
+    key: step.key,
+    type: step.type,
+    config: step.config ?? {},
+    position: step.position,
+  };
+}
+
+function formatAutomation(
+  automation: AutomationRow,
+  steps: AutomationStepRow[],
+) {
+  const ordered = [...steps].sort((a, b) => a.position - b.position);
+  return {
+    object: "automation" as const,
+    id: automation.id,
+    name: automation.name,
+    status: automation.status,
+    trigger_event_name: automation.triggerEventName,
+    connections: automation.connections ?? [],
+    steps: ordered.map(formatStep),
+    created_at: automation.createdAt,
+    updated_at: automation.updatedAt,
+  };
+}
+
+function formatAutomationListItem(automation: AutomationRow) {
+  return {
+    object: "automation" as const,
+    id: automation.id,
+    name: automation.name,
+    status: automation.status,
+    trigger_event_name: automation.triggerEventName,
+    created_at: automation.createdAt,
+    updated_at: automation.updatedAt,
+  };
+}
+
+function toExistingStepInputs(
+  steps: AutomationStepRow[],
+): AutomationStepInput[] {
+  return steps.map((step) => ({
+    key: step.key,
+    type: step.type as AutomationStepInput["type"],
+    config: step.config ?? {},
+    position: step.position,
+  }));
+}
+
+function buildUpdateData(
+  input: AutomationMutationPayload,
+): Partial<AutomationInsert> {
+  const updates: Partial<AutomationInsert> = {};
+  if (input.name !== undefined) updates.name = input.name;
+  if (input.status !== undefined) updates.status = input.status;
+  if (input.trigger_event_name !== undefined) {
+    updates.triggerEventName = input.trigger_event_name;
+  }
+  if (input.triggerEventName !== undefined) {
+    updates.triggerEventName = input.triggerEventName;
+  }
+  return updates;
+}
+
+export function createAutomationService({
+  repository = defaultRepository(),
+}: AutomationServiceDependencies = {}) {
+  async function getExistingOrThrow(id: string, userId: string | null) {
+    const automation = await repository.findByIdForUser(id, userId);
+    if (!automation) {
+      throw new AutomationServiceError("not_found", "Automation not found");
+    }
+    return automation;
+  }
+
+  return {
+    async createAutomation(
+      input: CreateAutomationServiceInput,
+    ): Promise<AutomationDetailResponse> {
+      const created = await repository.create(toCreateInput(input));
+      return formatAutomation(created.automation, created.steps);
+    },
+
+    async listAutomations(
+      input: ListAutomationsServiceInput,
+    ): Promise<AutomationListResponse> {
+      const { data, hasMore } = await repository.list({
+        limit: input.limit ?? 25,
+        after: input.after,
+        status: input.status,
+        search: input.search,
+        userId: input.userId,
+      });
+      const automationIds = data.map((automation) => automation.id);
+      const [stepCountsByAutomationId, lastRunByAutomationId] =
+        await Promise.all([
+          repository.countStepsByAutomationIds(automationIds),
+          repository.findLastRunsByAutomationIds(automationIds),
+        ]);
+
+      return {
+        object: "list",
+        data: data.map((automation) => ({
+          ...formatAutomationListItem(automation),
+          step_count: stepCountsByAutomationId.get(automation.id) ?? 0,
+          last_run: lastRunByAutomationId.get(automation.id) ?? null,
+        })),
+        has_more: hasMore,
+      };
+    },
+
+    async getAutomation(
+      userId: string | null,
+      id: string,
+    ): Promise<AutomationDetailResponse> {
+      const automation = await getExistingOrThrow(id, userId);
+      return formatAutomation(automation, await repository.listSteps(id));
+    },
+
+    async updateAutomation(
+      input: UpdateAutomationServiceInput,
+    ): Promise<AutomationDetailResponse> {
+      const existing = await getExistingOrThrow(input.id, input.userId);
+
+      if (input.data.steps) {
+        const normalized = repository.validate({
+          name: input.data.name ?? existing.name,
+          status: input.data.status ?? (existing.status as AutomationStatus),
+          triggerEventName:
+            input.data.trigger_event_name ??
+            input.data.triggerEventName ??
+            existing.triggerEventName ??
+            undefined,
+          steps: toStepInputs(input.data.steps),
+          connections: input.data.connections,
+          userId: input.userId,
+        });
+
+        await repository.replaceStepsAndUpdate({
+          automationId: existing.id,
+          steps: normalized.steps,
+          update: {
+            name: input.data.name ?? existing.name,
+            status: input.data.status ?? existing.status,
+            triggerEventName: normalized.triggerEventName,
+            connections: normalized.connections as AutomationConnection[],
+          },
+        });
+      } else {
+        const updates = buildUpdateData(input.data);
+        if (input.data.connections !== undefined) {
+          const existingSteps = await repository.listSteps(existing.id);
+          const normalized = repository.validate({
+            name: input.data.name ?? existing.name,
+            status: input.data.status ?? (existing.status as AutomationStatus),
+            triggerEventName:
+              updates.triggerEventName ??
+              existing.triggerEventName ??
+              undefined,
+            steps: toExistingStepInputs(existingSteps),
+            connections: input.data.connections,
+            userId: input.userId,
+          });
+          updates.triggerEventName = normalized.triggerEventName;
+          updates.connections =
+            normalized.connections as AutomationConnection[];
+        }
+        if (Object.keys(updates).length > 0) {
+          await repository.update(existing.id, updates);
+        }
+      }
+
+      const refreshed = await getExistingOrThrow(input.id, input.userId);
+      return formatAutomation(refreshed, await repository.listSteps(input.id));
+    },
+
+    async deleteAutomation(
+      userId: string | null,
+      id: string,
+    ): Promise<AutomationDeleteResponse> {
+      const automation = await getExistingOrThrow(id, userId);
+      if (automation.status === "enabled") {
+        throw new AutomationServiceError(
+          "delete_forbidden",
+          "Disable the automation before deleting",
+        );
+      }
+
+      await repository.delete(automation.id);
+      return {
+        object: "automation",
+        id: automation.id,
+        deleted: true,
+      };
+    },
+  };
+}

--- a/src/app/api/automations/[id]/route.ts
+++ b/src/app/api/automations/[id]/route.ts
@@ -1,47 +1,30 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { formatAutomation } from "@/lib/automations";
-import { db } from "@/lib/db";
-import { automationSteps, automations } from "@/lib/db/schema";
 import { updateAutomationSchema } from "@/lib/validation/automations";
 import {
-  type AutomationStepInput,
+  AutomationServiceError,
   AutomationValidationError,
-  automationRepo,
+  createAutomationService,
 } from "@opensend/core";
-import { and, asc, eq } from "drizzle-orm";
 
-async function findAutomationForCaller(id: string, userId: string | null) {
-  const conditions = [eq(automations.id, id)];
-  if (userId) conditions.push(eq(automations.userId, userId));
-  return (
-    (await db.query.automations.findFirst({ where: and(...conditions) })) ??
-    null
-  );
-}
+const automationService = createAutomationService();
 
-async function loadSteps(automationId: string) {
-  return await db
-    .select()
-    .from(automationSteps)
-    .where(eq(automationSteps.automationId, automationId))
-    .orderBy(asc(automationSteps.position));
-}
-
-function toStepInputs(
-  steps: Array<{
-    key: string;
-    type: AutomationStepInput["type"];
-    config?: Record<string, unknown>;
-    position?: number;
-  }>,
-): AutomationStepInput[] {
-  return steps.map((step) => ({
-    key: step.key,
-    type: step.type,
-    config: step.config ?? {},
-    position: step.position,
-  }));
+function mapAutomationServiceError(err: unknown): Response | null {
+  if (err instanceof AutomationServiceError) {
+    if (err.code === "not_found") {
+      return Response.json({ error: "Automation not found" }, { status: 404 });
+    }
+    if (err.code === "delete_forbidden") {
+      return Response.json(
+        {
+          error: err.message,
+          code: "automation_enabled",
+        },
+        { status: 409 },
+      );
+    }
+  }
+  return null;
 }
 
 export async function GET(
@@ -55,12 +38,12 @@ export async function GET(
 
   const { id } = await params;
   try {
-    const automation = await findAutomationForCaller(id, auth.userId);
-    if (!automation) {
-      return Response.json({ error: "Automation not found" }, { status: 404 });
-    }
-    return Response.json(formatAutomation(automation, await loadSteps(id)));
+    return Response.json(
+      await automationService.getAutomation(auth.userId, id),
+    );
   } catch (err) {
+    const mapped = mapAutomationServiceError(err);
+    if (mapped) return mapped;
     const message =
       err instanceof Error ? err.message : "Failed to retrieve automation";
     return Response.json({ error: message }, { status: 500 });
@@ -92,95 +75,17 @@ export async function PATCH(
   }
 
   const { id } = await params;
-  const validated = parsed.data;
   try {
-    const existing = await findAutomationForCaller(id, auth.userId);
-    if (!existing) {
-      return Response.json({ error: "Automation not found" }, { status: 404 });
-    }
-
-    if (validated.steps) {
-      const normalized = automationRepo.validate({
-        name: validated.name ?? existing.name,
-        status:
-          validated.status ??
-          (existing.status as "draft" | "enabled" | "disabled"),
-        triggerEventName:
-          validated.trigger_event_name ??
-          validated.triggerEventName ??
-          existing.triggerEventName ??
-          undefined,
-        steps: toStepInputs(validated.steps),
-        connections: validated.connections,
+    return Response.json(
+      await automationService.updateAutomation({
         userId: auth.userId,
-      });
-
-      await db.transaction(async (tx) => {
-        await tx
-          .delete(automationSteps)
-          .where(eq(automationSteps.automationId, existing.id));
-        await tx.insert(automationSteps).values(
-          normalized.steps.map((step) => ({
-            automationId: existing.id,
-            key: step.key,
-            type: step.type,
-            config: step.config,
-            position: step.position ?? 0,
-          })),
-        );
-        await tx
-          .update(automations)
-          .set({
-            name: validated.name ?? existing.name,
-            status: validated.status ?? existing.status,
-            triggerEventName: normalized.triggerEventName,
-            connections: normalized.connections,
-            updatedAt: new Date(),
-          })
-          .where(eq(automations.id, existing.id));
-      });
-    } else {
-      const updates: Partial<typeof automations.$inferInsert> = {};
-      if (validated.name !== undefined) updates.name = validated.name;
-      if (validated.status !== undefined) updates.status = validated.status;
-      if (validated.trigger_event_name !== undefined) {
-        updates.triggerEventName = validated.trigger_event_name;
-      }
-      if (validated.triggerEventName !== undefined) {
-        updates.triggerEventName = validated.triggerEventName;
-      }
-      if (validated.connections !== undefined) {
-        const existingSteps = await loadSteps(existing.id);
-        const normalized = automationRepo.validate({
-          name: validated.name ?? existing.name,
-          status:
-            validated.status ??
-            (existing.status as "draft" | "enabled" | "disabled"),
-          triggerEventName:
-            updates.triggerEventName ?? existing.triggerEventName ?? undefined,
-          steps: existingSteps.map((step) => ({
-            key: step.key,
-            type: step.type as AutomationStepInput["type"],
-            config: step.config ?? {},
-            position: step.position,
-          })),
-          connections: validated.connections,
-          userId: auth.userId,
-        });
-        updates.triggerEventName = normalized.triggerEventName;
-        updates.connections = normalized.connections;
-      }
-      if (Object.keys(updates).length > 0) {
-        await automationRepo.update(existing.id, updates);
-      }
-    }
-
-    const refreshed = await findAutomationForCaller(id, auth.userId);
-    if (!refreshed) {
-      return Response.json({ error: "Automation not found" }, { status: 404 });
-    }
-    return Response.json(formatAutomation(refreshed, await loadSteps(id)));
+        id,
+        data: parsed.data,
+      }),
+    );
   } catch (err) {
+    const mapped = mapAutomationServiceError(err);
+    if (mapped) return mapped;
     if (err instanceof AutomationValidationError) {
       return Response.json(
         { error: err.message, code: err.code },
@@ -204,26 +109,12 @@ export async function DELETE(
 
   const { id } = await params;
   try {
-    const automation = await findAutomationForCaller(id, auth.userId);
-    if (!automation) {
-      return Response.json({ error: "Automation not found" }, { status: 404 });
-    }
-    if (automation.status === "enabled") {
-      return Response.json(
-        {
-          error: "Disable the automation before deleting",
-          code: "automation_enabled",
-        },
-        { status: 409 },
-      );
-    }
-    await automationRepo.delete(automation.id);
-    return Response.json({
-      object: "automation",
-      id: automation.id,
-      deleted: true,
-    });
+    return Response.json(
+      await automationService.deleteAutomation(auth.userId, id),
+    );
   } catch (err) {
+    const mapped = mapAutomationServiceError(err);
+    if (mapped) return mapped;
     const message =
       err instanceof Error ? err.message : "Failed to delete automation";
     return Response.json({ error: message }, { status: 500 });

--- a/src/app/api/automations/route.ts
+++ b/src/app/api/automations/route.ts
@@ -1,32 +1,15 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { formatAutomation, formatAutomationListItem } from "@/lib/automations";
-import { db } from "@/lib/db";
-import { automationRuns, automationSteps } from "@/lib/db/schema";
-import { listAutomationsQuerySchema } from "@/lib/validation/automations";
-import { createAutomationSchema } from "@/lib/validation/automations";
 import {
-  type AutomationStepInput,
+  createAutomationSchema,
+  listAutomationsQuerySchema,
+} from "@/lib/validation/automations";
+import {
   AutomationValidationError,
-  automationRepo,
+  createAutomationService,
 } from "@opensend/core";
-import { count, desc, inArray } from "drizzle-orm";
 
-function toStepInputs(
-  steps: Array<{
-    key: string;
-    type: AutomationStepInput["type"];
-    config?: Record<string, unknown>;
-    position?: number;
-  }>,
-): AutomationStepInput[] {
-  return steps.map((step) => ({
-    key: step.key,
-    type: step.type,
-    config: step.config ?? {},
-    position: step.position,
-  }));
-}
+const automationService = createAutomationService();
 
 export async function POST(request: Request): Promise<Response> {
   const auth = await validateApiKey(request.headers.get("authorization"));
@@ -49,21 +32,13 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  const validated = parsed.data;
   try {
-    const created = await automationRepo.create({
-      name: validated.name,
-      status: validated.status,
-      triggerEventName:
-        validated.trigger_event_name ?? validated.triggerEventName,
-      steps: toStepInputs(validated.steps),
-      connections: validated.connections,
+    const created = await automationService.createAutomation({
       userId: auth.userId,
+      data: parsed.data,
     });
 
-    return Response.json(formatAutomation(created.automation, created.steps), {
-      status: 201,
-    });
+    return Response.json(created, { status: 201 });
   } catch (err) {
     if (err instanceof AutomationValidationError) {
       return Response.json(
@@ -98,63 +73,15 @@ export async function GET(request: Request): Promise<Response> {
   }
 
   try {
-    const { data, hasMore } = await automationRepo.list({
-      limit: parsed.data.limit ?? 25,
+    const list = await automationService.listAutomations({
+      userId: auth.userId,
+      limit: parsed.data.limit,
       after: parsed.data.after,
       status: parsed.data.status,
       search: parsed.data.search,
-      userId: auth.userId,
     });
-    const automationIds = data.map((automation) => automation.id);
-    const stepCountsByAutomationId = new Map<string, number>();
-    const lastRunByAutomationId = new Map<
-      string,
-      { status: string; created_at: Date }
-    >();
 
-    if (automationIds.length > 0) {
-      const stepCounts = await db
-        .select({
-          automationId: automationSteps.automationId,
-          total: count(),
-        })
-        .from(automationSteps)
-        .where(inArray(automationSteps.automationId, automationIds))
-        .groupBy(automationSteps.automationId);
-
-      for (const row of stepCounts) {
-        stepCountsByAutomationId.set(row.automationId, Number(row.total));
-      }
-
-      const runs = await db
-        .select({
-          automationId: automationRuns.automationId,
-          status: automationRuns.status,
-          createdAt: automationRuns.createdAt,
-        })
-        .from(automationRuns)
-        .where(inArray(automationRuns.automationId, automationIds))
-        .orderBy(desc(automationRuns.createdAt));
-
-      for (const run of runs) {
-        if (!lastRunByAutomationId.has(run.automationId)) {
-          lastRunByAutomationId.set(run.automationId, {
-            status: run.status,
-            created_at: run.createdAt,
-          });
-        }
-      }
-    }
-
-    return Response.json({
-      object: "list",
-      data: data.map((automation) => ({
-        ...formatAutomationListItem(automation),
-        step_count: stepCountsByAutomationId.get(automation.id) ?? 0,
-        last_run: lastRunByAutomationId.get(automation.id) ?? null,
-      })),
-      has_more: hasMore,
-    });
+    return Response.json(list);
   } catch (err) {
     const message =
       err instanceof Error ? err.message : "Failed to list automations";

--- a/tests/api-automations-events.test.ts
+++ b/tests/api-automations-events.test.ts
@@ -1,8 +1,17 @@
+import type {
+  CreateAutomationServiceInput,
+  ListAutomationsServiceInput,
+} from "@opensend/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockValidateApiKey = vi.hoisted(() => vi.fn());
 const mockAutomationCreate = vi.hoisted(() => vi.fn());
 const mockAutomationList = vi.hoisted(() => vi.fn());
+const mockServiceCreateAutomation = vi.hoisted(() => vi.fn());
+const mockServiceListAutomations = vi.hoisted(() => vi.fn());
+const mockServiceGetAutomation = vi.hoisted(() => vi.fn());
+const mockServiceUpdateAutomation = vi.hoisted(() => vi.fn());
+const mockServiceDeleteAutomation = vi.hoisted(() => vi.fn());
 const mockAutomationValidate = vi.hoisted(() => vi.fn());
 const mockAutomationDelete = vi.hoisted(() => vi.fn());
 const mockFindEnabledByTriggerEventName = vi.hoisted(() => vi.fn());
@@ -41,6 +50,16 @@ class TestAutomationRunServiceError extends Error {
   constructor(code: string, message: string) {
     super(message);
     this.name = "AutomationRunServiceError";
+    this.code = code;
+  }
+}
+
+class TestAutomationServiceError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "AutomationServiceError";
     this.code = code;
   }
 }
@@ -93,6 +112,14 @@ vi.mock("@/lib/db", () => ({
 vi.mock("@opensend/core", () => ({
   AutomationValidationError: TestAutomationValidationError,
   AutomationRunServiceError: TestAutomationRunServiceError,
+  AutomationServiceError: TestAutomationServiceError,
+  createAutomationService: () => ({
+    createAutomation: mockServiceCreateAutomation,
+    listAutomations: mockServiceListAutomations,
+    getAutomation: mockServiceGetAutomation,
+    updateAutomation: mockServiceUpdateAutomation,
+    deleteAutomation: mockServiceDeleteAutomation,
+  }),
   createAutomationRunService: () => ({
     listRuns: mockListRuns,
     getRun: mockGetRun,
@@ -168,6 +195,16 @@ const customEvent = {
   createdAt: now,
   updatedAt: now,
 };
+type TestCreatedAutomation = {
+  automation: typeof automation;
+  steps: Array<typeof triggerStep>;
+};
+
+type TestAutomationListResult = {
+  data: Array<typeof automation>;
+  hasMore: boolean;
+};
+
 const queuedRun = {
   id: "run_1",
   automationId: "auto_1",
@@ -207,6 +244,95 @@ describe("automation API routes", () => {
     mockValidateApiKey.mockResolvedValue(auth);
     mockResumeWaitingRunsForEvent.mockResolvedValue([]);
     mockDbSelect.mockReturnValue(queryRows([triggerStep]));
+    mockServiceCreateAutomation.mockImplementation(
+      async (input: CreateAutomationServiceInput) => {
+        const created = (await mockAutomationCreate({
+          name: input.data.name,
+          status: input.data.status,
+          triggerEventName:
+            input.data.trigger_event_name ?? input.data.triggerEventName,
+          steps: input.data.steps.map((step) => ({
+            key: step.key,
+            type: step.type,
+            config: step.config ?? {},
+            position: step.position,
+          })),
+          connections: input.data.connections,
+          userId: input.userId,
+        })) as TestCreatedAutomation;
+        return {
+          object: "automation",
+          id: created.automation.id,
+          name: created.automation.name,
+          status: created.automation.status,
+          trigger_event_name: created.automation.triggerEventName,
+          connections: created.automation.connections ?? [],
+          steps: created.steps.map((step) => ({
+            id: step.id,
+            key: step.key,
+            type: step.type,
+            config: step.config ?? {},
+            position: step.position,
+          })),
+          created_at: created.automation.createdAt,
+          updated_at: created.automation.updatedAt,
+        };
+      },
+    );
+    mockServiceListAutomations.mockImplementation(
+      async (input: ListAutomationsServiceInput) => {
+        const listed = (await mockAutomationList({
+          userId: input.userId,
+          limit: input.limit ?? 25,
+          after: input.after,
+          status: input.status,
+          search: input.search,
+        })) as TestAutomationListResult;
+        return {
+          object: "list",
+          data: listed.data.map((item) => ({
+            object: "automation",
+            id: item.id,
+            name: item.name,
+            status: item.status,
+            trigger_event_name: item.triggerEventName,
+            created_at: item.createdAt,
+            updated_at: item.updatedAt,
+            step_count: 1,
+            last_run: null,
+          })),
+          has_more: listed.hasMore,
+        };
+      },
+    );
+    mockServiceGetAutomation.mockImplementation(async (_userId, id) => {
+      const found = await mockAutomationFindFirst({ id });
+      if (!found) {
+        throw new TestAutomationServiceError(
+          "not_found",
+          "Automation not found",
+        );
+      }
+      return {
+        object: "automation",
+        id: found.id,
+        name: found.name,
+        status: found.status,
+        trigger_event_name: found.triggerEventName,
+        connections: found.connections ?? [],
+        steps: [
+          {
+            id: triggerStep.id,
+            key: triggerStep.key,
+            type: triggerStep.type,
+            config: triggerStep.config,
+            position: triggerStep.position,
+          },
+        ],
+        created_at: found.createdAt,
+        updated_at: found.updatedAt,
+      };
+    });
   });
 
   it("returns 401 for missing API auth", async () => {

--- a/tests/automation-service.test.ts
+++ b/tests/automation-service.test.ts
@@ -1,0 +1,354 @@
+import {
+  AutomationServiceError,
+  type AutomationServiceRepository,
+  createAutomationService,
+} from "@opensend/core";
+import { describe, expect, it } from "vitest";
+
+type AutomationRow = NonNullable<
+  Awaited<ReturnType<AutomationServiceRepository["findByIdForUser"]>>
+>;
+type AutomationStepRow = Awaited<
+  ReturnType<AutomationServiceRepository["listSteps"]>
+>[number];
+type CreateInput = Parameters<AutomationServiceRepository["create"]>[0];
+type ListInput = Parameters<AutomationServiceRepository["list"]>[0];
+type UpdateData = Parameters<AutomationServiceRepository["update"]>[1];
+type ReplaceStepsInput = Parameters<
+  AutomationServiceRepository["replaceStepsAndUpdate"]
+>[0];
+
+const now = new Date("2026-05-02T00:00:00.000Z");
+
+function makeAutomation(overrides: Partial<AutomationRow> = {}): AutomationRow {
+  return {
+    id: "auto_1",
+    name: "Welcome",
+    status: "enabled",
+    triggerEventName: "user.signed_up",
+    connections: [],
+    createdAt: now,
+    updatedAt: now,
+    document: null,
+    userId: "user_1",
+    ...overrides,
+  };
+}
+
+function makeStep(
+  overrides: Partial<AutomationStepRow> = {},
+): AutomationStepRow {
+  return {
+    id: "step_1",
+    automationId: "auto_1",
+    key: "trigger",
+    type: "trigger",
+    config: { event_name: "user.signed_up" },
+    position: 0,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function makeRepository(
+  overrides: Partial<AutomationServiceRepository> = {},
+): AutomationServiceRepository {
+  const repository: AutomationServiceRepository = {
+    async create(input) {
+      return {
+        automation: makeAutomation({
+          name: input.name ?? "Untitled",
+          status: input.status ?? "draft",
+          triggerEventName: input.triggerEventName ?? "user.signed_up",
+          connections: input.connections ?? [],
+          userId: input.userId ?? null,
+        }),
+        steps: input.steps.map((step, index) =>
+          makeStep({
+            id: `step_${index}`,
+            key: step.key,
+            type: step.type,
+            config: step.config,
+            position: step.position ?? index,
+          }),
+        ),
+      };
+    },
+    async list() {
+      return { data: [makeAutomation()], hasMore: false };
+    },
+    async findByIdForUser(id, userId) {
+      if (id !== "auto_1") return undefined;
+      if (userId && userId !== "user_1") return undefined;
+      return makeAutomation();
+    },
+    async listSteps() {
+      return [makeStep()];
+    },
+    validate(input) {
+      return {
+        triggerEventName: input.triggerEventName ?? "user.signed_up",
+        steps: input.steps.map((step, index) => ({
+          ...step,
+          config: step.config ?? {},
+          position: step.position ?? index,
+        })),
+        connections: input.connections ?? [],
+      };
+    },
+    async update() {
+      return [makeAutomation({ name: "Updated" })];
+    },
+    async replaceStepsAndUpdate() {},
+    async delete(id) {
+      return [{ id }];
+    },
+    async countStepsByAutomationIds(automationIds) {
+      return new Map(automationIds.map((id) => [id, 2]));
+    },
+    async findLastRunsByAutomationIds(automationIds) {
+      return new Map(
+        automationIds.map((id) => [
+          id,
+          { status: "completed", created_at: now },
+        ]),
+      );
+    },
+  };
+
+  return { ...repository, ...overrides };
+}
+
+describe("automation CRUD service boundary", () => {
+  it("creates automations with caller scope and public response formatting", async () => {
+    let capturedInput: CreateInput | undefined;
+    const service = createAutomationService({
+      repository: makeRepository({
+        async create(input) {
+          capturedInput = input;
+          return {
+            automation: makeAutomation({
+              name: input.name,
+              status: input.status,
+              triggerEventName: input.triggerEventName,
+              userId: input.userId,
+            }),
+            steps: [
+              makeStep({ key: "trigger", config: input.steps[0].config }),
+            ],
+          };
+        },
+      }),
+    });
+
+    const result = await service.createAutomation({
+      userId: "user_1",
+      data: {
+        name: "Welcome",
+        status: "enabled",
+        trigger_event_name: "user.signed_up",
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { eventName: "user.signed_up" },
+          },
+        ],
+      },
+    });
+
+    expect(capturedInput).toMatchObject({
+      name: "Welcome",
+      status: "enabled",
+      triggerEventName: "user.signed_up",
+      userId: "user_1",
+      steps: [{ key: "trigger", config: { eventName: "user.signed_up" } }],
+    });
+    expect(result).toMatchObject({
+      object: "automation",
+      id: "auto_1",
+      trigger_event_name: "user.signed_up",
+      steps: [{ key: "trigger" }],
+    });
+  });
+
+  it("lists automations with filters, step counts, last run enrichment, and list envelope", async () => {
+    let capturedListInput: ListInput | undefined;
+    const service = createAutomationService({
+      repository: makeRepository({
+        async list(input) {
+          capturedListInput = input;
+          return {
+            data: [
+              makeAutomation({ id: "auto_1" }),
+              makeAutomation({ id: "auto_2" }),
+            ],
+            hasMore: true,
+          };
+        },
+        async countStepsByAutomationIds() {
+          return new Map([["auto_1", 3]]);
+        },
+        async findLastRunsByAutomationIds() {
+          return new Map([["auto_2", { status: "failed", created_at: now }]]);
+        },
+      }),
+    });
+
+    const result = await service.listAutomations({
+      userId: "user_1",
+      status: "enabled",
+      search: "Welcome",
+      limit: 10,
+      after: "auto_9",
+    });
+
+    expect(capturedListInput).toEqual({
+      userId: "user_1",
+      status: "enabled",
+      search: "Welcome",
+      limit: 10,
+      after: "auto_9",
+    });
+    expect(result).toMatchObject({
+      object: "list",
+      has_more: true,
+      data: [
+        { id: "auto_1", step_count: 3, last_run: null },
+        {
+          id: "auto_2",
+          step_count: 0,
+          last_run: { status: "failed", created_at: now },
+        },
+      ],
+    });
+  });
+
+  it("retrieves detail through user-scoped lookup and ordered step formatting", async () => {
+    const service = createAutomationService({
+      repository: makeRepository({
+        async listSteps() {
+          return [
+            makeStep({
+              id: "step_2",
+              key: "send",
+              type: "send_email",
+              position: 2,
+            }),
+            makeStep({ id: "step_1", key: "trigger", position: 0 }),
+          ];
+        },
+      }),
+    });
+
+    await expect(
+      service.getAutomation("user_1", "auto_1"),
+    ).resolves.toMatchObject({
+      id: "auto_1",
+      steps: [{ key: "trigger" }, { key: "send" }],
+    });
+    await expect(
+      service.getAutomation("user_2", "auto_1"),
+    ).rejects.toMatchObject({
+      code: "not_found",
+      message: "Automation not found",
+    });
+  });
+
+  it("replaces steps and updates automation metadata when patching steps", async () => {
+    let capturedReplace: ReplaceStepsInput | undefined;
+    const service = createAutomationService({
+      repository: makeRepository({
+        async replaceStepsAndUpdate(input) {
+          capturedReplace = input;
+        },
+      }),
+    });
+
+    await service.updateAutomation({
+      userId: "user_1",
+      id: "auto_1",
+      data: {
+        name: "Updated",
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { event_name: "invoice.paid" },
+          },
+          { key: "end", type: "end" },
+        ],
+        connections: [{ from: "trigger", to: "end" }],
+      },
+    });
+
+    expect(capturedReplace).toMatchObject({
+      automationId: "auto_1",
+      steps: [
+        { key: "trigger", position: 0 },
+        { key: "end", config: {}, position: 1 },
+      ],
+      update: {
+        name: "Updated",
+        status: "enabled",
+        triggerEventName: "user.signed_up",
+        connections: [{ from: "trigger", to: "end" }],
+      },
+    });
+  });
+
+  it("validates connection-only updates against existing steps before scoped update", async () => {
+    let capturedUpdate: UpdateData | undefined;
+    const service = createAutomationService({
+      repository: makeRepository({
+        async update(_id, data) {
+          capturedUpdate = data;
+          return [makeAutomation(data)];
+        },
+      }),
+    });
+
+    await service.updateAutomation({
+      userId: "user_1",
+      id: "auto_1",
+      data: { connections: [{ from: "trigger", to: "trigger" }] },
+    });
+
+    expect(capturedUpdate).toMatchObject({
+      triggerEventName: "user.signed_up",
+      connections: [{ from: "trigger", to: "trigger" }],
+    });
+  });
+
+  it("rejects enabled deletes and preserves the delete response shape for disabled automations", async () => {
+    const enabledService = createAutomationService({
+      repository: makeRepository(),
+    });
+    await expect(
+      enabledService.deleteAutomation("user_1", "auto_1"),
+    ).rejects.toBeInstanceOf(AutomationServiceError);
+    await expect(
+      enabledService.deleteAutomation("user_1", "auto_1"),
+    ).rejects.toMatchObject({
+      code: "delete_forbidden",
+      message: "Disable the automation before deleting",
+    });
+
+    const disabledService = createAutomationService({
+      repository: makeRepository({
+        async findByIdForUser() {
+          return makeAutomation({ status: "disabled" });
+        },
+      }),
+    });
+
+    await expect(
+      disabledService.deleteAutomation("user_1", "auto_1"),
+    ).resolves.toEqual({
+      object: "automation",
+      id: "auto_1",
+      deleted: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a reusable core automation CRUD service for create/list/detail/update/delete orchestration and public DTO formatting.
- Thin the Next automation collection/detail route adapters down to auth, request validation, service invocation, and HTTP error mapping.
- Add focused service-boundary coverage and update route tests to assert adapter behavior through the service seam.

Closes #332

## Validation
- bun run test -- tests/api-automations-events.test.ts
- bun run test -- tests/automation-service.test.ts
- make check
- make test
- git push pre-push guardrail: scripts/check-changed-files.mjs

## Residual risk
- Playwright E2E not run; this is a backend service-boundary extraction with full unit coverage passing.