### PR TITLE
Add Hono webhook control-plane parity

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-344-webhooks-hono-shared-handlers.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-344-webhooks-hono-shared-handlers.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-11
+issue: "#344"
+type: pattern
+promoted_to: null
+---
+
+## Webhook Hono parity should share request handlers, not Next route modules
+
+For control-plane webhook parity, keep the Next App Router files as thin adapters over shared `Request -> Response` handlers under `src/lib/api/webhooks/`. The Hono service can mount those same handlers from `services/api/src/routes/webhooks.ts` without importing `src/app/api/...` route modules or manufacturing Next `params` objects.
+
+This preserves the existing public response mapping and validation behavior while keeping the control-plane service out of Next route internals. Future public API route-family parity slices should prefer this shape when the existing logic still depends on app-level auth/validation helpers and is not ready for a deeper `packages/core` extraction.

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -1,16 +1,8 @@
 import { handleMcpHttpRequest } from "@opensend/mcp";
 import { Hono } from "hono";
-import {
-  DELETE as deleteWebhook,
-  GET as getWebhook,
-  PATCH as patchWebhook,
-} from "../../../src/app/api/webhooks/[id]/route";
-import {
-  GET as listWebhooks,
-  POST as postWebhook,
-} from "../../../src/app/api/webhooks/route";
 import { handlePostEmailBatchRequest } from "../../../src/lib/api/emails/batch-send";
 import { handlePostEmailRequest } from "../../../src/lib/api/emails/send";
+import { registerWebhookRoutes } from "./routes/webhooks";
 
 export const CONTROL_PLANE_API_SERVICE = "control-plane-api";
 export const CONTROL_PLANE_API_VERSION = "0.1.0";
@@ -51,33 +43,7 @@ export function createApp(options: ControlPlaneAppOptions = {}) {
     async (c) => await handlePostEmailBatchRequest(c.req.raw),
   );
 
-  app.get("/webhooks", async (c) => await listWebhooks(c.req.raw));
-
-  app.post("/webhooks", async (c) => await postWebhook(c.req.raw));
-
-  app.get(
-    "/webhooks/:id",
-    async (c) =>
-      await getWebhook(c.req.raw, {
-        params: Promise.resolve({ id: c.req.param("id") }),
-      }),
-  );
-
-  app.patch(
-    "/webhooks/:id",
-    async (c) =>
-      await patchWebhook(c.req.raw, {
-        params: Promise.resolve({ id: c.req.param("id") }),
-      }),
-  );
-
-  app.delete(
-    "/webhooks/:id",
-    async (c) =>
-      await deleteWebhook(c.req.raw, {
-        params: Promise.resolve({ id: c.req.param("id") }),
-      }),
-  );
+  registerWebhookRoutes(app);
 
   app.all(
     "/mcp",

--- a/services/api/src/routes/webhooks.ts
+++ b/services/api/src/routes/webhooks.ts
@@ -1,0 +1,32 @@
+import type { Hono } from "hono";
+import {
+  handleCreateWebhookRequest,
+  handleDeleteWebhookRequest,
+  handleGetWebhookRequest,
+  handleListWebhooksRequest,
+  handleUpdateWebhookRequest,
+} from "../../../../src/lib/api/webhooks";
+
+export function registerWebhookRoutes(app: Hono) {
+  app.get("/webhooks", async (c) => await handleListWebhooksRequest(c.req.raw));
+
+  app.post(
+    "/webhooks",
+    async (c) => await handleCreateWebhookRequest(c.req.raw),
+  );
+
+  app.get(
+    "/webhooks/:id",
+    async (c) => await handleGetWebhookRequest(c.req.raw, c.req.param("id")),
+  );
+
+  app.patch(
+    "/webhooks/:id",
+    async (c) => await handleUpdateWebhookRequest(c.req.raw, c.req.param("id")),
+  );
+
+  app.delete(
+    "/webhooks/:id",
+    async (c) => await handleDeleteWebhookRequest(c.req.raw, c.req.param("id")),
+  );
+}

--- a/src/app/api/webhooks/[id]/route.ts
+++ b/src/app/api/webhooks/[id]/route.ts
@@ -1,147 +1,29 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { updateWebhookSchema } from "@/lib/validation/webhooks";
-import { createWebhookService } from "@opensend/core";
-
-function webhookService() {
-  return createWebhookService();
-}
-
-function mapDelivery(delivery: {
-  id: string;
-  status: string;
-  attempt: number;
-  statusCode: number | null;
-  responseBody: string | null;
-  attemptedAt: Date | string | null;
-  nextRetryAt: Date | string | null;
-  createdAt: Date | string;
-}) {
-  return {
-    id: delivery.id,
-    status: delivery.status,
-    attempt: delivery.attempt,
-    status_code: delivery.statusCode,
-    response_body: delivery.responseBody,
-    attempted_at: delivery.attemptedAt,
-    next_retry_at: delivery.nextRetryAt,
-    created_at: delivery.createdAt,
-  };
-}
-
-function mapWebhookError(error: unknown, fallback: string): Response {
-  const message = error instanceof Error ? error.message : fallback;
-  return Response.json({ error: message }, { status: 500 });
-}
+import {
+  handleDeleteWebhookRequest,
+  handleGetWebhookRequest,
+  handleUpdateWebhookRequest,
+} from "@/lib/api/webhooks";
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth?.userId) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
-
   const { id } = await params;
