### PR TITLE
Extract broadcast send and metrics service boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-334-route-smoke-service-mocks.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-334-route-smoke-service-mocks.md
@@ -1,0 +1,10 @@
+---
+date: 2026-05-11
+issue: "#334"
+type: pattern
+promoted_to: null
+---
+
+## Boundary extractions must update cross-route smoke mocks, not only focused route tests
+
+When moving broadcast send/metrics logic behind `createBroadcastService()`, focused broadcast tests passed but `tests/api-auth-date-range-routes.test.ts` still mocked `@opensend/core` with the older CRUD-only service surface. Service-boundary PRs should update shared smoke-test mocks for every new service method the route adapter calls, or full `make test` can fail even when the focused route tests pass.

--- a/packages/core/src/services/broadcast.ts
+++ b/packages/core/src/services/broadcast.ts
@@ -1,5 +1,7 @@
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "../db/client";
 import { broadcastRepo } from "../db/repositories/broadcastRepo";
-import type { broadcasts } from "../db/schema";
+import { broadcasts, emails } from "../db/schema";
 
 type BroadcastRow = typeof broadcasts.$inferSelect;
 type BroadcastInsert = typeof broadcasts.$inferInsert;
@@ -41,6 +43,36 @@ export type BroadcastDeleteResult = {
   id: string;
 };
 
