### PR TITLE
Extract email detail service boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-342-email-detail-export-name.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-342-email-detail-export-name.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-11
+issue: "#342"
+type: mistake
+promoted_to: null
+---
+
+## Avoid core export name collisions with DTO aliases
+
+Issue #342 added an email detail service under `packages/core/src/services/`. Exporting a type named `EmailDetailResponse` collided with the existing `packages/core/src/dto` export of the same name when `packages/core/src/index.ts` re-exported the service.
+
+Service-boundary DTOs that overlap public SDK/API DTO names should use service-scoped names such as `EmailDetailServiceResponse`, or the barrel export will fail TypeScript with duplicate star-export ambiguity.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,7 @@ export * from "./services/contact-operations";
 export * from "./services/email";
 export * from "./services/emailLifecycle";
 export * from "./services/emailRead";
+export * from "./services/emailDetail";
 export * from "./services/logs";
 export * from "./services/suppressions";
 export * from "./services/emailProvider";

--- a/packages/core/src/services/emailDetail.ts
+++ b/packages/core/src/services/emailDetail.ts
@@ -1,0 +1,283 @@
+import { emailRepo } from "../db/repositories/emailRepo";
+import type { emails } from "../db/schema";
+
+type EmailRow = typeof emails.$inferSelect;
+type EmailUpdateResult = Pick<EmailRow, "id">;
+type ProviderRetryRow = Pick<
+  EmailRow,
+  | "providerRetryCount"
+  | "providerLastAttemptedAt"
+  | "providerNextRetryAt"
+  | "providerLastErrorCode"
+  | "providerLastErrorMessage"
+  | "providerDeadLetteredAt"
+>;
+
+export type EmailDetailServiceResponse = {
+  object: "email";
+  id: string;
+  from: string;
+  to: string[];
+  subject: string;
+  html: string | null;
+  text: string | null;
+  cc: string[] | null;
+  bcc: string[] | null;
+  reply_to: string[] | null;
+  last_event: string;
+  provider_retry_count: number;
+  provider_last_attempted_at: Date | null;
+  provider_next_retry_at: Date | null;
+  provider_last_error: {
+    code: string;
+    message: string;
+  } | null;
+  provider_dead_lettered_at: Date | null;
+  scheduled_at: Date | null;
+  sent_at: Date | null;
+  tags: Array<{ name: string; value: string }> | null;
+  created_at: Date;
+};
+
+export type EmailDetailServiceUpdateResponse = {
+  object: "email";
+  id: string;
+};
+
+export type EmailDetailRepository = {
+  findEmailForUser(id: string, userId: string): Promise<EmailRow | undefined>;
+  updateScheduledAtForUser(
+    id: string,
+    userId: string,
+    scheduledAt: Date | null,
+  ): Promise<EmailUpdateResult | undefined>;
+};
+
+export type EmailDetailParseScheduledAtResult =
+  | { ok: true; date: Date }
+  | { ok: false; message: string };
+
+export type EmailDetailServiceErrorCode =
+  | "not_found"
+  | "invalid_state"
+  | "invalid_scheduled_at"
+  | "no_fields";
+
+export class EmailDetailServiceError extends Error {
+  constructor(
+    readonly code: EmailDetailServiceErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "EmailDetailServiceError";
+  }
+}
+
+export type EmailDetailServiceDependencies = {
+  repository?: EmailDetailRepository;
+  parseScheduledAt?: (value: string) => EmailDetailParseScheduledAtResult;
+};
+
+export type GetEmailDetailInput = {
+  userId: string;
+  id: string;
+};
+
+export type UpdateEmailDetailInput = {
+  userId: string;
+  id: string;
+  body: unknown;
+};
+
+const maxScheduleDelayMs = 30 * 24 * 60 * 60 * 1000;
+const naturalLanguageSchedulePattern =
+  /^in\s+([1-9]\d*)\s+(min|minute|minutes|hour|hours|day|days)$/i;
+const iso8601WithTimezonePattern =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function defaultParseScheduledAt(
+  value: string,
+  now: Date = new Date(),
+): EmailDetailParseScheduledAtResult {
+  const trimmed = value.trim();
+  const naturalDate = parseNaturalLanguageScheduledAt(trimmed, now);
+  const parsedDate = naturalDate
+    ? naturalDate
+    : iso8601WithTimezonePattern.test(trimmed)
+      ? new Date(trimmed)
+      : null;
+
+  if (!parsedDate || !isAllowedScheduledDate(parsedDate, now)) {
+    return {
+      ok: false,
+      message:
+        "scheduled_at must be a future ISO 8601 date-time or 'in <positive integer> <minute|min|minutes|hour|hours|day|days>' within 30 days.",
+    };
+  }
+
+  return { ok: true, date: parsedDate };
+}
+
+function isAllowedScheduledDate(date: Date, now: Date): boolean {
+  const time = date.getTime();
+  const nowTime = now.getTime();
+  return (
+    Number.isFinite(time) &&
+    time > nowTime &&
+    time <= nowTime + maxScheduleDelayMs
+  );
+}
+
+function parseNaturalLanguageScheduledAt(
+  value: string,
+  now: Date,
+): Date | null {
+  const match = naturalLanguageSchedulePattern.exec(value.trim());
+  if (!match) return null;
+
+  const amount = Number(match[1]);
+  const unit = match[2]?.toLowerCase();
+  if (!Number.isSafeInteger(amount)) return null;
+
+  const multiplier = unit?.startsWith("day")
+    ? 24 * 60 * 60 * 1000
+    : unit?.startsWith("hour")
+      ? 60 * 60 * 1000
+      : 60 * 1000;
+
+  return new Date(now.getTime() + amount * multiplier);
+}
+
+function providerLastError(row: ProviderRetryRow) {
+  return row.providerLastErrorCode
+    ? {
+        code: row.providerLastErrorCode,
+        message: row.providerLastErrorMessage ?? "Provider send failed.",
+      }
+    : null;
+}
+
+function toDetail(row: EmailRow): EmailDetailServiceResponse {
+  return {
+    object: "email",
+    id: row.id,
+    from: row.from,
+    to: row.to,
+    subject: row.subject,
+    html: row.html,
+    text: row.text,
+    cc: row.cc,
+    bcc: row.bcc,
+    reply_to: row.replyTo,
+    last_event: row.status,
+    provider_retry_count: row.providerRetryCount,
+    provider_last_attempted_at: row.providerLastAttemptedAt,
+    provider_next_retry_at: row.providerNextRetryAt,
+    provider_last_error: providerLastError(row),
+    provider_dead_lettered_at: row.providerDeadLetteredAt,
+    scheduled_at: row.scheduledAt,
+    sent_at: row.sentAt,
+    tags: row.tags,
+    created_at: row.createdAt,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function invalidScheduledAt(): never {
+  throw new EmailDetailServiceError(
+    "invalid_scheduled_at",
+    "Invalid scheduled_at",
+  );
+}
+
+const defaultRepository: EmailDetailRepository = {
+  async findEmailForUser(id, userId) {
+    return await emailRepo.findByIdForUser(id, userId);
+  },
+
+  async updateScheduledAtForUser(id, userId, scheduledAt) {
+    const [updated] = await emailRepo.update(id, { scheduledAt }, userId);
+    return updated ? { id: updated.id } : undefined;
+  },
+};
+
+export function createEmailDetailService({
+  repository = defaultRepository,
+  parseScheduledAt = defaultParseScheduledAt,
+}: EmailDetailServiceDependencies = {}) {
+  return {
+    async getEmail(
+      input: GetEmailDetailInput,
+    ): Promise<EmailDetailServiceResponse> {
+      const email = await repository.findEmailForUser(input.id, input.userId);
+
+      if (!email) {
+        throw new EmailDetailServiceError("not_found", "Email not found");
+      }
+
+      return toDetail(email);
+    },
+
+    async updateEmail(
+      input: UpdateEmailDetailInput,
+    ): Promise<EmailDetailServiceUpdateResponse> {
+      if (!isRecord(input.body)) {
+        invalidScheduledAt();
+      }
+
+      const existing = await repository.findEmailForUser(
+        input.id,
+        input.userId,
+      );
+
+      if (!existing) {
+        throw new EmailDetailServiceError("not_found", "Email not found");
+      }
+
+      if (existing.status !== "scheduled") {
+        throw new EmailDetailServiceError(
+          "invalid_state",
+          `Cannot update a ${existing.status} email`,
+        );
+      }
+
+      let scheduledAt: Date | null | undefined;
+      if ("scheduled_at" in input.body) {
+        const value = input.body.scheduled_at;
+        if (value === null) {
+          scheduledAt = null;
+        } else if (typeof value === "string") {
+          const parsed = parseScheduledAt(value);
+          if (!parsed.ok) invalidScheduledAt();
+          scheduledAt = parsed.date;
+        } else {
+          invalidScheduledAt();
+        }
+      }
+
+      if (scheduledAt === undefined) {
+        throw new EmailDetailServiceError("no_fields", "No fields to update");
+      }
+
+      const updated = await repository.updateScheduledAtForUser(
+        input.id,
+        input.userId,
+        scheduledAt,
+      );
+
+      if (!updated) {
+        throw new Error("Email update returned no row");
+      }
+
+      return {
+        object: "email",
+        id: updated.id,
+      };
+    },
+  };
+}
+
+export const emailDetailService = createEmailDetailService();

--- a/src/app/api/emails/[id]/route.ts
+++ b/src/app/api/emails/[id]/route.ts
@@ -1,16 +1,16 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { publicApiError } from "@/lib/api-errors";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { db } from "@/lib/db";
-import { emails } from "@/lib/db/schema";
 import {
   parseScheduledAt,
   scheduledAtValidationMessage,
 } from "@/lib/validation/emails";
-import { EmailReadServiceError, createEmailReadService } from "@opensend/core";
-import { and, eq } from "drizzle-orm";
+import {
+  EmailDetailServiceError,
+  createEmailDetailService,
+} from "@opensend/core";
 
-const emailReadService = createEmailReadService();
+const emailDetailService = createEmailDetailService({ parseScheduledAt });
 
 export async function GET(
   request: Request,
@@ -24,10 +24,13 @@ export async function GET(
   const { id } = await params;
 
   try {
-    const email = await emailReadService.getEmail(auth.userId, id);
+    const email = await emailDetailService.getEmail({
+      userId: auth.userId,
+      id,
+    });
     return Response.json(email);
   } catch (err) {
-    if (err instanceof EmailReadServiceError && err.code === "not_found") {
+    if (err instanceof EmailDetailServiceError && err.code === "not_found") {
       return Response.json({ error: "Email not found" }, { status: 404 });
     }
 
@@ -49,10 +52,6 @@ function scheduledAtValidationResponse(): Response {
   );
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
@@ -71,55 +70,32 @@ export async function PATCH(
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  if (!isRecord(body)) {
-    return scheduledAtValidationResponse();
-  }
-
   try {
-    const existing = await db.query.emails.findFirst({
-      where: and(eq(emails.id, id), eq(emails.userId, auth.userId)),
+    const updated = await emailDetailService.updateEmail({
+      userId: auth.userId,
+      id,
+      body,
     });
+    return Response.json(updated);
+  } catch (err) {
+    if (err instanceof EmailDetailServiceError) {
+      if (err.code === "not_found") {
+        return Response.json({ error: "Email not found" }, { status: 404 });
+      }
 
-    if (!existing) {
-      return Response.json({ error: "Email not found" }, { status: 404 });
-    }
+      if (err.code === "invalid_state") {
+        return Response.json({ error: err.message }, { status: 400 });
+      }
 
-    if (existing.status !== "scheduled") {
-      return Response.json(
-        { error: `Cannot update a ${existing.status} email` },
-        { status: 400 },
-      );
-    }
-
-    const updates: { scheduledAt?: Date | null } = {};
-    if ("scheduled_at" in body) {
-      const scheduledAt = body.scheduled_at;
-      if (scheduledAt === null) {
-        updates.scheduledAt = null;
-      } else if (typeof scheduledAt === "string") {
-        const parsed = parseScheduledAt(scheduledAt);
-        if (!parsed.ok) return scheduledAtValidationResponse();
-        updates.scheduledAt = parsed.date;
-      } else {
+      if (err.code === "invalid_scheduled_at") {
         return scheduledAtValidationResponse();
+      }
+
+      if (err.code === "no_fields") {
+        return Response.json({ error: "No fields to update" }, { status: 400 });
       }
     }
 
-    if (Object.keys(updates).length === 0) {
-      return Response.json({ error: "No fields to update" }, { status: 400 });
-    }
-
-    const [updated] = await db
-      .update(emails)
-      .set(updates)
-      .where(and(eq(emails.id, id), eq(emails.userId, auth.userId)))
-      .returning();
-
-    return Response.json({
-      object: "email",
-      id: updated.id,
-    });
-  } catch (err) {
     const message =
       err instanceof Error ? err.message : "Failed to update email";
     return Response.json({ error: message }, { status: 500 });

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -16,12 +16,28 @@ const mockEmailReadService = vi.hoisted(() => ({
   getEmail: vi.fn(),
   deleteEmail: vi.fn(),
 }));
+const mockEmailDetailService = vi.hoisted(() => ({
+  getEmail: vi.fn(),
+  updateEmail: vi.fn(),
+}));
 const mockEmailLifecycleService = vi.hoisted(() => ({
   listAttachments: vi.fn(),
   getAttachment: vi.fn(),
   cancelEmail: vi.fn(),
   listEvents: vi.fn(),
 }));
+const MockEmailDetailServiceError = vi.hoisted(
+  () =>
+    class EmailDetailServiceError extends Error {
+      constructor(
+        readonly code: string,
+        message: string,
+      ) {
+        super(message);
+        this.name = "EmailDetailServiceError";
+      }
+    },
+);
 const MockEmailReadServiceError = vi.hoisted(
   () =>
     class EmailReadServiceError extends Error {
@@ -79,12 +95,14 @@ vi.mock("@opensend/core", () => {
   };
 
   return {
+    EmailDetailServiceError: MockEmailDetailServiceError,
     EmailReadServiceError: MockEmailReadServiceError,
     EmailLifecycleServiceError: MockEmailLifecycleServiceError,
     createBackgroundJob: (job: Record<string, unknown>) => ({
       ...job,
       requestedAt: "2026-04-28T00:00:00.000Z",
     }),
+    createEmailDetailService: () => mockEmailDetailService,
     createEmailLifecycleService: () => mockEmailLifecycleService,
     createEmailReadService: () => mockEmailReadService,
     detectSandboxTestRecipient: (recipient: string) => {
@@ -2295,12 +2313,12 @@ describe("GET /api/emails", () => {
 describe("GET /api/emails/:id", () => {
   beforeEach(() => {
     vi.resetModules();
-    mockEmailReadService.getEmail.mockReset();
+    mockEmailDetailService.getEmail.mockReset();
     mockValidateApiKey.mockResolvedValue(AUTH_RESULT);
   });
 
-  it("returns email detail from the read service", async () => {
-    mockEmailReadService.getEmail.mockResolvedValueOnce({
+  it("returns email detail from the detail service", async () => {
+    mockEmailDetailService.getEmail.mockResolvedValueOnce({
       object: "email",
       id: "email-uuid",
       from: "sender@domain.com",
@@ -2336,15 +2354,15 @@ describe("GET /api/emails/:id", () => {
     expect(json).toHaveProperty("id", "email-uuid");
     expect(json).toHaveProperty("last_event", "delivered");
     expect(json).toHaveProperty("sent_at", "2024-01-01T00:00:05.000Z");
-    expect(mockEmailReadService.getEmail).toHaveBeenCalledWith(
-      AUTH_RESULT.userId,
-      "email-uuid",
-    );
+    expect(mockEmailDetailService.getEmail).toHaveBeenCalledWith({
+      userId: AUTH_RESULT.userId,
+      id: "email-uuid",
+    });
   });
 
   it("returns 404 for non-existent email", async () => {
-    mockEmailReadService.getEmail.mockRejectedValueOnce(
-      new MockEmailReadServiceError("not_found", "Email not found"),
+    mockEmailDetailService.getEmail.mockRejectedValueOnce(
+      new MockEmailDetailServiceError("not_found", "Email not found"),
     );
 
     const { GET } = await import("@/app/api/emails/[id]/route");
@@ -2356,106 +2374,28 @@ describe("GET /api/emails/:id", () => {
     });
     expect(res.status).toBe(404);
     await expect(res.json()).resolves.toEqual({ error: "Email not found" });
-    expect(mockEmailReadService.getEmail).toHaveBeenCalledWith(
-      AUTH_RESULT.userId,
-      "nonexistent",
-    );
+    expect(mockEmailDetailService.getEmail).toHaveBeenCalledWith({
+      userId: AUTH_RESULT.userId,
+      id: "nonexistent",
+    });
   });
 });
 
 describe("PATCH /api/emails/:id", () => {
   beforeEach(() => {
     vi.resetModules();
+    mockEmailDetailService.updateEmail.mockReset();
     mockValidateApiKey.mockResolvedValue(AUTH_RESULT);
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("scopes scheduled email updates to the authenticated user", async () => {
-    // Freeze time so the hardcoded `scheduled_at` stays a valid future moment
-    // regardless of when CI runs the suite.
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-05-07T00:00:00.000Z"));
-
-    const findFirst = vi.fn().mockResolvedValue({
+  it("delegates parsed JSON bodies to the detail service with auth scope", async () => {
+    mockEmailDetailService.updateEmail.mockResolvedValueOnce({
+      object: "email",
       id: "email-uuid",
-      status: "scheduled",
     });
-    mockDb.query = {
-      emails: {
-        findFirst,
-      },
-    } as unknown as ReturnType<typeof vi.fn>;
-    const returning = vi.fn().mockResolvedValue([{ id: "email-uuid" }]);
-    const where = vi.fn().mockReturnValue({ returning });
-    const set = vi.fn().mockReturnValue({ where });
-    mockDb.update = vi.fn().mockReturnValue({ set });
 
-    const scheduledAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
     const { PATCH } = await import("@/app/api/emails/[id]/route");
     const res = await PATCH(
-      new Request("http://localhost:3015/api/emails/email-uuid", {
-        method: "PATCH",
-        headers: { Authorization: "Bearer re_test123" },
-        body: JSON.stringify({ scheduled_at: scheduledAt }),
-      }),
-      { params: Promise.resolve({ id: "email-uuid" }) },
-    );
-
-    expect(res.status).toBe(200);
-    expect(findFirst).toHaveBeenCalledWith({
-      where: expect.objectContaining({
-        op: "and",
-        args: expect.arrayContaining([
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining(["email-uuid"]),
-          }),
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining([AUTH_RESULT.userId]),
-          }),
-        ]),
-      }),
-    });
-    expect(where).toHaveBeenCalledWith(
-      expect.objectContaining({
-        op: "and",
-        args: expect.arrayContaining([
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining(["email-uuid"]),
-          }),
-          expect.objectContaining({
-            op: "eq",
-            args: expect.arrayContaining([AUTH_RESULT.userId]),
-          }),
-        ]),
-      }),
-    );
-  });
-
-  it("normalizes ISO and natural-language scheduled_at updates", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-05-07T00:00:00.000Z"));
-
-    const findFirst = vi.fn().mockResolvedValue({
-      id: "email-uuid",
-      status: "scheduled",
-    });
-    mockDb.query = {
-      emails: { findFirst },
-    } as unknown as ReturnType<typeof vi.fn>;
-
-    const returning = vi.fn().mockResolvedValue([{ id: "email-uuid" }]);
-    const where = vi.fn().mockReturnValue({ returning });
-    const set = vi.fn().mockReturnValue({ where });
-    mockDb.update = vi.fn().mockReturnValue({ set });
-
-    const { PATCH } = await import("@/app/api/emails/[id]/route");
-    const isoRes = await PATCH(
       new Request("http://localhost:3015/api/emails/email-uuid", {
         method: "PATCH",
         headers: { Authorization: "Bearer re_test123" },
@@ -2463,67 +2403,99 @@ describe("PATCH /api/emails/:id", () => {
       }),
       { params: Promise.resolve({ id: "email-uuid" }) },
     );
-    const naturalRes = await PATCH(
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      object: "email",
+      id: "email-uuid",
+    });
+    expect(mockEmailDetailService.updateEmail).toHaveBeenCalledWith({
+      userId: AUTH_RESULT.userId,
+      id: "email-uuid",
+      body: { scheduled_at: "2026-05-08T00:00:00.000Z" },
+    });
+  });
+
+  it("returns 400 for invalid JSON before calling the service", async () => {
+    const { PATCH } = await import("@/app/api/emails/[id]/route");
+    const res = await PATCH(
       new Request("http://localhost:3015/api/emails/email-uuid", {
         method: "PATCH",
         headers: { Authorization: "Bearer re_test123" },
-        body: JSON.stringify({ scheduled_at: "in 1 day" }),
+        body: "{invalid",
       }),
       { params: Promise.resolve({ id: "email-uuid" }) },
     );
 
-    expect(isoRes.status).toBe(200);
-    expect(naturalRes.status).toBe(200);
-    expect(set).toHaveBeenNthCalledWith(1, {
-      scheduledAt: new Date("2026-05-08T00:00:00.000Z"),
-    });
-    expect(set).toHaveBeenNthCalledWith(2, {
-      scheduledAt: new Date("2026-05-08T00:00:00.000Z"),
-    });
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+    expect(mockEmailDetailService.updateEmail).not.toHaveBeenCalled();
   });
 
-  it("rejects invalid, past, and out-of-policy scheduled_at updates before writing", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-05-07T00:00:00.000Z"));
-
-    const findFirst = vi.fn().mockResolvedValue({
-      id: "email-uuid",
-      status: "scheduled",
-    });
-    mockDb.query = {
-      emails: { findFirst },
-    } as unknown as ReturnType<typeof vi.fn>;
-    const set = vi.fn();
-    mockDb.update = vi.fn().mockReturnValue({ set });
-
+  it("maps detail service update errors to legacy responses", async () => {
     const { PATCH } = await import("@/app/api/emails/[id]/route");
 
-    for (const scheduled_at of [
-      "later today",
-      "2026-05-06T23:59:00.000Z",
-      "in 31 days",
-    ]) {
+    for (const [error, status, expected] of [
+      [
+        new MockEmailDetailServiceError("not_found", "Email not found"),
+        404,
+        { error: "Email not found" },
+      ],
+      [
+        new MockEmailDetailServiceError(
+          "invalid_state",
+          "Cannot update a delivered email",
+        ),
+        400,
+        { error: "Cannot update a delivered email" },
+      ],
+      [
+        new MockEmailDetailServiceError("no_fields", "No fields to update"),
+        400,
+        { error: "No fields to update" },
+      ],
+    ] as const) {
+      mockEmailDetailService.updateEmail.mockRejectedValueOnce(error);
       const res = await PATCH(
         new Request("http://localhost:3015/api/emails/email-uuid", {
           method: "PATCH",
           headers: { Authorization: "Bearer re_test123" },
-          body: JSON.stringify({ scheduled_at }),
+          body: JSON.stringify({ scheduled_at: null }),
         }),
         { params: Promise.resolve({ id: "email-uuid" }) },
       );
-      expect(res.status).toBe(422);
-      await expect(res.json()).resolves.toMatchObject({
-        name: "validation_error",
-        details: {
-          fieldErrors: {
-            scheduled_at: [expect.stringContaining("future ISO 8601")],
-          },
-        },
-      });
+      expect(res.status).toBe(status);
+      await expect(res.json()).resolves.toEqual(expected);
     }
+  });
 
-    expect(mockDb.update).not.toHaveBeenCalled();
-    expect(set).not.toHaveBeenCalled();
+  it("maps invalid scheduled_at service errors to the existing validation envelope", async () => {
+    mockEmailDetailService.updateEmail.mockRejectedValueOnce(
+      new MockEmailDetailServiceError(
+        "invalid_scheduled_at",
+        "Invalid scheduled_at",
+      ),
+    );
+
+    const { PATCH } = await import("@/app/api/emails/[id]/route");
+    const res = await PATCH(
+      new Request("http://localhost:3015/api/emails/email-uuid", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer re_test123" },
+        body: JSON.stringify([]),
+      }),
+      { params: Promise.resolve({ id: "email-uuid" }) },
+    );
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "validation_error",
+      details: {
+        fieldErrors: {
+          scheduled_at: [expect.stringContaining("future ISO 8601")],
+        },
+      },
+    });
   });
 });
 

--- a/tests/email-detail-service.test.ts
+++ b/tests/email-detail-service.test.ts
@@ -1,0 +1,316 @@
+import {
+  type EmailDetailRepository,
+  EmailDetailServiceError,
+  createEmailDetailService,
+} from "@opensend/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type EmailRow = NonNullable<
+  Awaited<ReturnType<EmailDetailRepository["findEmailForUser"]>>
+>;
+
+function makeEmail(overrides: Partial<EmailRow> = {}): EmailRow {
+  return {
+    id: "email-1",
+    from: "sender@example.com",
+    to: ["user@example.com"],
+    cc: null,
+    bcc: null,
+    replyTo: null,
+    subject: "Hello",
+    html: "<p>Hello</p>",
+    text: null,
+    status: "scheduled",
+    providerRetryCount: 0,
+    providerLastAttemptedAt: null,
+    providerNextRetryAt: null,
+    providerLastErrorCode: null,
+    providerLastErrorMessage: null,
+    providerDeadLetteredAt: null,
+    tags: null,
+    headers: null,
+    attachments: null,
+    scheduledAt: new Date("2026-05-08T00:00:00.000Z"),
+    sentAt: null,
+    createdAt: new Date("2026-05-07T00:00:00.000Z"),
+    document: null,
+    userId: "user-1",
+    topicId: null,
+    idempotencyKey: null,
+    ...overrides,
+  };
+}
+
+function makeRepository(
+  overrides: Partial<EmailDetailRepository> = {},
+): EmailDetailRepository {
+  return {
+    async findEmailForUser() {
+      return makeEmail();
+    },
+    async updateScheduledAtForUser(id) {
+      return { id };
+    },
+    ...overrides,
+  };
+}
+
+describe("email detail service boundary", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("scopes detail reads and preserves the public DTO shape", async () => {
+    let capturedScope: { id: string; userId: string } | undefined;
+    const service = createEmailDetailService({
+      repository: makeRepository({
+        async findEmailForUser(id, userId) {
+          capturedScope = { id, userId };
+          return makeEmail({
+            id,
+            userId,
+            status: "delivered",
+            providerRetryCount: 2,
+            providerLastAttemptedAt: new Date("2026-05-07T00:00:02.000Z"),
+            providerNextRetryAt: new Date("2026-05-07T00:05:00.000Z"),
+            providerLastErrorCode: "Throttling",
+            providerLastErrorMessage: null,
+            providerDeadLetteredAt: new Date("2026-05-07T00:10:00.000Z"),
+            sentAt: new Date("2026-05-07T00:00:05.000Z"),
+            tags: [{ name: "campaign", value: "launch" }],
+          });
+        },
+      }),
+    });
+
+    const result = await service.getEmail({
+      userId: "user-2",
+      id: "email-2",
+    });
+
+    expect(capturedScope).toEqual({ id: "email-2", userId: "user-2" });
+    expect(Object.keys(result)).toEqual([
+      "object",
+      "id",
+      "from",
+      "to",
+      "subject",
+      "html",
+      "text",
+      "cc",
+      "bcc",
+      "reply_to",
+      "last_event",
+      "provider_retry_count",
+      "provider_last_attempted_at",
+      "provider_next_retry_at",
+      "provider_last_error",
+      "provider_dead_lettered_at",
+      "scheduled_at",
+      "sent_at",
+      "tags",
+      "created_at",
+    ]);
+    expect(result).toEqual({
+      object: "email",
+      id: "email-2",
+      from: "sender@example.com",
+      to: ["user@example.com"],
+      subject: "Hello",
+      html: "<p>Hello</p>",
+      text: null,
+      cc: null,
+      bcc: null,
+      reply_to: null,
+      last_event: "delivered",
+      provider_retry_count: 2,
+      provider_last_attempted_at: new Date("2026-05-07T00:00:02.000Z"),
+      provider_next_retry_at: new Date("2026-05-07T00:05:00.000Z"),
+      provider_last_error: {
+        code: "Throttling",
+        message: "Provider send failed.",
+      },
+      provider_dead_lettered_at: new Date("2026-05-07T00:10:00.000Z"),
+      scheduled_at: new Date("2026-05-08T00:00:00.000Z"),
+      sent_at: new Date("2026-05-07T00:00:05.000Z"),
+      tags: [{ name: "campaign", value: "launch" }],
+      created_at: new Date("2026-05-07T00:00:00.000Z"),
+    });
+  });
+
+  it("raises not_found for missing or unowned detail reads", async () => {
+    const service = createEmailDetailService({
+      repository: makeRepository({
+        async findEmailForUser() {
+          return undefined;
+        },
+      }),
+    });
+
+    await expect(
+      service.getEmail({ userId: "user-1", id: "missing" }),
+    ).rejects.toEqual(
+      new EmailDetailServiceError("not_found", "Email not found"),
+    );
+  });
+
+  it("updates scheduled_at with tenant scope for ISO, natural language, and null values", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-07T00:00:00.000Z"));
+
+    const updates: Array<{
+      id: string;
+      userId: string;
+      scheduledAt: Date | null;
+    }> = [];
+    const service = createEmailDetailService({
+      repository: makeRepository({
+        async findEmailForUser(id, userId) {
+          return makeEmail({ id, userId, status: "scheduled" });
+        },
+        async updateScheduledAtForUser(id, userId, scheduledAt) {
+          updates.push({ id, userId, scheduledAt });
+          return { id };
+        },
+      }),
+    });
+
+    await expect(
+      service.updateEmail({
+        userId: "user-1",
+        id: "email-1",
+        body: { scheduled_at: "2026-05-08T00:00:00.000Z" },
+      }),
+    ).resolves.toEqual({ object: "email", id: "email-1" });
+    await service.updateEmail({
+      userId: "user-1",
+      id: "email-1",
+      body: { scheduled_at: "in 1 day" },
+    });
+    await service.updateEmail({
+      userId: "user-1",
+      id: "email-1",
+      body: { scheduled_at: null },
+    });
+
+    expect(updates).toEqual([
+      {
+        id: "email-1",
+        userId: "user-1",
+        scheduledAt: new Date("2026-05-08T00:00:00.000Z"),
+      },
+      {
+        id: "email-1",
+        userId: "user-1",
+        scheduledAt: new Date("2026-05-08T00:00:00.000Z"),
+      },
+      { id: "email-1", userId: "user-1", scheduledAt: null },
+    ]);
+  });
+
+  it("returns not_found before validating fields for missing or unowned update rows", async () => {
+    const service = createEmailDetailService({
+      repository: makeRepository({
+        async findEmailForUser() {
+          return undefined;
+        },
+        async updateScheduledAtForUser() {
+          throw new Error("update should not run");
+        },
+      }),
+    });
+
+    await expect(
+      service.updateEmail({
+        userId: "user-1",
+        id: "missing",
+        body: { scheduled_at: "bad" },
+      }),
+    ).rejects.toEqual(
+      new EmailDetailServiceError("not_found", "Email not found"),
+    );
+  });
+
+  it("rejects non-scheduled emails with the existing status message", async () => {
+    const service = createEmailDetailService({
+      repository: makeRepository({
+        async findEmailForUser() {
+          return makeEmail({ status: "delivered" });
+        },
+      }),
+    });
+
+    await expect(
+      service.updateEmail({
+        userId: "user-1",
+        id: "email-1",
+        body: { scheduled_at: null },
+      }),
+    ).rejects.toEqual(
+      new EmailDetailServiceError(
+        "invalid_state",
+        "Cannot update a delivered email",
+      ),
+    );
+  });
+
+  it("rejects invalid scheduled_at values and non-object bodies before writing", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-07T00:00:00.000Z"));
+
+    const updateScheduledAtForUser = vi.fn();
+    const service = createEmailDetailService({
+      repository: makeRepository({ updateScheduledAtForUser }),
+    });
+
+    for (const body of [
+      null,
+      [],
+      { scheduled_at: "later today" },
+      { scheduled_at: "2026-05-06T23:59:00.000Z" },
+      { scheduled_at: "in 31 days" },
+      { scheduled_at: 123 },
+    ]) {
+      await expect(
+        service.updateEmail({ userId: "user-1", id: "email-1", body }),
+      ).rejects.toMatchObject({
+        name: "EmailDetailServiceError",
+        code: "invalid_scheduled_at",
+      });
+    }
+
+    expect(updateScheduledAtForUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects requests with no accepted update fields", async () => {
+    const service = createEmailDetailService({ repository: makeRepository() });
+
+    await expect(
+      service.updateEmail({
+        userId: "user-1",
+        id: "email-1",
+        body: { subject: "Ignored" },
+      }),
+    ).rejects.toEqual(
+      new EmailDetailServiceError("no_fields", "No fields to update"),
+    );
+  });
+
+  it("surfaces unexpected empty update results as 500-compatible errors", async () => {
+    const service = createEmailDetailService({
+      repository: makeRepository({
+        async updateScheduledAtForUser() {
+          return undefined;
+        },
+      }),
+    });
+
+    await expect(
+      service.updateEmail({
+        userId: "user-1",
+        id: "email-1",
+        body: { scheduled_at: null },
+      }),
+    ).rejects.toThrow("Email update returned no row");
+  });
+});


### PR DESCRIPTION
## Summary
- Add a reusable @opensend/core email detail service for public detail GET and scheduled_at PATCH behavior.
- Keep the Next /api/emails/[id] route as an auth/permission/JSON/HTTP adapter.
- Add focused service coverage plus route compatibility tests, and document the core export-name pitfall.

Closes #342

## Validation
- `make check`
- `make test`
- `bun run test tests/email-detail-service.test.ts tests/api-emails.test.ts`

## Notes
- No attachment, cancel, events, send/batch, SDK, UI, migration, or Hono adapter changes.