-
-  try {
-    const webhook = await webhookService().getWebhook(id, auth.userId);
-
-    if (!webhook) {
-      return Response.json({ error: "Webhook not found" }, { status: 404 });
-    }
-
-    return Response.json({
-      object: "webhook",
-      id: webhook.id,
-      endpoint: webhook.endpoint,
-      events: webhook.events,
-      status: webhook.status,
-      created_at: webhook.createdAt,
-      recent_deliveries: (webhook.recentDeliveries ?? []).map(mapDelivery),
-    });
-  } catch (error) {
-    return mapWebhookError(error, "Failed to retrieve webhook");
-  }
+  return await handleGetWebhookRequest(request, id);
 }
 
 export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth?.userId) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
-
   const { id } = await params;
-
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
-  const result = updateWebhookSchema.safeParse(body);
-  if (!result.success) {
-    return Response.json(
-      { error: "Validation failed", details: result.error.flatten() },
-      { status: 422 },
-    );
-  }
-
-  try {
-    const validated = result.data;
-    const updated = await webhookService().updateWebhook(id, auth.userId, {
-      endpoint: validated.endpoint ?? validated.url,
-      events: validated.events ?? validated.event_types,
-      status: validated.status,
-      active: validated.active,
-    });
-
-    if (!updated) {
-      return Response.json({ error: "Webhook not found" }, { status: 404 });
-    }
-
-    return Response.json({
-      object: "webhook",
-      id: updated.id,
-      endpoint: updated.endpoint,
-      events: updated.events,
-      status: updated.status,
-      created_at: updated.createdAt,
-    });
-  } catch (error) {
-    return mapWebhookError(error, "Failed to update webhook");
-  }
+  return await handleUpdateWebhookRequest(request, id);
 }
 
 export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth?.userId) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
-
   const { id } = await params;
-
-  try {
-    const deleted = await webhookService().deleteWebhook(id, auth.userId);
-
-    if (!deleted) {
-      return Response.json({ error: "Webhook not found" }, { status: 404 });
-    }
-
-    return Response.json({
-      object: "webhook",
-      id: deleted.id,
-      deleted: true,
-    });
-  } catch (error) {
-    return mapWebhookError(error, "Failed to delete webhook");
-  }
+  return await handleDeleteWebhookRequest(request, id);
 }

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -1,102 +1,12 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { createWebhookSchema } from "@/lib/validation/webhooks";
-import { createWebhookService } from "@opensend/core";
-
-function webhookService() {
-  return createWebhookService();
-}
-
-function mapWebhookError(error: unknown, fallback: string): Response {
-  const message = error instanceof Error ? error.message : fallback;
-  return Response.json({ error: message }, { status: 500 });
-}
+import {
+  handleCreateWebhookRequest,
+  handleListWebhooksRequest,
+} from "@/lib/api/webhooks";
 
 export async function GET(request: Request): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth?.userId) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
-
-  const url = new URL(request.url);
-  const limit = Number(url.searchParams.get("limit")) || 20;
-  const after = url.searchParams.get("after") || "";
-
-  try {
-    const result = await webhookService().listWebhooks({
-      userId: auth.userId,
-      limit,
-      after,
-    });
-
-    return Response.json({
-      object: "list",
-      data: result.data.map((webhook) => ({
-        id: webhook.id,
-        endpoint: webhook.endpoint,
-        events: webhook.events,
-        status: webhook.status,
-        created_at: webhook.createdAt,
-      })),
-      has_more: result.hasMore,
-    });
-  } catch (error) {
-    return mapWebhookError(error, "Failed to list webhooks");
-  }
+  return await handleListWebhooksRequest(request);
 }
 
 export async function POST(request: Request): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth?.userId) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
