### PR TITLE
Extract contacts operations service boundary

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,7 @@ export * from "./services/domain-events";
 export * from "./services/webhook";
 export * from "./services/apiKeys";
 export * from "./services/contact";
+export * from "./services/contact-operations";
 export * from "./services/email";
 export * from "./services/emailRead";
 export * from "./services/logs";

--- a/packages/core/src/services/contact-operations.ts
+++ b/packages/core/src/services/contact-operations.ts
@@ -1,0 +1,499 @@
+import { and, eq, inArray, or } from "drizzle-orm";
+import { db } from "../db/client";
+import { contacts, segments, topics } from "../db/schema";
+
+type ContactRow = typeof contacts.$inferSelect;
+type ContactInsert = typeof contacts.$inferInsert;
+type SegmentRow = typeof segments.$inferSelect;
+type TopicRow = typeof topics.$inferSelect;
+
+type ContactTopicSubscription = { topicId: string; subscribed: boolean };
+type PublicContactTopicSubscription = "opt_in" | "opt_out";
+
+type ImportCsvRow = Record<string, string | undefined>;
+type ImportMapping = Record<string, string>;
+
+type ImportMappedContact = {
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+};
+
+export type ContactBulkActionInput = {
+  userId: string;
+  body: unknown;
+};
+
+export type ImportContactsInput = {
+  userId: string;
+  rows: ImportCsvRow[];
+  mapping: ImportMapping;
+  segmentId?: string | null;
+};
+
+export type ListContactTopicsInput = {
+  userId: string;
+  idOrEmail: string;
+};
+
+export type UpdateContactTopicsInput = {
+  userId: string;
+  idOrEmail: string;
+  body: unknown | (() => Promise<unknown>);
+};
+
+export type ContactBulkActionResult = {
+  object: "bulk_action";
+  success: true;
+  count: number;
+};
+
+export type ImportContactsResult = {
+  object: "import";
+  created_count: number;
+  ids: string[];
+};
+
+export type ContactTopicListItem = {
+  id: string;
+  name: string;
+  subscription: PublicContactTopicSubscription;
+};
+
+export type ContactTopicsListResult = {
+  object: "list";
+  data: ContactTopicListItem[];
+};
+
+export type ContactTopicsUpdateResult = {
+  object: "contact_topics";
+  contact_id: string;
+  updated: true;
+};
+
+export type ContactOperationsServiceErrorCode = "invalid_input" | "not_found";
+
+export class ContactOperationsServiceError extends Error {
+  constructor(
+    readonly code: ContactOperationsServiceErrorCode,
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "ContactOperationsServiceError";
+  }
+}
+
+export type ContactOperationsRepository = {
+  findContactByIdOrEmailForUser(
+    idOrEmail: string,
+    userId: string,
+  ): Promise<ContactRow | undefined>;
+  findContactByEmailForUser(
+    email: string,
+    userId: string,
+  ): Promise<ContactRow | undefined>;
+  findContactsByIdsForUser(
+    contactIds: unknown[],
+    userId: string,
+  ): Promise<ContactRow[]>;
+  createContact(data: ContactInsert): Promise<Array<{ id: string }>>;
+  updateContactForUser(
+    id: string,
+    userId: string,
+    data: Partial<ContactInsert>,
+  ): Promise<unknown>;
+  findSegmentByIdForUser(
+    segmentId: string,
+    userId: string,
+  ): Promise<SegmentRow | undefined>;
+  findTopicByIdForUser(
+    topicId: string,
+    userId: string,
+  ): Promise<TopicRow | undefined>;
+};
+
+export type ContactOperationsServiceDependencies = {
+  repository?: ContactOperationsRepository;
+};
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeSegments(value: ContactRow["segments"]): string[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeTopicSubscriptions(
+  value: ContactRow["topicSubscriptions"],
+): ContactTopicSubscription[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeCustomProperties(
+  value: ContactRow["customProperties"],
+): Record<string, string> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : {};
+}
+
+function mapInternalToPublicSubscription(
+  subscribed: boolean,
+): PublicContactTopicSubscription {
+  return subscribed ? "opt_in" : "opt_out";
+}
+
+function mapPublicToInternalSubscription(subscription: unknown): boolean {
+  return subscription === "opt_in";
+}
+
+function invalidInput(message: string, status = 422) {
+  return new ContactOperationsServiceError("invalid_input", message, status);
+}
+
+function notFound(message: string) {
+  return new ContactOperationsServiceError("not_found", message, 404);
+}
+
+function defaultRepository(): ContactOperationsRepository {
+  return {
+    async findContactByIdOrEmailForUser(idOrEmail, userId) {
+      return await db.query.contacts.findFirst({
+        where: and(
+          isUuid(idOrEmail)
+            ? or(eq(contacts.id, idOrEmail), eq(contacts.email, idOrEmail))
+            : eq(contacts.email, idOrEmail),
+          eq(contacts.userId, userId),
+        ),
+      });
+    },
+    async findContactByEmailForUser(email, userId) {
+      return await db.query.contacts.findFirst({
+        where: and(eq(contacts.email, email), eq(contacts.userId, userId)),
+      });
+    },
+    async findContactsByIdsForUser(contactIds, userId) {
+      return await db.query.contacts.findMany({
+        where: and(
+          inArray(contacts.id, contactIds as string[]),
+          eq(contacts.userId, userId),
+        ),
+      });
+    },
+    async createContact(data) {
+      return await db
+        .insert(contacts)
+        .values(data)
+        .returning({ id: contacts.id });
+    },
+    async updateContactForUser(id, userId, data) {
+      return await db
+        .update(contacts)
+        .set(data)
+        .where(and(eq(contacts.id, id), eq(contacts.userId, userId)));
+    },
+    async findSegmentByIdForUser(segmentId, userId) {
+      return await db.query.segments.findFirst({
+        where: and(eq(segments.id, segmentId), eq(segments.userId, userId)),
+      });
+    },
+    async findTopicByIdForUser(topicId, userId) {
+      return await db.query.topics.findFirst({
+        where: and(eq(topics.id, topicId), eq(topics.userId, userId)),
+      });
+    },
+  };
+}
+
+function parseBulkBody(body: unknown): {
+  contactIds: unknown[];
+  segmentId?: string;
+  topicId?: string;
+  action?: unknown;
+} {
+  const payload = isRecord(body) ? body : {};
+  const contactIds = payload.contact_ids;
+
+  if (!Array.isArray(contactIds) || contactIds.length === 0) {
+    throw invalidInput("contact_ids must be a non-empty array");
+  }
+
+  return {
+    contactIds,
+    segmentId:
+      typeof payload.segment_id === "string" ? payload.segment_id : undefined,
+    topicId:
+      typeof payload.topic_id === "string" ? payload.topic_id : undefined,
+    action: payload.action,
+  };
+}
+
+function mapImportRow(
+  row: ImportCsvRow,
+  mapping: ImportMapping,
+): { data: ImportMappedContact; customProps: Record<string, string> } {
+  const data: ImportMappedContact = {};
+  const customProps: Record<string, string> = {};
+
+  for (const [colName, colValue] of Object.entries(row)) {
+    const mappedKey = mapping[colName];
+    if (!mappedKey) continue;
+
+    const value = colValue?.trim();
+    if (mappedKey === "email") data.email = value?.toLowerCase();
+    else if (mappedKey === "first_name") data.firstName = value;
+    else if (mappedKey === "last_name") data.lastName = value;
+    else if (value !== undefined) customProps[mappedKey] = value;
+  }
+
+  return { data, customProps };
+}
+
+async function resolveRequestBody(
+  body: unknown | (() => Promise<unknown>),
+): Promise<unknown> {
+  return typeof body === "function" ? await body() : body;
+}
+
+function parseTopicsBody(body: unknown): Array<{
+  id: unknown;
+  subscription: unknown;
+}> {
+  const payload = isRecord(body) ? body : {};
+  const newTopics = payload.topics;
+
+  if (!Array.isArray(newTopics)) {
+    throw invalidInput("topics must be an array");
+  }
+
+  return newTopics.map((topic) => {
+    const record = isRecord(topic) ? topic : {};
+    return {
+      id: record.id,
+      subscription: record.subscription,
+    };
+  });
+}
+
+export function createContactOperationsService({
+  repository = defaultRepository(),
+}: ContactOperationsServiceDependencies = {}) {
+  return {
+    async bulkAction(
+      input: ContactBulkActionInput,
+    ): Promise<ContactBulkActionResult> {
+      const { contactIds, segmentId, topicId, action } = parseBulkBody(
+        input.body,
+      );
+
+      if (action === "add_to_segment") {
+        if (!segmentId) throw invalidInput("segment_id is required");
+
+        const segment = await repository.findSegmentByIdForUser(
+          segmentId,
+          input.userId,
+        );
+        if (!segment) throw notFound("Segment not found");
+
+        const targetContacts = await repository.findContactsByIdsForUser(
+          contactIds,
+          input.userId,
+        );
+
+        await Promise.all(
+          targetContacts.map(async (contact) => {
+            const currentSegments = normalizeSegments(contact.segments);
+            if (!currentSegments.includes(segment.name)) {
+              await repository.updateContactForUser(contact.id, input.userId, {
+                segments: [...currentSegments, segment.name],
+              });
+            }
+          }),
+        );
+
+        return {
+          object: "bulk_action",
+          success: true,
+          count: targetContacts.length,
+        };
+      }
+
+      if (action === "subscribe_to_topic") {
+        if (!topicId) throw invalidInput("topic_id is required");
+
+        const topic = await repository.findTopicByIdForUser(
+          topicId,
+          input.userId,
+        );
+        if (!topic) throw notFound("Topic not found");
+
+        const targetContacts = await repository.findContactsByIdsForUser(
+          contactIds,
+          input.userId,
+        );
+
+        await Promise.all(
+          targetContacts.map(async (contact) => {
+            const currentTopics = normalizeTopicSubscriptions(
+              contact.topicSubscriptions,
+            );
+            const exists = currentTopics.some(
+              (subscription) => subscription.topicId === topic.id,
+            );
+            const updatedSubscriptions = exists
+              ? currentTopics.map((subscription) =>
+                  subscription.topicId === topic.id
+                    ? { ...subscription, subscribed: true }
+                    : subscription,
+                )
+              : [...currentTopics, { topicId: topic.id, subscribed: true }];
+
+            await repository.updateContactForUser(contact.id, input.userId, {
+              topicSubscriptions: updatedSubscriptions,
+            });
+          }),
+        );
+
+        return {
+          object: "bulk_action",
+          success: true,
+          count: targetContacts.length,
+        };
+      }
+
+      throw invalidInput("Invalid action", 400);
+    },
+
+    async importContacts(
+      input: ImportContactsInput,
+    ): Promise<ImportContactsResult> {
+      let segmentName = "";
+      if (input.segmentId) {
+        const segment = await repository.findSegmentByIdForUser(
+          input.segmentId,
+          input.userId,
+        );
+        if (segment) segmentName = segment.name;
+      }
+
+      const createdIds: string[] = [];
+
+      for (const row of input.rows) {
+        const { data, customProps } = mapImportRow(row, input.mapping);
+        if (!data.email) continue;
+
+        const existing = await repository.findContactByEmailForUser(
+          data.email,
+          input.userId,
+        );
+
+        if (existing) {
+          const currentSegments = normalizeSegments(existing.segments);
+          const updatedSegments =
+            segmentName && !currentSegments.includes(segmentName)
+              ? [...currentSegments, segmentName]
+              : currentSegments;
+
+          await repository.updateContactForUser(existing.id, input.userId, {
+            firstName: data.firstName || existing.firstName,
+            lastName: data.lastName || existing.lastName,
+            segments: updatedSegments,
+            customProperties: {
+              ...normalizeCustomProperties(existing.customProperties),
+              ...customProps,
+            },
+          });
+          createdIds.push(existing.id);
+        } else {
+          const [inserted] = await repository.createContact({
+            email: data.email,
+            firstName: data.firstName || null,
+            lastName: data.lastName || null,
+            segments: segmentName ? [segmentName] : null,
+            customProperties: customProps,
+            userId: input.userId,
+          });
+          createdIds.push(inserted.id);
+        }
+      }
+
+      return {
+        object: "import",
+        created_count: createdIds.length,
+        ids: createdIds,
+      };
+    },
+
+    async listContactTopics(
+      input: ListContactTopicsInput,
+    ): Promise<ContactTopicsListResult> {
+      const contact = await repository.findContactByIdOrEmailForUser(
+        input.idOrEmail,
+        input.userId,
+      );
+      if (!contact) throw notFound("Contact not found");
+
+      const subscriptions = normalizeTopicSubscriptions(
+        contact.topicSubscriptions,
+      );
+      const data = await Promise.all(
+        subscriptions.map(async (subscription) => {
+          const topic = await repository.findTopicByIdForUser(
+            subscription.topicId,
+            input.userId,
+          );
+          if (!topic) return null;
+          return {
+            id: topic.id,
+            name: topic.name,
+            subscription: mapInternalToPublicSubscription(
+              subscription.subscribed,
+            ),
+          };
+        }),
+      ).then((results) => results.filter((row) => row !== null));
+
+      return {
+        object: "list",
+        data,
+      };
+    },
+
+    async updateContactTopics(
+      input: UpdateContactTopicsInput,
+    ): Promise<ContactTopicsUpdateResult> {
+      const contact = await repository.findContactByIdOrEmailForUser(
+        input.idOrEmail,
+        input.userId,
+      );
+      if (!contact) throw notFound("Contact not found");
+
+      const body = await resolveRequestBody(input.body);
+      const newTopics = parseTopicsBody(body);
+      const updatedSubscriptions = newTopics.map((topic) => ({
+        topicId: topic.id as string,
+        subscribed: mapPublicToInternalSubscription(topic.subscription),
+      }));
+
+      await repository.updateContactForUser(contact.id, input.userId, {
+        topicSubscriptions: updatedSubscriptions,
+      });
+
+      return {
+        object: "contact_topics",
+        contact_id: contact.id,
+        updated: true,
+      };
+    },
+  };
+}
+
+export const contactOperationsService = createContactOperationsService();

--- a/src/app/api/contacts/[id]/topics/route.ts
+++ b/src/app/api/contacts/[id]/topics/route.ts
@@ -1,43 +1,50 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { contacts, topics } from "@/lib/db/schema";
-import { and, eq, or } from "drizzle-orm";
+import {
+  ContactOperationsServiceError,
+  createContactOperationsService,
+} from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 
-async function findContact(idOrEmail: string, userId: string) {
-  const isUuid =
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-      idOrEmail,
+function contactOperationsService() {
+  return createContactOperationsService();
+}
+
+function mapFetchContactTopicsError(error: unknown) {
+  if (error instanceof ContactOperationsServiceError) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: error.status },
     );
+  }
 