+export type BroadcastSendResult = Pick<
+  BroadcastRow,
+  "id" | "status" | "scheduledAt"
+>;
+
+export type BroadcastMetricsCounts = {
+  total: number;
+  delivered: number;
+  bounced: number;
+  complained: number;
+  opened: number;
+  clicked: number;
+};
+
+export type BroadcastMetricsPayload = BroadcastMetricsCounts & {
+  object: "broadcast_metrics";
+  broadcast_id: string;
+  delivery_rate: number;
+  open_rate: number;
+  click_rate: number;
+  bounce_rate: number;
+};
+
+export type BroadcastMetricsCacheStatus = "hit" | "miss";
+
+export type BroadcastMetricsResult = {
+  payload: BroadcastMetricsPayload;
+  cacheStatus: BroadcastMetricsCacheStatus;
+};
+
 export type BroadcastListResult = {
   data: BroadcastListItem[];
   hasMore: boolean;
@@ -49,7 +81,8 @@ export type BroadcastListResult = {
 export type BroadcastServiceErrorCode =
   | "invalid_input"
   | "not_found"
-  | "delete_forbidden";
+  | "delete_forbidden"
+  | "send_forbidden";
 
 export class BroadcastServiceError extends Error {
   constructor(
@@ -77,6 +110,24 @@ export type BroadcastRepository = {
     id: string,
     userId: string,
   ): Promise<Pick<BroadcastRow, "status"> | undefined>;
+  findSendCandidateForUser(
+    id: string,
+    userId: string,
+  ): Promise<Pick<BroadcastRow, "status"> | undefined>;
+  updateSendStatusForUser(input: {
+    id: string;
+    userId: string;
+    status: string;
+    scheduledAt: Date | null;
+  }): Promise<BroadcastSendResult[]>;
+  findMetricsCandidateForUser(
+    id: string,
+    userId: string,
+  ): Promise<Pick<BroadcastRow, "id"> | undefined>;
+  aggregateMetricsForBroadcast(input: {
+    userId: string;
+    broadcastId: string;
+  }): Promise<BroadcastMetricsCounts>;
   listForApi(options: {
     userId: string;
     limit: number;
@@ -87,8 +138,16 @@ export type BroadcastRepository = {
   }): Promise<BroadcastListResult>;
 };
 
+export type BroadcastMetricsCache = {
+  ttlSeconds: number;
+  getKey(input: { userId: string; broadcastId: string }): string;
+  read<T>(key: string): Promise<T | null>;
+  write(key: string, value: unknown, ttlSeconds: number): Promise<void>;
+};
+
 export type BroadcastServiceDependencies = {
   repository?: BroadcastRepository;
+  metricsCache?: BroadcastMetricsCache;
 };
 
 export type ListBroadcastsInput = {
@@ -111,6 +170,17 @@ export type UpdateBroadcastInput = {
   body: unknown;
 };
 
+export type SendBroadcastInput = {
+  userId: string;
+  id: string;
+  body: unknown;
+};
+
+export type GetBroadcastMetricsInput = {
+  userId: string;
+  id: string;
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -129,6 +199,102 @@ function optionalStoredString(value: unknown): string | null {
 
 function normalizeLimit(limit: number | undefined): number {
   return Math.min(120, Math.max(1, limit || 40));
+}
+
+const emptyBroadcastMetricsCounts: BroadcastMetricsCounts = {
+  total: 0,
+  delivered: 0,
+  bounced: 0,
+  complained: 0,
+  opened: 0,
+  clicked: 0,
+};
+
+const defaultBroadcastRepository: BroadcastRepository = {
+  ...broadcastRepo,
+  async findSendCandidateForUser(id, userId) {
+    const [broadcast] = await db
+      .select({ status: broadcasts.status })
+      .from(broadcasts)
+      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
+      .limit(1);
+
+    return broadcast;
+  },
+  async updateSendStatusForUser(input) {
+    return await db
+      .update(broadcasts)
+      .set({
+        status: input.status,
+        scheduledAt: input.scheduledAt,
+      })
+      .where(
+        and(eq(broadcasts.id, input.id), eq(broadcasts.userId, input.userId)),
+      )
+      .returning({
+        id: broadcasts.id,
+        status: broadcasts.status,
+        scheduledAt: broadcasts.scheduledAt,
+      });
+  },
+  async findMetricsCandidateForUser(id, userId) {
+    const [broadcast] = await db
+      .select({ id: broadcasts.id })
+      .from(broadcasts)
+      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
+      .limit(1);
+
+    return broadcast;
+  },
+  async aggregateMetricsForBroadcast(input) {
+    const condition = and(
+      eq(emails.userId, input.userId),
+      sql`${emails.tags} @> ${JSON.stringify([
+        { name: "broadcast_id", value: input.broadcastId },
+      ])}::jsonb`,
+    );
+
+    const [stats] = await db
+      .select({
+        total: sql<number>`count(*)::int`,
+        delivered: sql<number>`count(*) filter (where ${emails.status} = 'delivered')::int`,
+        bounced: sql<number>`count(*) filter (where ${emails.status} in ('bounced', 'hard_bounced', 'soft_bounced'))::int`,
+        complained: sql<number>`count(*) filter (where ${emails.status} = 'complained')::int`,
+        opened: sql<number>`count(*) filter (where ${emails.status} = 'opened')::int`,
+        clicked: sql<number>`count(*) filter (where ${emails.status} = 'clicked')::int`,
+      })
+      .from(emails)
+      .where(condition);
+
+    return stats ?? emptyBroadcastMetricsCounts;
+  },
+};
+
+function readScheduledAt(body: unknown): Date | null {
+  const record = asRecord(body);
+  return record.scheduled_at ? new Date(String(record.scheduled_at)) : null;
+}
+
+function buildMetricsPayload(
+  broadcastId: string,
+  stats: BroadcastMetricsCounts,
+): BroadcastMetricsPayload {
+  const total = stats.total;
+
+  return {
+    object: "broadcast_metrics",
+    broadcast_id: broadcastId,
+    total,
+    delivered: stats.delivered,
+    bounced: stats.bounced,
+    complained: stats.complained,
+    opened: stats.opened,
+    clicked: stats.clicked,
+    delivery_rate: total > 0 ? (stats.delivered / total) * 100 : 0,
+    open_rate: total > 0 ? (stats.opened / total) * 100 : 0,
+    click_rate: total > 0 ? (stats.clicked / total) * 100 : 0,
+    bounce_rate: total > 0 ? (stats.bounced / total) * 100 : 0,
+  };
 }
 
 function toDetail(row: BroadcastRow): BroadcastDetail {
@@ -175,7 +341,8 @@ function buildUpdateData(
 }
 
 export function createBroadcastService({
-  repository = broadcastRepo,
+  repository = defaultBroadcastRepository,
+  metricsCache,
 }: BroadcastServiceDependencies = {}) {
   return {
     async listBroadcasts(
@@ -257,6 +424,78 @@ export function createBroadcastService({
       }
 
       return toDetail(updated);
+    },
+
+    async sendBroadcast(
+      input: SendBroadcastInput,
+    ): Promise<BroadcastSendResult> {
+      const existing = await repository.findSendCandidateForUser(
+        input.id,
+        input.userId,
+      );
+
+      if (!existing) {
+        throw new BroadcastServiceError("not_found", "Broadcast not found");
+      }
+
+      if (existing.status !== "draft") {
+        throw new BroadcastServiceError(
+          "send_forbidden",
+          `Cannot send a broadcast in ${existing.status} status`,
+        );
+      }
+
+      const scheduledAt = readScheduledAt(input.body);
+      const [updated] = await repository.updateSendStatusForUser({
+        id: input.id,
+        userId: input.userId,
+        status: scheduledAt ? "scheduled" : "queued",
+        scheduledAt,
+      });
+
+      if (!updated) {
+        throw new Error("Failed to update broadcast send status");
+      }
+
+      return updated;
+    },
+
+    async getBroadcastMetrics(
+      input: GetBroadcastMetricsInput,
+    ): Promise<BroadcastMetricsResult> {
+      const broadcast = await repository.findMetricsCandidateForUser(
+        input.id,
+        input.userId,
+      );
+
+      if (!broadcast) {
+        throw new BroadcastServiceError("not_found", "Broadcast not found");
+      }
+
+      const cacheKey = metricsCache?.getKey({
+        userId: input.userId,
+        broadcastId: input.id,
+      });
+
+      if (cacheKey && metricsCache) {
+        const cached =
+          await metricsCache.read<BroadcastMetricsPayload>(cacheKey);
+        if (cached) {
+          return { payload: cached, cacheStatus: "hit" };
+        }
+      }
+
+      const stats = await repository.aggregateMetricsForBroadcast({
+        userId: input.userId,
+        broadcastId: input.id,
+      });
+      const payload = buildMetricsPayload(input.id, stats);
+
+      if (cacheKey && metricsCache) {
+        await metricsCache.write(cacheKey, payload, metricsCache.ttlSeconds);
+      }
+
+      return { payload, cacheStatus: "miss" };
     },
 
     async deleteBroadcast(

--- a/src/app/api/broadcasts/[id]/metrics/route.ts
+++ b/src/app/api/broadcasts/[id]/metrics/route.ts
@@ -5,11 +5,22 @@ import {
   readDashboardAggregateCache,
   writeDashboardAggregateCache,
 } from "@/lib/cache/dashboard-aggregates";
-import { db } from "@/lib/db";
-import { broadcasts, emails } from "@/lib/db/schema";
-import { and, eq, sql } from "drizzle-orm";
+import { BroadcastServiceError, createBroadcastService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 import { resolveBroadcastRouteUserId } from "../../auth";
+
+const broadcastService = createBroadcastService({
+  metricsCache: {
+    ttlSeconds: BROADCAST_METRICS_CACHE_TTL_SECONDS,
+    getKey: getBroadcastMetricsCacheKey,
+    read: readDashboardAggregateCache,
+    write: writeDashboardAggregateCache,
+  },
+});
+
+function notFoundResponse() {
+  return NextResponse.json({ error: "Broadcast not found" }, { status: 404 });
+}
 
 export async function GET(
   request: NextRequest,
@@ -22,85 +33,16 @@ export async function GET(
 
   try {
     const { id } = await params;
+    const result = await broadcastService.getBroadcastMetrics({ userId, id });
 
-    const [broadcast] = await db
-      .select({ id: broadcasts.id })
-      .from(broadcasts)
-      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
-      .limit(1);
-
-    if (!broadcast) {
-      return NextResponse.json(
-        { error: "Broadcast not found" },
-        { status: 404 },
-      );
-    }
-
-    const cacheKey = getBroadcastMetricsCacheKey({
-      userId,
-      broadcastId: id,
-    });
-
-    const cached = await readDashboardAggregateCache<unknown>(cacheKey);
-    if (cached) {
-      return NextResponse.json(cached, {
-        headers: { "x-opensend-cache": "hit" },
-      });
-    }
-
-    const condition = and(
-      eq(emails.userId, userId),
-      sql`${emails.tags} @> ${JSON.stringify([{ name: "broadcast_id", value: id }])}::jsonb`,
-    );
-
-    const result = await db
-      .select({
-        total: sql<number>`count(*)::int`,
-        delivered: sql<number>`count(*) filter (where ${emails.status} = 'delivered')::int`,
-        bounced: sql<number>`count(*) filter (where ${emails.status} in ('bounced', 'hard_bounced', 'soft_bounced'))::int`,
-        complained: sql<number>`count(*) filter (where ${emails.status} = 'complained')::int`,
-        opened: sql<number>`count(*) filter (where ${emails.status} = 'opened')::int`,
-        clicked: sql<number>`count(*) filter (where ${emails.status} = 'clicked')::int`,
-      })
-      .from(emails)
-      .where(condition);
-
-    const stats = result[0] || {
-      total: 0,
-      delivered: 0,
-      bounced: 0,
-      complained: 0,
-      opened: 0,
-      clicked: 0,
-    };
-
-    const total = stats.total;
-
-    const payload = {
-      object: "broadcast_metrics",
-      broadcast_id: id,
-      total,
-      delivered: stats.delivered,
-      bounced: stats.bounced,
-      complained: stats.complained,
-      opened: stats.opened,
-      clicked: stats.clicked,
-      delivery_rate: total > 0 ? (stats.delivered / total) * 100 : 0,
-      open_rate: total > 0 ? (stats.opened / total) * 100 : 0,
-      click_rate: total > 0 ? (stats.clicked / total) * 100 : 0,
-      bounce_rate: total > 0 ? (stats.bounced / total) * 100 : 0,
-    };
-
-    await writeDashboardAggregateCache(
-      cacheKey,
-      payload,
-      BROADCAST_METRICS_CACHE_TTL_SECONDS,
-    );
-
-    return NextResponse.json(payload, {
-      headers: { "x-opensend-cache": "miss" },
+    return NextResponse.json(result.payload, {
+      headers: { "x-opensend-cache": result.cacheStatus },
     });
   } catch (error) {
+    if (error instanceof BroadcastServiceError && error.code === "not_found") {
+      return notFoundResponse();
+    }
+
     console.error("Failed to fetch broadcast metrics:", error);
     return NextResponse.json(
       { error: "Failed to fetch broadcast metrics" },

--- a/src/app/api/broadcasts/[id]/send/route.ts
+++ b/src/app/api/broadcasts/[id]/send/route.ts
@@ -1,9 +1,13 @@
 import { unauthorizedResponse } from "@/lib/api-auth";
-import { db } from "@/lib/db";
-import { broadcasts } from "@/lib/db/schema";
-import { and, eq } from "drizzle-orm";
+import { BroadcastServiceError, createBroadcastService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 import { resolveBroadcastRouteUserId } from "../../auth";
+
+const broadcastService = createBroadcastService();
+
+function notFoundResponse() {
+  return NextResponse.json({ error: "Broadcast not found" }, { status: 404 });
+}
 
 export async function POST(
   request: NextRequest,
@@ -17,38 +21,7 @@ export async function POST(
   try {
     const { id } = await params;
     const body = await request.json().catch(() => ({}));
-    const scheduledAt = body.scheduled_at ? new Date(body.scheduled_at) : null;
-
-    const [existing] = await db
-      .select({ status: broadcasts.status })
-      .from(broadcasts)
-      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
-      .limit(1);
-
-    if (!existing) {
-      return NextResponse.json(
-        { error: "Broadcast not found" },
-        { status: 404 },
-      );
-    }
-
-    if (existing.status !== "draft") {
-      return NextResponse.json(
-        { error: `Cannot send a broadcast in ${existing.status} status` },
-        { status: 400 },
-      );
-    }
-
-    const nextStatus = scheduledAt ? "scheduled" : "queued";
-
-    const [updated] = await db
-      .update(broadcasts)
-      .set({
-        status: nextStatus,
-        scheduledAt: scheduledAt,
-      })
-      .where(and(eq(broadcasts.id, id), eq(broadcasts.userId, userId)))
-      .returning();
+    const updated = await broadcastService.sendBroadcast({ userId, id, body });
 
     return NextResponse.json({
       object: "broadcast",
@@ -57,6 +30,13 @@ export async function POST(
       scheduled_at: updated.scheduledAt,
     });
   } catch (error) {
+    if (error instanceof BroadcastServiceError) {
+      if (error.code === "not_found") return notFoundResponse();
+      if (error.code === "send_forbidden") {
+        return NextResponse.json({ error: error.message }, { status: 400 });
+      }
+    }
+
     console.error("Failed to send broadcast:", error);
     return NextResponse.json(
       { error: "Failed to send broadcast" },

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -319,6 +319,75 @@ describe("route smoke coverage", () => {
             }
             return broadcast;
           },
+          async sendBroadcast(input: {
+            id: string;
+            body: Record<string, unknown>;
+          }) {
+            const [existing] = await mockSelect()
+              .from()
+              .where({ id: input.id })
+              .limit(1);
+            if (!existing) {
+              throw new BroadcastServiceError(
+                "not_found",
+                "Broadcast not found",
+              );
+            }
+            if (existing.status !== "draft") {
+              throw new BroadcastServiceError(
+                "send_forbidden",
+                `Cannot send a broadcast in ${existing.status} status`,
+              );
+            }
+            const scheduledAt = input.body.scheduled_at
+              ? new Date(String(input.body.scheduled_at))
+              : null;
+            const [broadcast] = await mockUpdate()
+              .set({
+                status: scheduledAt ? "scheduled" : "queued",
+                scheduledAt,
+              })
+              .where({ id: input.id })
+              .returning();
+            return {
+              id: broadcast.id,
+              status: broadcast.status,
+              scheduledAt: broadcast.scheduledAt ?? null,
+            };
+          },
+          async getBroadcastMetrics(_input: { userId: string; id: string }) {
+            const [broadcast] = await mockSelect().from().where().limit(1);
+            if (!broadcast) {
+              throw new BroadcastServiceError(
+                "not_found",
+                "Broadcast not found",
+              );
+            }
+            const [stats] = await mockSelect().from().where();
+            const total = Number(stats?.total ?? 0);
+            const delivered = Number(stats?.delivered ?? 0);
+            const bounced = Number(stats?.bounced ?? 0);
+            const complained = Number(stats?.complained ?? 0);
+            const opened = Number(stats?.opened ?? 0);
+            const clicked = Number(stats?.clicked ?? 0);
+            return {
+              cacheStatus: "miss",
+              payload: {
+                object: "broadcast_metrics",
+                broadcast_id: _input.id,
+                total,
+                delivered,
+                bounced,
+                complained,
+                opened,
+                clicked,
+                delivery_rate: total > 0 ? (delivered / total) * 100 : 0,
+                open_rate: total > 0 ? (opened / total) * 100 : 0,
+                click_rate: total > 0 ? (clicked / total) * 100 : 0,
+                bounce_rate: total > 0 ? (bounced / total) * 100 : 0,
+              },
+            };
+          },
         }),
         createAudienceMetadataService: () => ({
           async listSegments() {

--- a/tests/broadcast-metrics-route.test.ts
+++ b/tests/broadcast-metrics-route.test.ts
@@ -4,18 +4,30 @@ const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
 const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockReadDashboardAggregateCache = vi.hoisted(() => vi.fn());
 const mockWriteDashboardAggregateCache = vi.hoisted(() => vi.fn());
-const mockSelect = vi.hoisted(() => vi.fn());
+const mockBroadcastService = vi.hoisted(() => ({
+  getBroadcastMetrics: vi.fn(),
+}));
+const mockCreateBroadcastService = vi.hoisted(() =>
+  vi.fn(() => mockBroadcastService),
+);
 
-function makeChain<T>(rows: T[]) {
-  const chain = {
-    from: vi.fn().mockReturnThis(),
-    where: vi.fn().mockReturnThis(),
-    limit: vi.fn().mockReturnThis(),
-    // biome-ignore lint/suspicious/noThenProperty: mocks Drizzle's thenable query builder
-    then: (resolve: (value: T[]) => unknown) => Promise.resolve(resolve(rows)),
-  };
+const MockBroadcastServiceError = vi.hoisted(
+  () =>
+    class BroadcastServiceError extends Error {
+      constructor(
+        readonly code: "not_found",
+        message: string,
+      ) {
+        super(message);
+        this.name = "BroadcastServiceError";
+      }
+    },
+);
 
-  return chain;
+function makeNextRequest(url: string, init?: RequestInit) {
+  const request = new Request(url, init) as Request & { nextUrl: URL };
+  request.nextUrl = new URL(url);
+  return request;
 }
 
 vi.mock("@/lib/api-auth", () => ({
@@ -39,17 +51,10 @@ vi.mock("@/lib/cache/dashboard-aggregates", () => ({
   writeDashboardAggregateCache: mockWriteDashboardAggregateCache,
 }));
 
-vi.mock("@/lib/db", () => ({
-  db: {
-    select: mockSelect,
-  },
+vi.mock("@opensend/core", () => ({
+  BroadcastServiceError: MockBroadcastServiceError,
+  createBroadcastService: mockCreateBroadcastService,
 }));
-
-function makeNextRequest(url: string, init?: RequestInit) {
-  const request = new Request(url, init) as Request & { nextUrl: URL };
-  request.nextUrl = new URL(url);
-  return request;
-}
 
 describe("broadcast metrics route cache", () => {
   beforeEach(() => {
@@ -64,21 +69,23 @@ describe("broadcast metrics route cache", () => {
     mockWriteDashboardAggregateCache.mockResolvedValue(undefined);
   });
 
-  it("returns cached broadcast aggregates after verifying broadcast ownership", async () => {
-    mockSelect.mockReturnValueOnce(makeChain([{ id: "b1" }]));
-    mockReadDashboardAggregateCache.mockResolvedValue({
-      object: "broadcast_metrics",
-      broadcast_id: "b1",
-      total: 5,
-      delivered: 4,
-      bounced: 1,
-      complained: 0,
-      opened: 3,
-      clicked: 1,
-      delivery_rate: 80,
-      open_rate: 60,
-      click_rate: 20,
-      bounce_rate: 20,
+  it("returns cached broadcast aggregates after service ownership verification", async () => {
+    mockBroadcastService.getBroadcastMetrics.mockResolvedValue({
+      cacheStatus: "hit",
+      payload: {
+        object: "broadcast_metrics",
+        broadcast_id: "b1",
+        total: 5,
+        delivered: 4,
+        bounced: 1,
+        complained: 0,
+        opened: 3,
+        clicked: 1,
+        delivery_rate: 80,
+        open_rate: 60,
+        click_rate: 20,
+        bounce_rate: 20,
+      },
     });
 
     const route = await import("@/app/api/broadcasts/[id]/metrics/route");
@@ -91,25 +98,57 @@ describe("broadcast metrics route cache", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("x-opensend-cache")).toBe("hit");
-    expect(mockSelect).toHaveBeenCalledOnce();
-    expect(mockWriteDashboardAggregateCache).not.toHaveBeenCalled();
+    expect(mockBroadcastService.getBroadcastMetrics).toHaveBeenCalledWith({
+      userId: "user-1",
+      id: "b1",
+    });
+    expect(mockCreateBroadcastService).toHaveBeenCalledWith({
+      metricsCache: {
+        ttlSeconds: 120,
+        getKey: expect.any(Function),
+        read: mockReadDashboardAggregateCache,
+        write: mockWriteDashboardAggregateCache,
+      },
+    });
   });
 
-  it("caches fresh broadcast aggregates with a short ttl", async () => {
-    mockSelect
-      .mockReturnValueOnce(makeChain([{ id: "b1" }]))
-      .mockReturnValueOnce(
-        makeChain([
-          {
-            total: 100,
-            delivered: 95,
-            bounced: 2,
-            complained: 0,
-            opened: 40,
-            clicked: 10,
-          },
-        ]),
-      );
+  it("returns 404 when the broadcast metrics service reports not found", async () => {
+    mockBroadcastService.getBroadcastMetrics.mockRejectedValueOnce(
+      new MockBroadcastServiceError("not_found", "Broadcast not found"),
+    );
+
+    const route = await import("@/app/api/broadcasts/[id]/metrics/route");
+    const response = await route.GET(
+      makeNextRequest("http://localhost/api/broadcasts/missing/metrics", {
+        headers: { authorization: "Bearer token" },
+      }) as never,
+      { params: Promise.resolve({ id: "missing" }) },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Broadcast not found",
+    });
+  });
+
+  it("returns fresh broadcast aggregates with miss cache header", async () => {
+    mockBroadcastService.getBroadcastMetrics.mockResolvedValue({
+      cacheStatus: "miss",
+      payload: {
+        object: "broadcast_metrics",
+        broadcast_id: "b1",
+        total: 100,
+        delivered: 95,
+        bounced: 2,
+        complained: 0,
+        opened: 40,
+        clicked: 10,
+        delivery_rate: 95,
+        open_rate: 40,
+        click_rate: 10,
+        bounce_rate: 2,
+      },
+    });
 
     const route = await import("@/app/api/broadcasts/[id]/metrics/route");
     const response = await route.GET(
@@ -121,15 +160,10 @@ describe("broadcast metrics route cache", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("x-opensend-cache")).toBe("miss");
-    expect(mockWriteDashboardAggregateCache).toHaveBeenCalledOnce();
-    expect(mockWriteDashboardAggregateCache).toHaveBeenCalledWith(
-      "dashboard-aggregate:v1:broadcast-metrics:user-1:b1",
-      expect.objectContaining({
-        object: "broadcast_metrics",
-        broadcast_id: "b1",
-        total: 100,
-      }),
-      120,
-    );
+    await expect(response.json()).resolves.toMatchObject({
+      object: "broadcast_metrics",
+      broadcast_id: "b1",
+      total: 100,
+    });
   });
 });

--- a/tests/broadcast-service.test.ts
+++ b/tests/broadcast-service.test.ts
@@ -1,4 +1,5 @@
 import {
+  type BroadcastMetricsCache,
   type BroadcastRepository,
   BroadcastServiceError,
   createBroadcastService,
@@ -11,6 +12,12 @@ type BroadcastRow = NonNullable<
 type BroadcastInsert = Parameters<BroadcastRepository["create"]>[0];
 type BroadcastListOptions = Parameters<BroadcastRepository["listForApi"]>[0];
 type BroadcastUpdateData = Parameters<BroadcastRepository["updateForUser"]>[2];
+type BroadcastSendInput = Parameters<
+  BroadcastRepository["updateSendStatusForUser"]
+>[0];
+type BroadcastMetricsInput = Parameters<
+  BroadcastRepository["aggregateMetricsForBroadcast"]
+>[0];
 
 function makeBroadcast(overrides: Partial<BroadcastRow> = {}): BroadcastRow {
   return {
@@ -51,6 +58,31 @@ function makeRepository(
     },
     async findDeletionCandidateForUser() {
       return { status: "draft" };
+    },
+    async findSendCandidateForUser() {
+      return { status: "draft" };
+    },
+    async updateSendStatusForUser(input) {
+      return [
+        {
+          id: input.id,
+          status: input.status,
+          scheduledAt: input.scheduledAt,
+        },
+      ];
+    },
+    async findMetricsCandidateForUser(id) {
+      return { id };
+    },
+    async aggregateMetricsForBroadcast() {
+      return {
+        total: 0,
+        delivered: 0,
+        bounced: 0,
+        complained: 0,
+        opened: 0,
+        clicked: 0,
+      };
     },
     async listForApi() {
       return { data: [makeBroadcast()], hasMore: false };
@@ -189,6 +221,195 @@ describe("broadcast service boundary", () => {
       audienceId: "segment-3",
     });
     expect(result.replyTo).toBe("reply@example.com");
+  });
+
+  it("queues or schedules draft broadcasts through tenant-scoped send methods", async () => {
+    let candidateLookup: { id: string; userId: string } | undefined;
+    let updateInput: BroadcastSendInput | undefined;
+    const service = createBroadcastService({
+      repository: makeRepository({
+        async findSendCandidateForUser(id, userId) {
+          candidateLookup = { id, userId };
+          return { status: "draft" };
+        },
+        async updateSendStatusForUser(input) {
+          updateInput = input;
+          return [
+            {
+              id: input.id,
+              status: input.status,
+              scheduledAt: input.scheduledAt,
+            },
+          ];
+        },
+      }),
+    });
+
+    const result = await service.sendBroadcast({
+      id: "broadcast-4",
+      userId: "user-4",
+      body: { scheduled_at: "2026-06-01T00:00:00.000Z" },
+    });
+
+    expect(candidateLookup).toEqual({ id: "broadcast-4", userId: "user-4" });
+    expect(updateInput).toEqual({
+      id: "broadcast-4",
+      userId: "user-4",
+      status: "scheduled",
+      scheduledAt: new Date("2026-06-01T00:00:00.000Z"),
+    });
+    expect(result).toEqual({
+      id: "broadcast-4",
+      status: "scheduled",
+      scheduledAt: new Date("2026-06-01T00:00:00.000Z"),
+    });
+
+    const sentService = createBroadcastService({
+      repository: makeRepository({
+        async findSendCandidateForUser() {
+          return { status: "queued" };
+        },
+      }),
+    });
+
+    await expect(
+      sentService.sendBroadcast({
+        userId: "user-4",
+        id: "broadcast-4",
+        body: {},
+      }),
+    ).rejects.toMatchObject({
+      code: "send_forbidden",
+      message: "Cannot send a broadcast in queued status",
+    });
+  });
+
+  it("computes broadcast metrics with cache key behavior and tenant-scoped aggregation", async () => {
+    let metricsLookup: { id: string; userId: string } | undefined;
+    let aggregateInput: BroadcastMetricsInput | undefined;
+    const writes: Array<{ key: string; value: unknown; ttlSeconds: number }> =
+      [];
+    const cache: BroadcastMetricsCache = {
+      ttlSeconds: 120,
+      getKey(input) {
+        return `dashboard-aggregate:v1:broadcast-metrics:${input.userId}:${input.broadcastId}`;
+      },
+      async read() {
+        return null;
+      },
+      async write(key, value, ttlSeconds) {
+        writes.push({ key, value, ttlSeconds });
+      },
+    };
+    const service = createBroadcastService({
+      metricsCache: cache,
+      repository: makeRepository({
+        async findMetricsCandidateForUser(id, userId) {
+          metricsLookup = { id, userId };
+          return { id };
+        },
+        async aggregateMetricsForBroadcast(input) {
+          aggregateInput = input;
+          return {
+            total: 100,
+            delivered: 95,
+            bounced: 2,
+            complained: 1,
+            opened: 40,
+            clicked: 10,
+          };
+        },
+      }),
+    });
+
+    const result = await service.getBroadcastMetrics({
+      userId: "user-5",
+      id: "broadcast-5",
+    });
+
+    expect(metricsLookup).toEqual({ id: "broadcast-5", userId: "user-5" });
+    expect(aggregateInput).toEqual({
+      userId: "user-5",
+      broadcastId: "broadcast-5",
+    });
+    expect(result).toEqual({
+      cacheStatus: "miss",
+      payload: {
+        object: "broadcast_metrics",
+        broadcast_id: "broadcast-5",
+        total: 100,
+        delivered: 95,
+        bounced: 2,
+        complained: 1,
+        opened: 40,
+        clicked: 10,
+        delivery_rate: 95,
+        open_rate: 40,
+        click_rate: 10,
+        bounce_rate: 2,
+      },
+    });
+    expect(writes).toEqual([
+      {
+        key: "dashboard-aggregate:v1:broadcast-metrics:user-5:broadcast-5",
+        value: result.payload,
+        ttlSeconds: 120,
+      },
+    ]);
+  });
+
+  it("returns cached broadcast metrics after verifying broadcast ownership", async () => {
+    let verified = false;
+    let aggregateCalled = false;
+    const cachedPayload = {
+      object: "broadcast_metrics" as const,
+      broadcast_id: "broadcast-6",
+      total: 1,
+      delivered: 1,
+      bounced: 0,
+      complained: 0,
+      opened: 1,
+      clicked: 0,
+      delivery_rate: 100,
+      open_rate: 100,
+      click_rate: 0,
+      bounce_rate: 0,
+    };
+    const service = createBroadcastService({
+      metricsCache: {
+        ttlSeconds: 120,
+        getKey(input) {
+          return `${input.userId}:${input.broadcastId}`;
+        },
+        async read<T>() {
+          return cachedPayload as T;
+        },
+        async write() {},
+      },
+      repository: makeRepository({
+        async findMetricsCandidateForUser() {
+          verified = true;
+          return { id: "broadcast-6" };
+        },
+        async aggregateMetricsForBroadcast() {
+          aggregateCalled = true;
+          return {
+            total: 0,
+            delivered: 0,
+            bounced: 0,
+            complained: 0,
+            opened: 0,
+            clicked: 0,
+          };
+        },
+      }),
+    });
+
+    await expect(
+      service.getBroadcastMetrics({ userId: "user-6", id: "broadcast-6" }),
+    ).resolves.toEqual({ payload: cachedPayload, cacheStatus: "hit" });
+    expect(verified).toBe(true);
+    expect(aggregateCalled).toBe(false);
   });
 
   it("keeps delete preconditions in the service boundary", async () => {

--- a/tests/broadcast-tenant-routes.test.ts
+++ b/tests/broadcast-tenant-routes.test.ts
@@ -1,4 +1,3 @@
-import type { SQL } from "drizzle-orm";
 import type { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -12,12 +11,21 @@ const mockBroadcastService = vi.hoisted(() => ({
   getBroadcast: vi.fn(),
   updateBroadcast: vi.fn(),
   deleteBroadcast: vi.fn(),
+  sendBroadcast: vi.fn(),
+  getBroadcastMetrics: vi.fn(),
 }));
+const mockCreateBroadcastService = vi.hoisted(() =>
+  vi.fn(() => mockBroadcastService),
+);
 const MockBroadcastServiceError = vi.hoisted(
   () =>
     class BroadcastServiceError extends Error {
       constructor(
-        readonly code: "invalid_input" | "not_found" | "delete_forbidden",
+        readonly code:
+          | "invalid_input"
+          | "not_found"
+          | "delete_forbidden"
+          | "send_forbidden",
         message: string,
       ) {
         super(message);
@@ -25,13 +33,6 @@ const MockBroadcastServiceError = vi.hoisted(
       }
     },
 );
-const mockDb = vi.hoisted(() => ({
-  select: vi.fn(),
-  insert: vi.fn(),
-  update: vi.fn(),
-  delete: vi.fn(),
-}));
-
 vi.mock("@/lib/api-auth", () => ({
   authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
   getServerSession: mockGetServerSession,
@@ -50,38 +51,10 @@ vi.mock("@/lib/cache/dashboard-aggregates", async () => {
   };
 });
 
-vi.mock("@/lib/db", () => ({
-  db: mockDb,
-}));
-
 vi.mock("@opensend/core", () => ({
   BroadcastServiceError: MockBroadcastServiceError,
-  createBroadcastService: () => mockBroadcastService,
+  createBroadcastService: mockCreateBroadcastService,
 }));
-
-function deepValues(value: unknown, seen = new WeakSet<object>()): unknown[] {
-  if (value === null || typeof value !== "object") return [value];
-  if (seen.has(value)) return [];
-  seen.add(value);
-
-  if (Array.isArray(value)) {
-    return value.flatMap((item) => deepValues(item, seen));
-  }
-
-  return Object.values(value as Record<string, unknown>).flatMap((item) =>
-    deepValues(item, seen),
-  );
-}
-
-function expectTenantPredicate(
-  clause: SQL<unknown> | undefined,
-  userId = "user-b",
-) {
-  expect(clause).toBeDefined();
-  const values = deepValues(clause);
-  expect(values).toContain("user_id");
-  expect(values).toContain(userId);
-}
 
 function makeNextRequest(url: string, init?: RequestInit): NextRequest {
   const request = new Request(url, init) as Request & { nextUrl: URL };
@@ -98,32 +71,6 @@ function jsonRequest(url: string, body: Record<string, unknown>): NextRequest {
     },
     body: JSON.stringify(body),
   });
-}
-
-function selectRows<T>(rows: T[], whereClauses: SQL<unknown>[]) {
-  const chain = {
-    from: vi.fn(() => chain),
-    where: vi.fn((clause: SQL<unknown>) => {
-      whereClauses.push(clause);
-      return chain;
-    }),
-    orderBy: vi.fn(() => chain),
-    limit: vi.fn(() => chain),
-    // biome-ignore lint/suspicious/noThenProperty: mocks Drizzle's thenable query builder
-    then: (resolve: (value: T[]) => unknown) => Promise.resolve(resolve(rows)),
-  };
-  return chain;
-}
-
-function updateReturning<T>(rows: T[], whereClauses: SQL<unknown>[]) {
-  const returning = vi.fn().mockResolvedValue(rows);
-  const where = vi.fn((clause: SQL<unknown>) => {
-    whereClauses.push(clause);
-    return { returning };
-  });
-  const set = vi.fn(() => ({ where }));
-  mockDb.update.mockReturnValue({ set });
-  return { set, where, returning };
 }
 
 beforeEach(() => {
@@ -303,45 +250,90 @@ describe("broadcast tenant isolation", () => {
     );
   });
 
-  it("scopes broadcast send ownership checks and status updates", async () => {
-    const selectWheres: SQL<unknown>[] = [];
-    const updateWheres: SQL<unknown>[] = [];
-    mockDb.select.mockReturnValue(
-      selectRows([{ id: "broadcast-1", status: "draft" }], selectWheres),
-    );
-    updateReturning([{ id: "broadcast-1", status: "queued" }], updateWheres);
+  it("passes broadcast send requests through the service with tenant scope", async () => {
+    const scheduledAt = new Date("2026-06-01T00:00:00Z");
+    const body = { scheduled_at: scheduledAt.toISOString() };
+    mockBroadcastService.sendBroadcast.mockResolvedValueOnce({
+      id: "broadcast-1",
+      status: "scheduled",
+      scheduledAt,
+    });
 
     const { POST } = await import("@/app/api/broadcasts/[id]/send/route");
     const response = await POST(
-      jsonRequest("http://localhost:3015/api/broadcasts/broadcast-1/send", {}),
+      jsonRequest(
+        "http://localhost:3015/api/broadcasts/broadcast-1/send",
+        body,
+      ),
       { params: Promise.resolve({ id: "broadcast-1" }) },
     );
 
     expect(response.status).toBe(200);
-    expectTenantPredicate(selectWheres.at(-1));
-    expectTenantPredicate(updateWheres.at(-1));
+    await expect(response.json()).resolves.toEqual({
+      object: "broadcast",
+      id: "broadcast-1",
+      status: "scheduled",
+      scheduled_at: scheduledAt.toISOString(),
+    });
+    expect(mockBroadcastService.sendBroadcast).toHaveBeenCalledWith({
+      userId: "user-b",
+      id: "broadcast-1",
+      body,
+    });
   });
 
-  it("scopes broadcast metrics ownership, email aggregation, and cache key", async () => {
-    const broadcastWheres: SQL<unknown>[] = [];
-    const emailWheres: SQL<unknown>[] = [];
-    mockDb.select
-      .mockReturnValueOnce(selectRows([{ id: "broadcast-1" }], broadcastWheres))
-      .mockReturnValueOnce(
-        selectRows(
-          [
-            {
-              total: 2,
-              delivered: 2,
-              bounced: 0,
-              complained: 0,
-              opened: 1,
-              clicked: 1,
-            },
-          ],
-          emailWheres,
-        ),
-      );
+  it("maps broadcast send service errors to preserved HTTP responses", async () => {
+    mockBroadcastService.sendBroadcast.mockRejectedValueOnce(
+      new MockBroadcastServiceError(
+        "send_forbidden",
+        "Cannot send a broadcast in queued status",
+      ),
+    );
+
+    const { POST } = await import("@/app/api/broadcasts/[id]/send/route");
+    const forbiddenResponse = await POST(
+      jsonRequest("http://localhost:3015/api/broadcasts/broadcast-1/send", {}),
+      { params: Promise.resolve({ id: "broadcast-1" }) },
+    );
+
+    expect(forbiddenResponse.status).toBe(400);
+    await expect(forbiddenResponse.json()).resolves.toEqual({
+      error: "Cannot send a broadcast in queued status",
+    });
+
+    mockBroadcastService.sendBroadcast.mockRejectedValueOnce(
+      new MockBroadcastServiceError("not_found", "Broadcast not found"),
+    );
+
+    const missingResponse = await POST(
+      jsonRequest("http://localhost:3015/api/broadcasts/missing/send", {}),
+      { params: Promise.resolve({ id: "missing" }) },
+    );
+
+    expect(missingResponse.status).toBe(404);
+    await expect(missingResponse.json()).resolves.toEqual({
+      error: "Broadcast not found",
+    });
+  });
+
+  it("passes broadcast metrics requests through the service with cache headers", async () => {
+    mockBroadcastService.getBroadcastMetrics.mockResolvedValueOnce({
+      cacheStatus: "miss",
+      payload: {
+        object: "broadcast_metrics",
+        broadcast_id: "broadcast-1",
+        total: 2,
+        delivered: 2,
+        bounced: 0,
+        complained: 0,
+        opened: 1,
+        clicked: 1,
+        delivery_rate: 100,
+        open_rate: 50,
+        click_rate: 50,
+        bounce_rate: 0,
+      },
+    });
 
     const { GET } = await import("@/app/api/broadcasts/[id]/metrics/route");
     const response = await GET(
@@ -353,15 +345,18 @@ describe("broadcast tenant isolation", () => {
     );
 
     expect(response.status).toBe(200);
-    expectTenantPredicate(broadcastWheres.at(-1));
-    expectTenantPredicate(emailWheres.at(-1));
-    expect(mockReadDashboardAggregateCache).toHaveBeenCalledWith(
-      "dashboard-aggregate:v1:broadcast-metrics:user-b:broadcast-1",
-    );
-    expect(mockWriteDashboardAggregateCache).toHaveBeenCalledWith(
-      "dashboard-aggregate:v1:broadcast-metrics:user-b:broadcast-1",
-      expect.objectContaining({ object: "broadcast_metrics" }),
-      120,
-    );
+    expect(response.headers.get("x-opensend-cache")).toBe("miss");
+    expect(mockBroadcastService.getBroadcastMetrics).toHaveBeenCalledWith({
+      userId: "user-b",
+      id: "broadcast-1",
+    });
+    expect(mockCreateBroadcastService).toHaveBeenLastCalledWith({
+      metricsCache: expect.objectContaining({
+        ttlSeconds: 120,
+        getKey: expect.any(Function),
+        read: mockReadDashboardAggregateCache,
+        write: mockWriteDashboardAggregateCache,
+      }),
+    });
   });
 });


### PR DESCRIPTION
## Summary\n- Extract broadcast send status transition and scheduled_at handling into the reusable broadcast core service.\n- Extract broadcast metrics ownership check, dashboard aggregate cache read/write, broadcast_id tag aggregation, and rate calculation into the core service.\n- Keep send and metrics route handlers as thin auth/request/response adapters and update focused route/service coverage.\n\nCloses #334\n\n## Validation\n- bun run test -- tests/broadcast-tenant-routes.test.ts\n- bun run test -- tests/broadcast-metrics-route.test.ts\n- bun run test -- tests/broadcast-service.test.ts\n- make check\n- make test\n