-
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
-  const result = createWebhookSchema.safeParse(body);
-  if (!result.success) {
-    return Response.json(
-      { error: "Validation failed", details: result.error.flatten() },
-      { status: 422 },
-    );
-  }
-
-  const validated = result.data;
-  const endpoint = validated.endpoint ?? validated.url;
-  const events = validated.events ?? validated.event_types;
-
-  if (!endpoint || !events) {
-    return Response.json(
-      { error: "Endpoint and events are required" },
-      { status: 422 },
-    );
-  }
-
-  try {
-    const webhook = await webhookService().createWebhook({
-      userId: auth.userId,
-      endpoint,
-      events,
-    });
-
-    return Response.json(
-      {
-        object: "webhook",
-        id: webhook.id,
-        endpoint: webhook.endpoint,
-        events: webhook.events,
-        status: webhook.status,
-        signing_secret: webhook.signingSecret,
-        created_at: webhook.createdAt,
-      },
-      { status: 201 },
-    );
-  } catch (error) {
-    return mapWebhookError(error, "Failed to create webhook");
-  }
+  return await handleCreateWebhookRequest(request);
 }

--- a/src/lib/api/webhooks/handlers.ts
+++ b/src/lib/api/webhooks/handlers.ts
@@ -1,0 +1,253 @@
+import {
+  type AuthResult,
+  unauthorizedResponse,
+  validateApiKey,
+} from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
+import {
+  createWebhookSchema,
+  updateWebhookSchema,
+} from "@/lib/validation/webhooks";
+import {
+  type WebhookDeliveryListItem,
+  type WebhookServiceCreateResult,
+  type WebhookServiceDetail,
+  type WebhookServiceListItem,
+  createWebhookService,
+} from "@opensend/core";
+
+function webhookService() {
+  return createWebhookService();
+}
+
+function mapWebhookError(error: unknown, fallback: string): Response {
+  const message = error instanceof Error ? error.message : fallback;
+  return Response.json({ error: message }, { status: 500 });
+}
+
+function mapWebhookListItem(webhook: WebhookServiceListItem) {
+  return {
+    id: webhook.id,
+    endpoint: webhook.endpoint,
+    events: webhook.events,
+    status: webhook.status,
+    created_at: webhook.createdAt,
+  };
+}
+
+function mapWebhookCreateResult(webhook: WebhookServiceCreateResult) {
+  return {
+    object: "webhook",
+    ...mapWebhookListItem(webhook),
+    signing_secret: webhook.signingSecret,
+  };
+}
+
+function mapDelivery(delivery: WebhookDeliveryListItem) {
+  return {
+    id: delivery.id,
+    status: delivery.status,
+    attempt: delivery.attempt,
+    status_code: delivery.statusCode,
+    response_body: delivery.responseBody,
+    attempted_at: delivery.attemptedAt,
+    next_retry_at: delivery.nextRetryAt,
+    created_at: delivery.createdAt,
+  };
+}
+
+function mapWebhookDetail(webhook: WebhookServiceDetail) {
+  return {
+    object: "webhook",
+    ...mapWebhookListItem(webhook),
+    recent_deliveries: (webhook.recentDeliveries ?? []).map(mapDelivery),
+  };
+}
+
+type WebhookAuth = AuthResult & { userId: string };
+
+type WebhookAuthResult =
+  | { ok: true; auth: WebhookAuth }
+  | { ok: false; response: Response };
+
+async function requireWebhookAuth(
+  request: Request,
+): Promise<WebhookAuthResult> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth?.userId) return { ok: false, response: unauthorizedResponse() };
+
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return { ok: false, response: permissionError };
+
+  return { ok: true, auth: { ...auth, userId: auth.userId } };
+}
+
+export async function handleListWebhooksRequest(
+  request: Request,
+): Promise<Response> {
+  const authResult = await requireWebhookAuth(request);
+  if (!authResult.ok) return authResult.response;
+
+  const url = new URL(request.url);
+  const limit = Number(url.searchParams.get("limit")) || 20;
+  const after = url.searchParams.get("after") || "";
+
+  try {
+    const result = await webhookService().listWebhooks({
+      userId: authResult.auth.userId,
+      limit,
+      after,
+    });
+
+    return Response.json({
+      object: "list",
+      data: result.data.map(mapWebhookListItem),
+      has_more: result.hasMore,
+    });
+  } catch (error) {
+    return mapWebhookError(error, "Failed to list webhooks");
+  }
+}
+
+export async function handleCreateWebhookRequest(
+  request: Request,
+): Promise<Response> {
+  const authResult = await requireWebhookAuth(request);
+  if (!authResult.ok) return authResult.response;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = createWebhookSchema.safeParse(body);
+  if (!result.success) {
+    return Response.json(
+      { error: "Validation failed", details: result.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  const validated = result.data;
+  const endpoint = validated.endpoint ?? validated.url;
+  const events = validated.events ?? validated.event_types;
+
+  if (!endpoint || !events) {
+    return Response.json(
+      { error: "Endpoint and events are required" },
+      { status: 422 },
+    );
+  }
+
+  try {
+    const webhook = await webhookService().createWebhook({
+      userId: authResult.auth.userId,
+      endpoint,
+      events,
+    });
+
+    return Response.json(mapWebhookCreateResult(webhook), { status: 201 });
+  } catch (error) {
+    return mapWebhookError(error, "Failed to create webhook");
+  }
+}
+
+export async function handleGetWebhookRequest(
+  request: Request,
+  id: string,
+): Promise<Response> {
+  const authResult = await requireWebhookAuth(request);
+  if (!authResult.ok) return authResult.response;
+
+  try {
+    const webhook = await webhookService().getWebhook(
+      id,
+      authResult.auth.userId,
+    );
+
+    if (!webhook) {
+      return Response.json({ error: "Webhook not found" }, { status: 404 });
+    }
+
+    return Response.json(mapWebhookDetail(webhook));
+  } catch (error) {
+    return mapWebhookError(error, "Failed to retrieve webhook");
+  }
+}
+
+export async function handleUpdateWebhookRequest(
+  request: Request,
+  id: string,
+): Promise<Response> {
+  const authResult = await requireWebhookAuth(request);
+  if (!authResult.ok) return authResult.response;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = updateWebhookSchema.safeParse(body);
+  if (!result.success) {
+    return Response.json(
+      { error: "Validation failed", details: result.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  try {
+    const validated = result.data;
+    const updated = await webhookService().updateWebhook(
+      id,
+      authResult.auth.userId,
+      {
+        endpoint: validated.endpoint ?? validated.url,
+        events: validated.events ?? validated.event_types,
+        status: validated.status,
+        active: validated.active,
+      },
+    );
+
+    if (!updated) {
+      return Response.json({ error: "Webhook not found" }, { status: 404 });
+    }
+
+    return Response.json({
+      object: "webhook",
+      ...mapWebhookListItem(updated),
+    });
+  } catch (error) {
+    return mapWebhookError(error, "Failed to update webhook");
+  }
+}
+
+export async function handleDeleteWebhookRequest(
+  request: Request,
+  id: string,
+): Promise<Response> {
+  const authResult = await requireWebhookAuth(request);
+  if (!authResult.ok) return authResult.response;
+
+  try {
+    const deleted = await webhookService().deleteWebhook(
+      id,
+      authResult.auth.userId,
+    );
+
+    if (!deleted) {
+      return Response.json({ error: "Webhook not found" }, { status: 404 });
+    }
+
+    return Response.json({
+      object: "webhook",
+      id: deleted.id,
+      deleted: true,
+    });
+  } catch (error) {
+    return mapWebhookError(error, "Failed to delete webhook");
+  }
+}

--- a/src/lib/api/webhooks/index.ts
+++ b/src/lib/api/webhooks/index.ts
@@ -1,0 +1,7 @@
+export {
+  handleCreateWebhookRequest,
+  handleDeleteWebhookRequest,
+  handleGetWebhookRequest,
+  handleListWebhooksRequest,
+  handleUpdateWebhookRequest,
+} from "./handlers";


### PR DESCRIPTION
## Summary\n- Extract shared webhook Request handlers that preserve the existing Next.js response/status/auth/validation contract.\n- Mount Hono control-plane /webhooks and /webhooks/:id routes through a small services/api route module instead of importing Next App Router modules.\n- Record the shared-handler parity pattern in learnings.\n\nCloses #344\n\n## Validation\n- make check\n- bunx vitest run tests/webhooks-api-keys-tenant-isolation.test.ts tests/api-auth-date-range-routes.test.ts -t "webhook|control-plane webhooks|API key permission"\n- make test\n\n## Notes\n- No webhook delivery signing, dispatcher, dashboard UI, SDK, migration, billing, domains, emails, templates, or broad Hono migration changes.\n- Playwright e2e not run; API-only route parity change covered by Vitest and full unit suite.