-  return await db.query.contacts.findFirst({
-    where: and(
-      isUuid
-        ? or(eq(contacts.id, idOrEmail), eq(contacts.email, idOrEmail))
-        : eq(contacts.email, idOrEmail),
-      eq(contacts.userId, userId),
-    ),
-  });
+  console.error("Failed to fetch contact topics:", error);
+  return NextResponse.json(
+    { error: "Failed to fetch contact topics" },
+    { status: 500 },
+  );
 }
 
-function mapInternalToPublicSubscription(
-  subscribed: boolean,
-): "opt_in" | "opt_out" {
-  return subscribed ? "opt_in" : "opt_out";
-}
+function mapUpdateContactTopicsError(error: unknown) {
+  if (error instanceof ContactOperationsServiceError) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: error.status },
+    );
+  }
 
-function mapPublicToInternalSubscription(
-  subscription: "opt_in" | "opt_out",
-): boolean {
-  return subscription === "opt_in";
+  console.error("Failed to update contact topics:", error);
+  return NextResponse.json(
+    { error: "Failed to update contact topics" },
+    { status: 500 },
+  );
 }
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await validateApiKey(_request.headers.get("authorization"));
+  const auth = await validateApiKey(request.headers.get("authorization"));
   if (!auth) return unauthorizedResponse();
   const permissionError = requireFullAccessApiKey(auth);
   if (permissionError) return permissionError;
