### PR TITLE
Extract email lifecycle service boundary

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export * from "./services/apiKeys";
 export * from "./services/contact";
 export * from "./services/contact-operations";
 export * from "./services/email";
+export * from "./services/emailLifecycle";
 export * from "./services/emailRead";
 export * from "./services/logs";
 export * from "./services/suppressions";

--- a/packages/core/src/services/emailLifecycle.ts
+++ b/packages/core/src/services/emailLifecycle.ts
@@ -1,0 +1,263 @@
+import { and, asc, eq } from "drizzle-orm";
+import { db } from "../db/client";
+import { emailEvents, emails } from "../db/schema";
+import { storageService } from "./storage";
+
+type EmailRow = typeof emails.$inferSelect;
+type EmailEventRow = typeof emailEvents.$inferSelect;
+
+export type EmailLifecycleAttachmentRow = {
+  id?: string;
+  filename: string;
+  content_type?: string;
+  contentType?: string;
+  s3Key?: string;
+  path?: string;
+};
+
+type EmailLifecycleEmailRow = Pick<EmailRow, "id" | "status" | "attachments">;
+
+type EmailLifecycleStatusRow = Pick<EmailRow, "id" | "status">;
+
+export type EmailLifecycleAttachmentListItem = {
+  id: string;
+  filename: string;
+  content_type: string;
+};
+
+export type EmailLifecycleAttachmentListResponse = {
+  object: "list";
+  data: EmailLifecycleAttachmentListItem[];
+};
+
+export type EmailLifecycleAttachmentDetailResponse = {
+  object: "attachment";
+  id: string;
+  filename: string;
+  content_type: string;
+  download_url: string;
+  expires_at: string;
+};
+
+export type EmailLifecycleCancelResponse = {
+  object: "email";
+  id: string;
+  status: "canceled";
+};
+
+export type EmailLifecycleEventListItem = {
+  object: "email_event";
+  id: string;
+  type: string;
+  payload: unknown;
+  created_at: EmailEventRow["receivedAt"];
+};
+
+export type EmailLifecycleEventListResponse = {
+  object: "list";
+  data: EmailLifecycleEventListItem[];
+};
+
+export type EmailLifecycleRepository = {
+  findEmailForUser(
+    id: string,
+    userId: string,
+  ): Promise<EmailLifecycleEmailRow | undefined>;
+  updateEmailStatusForUser(
+    id: string,
+    userId: string,
+    status: string,
+  ): Promise<EmailLifecycleStatusRow | undefined>;
+  listEventsByEmailIdAsc(emailId: string): Promise<EmailEventRow[]>;
+};
+
+export type EmailLifecycleServiceErrorCode =
+  | "email_not_found"
+  | "attachment_not_found"
+  | "invalid_state";
+
+export class EmailLifecycleServiceError extends Error {
+  constructor(
+    readonly code: EmailLifecycleServiceErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "EmailLifecycleServiceError";
+  }
+}
+
+export type EmailLifecycleServiceDependencies = {
+  repository?: EmailLifecycleRepository;
+  getPresignedUrl?: (key: string) => Promise<string>;
+  now?: () => Date;
+};
+
+const defaultRepository: EmailLifecycleRepository = {
+  async findEmailForUser(id, userId) {
+    return await db.query.emails.findFirst({
+      where: and(eq(emails.id, id), eq(emails.userId, userId)),
+    });
+  },
+
+  async updateEmailStatusForUser(id, userId, status) {
+    const [updated] = await db
+      .update(emails)
+      .set({ status })
+      .where(and(eq(emails.id, id), eq(emails.userId, userId)))
+      .returning({ id: emails.id, status: emails.status });
+
+    return updated;
+  },
+
+  async listEventsByEmailIdAsc(emailId) {
+    return await db
+      .select()
+      .from(emailEvents)
+      .where(eq(emailEvents.emailId, emailId))
+      .orderBy(asc(emailEvents.receivedAt));
+  },
+};
+
+function attachmentId(attachment: EmailLifecycleAttachmentRow, index: number) {
+  return attachment.id || `att-${index}`;
+}
+
+function getAttachments(email: EmailLifecycleEmailRow) {
+  return (email.attachments ?? []) as EmailLifecycleAttachmentRow[];
+}
+
+function requireEmail(email: EmailLifecycleEmailRow | undefined) {
+  if (!email) {
+    throw new EmailLifecycleServiceError("email_not_found", "Email not found");
+  }
+
+  return email;
+}
+
+function toAttachmentListItem(
+  attachment: EmailLifecycleAttachmentRow,
+  index: number,
+): EmailLifecycleAttachmentListItem {
+  return {
+    id: attachmentId(attachment, index),
+    filename: attachment.filename,
+    content_type: attachment.content_type || "application/octet-stream",
+  };
+}
+
+function toEmailEventListItem(
+  event: EmailEventRow,
+): EmailLifecycleEventListItem {
+  return {
+    object: "email_event",
+    id: event.id,
+    type: event.type,
+    payload: event.payload,
+    created_at: event.receivedAt,
+  };
+}
+
+export function createEmailLifecycleService({
+  repository = defaultRepository,
+  getPresignedUrl = storageService.getPresignedUrl.bind(storageService),
+  now = () => new Date(),
+}: EmailLifecycleServiceDependencies = {}) {
+  return {
+    async listAttachments(
+      userId: string,
+      emailId: string,
+    ): Promise<EmailLifecycleAttachmentListResponse> {
+      const email = requireEmail(
+        await repository.findEmailForUser(emailId, userId),
+      );
+
+      return {
+        object: "list",
+        data: getAttachments(email).map(toAttachmentListItem),
+      };
+    },
+
+    async getAttachment(
+      userId: string,
+      emailId: string,
+      requestedAttachmentId: string,
+    ): Promise<EmailLifecycleAttachmentDetailResponse> {
+      const email = requireEmail(
+        await repository.findEmailForUser(emailId, userId),
+      );
+      const attachment = getAttachments(email).find(
+        (candidate, index) =>
+          attachmentId(candidate, index) === requestedAttachmentId,
+      );
+
+      if (!attachment) {
+        throw new EmailLifecycleServiceError(
+          "attachment_not_found",
+          "Attachment not found",
+        );
+      }
+
+      const s3Key =
+        attachment.s3Key ||
+        attachment.path ||
+        `sent-emails/${emailId}/${attachment.filename}`;
+      const downloadUrl = await getPresignedUrl(s3Key);
+
+      return {
+        object: "attachment",
+        id: attachment.id || requestedAttachmentId,
+        filename: attachment.filename,
+        content_type: attachment.contentType || "application/octet-stream",
+        download_url: downloadUrl,
+        expires_at: new Date(now().getTime() + 3600 * 1000).toISOString(),
+      };
+    },
+
+    async cancelEmail(
+      userId: string,
+      emailId: string,
+    ): Promise<EmailLifecycleCancelResponse> {
+      const existing = requireEmail(
+        await repository.findEmailForUser(emailId, userId),
+      );
+
+      if (existing.status !== "scheduled") {
+        throw new EmailLifecycleServiceError(
+          "invalid_state",
+          `Cannot cancel a ${existing.status} email`,
+        );
+      }
+
+      const updated = await repository.updateEmailStatusForUser(
+        emailId,
+        userId,
+        "canceled",
+      );
+
+      if (!updated) {
+        throw new Error("Email status update returned no row");
+      }
+
+      return {
+        object: "email",
+        id: updated.id,
+        status: "canceled",
+      };
+    },
+
+    async listEvents(
+      userId: string,
+      emailId: string,
+    ): Promise<EmailLifecycleEventListResponse> {
+      requireEmail(await repository.findEmailForUser(emailId, userId));
+      const events = await repository.listEventsByEmailIdAsc(emailId);
+
+      return {
+        object: "list",
+        data: events.map(toEmailEventListItem),
+      };
+    },
+  };
+}
+
+export const emailLifecycleService = createEmailLifecycleService();

