### PR TITLE
Extract domain detail service boundary

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export * from "./webhook-signing";
 export * from "./webhook-events";
 export * from "./services/dns";
 export * from "./services/domain";
+export * from "./services/domain-detail";
 export * from "./services/domain-events";
 export * from "./services/webhook";
 export * from "./services/apiKeys";

--- a/packages/core/src/services/domain-detail.ts
+++ b/packages/core/src/services/domain-detail.ts
@@ -1,0 +1,407 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "../db/client";
+import { domainRepo } from "../db/repositories/domainRepo";
+import { domains } from "../db/schema";
+import { getEffectiveReturnPathLabel } from "./domain";
+import { emailProvider } from "./emailProvider";
+
+type DomainRow = typeof domains.$inferSelect;
+type DomainInsert = typeof domains.$inferInsert;
+type DomainRecord = NonNullable<DomainRow["records"]>[number];
+type DomainCapability = NonNullable<DomainRow["capabilities"]>[number];
+
+type DomainDetailUpdateData = Partial<
+  Pick<
+    DomainInsert,
+    "trackClicks" | "trackOpens" | "trackingSubdomain" | "capabilities" | "tls"
+  >
+>;
+
+export type DomainDetailResponse = {
+  object: "domain";
+  id: string;
+  name: string;
+  status: string;
+  region: string;
+  records: DomainRecord[];
+  custom_return_path: string | null;
+  return_path: string;
+  open_tracking: boolean;
+  click_tracking: boolean;
+  tracking_subdomain: string | null;
+  tls: string;
+  capabilities: DomainCapability[] | null;
+  created_at: DomainRow["createdAt"];
+};
+
+export type UpdateDomainDetailInput = {
+  click_tracking?: boolean;
+  open_tracking?: boolean;
+  tracking_subdomain?: string;
+  capabilities?: DomainCapability[];
+  sending_enabled?: boolean;
+  receiving_enabled?: boolean;
+  tls?: string;
+};
+
+export type DomainDetailMutationResponse = {
+  object: "domain";
+  id: string;
+};
+
+export type DomainDetailDeleteResponse = DomainDetailMutationResponse & {
+  deleted: true;
+};
+
+export type DomainDetailWebhookPayload = {
+  id: string;
+  name: string;
+  status: string;
+  region: string;
+  records: DomainRecord[];
+  capabilities: DomainCapability[];
+  created_at: string | Date;
+};
+
+export type DomainDetailUpdateResult = {
+  response: DomainDetailMutationResponse;
+  changedFields: string[];
+  eventPayload?: {
+    id: string;
+    changed_fields: string[];
+    domain: DomainDetailWebhookPayload;
+  };
+};
+
+export type DomainDetailDeleteResult = {
+  response: DomainDetailDeleteResponse;
+  eventPayload: {
+    id: string;
+    name: string;
+  };
+};
+
+export type DomainDetailDnsRecord = {
+  id: string;
+  name: string;
+  content: string;
+};
+
+export type DomainDetailServiceErrorCode = "not_found";
+
+export class DomainDetailServiceError extends Error {
+  constructor(
+    readonly code: DomainDetailServiceErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "DomainDetailServiceError";
+  }
+}
+
+export type DomainDetailServiceDependencies = {
+  getDomainById?: (id: string) => Promise<DomainRow | null | undefined>;
+  updateDomainForUser?: (input: {
+    id: string;
+    userId: string;
+    updates: DomainDetailUpdateData;
+  }) => Promise<DomainRow | undefined>;
+  deleteDomainForUser?: (input: {
+    id: string;
+    userId: string;
+  }) => Promise<{ id: string; name: string } | undefined>;
+  deleteDomainIdentity?: (domain: string) => Promise<void>;
+  listDNSRecords?: (input: { name: string }) => Promise<
+    DomainDetailDnsRecord[]
+  >;
+  deleteDNSRecord?: (id: string) => Promise<void>;
+  invalidateDomainCaches?: (domain: {
+    id?: string | null;
+    name?: string | null;
+  }) => Promise<void>;
+  logger?: Pick<Console, "warn">;
+};
+
+const defaultCapabilities: DomainCapability[] = [
+  { name: "sending", enabled: true },
+  { name: "receiving", enabled: false },
+];
+
+async function defaultUpdateDomainForUser(input: {
+  id: string;
+  userId: string;
+  updates: DomainDetailUpdateData;
+}): Promise<DomainRow | undefined> {
+  const [updated] = await db
+    .update(domains)
+    .set(input.updates)
+    .where(and(eq(domains.id, input.id), eq(domains.userId, input.userId)))
+    .returning();
+
+  return updated;
+}
+
+async function defaultDeleteDomainForUser(input: {
+  id: string;
+  userId: string;
+}): Promise<{ id: string; name: string } | undefined> {
+  const [deleted] = await db
+    .delete(domains)
+    .where(and(eq(domains.id, input.id), eq(domains.userId, input.userId)))
+    .returning({ id: domains.id, name: domains.name });
+
+  return deleted;
+}
+
+function toDomainWebhookPayload(domain: DomainRow): DomainDetailWebhookPayload {
+  return {
+    id: domain.id,
+    name: domain.name,
+    status: domain.status,
+    region: domain.region,
+    records: domain.records ?? [],
+    capabilities: domain.capabilities ?? [],
+    created_at:
+      domain.createdAt instanceof Date
+        ? domain.createdAt.toISOString()
+        : domain.createdAt,
+  };
+}
+
+function toDomainDetailResponse(domain: DomainRow): DomainDetailResponse {
+  return {
+    object: "domain",
+    id: domain.id,
+    name: domain.name,
+    status: domain.status,
+    region: domain.region,
+    records: domain.records || [],
+    custom_return_path: domain.customReturnPath,
+    return_path: getEffectiveReturnPathLabel(domain.customReturnPath),
+    open_tracking: domain.trackOpens,
+    click_tracking: domain.trackClicks,
+    tracking_subdomain: domain.trackingSubdomain,
+    tls: domain.tls,
+    capabilities: domain.capabilities,
+    created_at: domain.createdAt,
+  };
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
+
+function toUpdateData(
+  input: UpdateDomainDetailInput,
+  existingDomain: DomainRow,
+): DomainDetailUpdateData {
+  const updates: DomainDetailUpdateData = {};
+
+  if (input.click_tracking !== undefined) {
+    updates.trackClicks = input.click_tracking;
+  }
+  if (input.open_tracking !== undefined) {
+    updates.trackOpens = input.open_tracking;
+  }
+  if (input.tracking_subdomain !== undefined) {
+    updates.trackingSubdomain = input.tracking_subdomain;
+  }
+
+  if (input.capabilities !== undefined) {
+    updates.capabilities = input.capabilities;
+  } else if (
+    input.sending_enabled !== undefined ||
+    input.receiving_enabled !== undefined
+  ) {
+    const currentCaps = existingDomain.capabilities || defaultCapabilities;
+    updates.capabilities = currentCaps.map((cap) => {
+      if (cap.name === "sending" && input.sending_enabled !== undefined) {
+        return { ...cap, enabled: input.sending_enabled };
+      }
+      if (cap.name === "receiving" && input.receiving_enabled !== undefined) {
+        return { ...cap, enabled: input.receiving_enabled };
+      }
+      return cap;
+    });
+  }
+
+  if (input.tls !== undefined) {
+    updates.tls = input.tls;
+  }
+
+  return updates;
+}
+
+function currentValueForField(domain: DomainRow, field: string): unknown {
+  if (field === "open_tracking") return domain.trackOpens;
+  if (field === "click_tracking") return domain.trackClicks;
+  if (field === "tracking_subdomain") return domain.trackingSubdomain;
+  if (field === "capabilities") return domain.capabilities;
+  return domain.tls;
+}
+
+function getChangedFields(
+  existingDomain: DomainRow,
+  updates: DomainDetailUpdateData,
+): string[] {
+  return Object.entries({
+    open_tracking: updates.trackOpens,
+    click_tracking: updates.trackClicks,
+    tracking_subdomain: updates.trackingSubdomain,
+    capabilities: updates.capabilities,
+    tls: updates.tls,
+  })
+    .filter(([, value]) => value !== undefined)
+    .filter(
+      ([field, value]) =>
+        !valuesEqual(currentValueForField(existingDomain, field), value),
+    )
+    .map(([field]) => field);
+}
+
+function shouldCleanupDnsRecord(record: DomainDetailDnsRecord): boolean {
+  return (
+    record.content.includes("amazonses.com") ||
+    record.name.includes("_domainkey") ||
+    record.content.startsWith("v=spf1")
+  );
+}
+
+export function createDomainDetailService({
+  getDomainById = (id: string) => domainRepo.findById(id),
+  updateDomainForUser = defaultUpdateDomainForUser,
+  deleteDomainForUser = defaultDeleteDomainForUser,
+  deleteDomainIdentity = (domain: string) =>
+    emailProvider.deleteDomainIdentity(domain),
+  listDNSRecords = async () => [],
+  deleteDNSRecord = async () => {},
+  invalidateDomainCaches = async () => {},
+  logger = console,
+}: DomainDetailServiceDependencies = {}) {
+  async function getExistingForUser(
+    id: string,
+    userId: string,
+  ): Promise<DomainRow> {
+    const domain = await getDomainById(id);
+
+    if (!domain || domain.userId !== userId) {
+      throw new DomainDetailServiceError("not_found", "Not found");
+    }
+
+    return domain;
+  }
+
+  return {
+    async getDomainDetail(input: {
+      id: string;
+      userId: string;
+    }): Promise<DomainDetailResponse> {
+      const domain = await getExistingForUser(input.id, input.userId);
+      return toDomainDetailResponse(domain);
+    },
+
+    async updateDomainDetail(input: {
+      id: string;
+      userId: string;
+      updates: UpdateDomainDetailInput;
+    }): Promise<DomainDetailUpdateResult> {
+      const existingDomain = await getExistingForUser(input.id, input.userId);
+      const updates = toUpdateData(input.updates, existingDomain);
+      const changedFields = getChangedFields(existingDomain, updates);
+
+      if (changedFields.length === 0) {
+        return {
+          response: {
+            object: "domain",
+            id: existingDomain.id,
+          },
+          changedFields,
+        };
+      }
+
+      const updated = await updateDomainForUser({
+        id: input.id,
+        userId: input.userId,
+        updates,
+      });
+
+      if (!updated) {
+        await invalidateDomainCaches({
+          id: input.id,
+          name: existingDomain.name,
+        });
+        throw new DomainDetailServiceError("not_found", "Not found");
+      }
+
+      await invalidateDomainCaches({ id: updated.id, name: updated.name });
+
+      return {
+        response: {
+          object: "domain",
+          id: updated.id,
+        },
+        changedFields,
+        eventPayload: {
+          id: updated.id,
+          changed_fields: changedFields,
+          domain: toDomainWebhookPayload(updated),
+        },
+      };
+    },
+
+    async deleteDomainDetail(input: {
+      id: string;
+      userId: string;
+    }): Promise<DomainDetailDeleteResult> {
+      const domain = await getExistingForUser(input.id, input.userId);
+
+      try {
+        await deleteDomainIdentity(domain.name);
+      } catch (sesErr) {
+        logger.warn(
+          `Failed to delete SES identity for ${domain.name}:`,
+          sesErr,
+        );
+      }
+
+      try {
+        const records = await listDNSRecords({ name: domain.name });
+        const sesRecords = records.filter(shouldCleanupDnsRecord);
+
+        await Promise.all(
+          sesRecords.map((record) => deleteDNSRecord(record.id)),
+        );
+      } catch (cfErr) {
+        logger.warn(
+          `Failed to cleanup Cloudflare records for ${domain.name}:`,
+          cfErr,
+        );
+      }
+
+      const deleted = await deleteDomainForUser({
+        id: input.id,
+        userId: input.userId,
+      });
+
+      await invalidateDomainCaches({ id: input.id, name: domain.name });
+
+      if (!deleted) {
+        throw new DomainDetailServiceError("not_found", "Not found");
+      }
+
+      return {
+        response: {
+          object: "domain",
+          id: deleted.id,
+          deleted: true,
+        },
+        eventPayload: {
+          id: deleted.id,
+          name: deleted.name,
+        },
+      };
+    },
+  };
+}
+
+export const domainDetailService = createDomainDetailService();

--- a/src/app/api/domains/[id]/route.ts
+++ b/src/app/api/domains/[id]/route.ts
@@ -5,8 +5,6 @@ import {
 } from "@/lib/api-auth";
 import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
 import { deleteDNSRecord, listDNSRecords } from "@/lib/cloudflare";
-import { db } from "@/lib/db";
-import { domains } from "@/lib/db/schema";
 import {
   getCachedDomainById,
   invalidateDomainCaches,
@@ -17,42 +15,25 @@ import {
   domainRouteParamsSchema,
   updateDomainSchema,
 } from "@/lib/validation/domains";
-import { getEffectiveReturnPathLabel } from "@opensend/core";
-import { and, eq } from "drizzle-orm";
+import {
+  DomainDetailServiceError,
+  createDomainDetailService,
+} from "@opensend/core";
 import { NextResponse } from "next/server";
 
-type DomainWebhookRow = typeof domains.$inferSelect;
-
-const defaultCapabilities = [
-  { name: "sending", enabled: true },
-  { name: "receiving", enabled: false },
-];
-
-function toDomainWebhookPayload(domain: DomainWebhookRow) {
-  return {
-    id: domain.id,
-    name: domain.name,
-    status: domain.status,
-    region: domain.region,
-    records: domain.records ?? [],
-    capabilities: domain.capabilities ?? [],
-    created_at:
-      domain.createdAt instanceof Date
-        ? domain.createdAt.toISOString()
-        : domain.createdAt,
-  };
+function domainDetailService() {
+  return createDomainDetailService({
+    getDomainById: getCachedDomainById,
+    deleteDomainIdentity,
+    listDNSRecords,
+    deleteDNSRecord,
+    invalidateDomainCaches,
+  });
 }
 
-function valuesEqual(a: unknown, b: unknown): boolean {
-  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
-}
-
-export async function GET(
-  _req: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
+async function resolveUserId(request: Request): Promise<string | Response> {
   const auth = await authorizeDashboardOrApiKey(
-    _req.headers.get("authorization"),
+    request.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
   const permissionError = requireFullAccessForApiKeyCaller(auth);
@@ -62,44 +43,57 @@ export async function GET(
   const userId = "userId" in auth ? auth.userId : session?.user?.id;
   if (!userId) return unauthorizedResponse();
 
+  return userId;
+}
+
+function isResponse(value: string | Response): value is Response {
+  return value instanceof Response;
+}
+
+function validationResponse(error: { flatten: () => unknown }) {
+  return NextResponse.json(
+    { error: "Validation failed", details: error.flatten() },
+    { status: 422 },
+  );
+}
+
+function notFoundResponse() {
+  return NextResponse.json({ error: "Not found" }, { status: 404 });
+}
+
+function internalErrorResponse() {
+  return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+}
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const userId = await resolveUserId(req);
+  if (isResponse(userId)) return userId;
+
   const parsedParams = domainRouteParamsSchema.safeParse(await params);
   if (!parsedParams.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsedParams.error.flatten() },
-      { status: 422 },
-    );
+    return validationResponse(parsedParams.error);
   }
 
   try {
-    const { id } = parsedParams.data;
-    const domain = await getCachedDomainById(id);
+    const domain = await domainDetailService().getDomainDetail({
+      id: parsedParams.data.id,
+      userId,
+    });
 
-    if (!domain || domain.userId !== userId) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(domain);
+  } catch (error) {
+    if (
+      error instanceof DomainDetailServiceError &&
+      error.code === "not_found"
+    ) {
+      return notFoundResponse();
     }
 
-    return NextResponse.json({
-      object: "domain",
-      id: domain.id,
-      name: domain.name,
-      status: domain.status,
-      region: domain.region,
-      records: domain.records || [],
-      custom_return_path: domain.customReturnPath,
-      return_path: getEffectiveReturnPathLabel(domain.customReturnPath),
-      open_tracking: domain.trackOpens,
-      click_tracking: domain.trackClicks,
-      tracking_subdomain: domain.trackingSubdomain,
-      tls: domain.tls,
-      capabilities: domain.capabilities,
-      created_at: domain.createdAt,
-    });
-  } catch (error) {
     console.error("Failed to retrieve domain:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
+    return internalErrorResponse();
   }
 }
 
@@ -107,16 +101,8 @@ export async function PATCH(
   req: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await authorizeDashboardOrApiKey(
-    req.headers.get("authorization"),
-  );
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessForApiKeyCaller(auth);
-  if (permissionError) return permissionError;
-
-  const session = "dashboard" in auth ? await getServerSession() : null;
-  const userId = "userId" in auth ? auth.userId : session?.user?.id;
-  if (!userId) return unauthorizedResponse();
+  const userId = await resolveUserId(req);
+  if (isResponse(userId)) return userId;
 
   let body: unknown;
   try {
@@ -127,216 +113,77 @@ export async function PATCH(
 
   const result = updateDomainSchema.safeParse(body);
   if (!result.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: result.error.flatten() },
-      { status: 422 },
-    );
+    return validationResponse(result.error);
   }
 
   const parsedParams = domainRouteParamsSchema.safeParse(await params);
   if (!parsedParams.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsedParams.error.flatten() },
-      { status: 422 },
-    );
+    return validationResponse(parsedParams.error);
   }
 
   try {
-    const { id } = parsedParams.data;
-    const validated = result.data;
-    const updates: Record<string, unknown> = {};
-    const existingDomain = await getCachedDomainById(id);
-
-    if (!existingDomain || existingDomain.userId !== userId) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
-    }
-
-    if (validated.click_tracking !== undefined) {
-      updates.trackClicks = validated.click_tracking;
-    }
-    if (validated.open_tracking !== undefined) {
-      updates.trackOpens = validated.open_tracking;
-    }
-    if (validated.tracking_subdomain !== undefined) {
-      updates.trackingSubdomain = validated.tracking_subdomain;
-    }
-
-    if (validated.capabilities !== undefined) {
-      updates.capabilities = validated.capabilities;
-    } else if (
-      validated.sending_enabled !== undefined ||
-      validated.receiving_enabled !== undefined
-    ) {
-      const currentCaps = existingDomain.capabilities || defaultCapabilities;
-      const newCaps = currentCaps.map((cap) => {
-        if (cap.name === "sending" && validated.sending_enabled !== undefined) {
-          return { ...cap, enabled: validated.sending_enabled };
-        }
-        if (
-          cap.name === "receiving" &&
-          validated.receiving_enabled !== undefined
-        ) {
-          return { ...cap, enabled: validated.receiving_enabled };
-        }
-        return cap;
-      });
-      updates.capabilities = newCaps;
-    }
-
-    if (validated.tls !== undefined) {
-      updates.tls = validated.tls;
-    }
-
-    const changedFields = Object.entries({
-      open_tracking: updates.trackOpens,
-      click_tracking: updates.trackClicks,
-      tracking_subdomain: updates.trackingSubdomain,
-      capabilities: updates.capabilities,
-      tls: updates.tls,
-    })
-      .filter(([, value]) => value !== undefined)
-      .filter(([field, value]) => {
-        const currentValue =
-          field === "open_tracking"
-            ? existingDomain.trackOpens
-            : field === "click_tracking"
-              ? existingDomain.trackClicks
-              : field === "tracking_subdomain"
-                ? existingDomain.trackingSubdomain
-                : field === "capabilities"
-                  ? existingDomain.capabilities
-                  : existingDomain.tls;
-        return !valuesEqual(currentValue, value);
-      })
-      .map(([field]) => field);
-
-    if (changedFields.length === 0) {
-      return NextResponse.json({
-        object: "domain",
-        id: existingDomain.id,
-      });
-    }
-
-    const [updated] = await db
-      .update(domains)
-      .set(updates)
-      .where(and(eq(domains.id, id), eq(domains.userId, userId)))
-      .returning();
-
-    if (!updated) {
-      await invalidateDomainCaches({ id, name: existingDomain.name });
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
-    }
-
-    await invalidateDomainCaches({ id: updated.id, name: updated.name });
-
-    await queueEvent({
-      type: "domain.updated",
+    const updated = await domainDetailService().updateDomainDetail({
+      id: parsedParams.data.id,
       userId,
-      payload: {
-        id: updated.id,
-        changed_fields: changedFields,
-        domain: toDomainWebhookPayload(updated),
-      },
+      updates: result.data,
     });
 
-    return NextResponse.json({
-      object: "domain",
-      id: updated.id,
-    });
+    if (updated.eventPayload) {
+      await queueEvent({
+        type: "domain.updated",
+        userId,
+        payload: updated.eventPayload,
+      });
+    }
+
+    return NextResponse.json(updated.response);
   } catch (error) {
+    if (
+      error instanceof DomainDetailServiceError &&
+      error.code === "not_found"
+    ) {
+      return notFoundResponse();
+    }
+
     console.error("Failed to update domain:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
+    return internalErrorResponse();
   }
 }
 
 export async function DELETE(
-  _req: Request,
+  req: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await authorizeDashboardOrApiKey(
-    _req.headers.get("authorization"),
-  );
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessForApiKeyCaller(auth);
-  if (permissionError) return permissionError;
-
-  const session = "dashboard" in auth ? await getServerSession() : null;
-  const userId = "userId" in auth ? auth.userId : session?.user?.id;
-  if (!userId) return unauthorizedResponse();
+  const userId = await resolveUserId(req);
+  if (isResponse(userId)) return userId;
 
   const parsedParams = domainRouteParamsSchema.safeParse(await params);
   if (!parsedParams.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsedParams.error.flatten() },
-      { status: 422 },
-    );
+    return validationResponse(parsedParams.error);
   }
 
   try {
-    const { id } = parsedParams.data;
-    const domain = await getCachedDomainById(id);
-
-    if (!domain || domain.userId !== userId) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
-    }
-
-    try {
-      await deleteDomainIdentity(domain.name);
-    } catch (sesErr) {
-      console.warn(`Failed to delete SES identity for ${domain.name}:`, sesErr);
-    }
-
-    try {
-      const records = await listDNSRecords({ name: domain.name });
-      const sesRecords = records.filter(
-        (record) =>
-          record.content.includes("amazonses.com") ||
-          record.name.includes("_domainkey") ||
-          record.content.startsWith("v=spf1"),
-      );
-
-      await Promise.all(sesRecords.map((record) => deleteDNSRecord(record.id)));
-    } catch (cfErr) {
-      console.warn(
-        `Failed to cleanup Cloudflare records for ${domain.name}:`,
-        cfErr,
-      );
-    }
-
-    const [deleted] = await db
-      .delete(domains)
-      .where(and(eq(domains.id, id), eq(domains.userId, userId)))
-      .returning({ id: domains.id, name: domains.name });
-
-    await invalidateDomainCaches({ id, name: domain.name });
-
-    if (!deleted) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
-    }
+    const deleted = await domainDetailService().deleteDomainDetail({
+      id: parsedParams.data.id,
+      userId,
+    });
 
     await queueEvent({
       type: "domain.deleted",
       userId,
-      payload: {
-        id: deleted.id,
-        name: deleted.name,
-      },
+      payload: deleted.eventPayload,
     });
 
-    return NextResponse.json({
-      object: "domain",
-      id: deleted.id,
-      deleted: true,
-    });
+    return NextResponse.json(deleted.response);
   } catch (error) {
+    if (
+      error instanceof DomainDetailServiceError &&
+      error.code === "not_found"
+    ) {
+      return notFoundResponse();
+    }
+
     console.error("Failed to delete domain:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
+    return internalErrorResponse();
   }
 }

--- a/tests/api-domains.test.ts
+++ b/tests/api-domains.test.ts
@@ -10,6 +10,21 @@ const mockGetDomainIdentity = vi.hoisted(() => vi.fn());
 const mockCreateDomainIdentity = vi.hoisted(() => vi.fn());
 const mockCheckDomainQuota = vi.hoisted(() => vi.fn());
 const mockCreateDomain = vi.hoisted(() => vi.fn());
+const mockGetDomainDetail = vi.hoisted(() => vi.fn());
+const mockUpdateDomainDetail = vi.hoisted(() => vi.fn());
+const mockDeleteDomainDetail = vi.hoisted(() => vi.fn());
+const MockDomainDetailServiceError = vi.hoisted(
+  () =>
+    class DomainDetailServiceError extends Error {
+      constructor(
+        readonly code: string,
+        message: string,
+      ) {
+        super(message);
+        this.name = "DomainDetailServiceError";
+      }
+    },
+);
 const mockReconcileVerification = vi.hoisted(() => vi.fn());
 const mockDb = vi.hoisted(() => ({
   insert: vi.fn(),
@@ -42,11 +57,17 @@ vi.mock("@/lib/billing/quota", () => ({
 }));
 
 vi.mock("@opensend/core", () => ({
+  DomainDetailServiceError: MockDomainDetailServiceError,
   DMARC_RECORD_VALUE: "v=DMARC1; p=none;",
   buildDmarcRecordName: (domain: string) => `_dmarc.${domain}`,
   createDomainService: () => ({
     createDomain: mockCreateDomain,
     listDomains: vi.fn(),
+  }),
+  createDomainDetailService: () => ({
+    getDomainDetail: mockGetDomainDetail,
+    updateDomainDetail: mockUpdateDomainDetail,
+    deleteDomainDetail: mockDeleteDomainDetail,
   }),
   domainService: {
     reconcileVerification: mockReconcileVerification,
@@ -116,6 +137,9 @@ describe("Domain API validation", () => {
       info: { limit: 10, used: 0 },
     });
     mockCreateDomain.mockReset();
+    mockGetDomainDetail.mockReset();
+    mockUpdateDomainDetail.mockReset();
+    mockDeleteDomainDetail.mockReset();
     mockDb.insert.mockReset();
     mockDb.update.mockReset();
     mockDb.delete.mockReset();
@@ -217,29 +241,76 @@ describe("Domain API validation", () => {
     );
   });
 
-  it("updates a domain and enqueues domain.updated for the caller tenant", async () => {
-    const existing = {
+  it("gets a domain detail through the service adapter with the public response shape", async () => {
+    const createdAt = new Date("2026-05-06T00:00:00.000Z");
+    mockGetDomainDetail.mockResolvedValueOnce({
+      object: "domain",
       id: VALID_DOMAIN_ID,
       name: "example.com",
-      userId: "user-1",
       status: "not_started",
       region: "us-east-1",
       records: [],
-      trackOpens: false,
-      trackClicks: false,
-      trackingSubdomain: null,
+      custom_return_path: null,
+      return_path: "send",
+      open_tracking: false,
+      click_tracking: true,
+      tracking_subdomain: "track.example.com",
       tls: "opportunistic",
       capabilities: [{ name: "sending", enabled: true }],
-      createdAt: new Date("2026-05-06T00:00:00.000Z"),
-    };
-    const updated = { ...existing, trackOpens: true };
-    mockDb.query.domains.findFirst.mockResolvedValueOnce(existing);
-    mockDb.update.mockReturnValueOnce({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([updated]),
-        }),
-      }),
+      created_at: createdAt,
+    });
+
+    const { GET } = await import("@/app/api/domains/[id]/route");
+    const req = makeRequest(
+      `http://localhost:3015/api/domains/${VALID_DOMAIN_ID}`,
+      "GET",
+    );
+
+    const res = await GET(req, {
+      params: Promise.resolve({ id: VALID_DOMAIN_ID }),
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockGetDomainDetail).toHaveBeenCalledWith({
+      id: VALID_DOMAIN_ID,
+      userId: "user-1",
+    });
+    expect(json).toEqual({
+      object: "domain",
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+      status: "not_started",
+      region: "us-east-1",
+      records: [],
+      custom_return_path: null,
+      return_path: "send",
+      open_tracking: false,
+      click_tracking: true,
+      tracking_subdomain: "track.example.com",
+      tls: "opportunistic",
+      capabilities: [{ name: "sending", enabled: true }],
+      created_at: "2026-05-06T00:00:00.000Z",
+    });
+  });
+
+  it("updates a domain and enqueues domain.updated for the caller tenant", async () => {
+    mockUpdateDomainDetail.mockResolvedValueOnce({
+      response: { object: "domain", id: VALID_DOMAIN_ID },
+      changedFields: ["open_tracking"],
+      eventPayload: {
+        id: VALID_DOMAIN_ID,
+        changed_fields: ["open_tracking"],
+        domain: {
+          id: VALID_DOMAIN_ID,
+          name: "example.com",
+          status: "not_started",
+          region: "us-east-1",
+          records: [],
+          capabilities: [{ name: "sending", enabled: true }],
+          created_at: "2026-05-06T00:00:00.000Z",
+        },
+      },
     });
 
     const { PATCH } = await import("@/app/api/domains/[id]/route");
@@ -254,6 +325,15 @@ describe("Domain API validation", () => {
     });
 
     expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      object: "domain",
+      id: VALID_DOMAIN_ID,
+    });
+    expect(mockUpdateDomainDetail).toHaveBeenCalledWith({
+      id: VALID_DOMAIN_ID,
+      userId: "user-1",
+      updates: { open_tracking: true },
+    });
     expect(mockQueueEvent).toHaveBeenCalledWith({
       type: "domain.updated",
       userId: "user-1",
@@ -269,20 +349,9 @@ describe("Domain API validation", () => {
   });
 
   it("deletes a domain and enqueues domain.deleted for the caller tenant", async () => {
-    mockDb.query.domains.findFirst.mockResolvedValueOnce({
-      id: VALID_DOMAIN_ID,
-      name: "example.com",
-      userId: "user-1",
-      status: "not_started",
-      records: [],
-    });
-    mockListDNSRecords.mockResolvedValueOnce([]);
-    mockDb.delete.mockReturnValueOnce({
-      where: vi.fn().mockReturnValue({
-        returning: vi
-          .fn()
-          .mockResolvedValue([{ id: VALID_DOMAIN_ID, name: "example.com" }]),
-      }),
+    mockDeleteDomainDetail.mockResolvedValueOnce({
+      response: { object: "domain", id: VALID_DOMAIN_ID, deleted: true },
+      eventPayload: { id: VALID_DOMAIN_ID, name: "example.com" },
     });
 
     const { DELETE } = await import("@/app/api/domains/[id]/route");
@@ -296,6 +365,15 @@ describe("Domain API validation", () => {
     });
 
     expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      object: "domain",
+      id: VALID_DOMAIN_ID,
+      deleted: true,
+    });
+    expect(mockDeleteDomainDetail).toHaveBeenCalledWith({
+      id: VALID_DOMAIN_ID,
+      userId: "user-1",
+    });
     expect(mockQueueEvent).toHaveBeenCalledWith({
       type: "domain.deleted",
       userId: "user-1",
@@ -356,7 +434,45 @@ describe("Domain API validation", () => {
     expect(json.error).toBe("Validation failed");
     expect(json.details.fieldErrors.click_tracking).toBeDefined();
     expect(json.details.fieldErrors.tls).toBeDefined();
-    expect(mockDb.update).not.toHaveBeenCalled();
+    expect(mockUpdateDomainDetail).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 for invalid domain detail params before calling the service", async () => {
+    const { GET } = await import("@/app/api/domains/[id]/route");
+    const req = makeRequest(
+      "http://localhost:3015/api/domains/not-a-uuid",
+      "GET",
+    );
+
+    const res = await GET(req, {
+      params: Promise.resolve({ id: "not-a-uuid" }),
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(json.error).toBe("Validation failed");
+    expect(json.details.fieldErrors.id).toBeDefined();
+    expect(mockGetDomainDetail).not.toHaveBeenCalled();
+  });
+
+  it("maps domain detail service not-found errors to the legacy 404 body", async () => {
+    mockUpdateDomainDetail.mockRejectedValueOnce(
+      new MockDomainDetailServiceError("not_found", "Not found"),
+    );
+
+    const { PATCH } = await import("@/app/api/domains/[id]/route");
+    const req = makeRequest(
+      `http://localhost:3015/api/domains/${VALID_DOMAIN_ID}`,
+      "PATCH",
+      { open_tracking: true },
+    );
+
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: VALID_DOMAIN_ID }),
+    });
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Not found" });
   });
 
   it("returns 422 for invalid domain verify params", async () => {

--- a/tests/cache-invalidation-routes.test.ts
+++ b/tests/cache-invalidation-routes.test.ts
@@ -15,6 +15,18 @@ const mockListDNSRecords = vi.hoisted(() => vi.fn());
 const mockDeleteDNSRecord = vi.hoisted(() => vi.fn());
 const mockQueueEvent = vi.hoisted(() => vi.fn());
 const mockReconcileVerification = vi.hoisted(() => vi.fn());
+const MockDomainDetailServiceError = vi.hoisted(
+  () =>
+    class DomainDetailServiceError extends Error {
+      constructor(
+        readonly code: string,
+        message: string,
+      ) {
+        super(message);
+        this.name = "DomainDetailServiceError";
+      }
+    },
+);
 
 const VALID_DOMAIN_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -26,6 +38,7 @@ const mockDb = vi.hoisted(() => ({
 }));
 
 vi.mock("@opensend/core", () => ({
+  DomainDetailServiceError: MockDomainDetailServiceError,
   ApiKeyServiceError: class ApiKeyServiceError extends Error {},
   createApiKeyService: () => ({
     createApiKey: mockCreateApiKey,
@@ -69,6 +82,48 @@ vi.mock("@opensend/core", () => ({
   }),
   createDomainService: () => ({
     createDomain: mockCreateDomain,
+  }),
+  createDomainDetailService: () => ({
+    updateDomainDetail: async (input: {
+      id: string;
+      userId: string;
+      updates: Record<string, unknown>;
+    }) => {
+      const existing = await mockGetCachedDomainById(input.id);
+      if (!existing || existing.userId !== input.userId) {
+        throw new MockDomainDetailServiceError("not_found", "Not found");
+      }
+      await mockInvalidateDomainCaches({ id: input.id, name: existing.name });
+      return {
+        response: { object: "domain", id: input.id },
+        changedFields: Object.keys(input.updates),
+        eventPayload: {
+          id: input.id,
+          changed_fields: Object.keys(input.updates),
+          domain: {
+            id: input.id,
+            name: existing.name,
+            status: existing.status ?? "not_started",
+            region: existing.region ?? "us-east-1",
+            records: existing.records ?? [],
+            capabilities: existing.capabilities ?? [],
+            created_at:
+              existing.createdAt ?? new Date("2026-05-06T00:00:00.000Z"),
+          },
+        },
+      };
+    },
+    deleteDomainDetail: async (input: { id: string; userId: string }) => {
+      const existing = await mockGetCachedDomainById(input.id);
+      if (!existing || existing.userId !== input.userId) {
+        throw new MockDomainDetailServiceError("not_found", "Not found");
+      }
+      await mockInvalidateDomainCaches({ id: input.id, name: existing.name });
+      return {
+        response: { object: "domain", id: input.id, deleted: true },
+        eventPayload: { id: input.id, name: existing.name },
+      };
+    },
   }),
   domainService: {
     reconcileVerification: mockReconcileVerification,

--- a/tests/domain-detail-service.test.ts
+++ b/tests/domain-detail-service.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, it, vi } from "vitest";
+import type { domains } from "../packages/core/src/db/schema";
+import {
+  type DomainDetailServiceDependencies,
+  DomainDetailServiceError,
+  createDomainDetailService,
+} from "../packages/core/src/services/domain-detail";
+
+type DomainRow = typeof domains.$inferSelect;
+type DomainUpdateInput = Parameters<
+  NonNullable<DomainDetailServiceDependencies["updateDomainForUser"]>
+>[0];
+type DomainDeleteInput = Parameters<
+  NonNullable<DomainDetailServiceDependencies["deleteDomainForUser"]>
+>[0];
+
+function domainRow(overrides: Partial<DomainRow> = {}): DomainRow {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    name: "example.com",
+    status: "not_started",
+    region: "us-east-1",
+    dkimTokens: ["dkim-a"],
+    records: [
+      {
+        type: "TXT",
+        name: "send.example.com",
+        value: "v=spf1 include:amazonses.com ~all",
+        status: "pending",
+        ttl: "Auto",
+      },
+    ],
+    trackClicks: false,
+    trackOpens: false,
+    tls: "opportunistic",
+    createdAt: new Date("2026-05-06T00:00:00.000Z"),
+    document: null,
+    userId: "user-1",
+    customReturnPath: null,
+    trackingSubdomain: null,
+    capabilities: [
+      { name: "sending", enabled: true },
+      { name: "receiving", enabled: false },
+    ],
+    dkimOrigin: "AWS_SES",
+    dkimSelector: null,
+    dkimPublicKey: null,
+    dkimPrivateKeyCt: null,
+    dkimPrivateKeyIv: null,
+    ...overrides,
+  };
+}
+
+describe("domain detail service", () => {
+  it("gets a user-scoped domain detail with the public API field shape", async () => {
+    const service = createDomainDetailService({
+      getDomainById: async () =>
+        domainRow({
+          customReturnPath: "outbound",
+          trackOpens: true,
+          trackClicks: true,
+          trackingSubdomain: "track.example.com",
+          tls: "enforced",
+        }),
+    });
+
+    const result = await service.getDomainDetail({
+      id: "11111111-1111-4111-8111-111111111111",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      object: "domain",
+      id: "11111111-1111-4111-8111-111111111111",
+      name: "example.com",
+      status: "not_started",
+      region: "us-east-1",
+      records: [
+        {
+          type: "TXT",
+          name: "send.example.com",
+          value: "v=spf1 include:amazonses.com ~all",
+          status: "pending",
+          ttl: "Auto",
+        },
+      ],
+      custom_return_path: "outbound",
+      return_path: "outbound",
+      open_tracking: true,
+      click_tracking: true,
+      tracking_subdomain: "track.example.com",
+      tls: "enforced",
+      capabilities: [
+        { name: "sending", enabled: true },
+        { name: "receiving", enabled: false },
+      ],
+      created_at: new Date("2026-05-06T00:00:00.000Z"),
+    });
+  });
+
+  it("rejects missing or cross-tenant domains before mutation", async () => {
+    const updateDomainForUser =
+      vi.fn<(_input: DomainUpdateInput) => Promise<DomainRow | undefined>>();
+    const service = createDomainDetailService({
+      getDomainById: async () => domainRow({ userId: "other-user" }),
+      updateDomainForUser,
+    });
+
+    await expect(
+      service.updateDomainDetail({
+        id: "11111111-1111-4111-8111-111111111111",
+        userId: "user-1",
+        updates: { open_tracking: true },
+      }),
+    ).rejects.toMatchObject({
+      code: "not_found",
+      name: "DomainDetailServiceError",
+    });
+    expect(updateDomainForUser).not.toHaveBeenCalled();
+  });
+
+  it("returns the legacy no-op update response without invalidating or queuing an event", async () => {
+    const updateDomainForUser =
+      vi.fn<(_input: DomainUpdateInput) => Promise<DomainRow | undefined>>();
+    const invalidateDomainCaches =
+      vi.fn<
+        (_input: { id?: string | null; name?: string | null }) => Promise<void>
+      >();
+    const service = createDomainDetailService({
+      getDomainById: async () => domainRow({ trackOpens: true }),
+      updateDomainForUser,
+      invalidateDomainCaches,
+    });
+
+    const result = await service.updateDomainDetail({
+      id: "11111111-1111-4111-8111-111111111111",
+      userId: "user-1",
+      updates: { open_tracking: true },
+    });
+
+    expect(result).toEqual({
+      response: {
+        object: "domain",
+        id: "11111111-1111-4111-8111-111111111111",
+      },
+      changedFields: [],
+    });
+    expect(updateDomainForUser).not.toHaveBeenCalled();
+    expect(invalidateDomainCaches).not.toHaveBeenCalled();
+  });
+
+  it("updates changed fields, invalidates caches, and returns the domain.updated payload", async () => {
+    const existing = domainRow({
+      capabilities: [
+        { name: "sending", enabled: true },
+        { name: "receiving", enabled: false },
+      ],
+    });
+    const updated = domainRow({
+      trackOpens: true,
+      capabilities: [
+        { name: "sending", enabled: false },
+        { name: "receiving", enabled: false },
+      ],
+    });
+    const updateCalls: DomainUpdateInput[] = [];
+    const invalidateDomainCaches =
+      vi.fn<
+        (_input: { id?: string | null; name?: string | null }) => Promise<void>
+      >();
+    const service = createDomainDetailService({
+      getDomainById: async () => existing,
+      updateDomainForUser: async (input) => {
+        updateCalls.push(input);
+        return updated;
+      },
+      invalidateDomainCaches,
+    });
+
+    const result = await service.updateDomainDetail({
+      id: existing.id,
+      userId: "user-1",
+      updates: {
+        open_tracking: true,
+        sending_enabled: false,
+      },
+    });
+
+    expect(updateCalls).toEqual([
+      {
+        id: existing.id,
+        userId: "user-1",
+        updates: {
+          trackOpens: true,
+          capabilities: [
+            { name: "sending", enabled: false },
+            { name: "receiving", enabled: false },
+          ],
+        },
+      },
+    ]);
+    expect(invalidateDomainCaches).toHaveBeenCalledWith({
+      id: existing.id,
+      name: "example.com",
+    });
+    expect(result).toEqual({
+      response: { object: "domain", id: existing.id },
+      changedFields: ["open_tracking", "capabilities"],
+      eventPayload: {
+        id: existing.id,
+        changed_fields: ["open_tracking", "capabilities"],
+        domain: {
+          id: existing.id,
+          name: "example.com",
+          status: "not_started",
+          region: "us-east-1",
+          records: [
+            {
+              type: "TXT",
+              name: "send.example.com",
+              value: "v=spf1 include:amazonses.com ~all",
+              status: "pending",
+              ttl: "Auto",
+            },
+          ],
+          capabilities: [
+            { name: "sending", enabled: false },
+            { name: "receiving", enabled: false },
+          ],
+          created_at: "2026-05-06T00:00:00.000Z",
+        },
+      },
+    });
+  });
+
+  it("invalidates stale caches when a user-scoped update races with deletion", async () => {
+    const invalidateDomainCaches =
+      vi.fn<
+        (_input: { id?: string | null; name?: string | null }) => Promise<void>
+      >();
+    const service = createDomainDetailService({
+      getDomainById: async () => domainRow(),
+      updateDomainForUser: async () => undefined,
+      invalidateDomainCaches,
+    });
+
+    await expect(
+      service.updateDomainDetail({
+        id: "11111111-1111-4111-8111-111111111111",
+        userId: "user-1",
+        updates: { click_tracking: true },
+      }),
+    ).rejects.toBeInstanceOf(DomainDetailServiceError);
+    expect(invalidateDomainCaches).toHaveBeenCalledWith({
+      id: "11111111-1111-4111-8111-111111111111",
+      name: "example.com",
+    });
+  });
+
+  it("deletes with best-effort SES and Cloudflare cleanup, cache invalidation, and event payload", async () => {
+    const deletedInputs: DomainDeleteInput[] = [];
+    const deleteDomainIdentity = vi.fn<(_: string) => Promise<void>>();
+    const deleteDNSRecord = vi.fn<(_: string) => Promise<void>>();
+    const invalidateDomainCaches =
+      vi.fn<
+        (_input: { id?: string | null; name?: string | null }) => Promise<void>
+      >();
+    const service = createDomainDetailService({
+      getDomainById: async () => domainRow(),
+      deleteDomainIdentity,
+      listDNSRecords: async () => [
+        {
+          id: "spf",
+          name: "send.example.com",
+          content: "v=spf1 include:amazonses.com ~all",
+        },
+        {
+          id: "dkim",
+          name: "abc._domainkey.example.com",
+          content: "abc.dkim.amazonses.com",
+        },
+        { id: "unrelated", name: "www.example.com", content: "1.2.3.4" },
+      ],
+      deleteDNSRecord,
+      deleteDomainForUser: async (input) => {
+        deletedInputs.push(input);
+        return { id: input.id, name: "example.com" };
+      },
+      invalidateDomainCaches,
+    });
+
+    const result = await service.deleteDomainDetail({
+      id: "11111111-1111-4111-8111-111111111111",
+      userId: "user-1",
+    });
+
+    expect(deleteDomainIdentity).toHaveBeenCalledWith("example.com");
+    expect(deleteDNSRecord).toHaveBeenCalledTimes(2);
+    expect(deleteDNSRecord).toHaveBeenCalledWith("spf");
+    expect(deleteDNSRecord).toHaveBeenCalledWith("dkim");
+    expect(deletedInputs).toEqual([
+      { id: "11111111-1111-4111-8111-111111111111", userId: "user-1" },
+    ]);
+    expect(invalidateDomainCaches).toHaveBeenCalledWith({
+      id: "11111111-1111-4111-8111-111111111111",
+      name: "example.com",
+    });
+    expect(result).toEqual({
+      response: {
+        object: "domain",
+        id: "11111111-1111-4111-8111-111111111111",
+        deleted: true,
+      },
+      eventPayload: {
+        id: "11111111-1111-4111-8111-111111111111",
+        name: "example.com",
+      },
+    });
+  });
+
+  it("continues deletion when SES and Cloudflare cleanup fail", async () => {
+    const warn = vi.fn<Console["warn"]>();
+    const service = createDomainDetailService({
+      getDomainById: async () => domainRow(),
+      deleteDomainIdentity: async () => {
+        throw new Error("ses unavailable");
+      },
+      listDNSRecords: async () => {
+        throw new Error("cloudflare unavailable");
+      },
+      deleteDomainForUser: async (input) => ({
+        id: input.id,
+        name: "example.com",
+      }),
+      logger: { warn },
+    });
+
+    const result = await service.deleteDomainDetail({
+      id: "11111111-1111-4111-8111-111111111111",
+      userId: "user-1",
+    });
+
+    expect(result.response.deleted).toBe(true);
+    expect(warn).toHaveBeenCalledWith(
+      "Failed to delete SES identity for example.com:",
+      expect.any(Error),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "Failed to cleanup Cloudflare records for example.com:",
+      expect.any(Error),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Extract GET/PATCH/DELETE domain detail behavior into `createDomainDetailService` in `@opensend/core`.
- Keep the Next.js route adapter responsible for auth, JSON parsing, Zod validation, and HTTP status/body mapping.
- Add focused service tests and route-adapter compatibility coverage for detail responses, validation, events, cache invalidation, and not-found mapping.

Closes #338

## Validation
- `bun run test -- tests/domain-detail-service.test.ts tests/api-domains.test.ts tests/cache-invalidation-routes.test.ts`
- `make check`
- `make test`

## Residual risk
- Playwright was not run; this is an API-only service-boundary extraction covered by Vitest and type/lint checks.