@@ -46,42 +53,14 @@ export async function GET(
 
   try {
     const { id: idOrEmail } = await params;
-    const contact = await findContact(idOrEmail, userId);
-
-    if (!contact) {
-      return NextResponse.json({ error: "Contact not found" }, { status: 404 });
-    }
-
-    const subscriptions =
-      (contact.topicSubscriptions as Array<{
-        topicId: string;
-        subscribed: boolean;
-      }> | null) ?? [];
-
-    const data = await Promise.all(
-      subscriptions.map(async (sub) => {
-        const topic = await db.query.topics.findFirst({
-          where: and(eq(topics.id, sub.topicId), eq(topics.userId, userId)),
-        });
-        if (!topic) return null;
-        return {
-          id: topic.id,
-          name: topic.name,
-          subscription: mapInternalToPublicSubscription(sub.subscribed),
-        };
-      }),
-    ).then((results) => results.filter((r) => r !== null));
-
-    return NextResponse.json({
-      object: "list",
-      data,
+    const result = await contactOperationsService().listContactTopics({
+      idOrEmail,
+      userId,
     });
+
+    return NextResponse.json(result);
   } catch (error) {
-    console.error("Failed to fetch contact topics:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch contact topics" },
-      { status: 500 },
-    );
+    return mapFetchContactTopicsError(error);
   }
 }
 
@@ -98,46 +77,14 @@ export async function PATCH(
 
   try {
     const { id: idOrEmail } = await params;
-    const contact = await findContact(idOrEmail, userId);
-
-    if (!contact) {
-      return NextResponse.json({ error: "Contact not found" }, { status: 404 });
-    }
-
-    const body = await request.json();
-    const newTopics = body.topics as Array<{
-      id: string;
-      subscription: "opt_in" | "opt_out";
-    }>;
-
-    if (!Array.isArray(newTopics)) {
-      return NextResponse.json(
-        { error: "topics must be an array" },
-        { status: 422 },
-      );
-    }
-
-    // Replace current subscriptions with new ones mapped to internal boolean
-    const updatedSubscriptions = newTopics.map((t) => ({
-      topicId: t.id,
-      subscribed: mapPublicToInternalSubscription(t.subscription),
-    }));
-
-    await db
-      .update(contacts)
-      .set({ topicSubscriptions: updatedSubscriptions })
-      .where(and(eq(contacts.id, contact.id), eq(contacts.userId, userId)));
-
-    return NextResponse.json({
-      object: "contact_topics",
-      contact_id: contact.id,
-      updated: true,
+    const result = await contactOperationsService().updateContactTopics({
+      idOrEmail,
+      userId,
+      body: () => request.json(),
     });
+
+    return NextResponse.json(result);
   } catch (error) {
-    console.error("Failed to update contact topics:", error);
-    return NextResponse.json(
-      { error: "Failed to update contact topics" },
-      { status: 500 },
-    );
+    return mapUpdateContactTopicsError(error);
   }
 }

--- a/src/app/api/contacts/bulk/route.ts
+++ b/src/app/api/contacts/bulk/route.ts
@@ -1,9 +1,26 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { contacts, segments, topics } from "@/lib/db/schema";
-import { and, eq, inArray } from "drizzle-orm";
+import {
+  ContactOperationsServiceError,
+  createContactOperationsService,
+} from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
+
+function contactOperationsService() {
+  return createContactOperationsService();
+}
+
+function mapContactOperationsError(error: unknown) {
+  if (error instanceof ContactOperationsServiceError) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: error.status },
+    );
+  }
+
+  console.error("Failed bulk action:", error);
+  return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+}
 
 export async function POST(request: NextRequest) {
   const auth = await validateApiKey(request.headers.get("authorization"));
@@ -15,120 +32,13 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { contact_ids, segment_id, topic_id, action } = body;
+    const result = await contactOperationsService().bulkAction({
+      userId,
+      body,
+    });
 
-    if (!Array.isArray(contact_ids) || contact_ids.length === 0) {
-      return NextResponse.json(
-        { error: "contact_ids must be a non-empty array" },
-        { status: 422 },
-      );
-    }
-
-    if (action === "add_to_segment") {
-      if (!segment_id)
-        return NextResponse.json(
-          { error: "segment_id is required" },
-          { status: 422 },
-        );
-
-      const segment = await db.query.segments.findFirst({
-        where: and(eq(segments.id, segment_id), eq(segments.userId, userId)),
-      });
-      if (!segment)
-        return NextResponse.json(
-          { error: "Segment not found" },
-          { status: 404 },
-        );
-
-      const targetContacts = await db.query.contacts.findMany({
-        where: and(
-          inArray(contacts.id, contact_ids),
-          eq(contacts.userId, userId),
-        ),
-      });
-
-      await Promise.all(
-        targetContacts.map(async (c) => {
-          const currentSegments = (c.segments as string[]) ?? [];
-          if (!currentSegments.includes(segment.name)) {
-            await db
-              .update(contacts)
-              .set({ segments: [...currentSegments, segment.name] })
-              .where(and(eq(contacts.id, c.id), eq(contacts.userId, userId)));
-          }
-        }),
-      );
-
-      return NextResponse.json({
-        object: "bulk_action",
-        success: true,
-        count: targetContacts.length,
-      });
-    }
-
-    if (action === "subscribe_to_topic") {
-      if (!topic_id)
-        return NextResponse.json(
-          { error: "topic_id is required" },
-          { status: 422 },
-        );
-
-      const topic = await db.query.topics.findFirst({
-        where: and(eq(topics.id, topic_id), eq(topics.userId, userId)),
-      });
-      if (!topic)
-        return NextResponse.json({ error: "Topic not found" }, { status: 404 });
-
-      const targetContacts = await db.query.contacts.findMany({
-        where: and(
-          inArray(contacts.id, contact_ids),
-          eq(contacts.userId, userId),
-        ),
-      });
-
-      await Promise.all(
-        targetContacts.map(async (c) => {
-          const currentTopics =
-            (c.topicSubscriptions as Array<{
-              topicId: string;
-              subscribed: boolean;
-            }> | null) ?? [];
-          const exists = currentTopics.some((t) => t.topicId === topic.id);
-          if (!exists) {
-            await db
-              .update(contacts)
-              .set({
-                topicSubscriptions: [
-                  ...currentTopics,
-                  { topicId: topic.id, subscribed: true },
-                ],
-              })
-              .where(and(eq(contacts.id, c.id), eq(contacts.userId, userId)));
-          } else {
-            const updated = currentTopics.map((t) =>
-              t.topicId === topic.id ? { ...t, subscribed: true } : t,
-            );
-            await db
-              .update(contacts)
-              .set({ topicSubscriptions: updated })
-              .where(and(eq(contacts.id, c.id), eq(contacts.userId, userId)));
-          }
-        }),
-      );
-
-      return NextResponse.json({
-        object: "bulk_action",
-        success: true,
-        count: targetContacts.length,
-      });
-    }
-
-    return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+    return NextResponse.json(result);
   } catch (error) {
-    console.error("Failed bulk action:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
+    return mapContactOperationsError(error);
   }
 }