--- a/src/app/api/emails/[id]/attachments/[attachmentId]/route.ts
+++ b/src/app/api/emails/[id]/attachments/[attachmentId]/route.ts
@@ -1,10 +1,12 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { emails } from "@/lib/db/schema";
-import { getPresignedUrl } from "@/lib/s3";
-import { and, eq } from "drizzle-orm";
+import {
+  EmailLifecycleServiceError,
+  createEmailLifecycleService,
+} from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
+
+const emailLifecycleService = createEmailLifecycleService();
 
 export async function GET(
   _request: NextRequest,
@@ -17,51 +19,30 @@ export async function GET(
 
   try {
     const { id, attachmentId } = await params;
-    const [email] = await db
-      .select({ attachments: emails.attachments })
-      .from(emails)
-      .where(and(eq(emails.id, id), eq(emails.userId, auth.userId)))
-      .limit(1);
-
-    if (!email) {
+    const result = await emailLifecycleService.getAttachment(
+      auth.userId,
+      id,
+      attachmentId,
+    );
+    return NextResponse.json(result);
+  } catch (error) {
+    if (
+      error instanceof EmailLifecycleServiceError &&
+      error.code === "email_not_found"
+    ) {
       return NextResponse.json({ error: "Email not found" }, { status: 404 });
     }
 
-    const attachments =
-      (email.attachments as Array<{
-        id?: string;
-        filename: string;
-        contentType?: string;
-        s3Key?: string;
-        path?: string;
-      }>) ?? [];
-    const attachment = attachments.find(
-      (a, index) => (a.id || `att-${index}`) === attachmentId,
-    );
-
-    if (!attachment) {
+    if (
+      error instanceof EmailLifecycleServiceError &&
+      error.code === "attachment_not_found"
+    ) {
       return NextResponse.json(
         { error: "Attachment not found" },
         { status: 404 },
       );
     }
 
-    // Resolve S3 key - if stored as raw content, we might need a placeholder or real upload path
-    const s3Key =
-      attachment.s3Key ||
-      attachment.path ||
-      `sent-emails/${id}/${attachment.filename}`;
-    const downloadUrl = await getPresignedUrl(s3Key);
-
-    return NextResponse.json({
-      object: "attachment",
-      id: attachment.id || attachmentId,
-      filename: attachment.filename,
-      content_type: attachment.contentType || "application/octet-stream",
-      download_url: downloadUrl,
-      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
-    });
-  } catch (error) {
     console.error("Failed to fetch email attachment:", error);
     return NextResponse.json(
       { error: "Failed to fetch email attachment" },

--- a/src/app/api/emails/[id]/attachments/route.ts
+++ b/src/app/api/emails/[id]/attachments/route.ts
@@ -1,9 +1,12 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { emails } from "@/lib/db/schema";
-import { and, eq } from "drizzle-orm";
+import {
+  EmailLifecycleServiceError,
+  createEmailLifecycleService,
+} from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
+
+const emailLifecycleService = createEmailLifecycleService();
 
 export async function GET(
   _request: NextRequest,
@@ -16,32 +19,16 @@ export async function GET(
 
   try {
     const { id } = await params;
-    const [email] = await db
-      .select({ attachments: emails.attachments })
-      .from(emails)
-      .where(and(eq(emails.id, id), eq(emails.userId, auth.userId)))
-      .limit(1);
-
-    if (!email) {
+    const result = await emailLifecycleService.listAttachments(auth.userId, id);
+    return NextResponse.json(result);
+  } catch (error) {
+    if (
+      error instanceof EmailLifecycleServiceError &&
+      error.code === "email_not_found"
+    ) {
       return NextResponse.json({ error: "Email not found" }, { status: 404 });
     }
 
-    const attachments =
-      (email.attachments as Array<{
-        id?: string;
-        filename: string;
-        content_type?: string;
-      }>) ?? [];
-
-    return NextResponse.json({
-      object: "list",
-      data: attachments.map((a, index) => ({
-        id: a.id || `att-${index}`,
-        filename: a.filename,
-        content_type: a.content_type || "application/octet-stream",
-      })),
-    });
-  } catch (error) {
     console.error("Failed to fetch email attachments:", error);
     return NextResponse.json(
       { error: "Failed to fetch email attachments" },

--- a/src/app/api/emails/[id]/cancel/route.ts
+++ b/src/app/api/emails/[id]/cancel/route.ts
@@ -1,9 +1,12 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { emails } from "@/lib/db/schema";
-import { and, eq } from "drizzle-orm";
+import {
+  EmailLifecycleServiceError,
+  createEmailLifecycleService,
+} from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
+
+const emailLifecycleService = createEmailLifecycleService();
 
 export async function POST(
   _request: NextRequest,
@@ -16,34 +19,23 @@ export async function POST(
 
   try {
     const { id } = await params;
-
-    const existing = await db.query.emails.findFirst({
-      where: and(eq(emails.id, id), eq(emails.userId, auth.userId)),
-    });
-
-    if (!existing) {
+    const result = await emailLifecycleService.cancelEmail(auth.userId, id);
+    return NextResponse.json(result);
+  } catch (error) {
+    if (
+      error instanceof EmailLifecycleServiceError &&
+      error.code === "email_not_found"
+    ) {
       return NextResponse.json({ error: "Email not found" }, { status: 404 });
     }
 
-    if (existing.status !== "scheduled") {
-      return NextResponse.json(
-        { error: `Cannot cancel a ${existing.status} email` },
-        { status: 400 },
-      );
+    if (
+      error instanceof EmailLifecycleServiceError &&
+      error.code === "invalid_state"
+    ) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
     }
 
-    const [updated] = await db
-      .update(emails)
-      .set({ status: "canceled" })
-      .where(and(eq(emails.id, id), eq(emails.userId, auth.userId)))
-      .returning();
-
-    return NextResponse.json({
-      object: "email",
-      id: updated.id,
-      status: "canceled",
-    });
-  } catch (error) {
     console.error("Failed to cancel email:", error);
     return NextResponse.json(
       { error: "Failed to cancel email" },

--- a/src/app/api/emails/[id]/events/route.ts
+++ b/src/app/api/emails/[id]/events/route.ts
@@ -1,9 +1,12 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { emailEvents, emails } from "@/lib/db/schema";
-import { and, asc, eq } from "drizzle-orm";
+import {
+  EmailLifecycleServiceError,
+  createEmailLifecycleService,
+} from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
+
+const emailLifecycleService = createEmailLifecycleService();
 
 export async function GET(
   _request: NextRequest,
@@ -16,31 +19,16 @@ export async function GET(
 
   try {
     const { id: emailId } = await params;
-    const email = await db.query.emails.findFirst({
-      where: and(eq(emails.id, emailId), eq(emails.userId, auth.userId)),
-    });
-
-    if (!email) {
+    const result = await emailLifecycleService.listEvents(auth.userId, emailId);
+    return NextResponse.json(result);
+  } catch (error) {
+    if (
+      error instanceof EmailLifecycleServiceError &&
+      error.code === "email_not_found"
+    ) {
       return NextResponse.json({ error: "Email not found" }, { status: 404 });
     }
 
-    const results = await db
-      .select()
-      .from(emailEvents)
-      .where(eq(emailEvents.emailId, emailId))
-      .orderBy(asc(emailEvents.receivedAt));
-
-    return NextResponse.json({
-      object: "list",
-      data: results.map((e) => ({
-        object: "email_event",
-        id: e.id,
-        type: e.type,
-        payload: e.payload,
-        created_at: e.receivedAt,
-      })),
-    });
-  } catch (error) {
     console.error("Failed to fetch email events:", error);
     return NextResponse.json(
       { error: "Failed to fetch email events" },

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -16,6 +16,12 @@ const mockEmailReadService = vi.hoisted(() => ({
   getEmail: vi.fn(),
   deleteEmail: vi.fn(),
 }));
+const mockEmailLifecycleService = vi.hoisted(() => ({
+  listAttachments: vi.fn(),
+  getAttachment: vi.fn(),
+  cancelEmail: vi.fn(),
+  listEvents: vi.fn(),
+}));
 const MockEmailReadServiceError = vi.hoisted(
   () =>
     class EmailReadServiceError extends Error {
@@ -25,6 +31,18 @@ const MockEmailReadServiceError = vi.hoisted(
       ) {
         super(message);
         this.name = "EmailReadServiceError";
+      }
+    },
+);
+const MockEmailLifecycleServiceError = vi.hoisted(
+  () =>
+    class EmailLifecycleServiceError extends Error {
+      constructor(
+        readonly code: string,
+        message: string,
+      ) {
+        super(message);
+        this.name = "EmailLifecycleServiceError";
       }
     },
 );
@@ -62,10 +80,12 @@ vi.mock("@opensend/core", () => {
 
   return {
     EmailReadServiceError: MockEmailReadServiceError,
+    EmailLifecycleServiceError: MockEmailLifecycleServiceError,
     createBackgroundJob: (job: Record<string, unknown>) => ({
       ...job,
       requestedAt: "2026-04-28T00:00:00.000Z",
     }),
+    createEmailLifecycleService: () => mockEmailLifecycleService,
     createEmailReadService: () => mockEmailReadService,
     detectSandboxTestRecipient: (recipient: string) => {
       const normalized = recipient.trim().toLowerCase();
@@ -2534,21 +2554,176 @@ describe("DELETE /api/emails", () => {
   });
 });
 
+describe("GET /api/emails/:id/attachments", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockEmailLifecycleService.listAttachments.mockReset();
+    mockEmailLifecycleService.getAttachment.mockReset();
+    mockValidateApiKey.mockResolvedValue(AUTH_RESULT);
+  });
+
+  it("returns the service attachment list response unchanged", async () => {
+    mockEmailLifecycleService.listAttachments.mockResolvedValueOnce({
+      object: "list",
+      data: [
+        {
+          id: "att-0",
+          filename: "receipt.txt",
+          content_type: "application/octet-stream",
+        },
+      ],
+    });
+
+    const { GET } = await import("@/app/api/emails/[id]/attachments/route");
+    const res = await GET(
+      new Request("http://localhost:3015/api/emails/email-uuid/attachments", {
+        headers: { Authorization: "Bearer re_test123" },
+      }) as never,
+      { params: Promise.resolve({ id: "email-uuid" }) },
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      object: "list",
+      data: [
+        {
+          id: "att-0",
+          filename: "receipt.txt",
+          content_type: "application/octet-stream",
+        },
+      ],
+    });
+    expect(mockEmailLifecycleService.listAttachments).toHaveBeenCalledWith(
+      AUTH_RESULT.userId,
+      "email-uuid",
+    );
+  });
+
+  it("preserves the list route email-not-found response", async () => {
+    mockEmailLifecycleService.listAttachments.mockRejectedValueOnce(
+      new MockEmailLifecycleServiceError("email_not_found", "Email not found"),
+    );
+
+    const { GET } = await import("@/app/api/emails/[id]/attachments/route");
+    const res = await GET(
+      new Request("http://localhost:3015/api/emails/email-uuid/attachments", {
+        headers: { Authorization: "Bearer re_test123" },
+      }) as never,
+      { params: Promise.resolve({ id: "email-uuid" }) },
+    );
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Email not found" });
+  });
+
+  it("preserves the detail route attachment-not-found response", async () => {
+    mockEmailLifecycleService.getAttachment.mockRejectedValueOnce(
+      new MockEmailLifecycleServiceError(
+        "attachment_not_found",
+        "Attachment not found",
+      ),
+    );
+
+    const { GET } = await import(
+      "@/app/api/emails/[id]/attachments/[attachmentId]/route"
+    );
+    const res = await GET(
+      new Request(
+        "http://localhost:3015/api/emails/email-uuid/attachments/missing",
+        {
+          headers: { Authorization: "Bearer re_test123" },
+        },
+      ) as never,
+      {
+        params: Promise.resolve({
+          id: "email-uuid",
+          attachmentId: "missing",
+        }),
+      },
+    );
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({
+      error: "Attachment not found",
+    });
+    expect(mockEmailLifecycleService.getAttachment).toHaveBeenCalledWith(
+      AUTH_RESULT.userId,
+      "email-uuid",
+      "missing",
+    );
+  });
+});
+
+describe("POST /api/emails/:id/cancel", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockEmailLifecycleService.cancelEmail.mockReset();
+    mockValidateApiKey.mockResolvedValue(AUTH_RESULT);
+  });
+
+  it("returns the canceled email response from the lifecycle service", async () => {
+    mockEmailLifecycleService.cancelEmail.mockResolvedValueOnce({
+      object: "email",
+      id: "email-uuid",
+      status: "canceled",
+    });
+
+    const { POST } = await import("@/app/api/emails/[id]/cancel/route");
+    const res = await POST(
+      new Request("http://localhost:3015/api/emails/email-uuid/cancel", {
+        method: "POST",
+        headers: { Authorization: "Bearer re_test123" },
+      }) as never,
+      { params: Promise.resolve({ id: "email-uuid" }) },
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      object: "email",
+      id: "email-uuid",
+      status: "canceled",
+    });
+    expect(mockEmailLifecycleService.cancelEmail).toHaveBeenCalledWith(
+      AUTH_RESULT.userId,
+      "email-uuid",
+    );
+  });
+
+  it("preserves the non-scheduled cancel response", async () => {
+    mockEmailLifecycleService.cancelEmail.mockRejectedValueOnce(
+      new MockEmailLifecycleServiceError(
+        "invalid_state",
+        "Cannot cancel a delivered email",
+      ),
+    );
+
+    const { POST } = await import("@/app/api/emails/[id]/cancel/route");
+    const res = await POST(
+      new Request("http://localhost:3015/api/emails/email-uuid/cancel", {
+        method: "POST",
+        headers: { Authorization: "Bearer re_test123" },
+      }) as never,
+      { params: Promise.resolve({ id: "email-uuid" }) },
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Cannot cancel a delivered email",
+    });
+  });
+});
+
 describe("GET /api/emails/:id/events", () => {
   beforeEach(() => {
     vi.resetModules();
+    mockEmailLifecycleService.listEvents.mockReset();
     mockValidateApiKey.mockResolvedValue(AUTH_RESULT);
   });
 
   it("does not list events for an email outside the authenticated user scope", async () => {
-    const findFirst = vi.fn().mockResolvedValue(null);
-    mockDb.query = {
-      emails: {
-        findFirst,
-      },
-    } as unknown as ReturnType<typeof vi.fn>;
-    const select = vi.fn();
-    mockDb.select = select;
+    mockEmailLifecycleService.listEvents.mockRejectedValueOnce(
+      new MockEmailLifecycleServiceError("email_not_found", "Email not found"),
+    );
 
     const { GET } = await import("@/app/api/emails/[id]/events/route");
     const res = await GET(
@@ -2559,21 +2734,47 @@ describe("GET /api/emails/:id/events", () => {
     );
 
     expect(res.status).toBe(404);
-    expect(select).not.toHaveBeenCalled();
-    expect(findFirst).toHaveBeenCalledWith({
-      where: expect.objectContaining({
-        op: "and",
-        args: expect.arrayContaining([
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining(["email-uuid"]),
-          }),
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining([AUTH_RESULT.userId]),
-          }),
-        ]),
-      }),
+    await expect(res.json()).resolves.toEqual({ error: "Email not found" });
+    expect(mockEmailLifecycleService.listEvents).toHaveBeenCalledWith(
+      AUTH_RESULT.userId,
+      "email-uuid",
+    );
+  });
+
+  it("returns ordered event DTOs from the lifecycle service unchanged", async () => {
+    mockEmailLifecycleService.listEvents.mockResolvedValueOnce({
+      object: "list",
+      data: [
+        {
+          object: "email_event",
+          id: "event-1",
+          type: "queued",
+          payload: { message: "queued" },
+          created_at: new Date("2026-05-01T00:00:00.000Z"),
+        },
+      ],
+    });
+
+    const { GET } = await import("@/app/api/emails/[id]/events/route");
+    const res = await GET(
+      new Request("http://localhost:3015/api/emails/email-uuid/events", {
+        headers: { Authorization: "Bearer re_test123" },
+      }) as never,
+      { params: Promise.resolve({ id: "email-uuid" }) },
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      object: "list",
+      data: [
+        {
+          object: "email_event",
+          id: "event-1",
+          type: "queued",
+          payload: { message: "queued" },
+          created_at: "2026-05-01T00:00:00.000Z",
+        },
+      ],
     });
   });
 });

--- a/tests/email-lifecycle-service.test.ts
+++ b/tests/email-lifecycle-service.test.ts
@@ -1,0 +1,291 @@
+import {
+  type EmailLifecycleAttachmentRow,
+  type EmailLifecycleRepository,
+  EmailLifecycleServiceError,
+  createEmailLifecycleService,
+} from "@opensend/core";
+import { describe, expect, it } from "vitest";
+
+type LifecycleEmail = NonNullable<
+  Awaited<ReturnType<EmailLifecycleRepository["findEmailForUser"]>>
+>;
+type LifecycleEvent = Awaited<
+  ReturnType<EmailLifecycleRepository["listEventsByEmailIdAsc"]>
+>[number];
+
+function makeEmail(overrides: Partial<LifecycleEmail> = {}): LifecycleEmail {
+  return {
+    id: "email-1",
+    status: "scheduled",
+    attachments: null,
+    ...overrides,
+  };
+}
+
+function makeAttachments(
+  attachments: EmailLifecycleAttachmentRow[],
+): LifecycleEmail["attachments"] {
+  return attachments as LifecycleEmail["attachments"];
+}
+
+function makeEvent(overrides: Partial<LifecycleEvent> = {}): LifecycleEvent {
+  return {
+    id: "event-1",
+    emailId: "email-1",
+    sourceId: null,
+    type: "delivered",
+    payload: { delivery: true },
+    userId: "user-1",
+    receivedAt: new Date("2026-05-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function makeRepository(
+  overrides: Partial<EmailLifecycleRepository> = {},
+): EmailLifecycleRepository {
+  return {
+    async findEmailForUser() {
+      return makeEmail();
+    },
+    async updateEmailStatusForUser(id, _userId, status) {
+      return { id, status };
+    },
+    async listEventsByEmailIdAsc() {
+      return [];
+    },
+    ...overrides,
+  };
+}
+
+describe("email lifecycle service boundary", () => {
+  it("lists attachments with scoped parent lookup and legacy fallbacks", async () => {
+    let capturedScope: { id: string; userId: string } | undefined;
+    const service = createEmailLifecycleService({
+      repository: makeRepository({
+        async findEmailForUser(id, userId) {
+          capturedScope = { id, userId };
+          return makeEmail({
+            id,
+            attachments: makeAttachments([
+              { filename: "receipt.txt" },
+              {
+                id: "att-custom",
+                filename: "logo.png",
+                content_type: "image/png",
+              },
+            ]),
+          });
+        },
+      }),
+    });
+
+    await expect(service.listAttachments("user-1", "email-1")).resolves.toEqual(
+      {
+        object: "list",
+        data: [
+          {
+            id: "att-0",
+            filename: "receipt.txt",
+            content_type: "application/octet-stream",
+          },
+          {
+            id: "att-custom",
+            filename: "logo.png",
+            content_type: "image/png",
+          },
+        ],
+      },
+    );
+    expect(capturedScope).toEqual({ id: "email-1", userId: "user-1" });
+  });
+
+  it("resolves attachment detail ids, S3 keys, URLs, and one-hour expiry", async () => {
+    const presignedKeys: string[] = [];
+    const service = createEmailLifecycleService({
+      repository: makeRepository({
+        async findEmailForUser(id) {
+          return makeEmail({
+            id,
+            attachments: makeAttachments([
+              {
+                filename: "stored.pdf",
+                contentType: "application/pdf",
+                s3Key: "stored/key.pdf",
+              },
+              {
+                filename: "path.txt",
+                contentType: "text/plain",
+                path: "path/key.txt",
+              },
+              {
+                id: "named",
+                filename: "fallback.bin",
+              },
+            ]),
+          });
+        },
+      }),
+      async getPresignedUrl(key) {
+        presignedKeys.push(key);
+        return `https://download.test/${key}`;
+      },
+      now: () => new Date("2026-05-01T12:00:00.000Z"),
+    });
+
+    await expect(
+      service.getAttachment("user-1", "email-1", "att-0"),
+    ).resolves.toMatchObject({
+      object: "attachment",
+      id: "att-0",
+      filename: "stored.pdf",
+      content_type: "application/pdf",
+      download_url: "https://download.test/stored/key.pdf",
+      expires_at: "2026-05-01T13:00:00.000Z",
+    });
+    await expect(
+      service.getAttachment("user-1", "email-1", "att-1"),
+    ).resolves.toMatchObject({
+      id: "att-1",
+      download_url: "https://download.test/path/key.txt",
+    });
+    await expect(
+      service.getAttachment("user-1", "email-1", "named"),
+    ).resolves.toMatchObject({
+      id: "named",
+      content_type: "application/octet-stream",
+      download_url: "https://download.test/sent-emails/email-1/fallback.bin",
+    });
+    expect(presignedKeys).toEqual([
+      "stored/key.pdf",
+      "path/key.txt",
+      "sent-emails/email-1/fallback.bin",
+    ]);
+  });
+
+  it("raises legacy not-found errors for missing emails or attachments", async () => {
+    const missingEmailService = createEmailLifecycleService({
+      repository: makeRepository({
+        async findEmailForUser() {
+          return undefined;
+        },
+      }),
+    });
+    const missingAttachmentService = createEmailLifecycleService({
+      repository: makeRepository({
+        async findEmailForUser() {
+          return makeEmail({ attachments: [{ filename: "only.txt" }] });
+        },
+      }),
+    });
+
+    await expect(
+      missingEmailService.listAttachments("user-1", "missing"),
+    ).rejects.toMatchObject({
+      name: "EmailLifecycleServiceError",
+      code: "email_not_found",
+      message: "Email not found",
+    });
+    await expect(
+      missingAttachmentService.getAttachment("user-1", "email-1", "missing"),
+    ).rejects.toMatchObject({
+      code: "attachment_not_found",
+      message: "Attachment not found",
+    });
+  });
+
+  it("cancels only scheduled emails with scoped update semantics", async () => {
+    let capturedUpdate:
+      | { id: string; userId: string; status: string }
+      | undefined;
+    const service = createEmailLifecycleService({
+      repository: makeRepository({
+        async findEmailForUser(id) {
+          return makeEmail({ id, status: "scheduled" });
+        },
+        async updateEmailStatusForUser(id, userId, status) {
+          capturedUpdate = { id, userId, status };
+          return { id, status };
+        },
+      }),
+    });
+
+    await expect(service.cancelEmail("user-1", "email-1")).resolves.toEqual({
+      object: "email",
+      id: "email-1",
+      status: "canceled",
+    });
+    expect(capturedUpdate).toEqual({
+      id: "email-1",
+      userId: "user-1",
+      status: "canceled",
+    });
+  });
+
+  it("rejects cancel for non-scheduled emails with the legacy message", async () => {
+    const service = createEmailLifecycleService({
+      repository: makeRepository({
+        async findEmailForUser() {
+          return makeEmail({ status: "delivered" });
+        },
+      }),
+    });
+
+    await expect(service.cancelEmail("user-1", "email-1")).rejects.toEqual(
+      new EmailLifecycleServiceError(
+        "invalid_state",
+        "Cannot cancel a delivered email",
+      ),
+    );
+  });
+
+  it("lists events after scoped parent lookup and preserves repository order", async () => {
+    let capturedScope: { id: string; userId: string } | undefined;
+    let capturedEmailId: string | undefined;
+    const service = createEmailLifecycleService({
+      repository: makeRepository({
+        async findEmailForUser(id, userId) {
+          capturedScope = { id, userId };
+          return makeEmail({ id });
+        },
+        async listEventsByEmailIdAsc(emailId) {
+          capturedEmailId = emailId;
+          return [
+            makeEvent({
+              id: "event-1",
+              type: "queued",
+              receivedAt: new Date("2026-05-01T00:00:00.000Z"),
+            }),
+            makeEvent({
+              id: "event-2",
+              type: "delivered",
+              receivedAt: new Date("2026-05-01T00:01:00.000Z"),
+            }),
+          ];
+        },
+      }),
+    });
+
+    await expect(service.listEvents("user-1", "email-1")).resolves.toEqual({
+      object: "list",
+      data: [
+        {
+          object: "email_event",
+          id: "event-1",
+          type: "queued",
+          payload: { delivery: true },
+          created_at: new Date("2026-05-01T00:00:00.000Z"),
+        },
+        {
+          object: "email_event",
+          id: "event-2",
+          type: "delivered",
+          payload: { delivery: true },
+          created_at: new Date("2026-05-01T00:01:00.000Z"),
+        },
+      ],
+    });
+    expect(capturedScope).toEqual({ id: "email-1", userId: "user-1" });
+    expect(capturedEmailId).toBe("email-1");
+  });
+});

--- a/tests/issue-200-missed-tenant-scope.test.tsx
+++ b/tests/issue-200-missed-tenant-scope.test.tsx
@@ -8,6 +8,11 @@ const mockFindLog = vi.hoisted(() => vi.fn());
 const mockSelect = vi.hoisted(() => vi.fn());
 const mockUpdate = vi.hoisted(() => vi.fn());
 const mockGetPresignedUrl = vi.hoisted(() => vi.fn());
+const mockEmailLifecycleService = vi.hoisted(() => ({
+  listAttachments: vi.fn(),
+  getAttachment: vi.fn(),
+  cancelEmail: vi.fn(),
+}));
 const mockCreateLogReadService = vi.hoisted(() => vi.fn());
 const mockListLogs = vi.hoisted(() => vi.fn());
 const mockGetLog = vi.hoisted(() => vi.fn());
@@ -20,6 +25,18 @@ const MockLogReadServiceError = vi.hoisted(
       ) {
         super(message);
         this.name = "LogReadServiceError";
+      }
+    },
+);
+const MockEmailLifecycleServiceError = vi.hoisted(
+  () =>
+    class EmailLifecycleServiceError extends Error {
+      constructor(
+        readonly code: string,
+        message: string,
+      ) {
+        super(message);
+        this.name = "EmailLifecycleServiceError";
       }
     },
 );
@@ -73,6 +90,8 @@ vi.mock("@/lib/s3", () => ({
 }));
 
 vi.mock("@opensend/core", () => ({
+  createEmailLifecycleService: () => mockEmailLifecycleService,
+  EmailLifecycleServiceError: MockEmailLifecycleServiceError,
   createLogReadService: mockCreateLogReadService,
   LogReadServiceError: MockLogReadServiceError,
 }));
@@ -151,6 +170,18 @@ describe("issue #200 missed tenant isolation gaps", () => {
     mockFindEmail.mockResolvedValue(null);
     mockFindLog.mockResolvedValue(null);
     mockGetPresignedUrl.mockResolvedValue("https://download.example/att-1");
+    mockEmailLifecycleService.cancelEmail.mockReset();
+    mockEmailLifecycleService.getAttachment.mockReset();
+    mockEmailLifecycleService.listAttachments.mockReset();
+    mockEmailLifecycleService.cancelEmail.mockRejectedValue(
+      new MockEmailLifecycleServiceError("email_not_found", "Email not found"),
+    );
+    mockEmailLifecycleService.getAttachment.mockRejectedValue(
+      new MockEmailLifecycleServiceError("email_not_found", "Email not found"),
+    );
+    mockEmailLifecycleService.listAttachments.mockRejectedValue(
+      new MockEmailLifecycleServiceError("email_not_found", "Email not found"),
+    );
     mockCreateLogReadService.mockReturnValue({
       listLogs: mockListLogs,
       getLog: mockGetLog,
@@ -176,12 +207,13 @@ describe("issue #200 missed tenant isolation gaps", () => {
     expect(response.status).toBe(404);
     expect(await response.json()).toEqual({ error: "Email not found" });
     expect(mockUpdate).not.toHaveBeenCalled();
-    expectConditionIncludes("email-a");
-    expectConditionIncludes(AUTH_RESULT.userId);
+    expect(mockEmailLifecycleService.cancelEmail).toHaveBeenCalledWith(
+      AUTH_RESULT.userId,
+      "email-a",
+    );
   });
 
   it("404s email attachment list for another tenant", async () => {
-    queueSelectRows([]);
     const { GET } = await import("@/app/api/emails/[id]/attachments/route");
 
     const response = await GET(
@@ -191,13 +223,13 @@ describe("issue #200 missed tenant isolation gaps", () => {
 
     expect(response.status).toBe(404);
     expect(await response.json()).toEqual({ error: "Email not found" });
-    expect(recordedWhere).toHaveLength(1);
-    expectConditionIncludes("email-a");
-    expectConditionIncludes(AUTH_RESULT.userId);
+    expect(mockEmailLifecycleService.listAttachments).toHaveBeenCalledWith(
+      AUTH_RESULT.userId,
+      "email-a",
+    );
   });
 
   it("404s email attachment detail for another tenant without issuing a download URL", async () => {
-    queueSelectRows([]);
     const { GET } = await import(
       "@/app/api/emails/[id]/attachments/[attachmentId]/route"
     );
@@ -210,9 +242,11 @@ describe("issue #200 missed tenant isolation gaps", () => {
     expect(response.status).toBe(404);
     expect(await response.json()).toEqual({ error: "Email not found" });
     expect(mockGetPresignedUrl).not.toHaveBeenCalled();
-    expect(recordedWhere).toHaveLength(1);
-    expectConditionIncludes("email-a");
-    expectConditionIncludes(AUTH_RESULT.userId);
+    expect(mockEmailLifecycleService.getAttachment).toHaveBeenCalledWith(
+      AUTH_RESULT.userId,
+      "email-a",
+      "att-1",
+    );
   });
 
   it("returns an empty public logs list when user-scoped predicates find no owned rows", async () => {


### PR DESCRIPTION
## Summary
- Extract public email lifecycle attachment, cancel, and events DB behavior into `createEmailLifecycleService()` in `packages/core`
- Keep API-key auth and full-access permission checks in the four Next route adapters
- Preserve legacy lifecycle response shapes, status codes, attachment fallbacks, S3 key resolution, cancel errors, and event ordering
- Add focused core service tests plus route compatibility coverage, including the existing tenant-scope regression mock

Closes #340

## Validation
- `bunx vitest run tests/issue-200-missed-tenant-scope.test.tsx tests/email-lifecycle-service.test.ts tests/api-emails.test.ts`
- `make check`
- `make test`

## Residual risk
- Playwright e2e not run; no UI or SDK surface changes in scope.