--- a/src/app/api/contacts/import/route.ts
+++ b/src/app/api/contacts/import/route.ts
@@ -1,10 +1,12 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { contacts, segments } from "@/lib/db/schema";
-import { and, eq } from "drizzle-orm";
+import { createContactOperationsService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 import Papa from "papaparse";
+
+function contactOperationsService() {
+  return createContactOperationsService();
+}
 
 export async function POST(request: NextRequest) {
   const auth = await validateApiKey(request.headers.get("authorization"));
@@ -32,83 +34,14 @@ export async function POST(request: NextRequest) {
     });
     const rows = parseResult.data as Record<string, string>[];
 
-    // Resolve segment if provided
-    let segmentName = "";
-    if (segmentId) {
-      const seg = await db.query.segments.findFirst({
-        where: and(eq(segments.id, segmentId), eq(segments.userId, userId)),
-      });
-      if (seg) segmentName = seg.name;
-    }
-
-    const createdIds: string[] = [];
-
-    for (const row of rows) {
-      const data: { email?: string; firstName?: string; lastName?: string } =
-        {};
-      const customProps: Record<string, string> = {};
-
-      for (const [colName, colValue] of Object.entries(row)) {
-        const mappedKey = mapping[colName];
-        if (mappedKey) {
-          const value = colValue?.trim();
-          if (mappedKey === "email") data.email = value?.toLowerCase();
-          else if (mappedKey === "first_name") data.firstName = value;
-          else if (mappedKey === "last_name") data.lastName = value;
-          else customProps[mappedKey] = value;
-        }
-      }
-
-      if (!data.email) continue;
-
-      // Simple upsert logic
-      const existing = await db.query.contacts.findFirst({
-        where: and(eq(contacts.email, data.email), eq(contacts.userId, userId)),
-      });
-
-      if (existing) {
-        const currentSegments = (existing.segments as string[]) ?? [];
-        const updatedSegments =
-          segmentName && !currentSegments.includes(segmentName)
-            ? [...currentSegments, segmentName]
-            : currentSegments;
-
-        await db
-          .update(contacts)
-          .set({
-            firstName: data.firstName || existing.firstName,
-            lastName: data.lastName || existing.lastName,
-            segments: updatedSegments,
-            customProperties: {
-              ...((existing.customProperties as Record<string, string>) || {}),
-              ...customProps,
-            },
-          })
-          .where(
-            and(eq(contacts.id, existing.id), eq(contacts.userId, userId)),
-          );
-        createdIds.push(existing.id);
-      } else {
-        const [inserted] = await db
-          .insert(contacts)
-          .values({
-            email: data.email,
-            firstName: data.firstName || null,
-            lastName: data.lastName || null,
-            segments: segmentName ? [segmentName] : null,
-            customProperties: customProps,
-            userId: userId,
-          })
-          .returning({ id: contacts.id });
-        createdIds.push(inserted.id);
-      }
-    }
-
-    return NextResponse.json({
-      object: "import",
-      created_count: createdIds.length,
-      ids: createdIds,
+    const result = await contactOperationsService().importContacts({
+      userId,
+      rows,
+      mapping,
+      segmentId,
     });
+
+    return NextResponse.json(result);
   } catch (error) {
     console.error("Failed contact import:", error);
     return NextResponse.json(

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -22,6 +22,12 @@ const mockContactService = vi.hoisted(() => ({
   addContactToSegment: vi.fn(),
   removeContactFromSegment: vi.fn(),
 }));
+const mockContactOperationsService = vi.hoisted(() => ({
+  bulkAction: vi.fn(),
+  importContacts: vi.fn(),
+  listContactTopics: vi.fn(),
+  updateContactTopics: vi.fn(),
+}));
 
 function makeChain<T>(rows: T[]) {
   return {
@@ -222,6 +228,16 @@ describe("route smoke coverage", () => {
           this.name = "ContactServiceError";
         }
       }
+      class ContactOperationsServiceError extends Error {
+        constructor(
+          readonly code: string,
+          message: string,
+          readonly status: number,
+        ) {
+          super(message);
+          this.name = "ContactOperationsServiceError";
+        }
+      }
       class BroadcastServiceError extends Error {
         constructor(
           readonly code: string,
@@ -251,6 +267,7 @@ describe("route smoke coverage", () => {
         createWebhookService: mockCreateWebhookService,
         TemplateServiceError,
         ContactServiceError,
+        ContactOperationsServiceError,
         BroadcastServiceError,
         AudienceMetadataServiceError,
         createBroadcastService: () => ({
@@ -590,6 +607,7 @@ describe("route smoke coverage", () => {
           },
         }),
         createContactService: () => mockContactService,
+        createContactOperationsService: () => mockContactOperationsService,
         createTemplateService: () => ({
           async getTemplate(id: string) {
             const [template] = await mockSelect().from().where({ id }).limit(1);
@@ -690,6 +708,29 @@ describe("route smoke coverage", () => {
     mockContactService.listContactSegments.mockReset();
     mockContactService.addContactToSegment.mockReset();
     mockContactService.removeContactFromSegment.mockReset();
+    mockContactOperationsService.bulkAction.mockReset();
+    mockContactOperationsService.importContacts.mockReset();
+    mockContactOperationsService.listContactTopics.mockReset();
+    mockContactOperationsService.updateContactTopics.mockReset();
+    mockContactOperationsService.bulkAction.mockResolvedValue({
+      object: "bulk_action",
+      success: true,
+      count: 1,
+    });
+    mockContactOperationsService.importContacts.mockResolvedValue({
+      object: "import",
+      created_count: 0,
+      ids: [],
+    });
+    mockContactOperationsService.listContactTopics.mockResolvedValue({
+      object: "list",
+      data: [{ id: "t1", name: "News", subscription: "opt_in" }],
+    });
+    mockContactOperationsService.updateContactTopics.mockResolvedValue({
+      object: "contact_topics",
+      contact_id: "c1",
+      updated: true,
+    });
     vi.doMock("@/lib/api-auth", async () => {
       const actual =
         await vi.importActual<typeof import("@/lib/api-auth")>(

--- a/tests/contact-operations-routes.test.ts
+++ b/tests/contact-operations-routes.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockBulkAction = vi.hoisted(() => vi.fn());
+const mockImportContacts = vi.hoisted(() => vi.fn());
+const mockListContactTopics = vi.hoisted(() => vi.fn());
+const mockUpdateContactTopics = vi.hoisted(() => vi.fn());
+
+const MockContactOperationsServiceError = vi.hoisted(
+  () =>
+    class ContactOperationsServiceError extends Error {
+      constructor(
+        readonly code: "invalid_input" | "not_found",
+        message: string,
+        readonly status: number,
+      ) {
+        super(message);
+        this.name = "ContactOperationsServiceError";
+      }
+    },
+);
+
+function makeRequest(url: string, init?: RequestInit) {
+  const request = new Request(url, init) as Request & { nextUrl: URL };
+  request.nextUrl = new URL(url);
+  return request;
+}
+
+vi.mock("@/lib/api-auth", () => ({
+  validateApiKey: mockValidateApiKey,
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/api-key-permissions", () => ({
+  requireFullAccessApiKey: (auth: { permission?: string }) =>
+    auth.permission === "full_access"
+      ? null
+      : Response.json({ error: "Forbidden" }, { status: 403 }),
+}));
+
+vi.mock("@opensend/core", () => ({
+  ContactOperationsServiceError: MockContactOperationsServiceError,
+  createContactOperationsService: () => ({
+    bulkAction: mockBulkAction,
+    importContacts: mockImportContacts,
+    listContactTopics: mockListContactTopics,
+    updateContactTopics: mockUpdateContactTopics,
+  }),
+}));
+
+describe("contact operations route adapters", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue({
+      apiKeyId: "key-1",
+      permission: "full_access",
+      domain: null,
+      userId: "user-1",
+    });
+  });
+
+  it("keeps /api/contacts/bulk auth in the route and delegates body/user to the service", async () => {
+    mockBulkAction.mockResolvedValueOnce({
+      object: "bulk_action",
+      success: true,
+      count: 1,
+    });
+
+    const route = await import("@/app/api/contacts/bulk/route");
+    const response = await route.POST(
+      makeRequest("http://localhost/api/contacts/bulk", {
+        method: "POST",
+        headers: { authorization: "Bearer key" },
+        body: JSON.stringify({
+          action: "add_to_segment",
+          segment_id: "segment-1",
+          contact_ids: ["contact-1"],
+        }),
+      }) as never,
+    );
+
+    expect(mockValidateApiKey).toHaveBeenCalledWith("Bearer key");
+    expect(mockBulkAction).toHaveBeenCalledWith({
+      userId: "user-1",
+      body: {
+        action: "add_to_segment",
+        segment_id: "segment-1",
+        contact_ids: ["contact-1"],
+      },
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      object: "bulk_action",
+      success: true,
+      count: 1,
+    });
+  });
+
+  it("maps bulk service validation and not-found errors to legacy response bodies", async () => {
+    mockBulkAction.mockRejectedValueOnce(
+      new MockContactOperationsServiceError(
+        "invalid_input",
+        "contact_ids must be a non-empty array",
+        422,
+      ),
+    );
+
+    const route = await import("@/app/api/contacts/bulk/route");
+    const validationResponse = await route.POST(
+      makeRequest("http://localhost/api/contacts/bulk", {
+        method: "POST",
+        headers: { authorization: "Bearer key" },
+        body: JSON.stringify({ action: "add_to_segment" }),
+      }) as never,
+    );
+
+    expect(validationResponse.status).toBe(422);
+    await expect(validationResponse.json()).resolves.toEqual({
+      error: "contact_ids must be a non-empty array",
+    });
+
+    mockBulkAction.mockRejectedValueOnce(
+      new MockContactOperationsServiceError(
+        "not_found",
+        "Segment not found",
+        404,
+      ),
+    );
+    const notFoundResponse = await route.POST(
+      makeRequest("http://localhost/api/contacts/bulk", {
+        method: "POST",
+        headers: { authorization: "Bearer key" },
+        body: JSON.stringify({
+          action: "add_to_segment",
+          segment_id: "missing",
+          contact_ids: ["contact-1"],
+        }),
+      }) as never,
+    );
+
+    expect(notFoundResponse.status).toBe(404);
+    await expect(notFoundResponse.json()).resolves.toEqual({
+      error: "Segment not found",
+    });
+  });
+
+  it("keeps import form-data and CSV parsing in the route while delegating mapped rows", async () => {
+    mockImportContacts.mockResolvedValueOnce({
+      object: "import",
+      created_count: 2,
+      ids: ["contact-1", "contact-2"],
+    });
+    const formData = {
+      get: (key: string) => {
+        if (key === "file") {
+          return { text: async () => "Email,Plan\nA@Example.com,pro\n" };
+        }
+        if (key === "mapping") {
+          return JSON.stringify({ Email: "email", Plan: "plan" });
+        }
+        if (key === "segment_id") return "segment-1";
+        return null;
+      },
+    };
+
+    const route = await import("@/app/api/contacts/import/route");
+    const response = await route.POST({
+      headers: new Headers({ authorization: "Bearer key" }),
+      formData: async () => formData,
+    } as never);
+
+    expect(mockImportContacts).toHaveBeenCalledWith({
+      userId: "user-1",
+      rows: [{ Email: "A@Example.com", Plan: "pro" }],
+      mapping: { Email: "email", Plan: "plan" },
+      segmentId: "segment-1",
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      object: "import",
+      created_count: 2,
+      ids: ["contact-1", "contact-2"],
+    });
+  });
+
+  it("returns the legacy import 400 before delegating when no file is provided", async () => {
+    const route = await import("@/app/api/contacts/import/route");
+    const response = await route.POST({
+      headers: new Headers({ authorization: "Bearer key" }),
+      formData: async () => new FormData(),
+    } as never);
+
+    expect(mockImportContacts).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "No file provided",
+    });
+  });
+
+  it("delegates contact topic listing and preserves the public response shape", async () => {
+    mockListContactTopics.mockResolvedValueOnce({
+      object: "list",
+      data: [{ id: "topic-1", name: "News", subscription: "opt_in" }],
+    });
+
+    const route = await import("@/app/api/contacts/[id]/topics/route");
+    const response = await route.GET(
+      makeRequest("http://localhost/api/contacts/contact-1/topics", {
+        headers: { authorization: "Bearer key" },
+      }) as never,
+      { params: Promise.resolve({ id: "contact-1" }) },
+    );
+
+    expect(mockListContactTopics).toHaveBeenCalledWith({
+      idOrEmail: "contact-1",
+      userId: "user-1",
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      object: "list",
+      data: [{ id: "topic-1", name: "News", subscription: "opt_in" }],
+    });
+  });
+
+  it("passes a deferred JSON body reader to topic updates and maps validation errors", async () => {
+    mockUpdateContactTopics.mockImplementationOnce(
+      async (input: {
+        idOrEmail: string;
+        userId: string;
+        body: () => Promise<unknown>;
+      }) => {
+        expect(input.idOrEmail).toBe("contact-1");
+        expect(input.userId).toBe("user-1");
+        await expect(input.body()).resolves.toEqual({ topics: "nope" });
+        throw new MockContactOperationsServiceError(
+          "invalid_input",
+          "topics must be an array",
+          422,
+        );
+      },
+    );
+
+    const route = await import("@/app/api/contacts/[id]/topics/route");
+    const response = await route.PATCH(
+      makeRequest("http://localhost/api/contacts/contact-1/topics", {
+        method: "PATCH",
+        headers: { authorization: "Bearer key" },
+        body: JSON.stringify({ topics: "nope" }),
+      }) as never,
+      { params: Promise.resolve({ id: "contact-1" }) },
+    );
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toEqual({
+      error: "topics must be an array",
+    });
+  });
+});

--- a/tests/contact-operations-service.test.ts
+++ b/tests/contact-operations-service.test.ts
@@ -1,0 +1,368 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ContactOperationsRepository,
+  type ContactOperationsServiceError,
+  createContactOperationsService,
+} from "../packages/core/src/services/contact-operations";
+
+type ContactRow = NonNullable<
+  Awaited<
+    ReturnType<ContactOperationsRepository["findContactByIdOrEmailForUser"]>
+  >
+>;
+type SegmentRow = NonNullable<
+  Awaited<ReturnType<ContactOperationsRepository["findSegmentByIdForUser"]>>
+>;
+type TopicRow = NonNullable<
+  Awaited<ReturnType<ContactOperationsRepository["findTopicByIdForUser"]>>
+>;
+type ContactInsert = Parameters<
+  ContactOperationsRepository["createContact"]
+>[0];
+
+const createdAt = new Date("2026-05-11T00:00:00.000Z");
+
+function contactRow(overrides: Partial<ContactRow> = {}): ContactRow {
+  return {
+    id: "contact-1",
+    email: "user@example.com",
+    firstName: "User",
+    lastName: "One",
+    unsubscribed: false,
+    customProperties: { plan: "pro" },
+    segments: [],
+    topicSubscriptions: [],
+    createdAt,
+    document: null,
+    userId: "user-1",
+    ...overrides,
+  };
+}
+
+function segmentRow(overrides: Partial<SegmentRow> = {}): SegmentRow {
+  return {
+    id: "segment-1",
+    name: "VIP",
+    contactsCount: 0,
+    unsubscribedCount: 0,
+    createdAt,
+    document: null,
+    userId: "user-1",
+    ...overrides,
+  };
+}
+
+function topicRow(overrides: Partial<TopicRow> = {}): TopicRow {
+  return {
+    id: "topic-1",
+    name: "News",
+    description: null,
+    defaultSubscription: "opt_out",
+    visibility: "public",
+    createdAt,
+    document: null,
+    userId: "user-1",
+    ...overrides,
+  };
+}
+
+function createRepository(
+  overrides: Partial<ContactOperationsRepository> = {},
+): ContactOperationsRepository {
+  return {
+    async findContactByIdOrEmailForUser() {
+      return contactRow();
+    },
+    async findContactByEmailForUser() {
+      return undefined;
+    },
+    async findContactsByIdsForUser() {
+      return [contactRow()];
+    },
+    async createContact(data: ContactInsert) {
+      return [{ id: data.email === "new@example.com" ? "contact-new" : "c" }];
+    },
+    async updateContactForUser() {},
+    async findSegmentByIdForUser() {
+      return segmentRow();
+    },
+    async findTopicByIdForUser() {
+      return topicRow();
+    },
+    ...overrides,
+  };
+}
+
+describe("contact operations service", () => {
+  it("bulk-adds a segment only to caller-scoped contacts missing that segment", async () => {
+    const findContactsByIdsForUser = vi
+      .fn<ContactOperationsRepository["findContactsByIdsForUser"]>()
+      .mockResolvedValue([
+        contactRow({ id: "contact-1", segments: [] }),
+        contactRow({ id: "contact-2", segments: ["VIP"] }),
+      ]);
+    const updateContactForUser = vi
+      .fn<ContactOperationsRepository["updateContactForUser"]>()
+      .mockResolvedValue(undefined);
+    const service = createContactOperationsService({
+      repository: createRepository({
+        findContactsByIdsForUser,
+        updateContactForUser,
+      }),
+    });
+
+    const result = await service.bulkAction({
+      userId: "user-1",
+      body: {
+        action: "add_to_segment",
+        segment_id: "segment-1",
+        contact_ids: ["contact-1", "contact-2", "outside-tenant"],
+      },
+    });
+
+    expect(findContactsByIdsForUser).toHaveBeenCalledWith(
+      ["contact-1", "contact-2", "outside-tenant"],
+      "user-1",
+    );
+    expect(updateContactForUser).toHaveBeenCalledTimes(1);
+    expect(updateContactForUser).toHaveBeenCalledWith("contact-1", "user-1", {
+      segments: ["VIP"],
+    });
+    expect(result).toEqual({
+      object: "bulk_action",
+      success: true,
+      count: 2,
+    });
+  });
+
+  it("bulk-subscribes caller-scoped contacts to a topic and preserves legacy validation statuses", async () => {
+    const updateContactForUser = vi
+      .fn<ContactOperationsRepository["updateContactForUser"]>()
+      .mockResolvedValue(undefined);
+    const service = createContactOperationsService({
+      repository: createRepository({
+        async findContactsByIdsForUser() {
+          return [
+            contactRow({
+              id: "contact-1",
+              topicSubscriptions: [{ topicId: "topic-1", subscribed: false }],
+            }),
+            contactRow({ id: "contact-2", topicSubscriptions: null }),
+          ];
+        },
+        updateContactForUser,
+      }),
+    });
+
+    await expect(
+      service.bulkAction({ userId: "user-1", body: { action: "whatever" } }),
+    ).rejects.toMatchObject({
+      code: "invalid_input",
+      message: "contact_ids must be a non-empty array",
+      status: 422,
+    } satisfies Partial<ContactOperationsServiceError>);
+
+    await expect(
+      service.bulkAction({
+        userId: "user-1",
+        body: { action: "whatever", contact_ids: ["contact-1"] },
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_input",
+      message: "Invalid action",
+      status: 400,
+    } satisfies Partial<ContactOperationsServiceError>);
+
+    const result = await service.bulkAction({
+      userId: "user-1",
+      body: {
+        action: "subscribe_to_topic",
+        topic_id: "topic-1",
+        contact_ids: ["contact-1", "contact-2"],
+      },
+    });
+
+    expect(updateContactForUser).toHaveBeenCalledWith("contact-1", "user-1", {
+      topicSubscriptions: [{ topicId: "topic-1", subscribed: true }],
+    });
+    expect(updateContactForUser).toHaveBeenCalledWith("contact-2", "user-1", {
+      topicSubscriptions: [{ topicId: "topic-1", subscribed: true }],
+    });
+    expect(result).toEqual({
+      object: "bulk_action",
+      success: true,
+      count: 2,
+    });
+  });
+
+  it("imports rows with lowercased email mapping, optional segment, upsert, and custom property merge", async () => {
+    const createdContacts: ContactInsert[] = [];
+    const updates: Array<
+      Parameters<ContactOperationsRepository["updateContactForUser"]>
+    > = [];
+    const service = createContactOperationsService({
+      repository: createRepository({
+        async findContactByEmailForUser(email) {
+          if (email === "existing@example.com") {
+            return contactRow({
+              id: "contact-existing",
+              email,
+              firstName: "Existing",
+              lastName: "Person",
+              segments: ["Old"],
+              customProperties: { plan: "free" },
+            });
+          }
+          return undefined;
+        },
+        async createContact(data) {
+          createdContacts.push(data);
+          return [{ id: "contact-new" }];
+        },
+        async updateContactForUser(...args) {
+          updates.push(args);
+        },
+      }),
+    });
+
+    const result = await service.importContacts({
+      userId: "user-1",
+      segmentId: "segment-1",
+      mapping: {
+        Email: "email",
+        First: "first_name",
+        Last: "last_name",
+        Plan: "plan",
+      },
+      rows: [
+        {
+          Email: " Existing@Example.com ",
+          First: "",
+          Last: "Updated",
+          Plan: "enterprise",
+        },
+        { Email: "NEW@Example.com", First: "New", Last: "User", Plan: "pro" },
+        { Email: "", First: "Skipped" },
+      ],
+    });
+
+    expect(updates).toEqual([
+      [
+        "contact-existing",
+        "user-1",
+        {
+          firstName: "Existing",
+          lastName: "Updated",
+          segments: ["Old", "VIP"],
+          customProperties: { plan: "enterprise" },
+        },
+      ],
+    ]);
+    expect(createdContacts).toEqual([
+      {
+        email: "new@example.com",
+        firstName: "New",
+        lastName: "User",
+        segments: ["VIP"],
+        customProperties: { plan: "pro" },
+        userId: "user-1",
+      },
+    ]);
+    expect(result).toEqual({
+      object: "import",
+      created_count: 2,
+      ids: ["contact-existing", "contact-new"],
+    });
+  });
+
+  it("lists contact topics with opt-in/out mapping and filters topics outside the caller tenant", async () => {
+    const service = createContactOperationsService({
+      repository: createRepository({
+        async findContactByIdOrEmailForUser(idOrEmail, userId) {
+          expect(idOrEmail).toBe("user@example.com");
+          expect(userId).toBe("user-1");
+          return contactRow({
+            topicSubscriptions: [
+              { topicId: "topic-1", subscribed: true },
+              { topicId: "topic-missing", subscribed: false },
+            ],
+          });
+        },
+        async findTopicByIdForUser(topicId) {
+          if (topicId === "topic-missing") return undefined;
+          return topicRow({ id: topicId, name: "News" });
+        },
+      }),
+    });
+
+    await expect(
+      service.listContactTopics({
+        userId: "user-1",
+        idOrEmail: "user@example.com",
+      }),
+    ).resolves.toEqual({
+      object: "list",
+      data: [{ id: "topic-1", name: "News", subscription: "opt_in" }],
+    });
+  });
+
+  it("replaces topic subscriptions after contact lookup and maps non-opt-in values to opt-out", async () => {
+    const updateContactForUser = vi
+      .fn<ContactOperationsRepository["updateContactForUser"]>()
+      .mockResolvedValue(undefined);
+    const readBody = vi.fn().mockResolvedValue({
+      topics: [
+        { id: "topic-1", subscription: "opt_in" },
+        { id: "topic-2", subscription: "opt_out" },
+        { id: "topic-3", subscription: "unexpected" },
+      ],
+    });
+    const service = createContactOperationsService({
+      repository: createRepository({ updateContactForUser }),
+    });
+
+    const result = await service.updateContactTopics({
+      userId: "user-1",
+      idOrEmail: "contact-1",
+      body: readBody,
+    });
+
+    expect(readBody).toHaveBeenCalledOnce();
+    expect(updateContactForUser).toHaveBeenCalledWith("contact-1", "user-1", {
+      topicSubscriptions: [
+        { topicId: "topic-1", subscribed: true },
+        { topicId: "topic-2", subscribed: false },
+        { topicId: "topic-3", subscribed: false },
+      ],
+    });
+    expect(result).toEqual({
+      object: "contact_topics",
+      contact_id: "contact-1",
+      updated: true,
+    });
+  });
+
+  it("does not parse update topics body when the contact is not found", async () => {
+    const readBody = vi.fn().mockResolvedValue({ topics: [] });
+    const service = createContactOperationsService({
+      repository: createRepository({
+        async findContactByIdOrEmailForUser() {
+          return undefined;
+        },
+      }),
+    });
+
+    await expect(
+      service.updateContactTopics({
+        userId: "user-1",
+        idOrEmail: "missing@example.com",
+        body: readBody,
+      }),
+    ).rejects.toMatchObject({
+      code: "not_found",
+      message: "Contact not found",
+      status: 404,
+    } satisfies Partial<ContactOperationsServiceError>);
+    expect(readBody).not.toHaveBeenCalled();
+  });
+});

--- a/tests/contact-tenant-isolation.test.ts
+++ b/tests/contact-tenant-isolation.test.ts
@@ -19,6 +19,12 @@ const mockContactService = vi.hoisted(() => ({
   updateContact: vi.fn(),
   deleteContact: vi.fn(),
 }));
+const mockContactOperationsService = vi.hoisted(() => ({
+  bulkAction: vi.fn(),
+  importContacts: vi.fn(),
+  listContactTopics: vi.fn(),
+  updateContactTopics: vi.fn(),
+}));
 const MockContactServiceError = vi.hoisted(
   () =>
     class ContactServiceError extends Error {
@@ -28,6 +34,19 @@ const MockContactServiceError = vi.hoisted(
       ) {
         super(message);
         this.name = "ContactServiceError";
+      }
+    },
+);
+const MockContactOperationsServiceError = vi.hoisted(
+  () =>
+    class ContactOperationsServiceError extends Error {
+      constructor(
+        readonly code: "invalid_input" | "not_found",
+        message: string,
+        readonly status: number,
+      ) {
+        super(message);
+        this.name = "ContactOperationsServiceError";
       }
     },
 );
@@ -68,27 +87,6 @@ function makeChain<T>(rows: T[]): Chain<T> {
   return chain;
 }
 
-function expressionContains(value: unknown, expected: string): boolean {
-  const seen = new Set<object>();
-
-  function visit(node: unknown): boolean {
-    if (node === expected) return true;
-    if (typeof node === "string") return node.includes(expected);
-    if (!node || typeof node !== "object") return false;
-    if (seen.has(node)) return false;
-    seen.add(node);
-
-    for (const key of Reflect.ownKeys(node)) {
-      const child = (node as Record<PropertyKey, unknown>)[key];
-      if (visit(child)) return true;
-    }
-
-    return false;
-  }
-
-  return visit(value);
-}
-
 vi.mock("@/lib/api-auth", () => ({
   authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
   getServerSession: mockGetServerSession,
@@ -103,7 +101,9 @@ vi.mock("@/lib/events", () => ({
 
 vi.mock("@opensend/core", () => ({
   ContactServiceError: MockContactServiceError,
+  ContactOperationsServiceError: MockContactOperationsServiceError,
   createContactService: () => mockContactService,
+  createContactOperationsService: () => mockContactOperationsService,
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -149,6 +149,10 @@ describe("contact API tenant isolation", () => {
     mockContactService.getContact.mockReset();
     mockContactService.updateContact.mockReset();
     mockContactService.deleteContact.mockReset();
+    mockContactOperationsService.bulkAction.mockReset();
+    mockContactOperationsService.importContacts.mockReset();
+    mockContactOperationsService.listContactTopics.mockReset();
+    mockContactOperationsService.updateContactTopics.mockReset();
   });
 
   it("enqueues contact.created for the caller tenant after creating a contact", async () => {
@@ -471,8 +475,11 @@ describe("contact API tenant isolation", () => {
   });
 
   it("does not bulk-mutate contacts outside the caller tenant", async () => {
-    mockSegmentFindFirst.mockResolvedValueOnce({ id: "seg-b", name: "VIP" });
-    mockContactFindMany.mockResolvedValueOnce([]);
+    mockContactOperationsService.bulkAction.mockResolvedValueOnce({
+      object: "bulk_action",
+      success: true,
+      count: 0,
+    });
 
     const route = await import("@/app/api/contacts/bulk/route");
     const response = await route.POST(
@@ -492,25 +499,23 @@ describe("contact API tenant isolation", () => {
       success: true,
       count: 0,
     });
+    expect(mockContactOperationsService.bulkAction).toHaveBeenCalledWith({
+      userId: "user-b",
+      body: {
+        action: "add_to_segment",
+        segment_id: "seg-b",
+        contact_ids: ["contact-a"],
+      },
+    });
     expect(mockUpdate).not.toHaveBeenCalled();
-    expect(
-      expressionContains(
-        mockContactFindMany.mock.calls[0]?.[0]?.where,
-        "user_id",
-      ),
-    ).toBe(true);
-    expect(
-      expressionContains(
-        mockContactFindMany.mock.calls[0]?.[0]?.where,
-        "user-b",
-      ),
-    ).toBe(true);
   });
 
   it("stamps imported contacts with the caller user", async () => {
-    mockContactFindFirst.mockResolvedValueOnce(null);
-    const insertChain = makeChain([{ id: "contact-b" }]);
-    mockInsert.mockReturnValueOnce(insertChain);
+    mockContactOperationsService.importContacts.mockResolvedValueOnce({
+      object: "import",
+      created_count: 1,
+      ids: ["contact-b"],
+    });
 
     const formData = {
       get: (key: string) => {
@@ -528,9 +533,11 @@ describe("contact API tenant isolation", () => {
     } as never);
 
     expect(response.status).toBe(200);
-    expect(insertChain.values.mock.calls[0]?.[0]).toMatchObject({
-      email: "b@example.com",
+    expect(mockContactOperationsService.importContacts).toHaveBeenCalledWith({
       userId: "user-b",
+      rows: [{ Email: "b@example.com" }],
+      mapping: { Email: "email" },
+      segmentId: null,
     });
   });
 


### PR DESCRIPTION
## Summary
- Move contacts bulk, import, and topic-subscription orchestration into a reusable core service boundary.
- Keep the public Next route adapters thin while preserving response compatibility and tenant scoping.
- Add focused service/route tests and update existing route mocks for the extracted service.

Closes #336

## Validation
- make check
- make test
- bunx vitest run tests/contact-operations-service.test.ts tests/contact-operations-routes.test.ts tests/contact-tenant-isolation.test.ts tests/api-auth-date-range-routes.test.ts
