### PR TITLE
Extract custom events API service boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-348-custom-events-boundary.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-348-custom-events-boundary.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-11
+issue: "#348"
+type: pattern
+promoted_to: null
+---
+
+## Custom event API boundary keeps transport validation in Next and injects wait-run resume
+
+Custom event create/list/delete/send orchestration now lives in `packages/core/src/services/customEvents.ts`. Next routes still own API-key auth, full-access gating, JSON/Zod parsing, and HTTP status/error mapping. The service owns response DTOs, tenant-scoped event repository calls, stored schema payload validation, contact resolution/upsert, delivery recording, wait-for-event resume handoff, and automation trigger fan-out.
+
+`resumeWaitingRunsForEvent` remains implemented in the app worker layer and is injected into `createCustomEventService()` from the Next send route. Preserve that dependency injection shape for future adapters instead of importing app worker code into `@opensend/core`.

--- a/packages/core/src/db/repositories/customEventRepo.ts
+++ b/packages/core/src/db/repositories/customEventRepo.ts
@@ -27,6 +27,14 @@ export const customEventRepo = {
     });
   },
 
+  async findByIdForUser(id: string, userId?: string | null) {
+    const conditions = [eq(customEvents.id, id)];
+    if (userId) conditions.push(eq(customEvents.userId, userId));
+    return await db.query.customEvents.findFirst({
+      where: and(...conditions),
+    });
+  },
+
   async findByName(name: string, userId?: string | null) {
     const conditions = [eq(customEvents.name, name)];
     if (userId) conditions.push(eq(customEvents.userId, userId));
@@ -72,6 +80,15 @@ export const customEventRepo = {
     return await db
       .delete(customEvents)
       .where(eq(customEvents.id, id))
+      .returning({ id: customEvents.id });
+  },
+
+  async deleteForUser(id: string, userId?: string | null) {
+    const conditions = [eq(customEvents.id, id)];
+    if (userId) conditions.push(eq(customEvents.userId, userId));
+    return await db
+      .delete(customEvents)
+      .where(and(...conditions))
       .returning({ id: customEvents.id });
   },
 };

--- a/packages/core/src/dto/automations.ts
+++ b/packages/core/src/dto/automations.ts
@@ -227,6 +227,264 @@ export class AutomationValidationError extends Error {
   }
 }
 
+const SUPPORTED_EVENT_SCHEMA_TYPES = [
+  "string",
+  "number",
+  "boolean",
+  "object",
+  "array",
+] as const;
+
+type EventSchemaType = (typeof SUPPORTED_EVENT_SCHEMA_TYPES)[number];
+
+export interface EventSchemaIssue {
+  path: string;
+  message: string;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSupportedEventSchemaType(value: unknown): value is EventSchemaType {
+  return (
+    typeof value === "string" &&
+    SUPPORTED_EVENT_SCHEMA_TYPES.includes(value as EventSchemaType)
+  );
+}
+
+function pushEventSchemaIssue(
+  issues: EventSchemaIssue[],
+  path: string[],
+  message: string,
+) {
+  issues.push({ path: path.join("."), message });
+}
+
+function validateRequiredList(
+  value: unknown,
+  path: string[],
+  issues: EventSchemaIssue[],
+) {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    pushEventSchemaIssue(
+      issues,
+      path,
+      `${path.join(".")} must be an array of strings`,
+    );
+    return;
+  }
+
+  value.forEach((entry, index) => {
+    if (typeof entry !== "string" || entry.trim().length === 0) {
+      pushEventSchemaIssue(
+        issues,
+        [...path, String(index)],
+        `${[...path, String(index)].join(".")} must be a non-empty string`,
+      );
+    }
+  });
+}
+
+function validatePropertiesObject(
+  value: unknown,
+  path: string[],
+  issues: EventSchemaIssue[],
+) {
+  if (value === undefined) return;
+  if (!isRecord(value)) {
+    pushEventSchemaIssue(issues, path, `${path.join(".")} must be an object`);
+    return;
+  }
+
+  for (const [propertyName, descriptor] of Object.entries(value)) {
+    if (propertyName.trim().length === 0) {
+      pushEventSchemaIssue(
+        issues,
+        [...path, propertyName],
+        `${path.join(".")} keys must be non-empty strings`,
+      );
+      continue;
+    }
+    validatePropertyDescriptor(descriptor, [...path, propertyName], issues);
+  }
+}
+
+function validateAllowedSchemaKeys(
+  value: Record<string, unknown>,
+  path: string[],
+  allowedKeys: ReadonlySet<string>,
+  issues: EventSchemaIssue[],
+) {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      pushEventSchemaIssue(
+        issues,
+        [...path, key],
+        `${[...path, key].join(".")} is not a supported schema keyword`,
+      );
+    }
+  }
+}
+
+function validatePropertyDescriptor(
+  value: unknown,
+  path: string[],
+  issues: EventSchemaIssue[],
+) {
+  if (!isRecord(value)) {
+    pushEventSchemaIssue(
+      issues,
+      path,
+      `${path.join(".")} must be an object descriptor`,
+    );
+    return;
+  }
+
+  validateAllowedSchemaKeys(
+    value,
+    path,
+    new Set(["type", "properties", "required"]),
+    issues,
+  );
+
+  if (!isSupportedEventSchemaType(value.type)) {
+    pushEventSchemaIssue(
+      issues,
+      [...path, "type"],
+      `${[...path, "type"].join(".")} must be one of: ${SUPPORTED_EVENT_SCHEMA_TYPES.join(", ")}`,
+    );
+    return;
+  }
+
+  if (value.type !== "object") {
+    if (value.properties !== undefined) {
+      pushEventSchemaIssue(
+        issues,
+        [...path, "properties"],
+        `${[...path, "properties"].join(".")} is only supported when type is "object"`,
+      );
+    }
+    if (value.required !== undefined) {
+      pushEventSchemaIssue(
+        issues,
+        [...path, "required"],
+        `${[...path, "required"].join(".")} is only supported when type is "object"`,
+      );
+    }
+    return;
+  }
+
+  validatePropertiesObject(value.properties, [...path, "properties"], issues);
+  validateRequiredList(value.required, [...path, "required"], issues);
+}
+
+export function validateCustomEventSchemaDefinition(
+  schema: Record<string, unknown>,
+): EventSchemaIssue[] {
+  const issues: EventSchemaIssue[] = [];
+  validateAllowedSchemaKeys(
+    schema,
+    ["schema"],
+    new Set(["type", "properties", "required"]),
+    issues,
+  );
+
+  if (schema.type !== "object") {
+    pushEventSchemaIssue(
+      issues,
+      ["schema", "type"],
+      'schema.type must be "object"',
+    );
+    return issues;
+  }
+
+  validatePropertiesObject(schema.properties, ["schema", "properties"], issues);
+  validateRequiredList(schema.required, ["schema", "required"], issues);
+  return issues;
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function valueMatchesEventSchemaType(
+  value: unknown,
+  type: EventSchemaType,
+): boolean {
+  switch (type) {
+    case "string":
+      return typeof value === "string";
+    case "number":
+      return typeof value === "number" && Number.isFinite(value);
+    case "boolean":
+      return typeof value === "boolean";
+    case "object":
+      return isRecord(value);
+    case "array":
+      return Array.isArray(value);
+  }
+}
+
+function validateObjectPayload(
+  payload: Record<string, unknown>,
+  schema: Record<string, unknown>,
+  path: string[],
+  issues: EventSchemaIssue[],
+) {
+  const required = Array.isArray(schema.required)
+    ? schema.required.filter(
+        (entry): entry is string => typeof entry === "string",
+      )
+    : [];
+
+  for (const field of required) {
+    if (!hasOwn(payload, field)) {
+      pushEventSchemaIssue(
+        issues,
+        [...path, field],
+        `Missing required field ${[...path, field].join(".")}`,
+      );
+    }
+  }
+
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+  for (const [field, descriptor] of Object.entries(properties)) {
+    if (!hasOwn(payload, field)) continue;
+    if (!isRecord(descriptor) || !isSupportedEventSchemaType(descriptor.type)) {
+      continue;
+    }
+
+    const value = payload[field];
+    const fieldPath = [...path, field];
+    if (!valueMatchesEventSchemaType(value, descriptor.type)) {
+      pushEventSchemaIssue(
+        issues,
+        fieldPath,
+        `Expected ${fieldPath.join(".")} to be "${descriptor.type}"`,
+      );
+      continue;
+    }
+
+    if (descriptor.type === "object" && isRecord(value)) {
+      validateObjectPayload(value, descriptor, fieldPath, issues);
+    }
+  }
+}
+
+export function validateEventPayloadAgainstSchema(
+  payload: Record<string, unknown>,
+  schema: Record<string, unknown>,
+): EventSchemaIssue[] {
+  const schemaIssues = validateCustomEventSchemaDefinition(schema);
+  if (schemaIssues.length > 0) return schemaIssues;
+
+  const issues: EventSchemaIssue[] = [];
+  validateObjectPayload(payload, schema, ["payload"], issues);
+  return issues;
+}
+
 export function assertEventNameAllowed(name: string): void {
   if (!name || !name.trim()) {
     throw new AutomationValidationError(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,5 +54,6 @@ export * from "./services/broadcast";
 export * from "./services/audience-metadata";
 export * from "./services/automations";
 export * from "./services/automationRuns";
+export * from "./services/customEvents";
 export * from "./jobs/background-jobs";
 export * from "./observability/telemetry";

--- a/packages/core/src/services/customEvents.ts
+++ b/packages/core/src/services/customEvents.ts
@@ -1,0 +1,370 @@
+import { eq } from "drizzle-orm";
+import { db } from "../db/client";
+import { automationRepo } from "../db/repositories/automationRepo";
+import { automationRunRepo } from "../db/repositories/automationRunRepo";
+import {
+  type CreateCustomEventInput,
+  type RecordCustomEventDeliveryInput,
+  customEventDeliveryRepo,
+  customEventRepo,
+} from "../db/repositories/customEventRepo";
+import {
+  type AutomationStepStateEntry,
+  type automationRuns,
+  type automations,
+  contacts,
+  type customEventDeliveries,
+  type customEvents,
+} from "../db/schema";
+import {
+  type EventSchemaIssue,
+  isRecord,
+  validateEventPayloadAgainstSchema,
+} from "../dto/automations";
+
+export type CustomEventRow = typeof customEvents.$inferSelect;
+export type CustomEventDeliveryRow = typeof customEventDeliveries.$inferSelect;
+export type CustomEventAutomationRunRow = typeof automationRuns.$inferSelect;
+type AutomationRow = typeof automations.$inferSelect;
+type StepState = AutomationStepStateEntry;
+
+export type CreateCustomEventServiceInput = {
+  userId: string | null;
+  data: {
+    name: string;
+    schema?: Record<string, unknown> | null;
+  };
+};
+
+export type ListCustomEventsServiceInput = {
+  userId: string | null;
+  limit?: number;
+  after?: string;
+};
+
+export type DeleteCustomEventServiceInput = {
+  userId: string | null;
+  id: string;
+};
+
+export type SendCustomEventServiceInput = {
+  userId: string | null;
+  data: {
+    event: string;
+    contact_id?: string;
+    contactId?: string;
+    email?: string;
+    payload?: Record<string, unknown>;
+  };
+};
+
+export type CustomEventServiceErrorCode =
+  | "event_payload_invalid"
+  | "event_schema_invalid"
+  | "not_found";
+
+export class CustomEventServiceError extends Error {
+  constructor(
+    readonly code: CustomEventServiceErrorCode,
+    message: string,
+    readonly details?: EventSchemaIssue[],
+  ) {
+    super(message);
+    this.name = "CustomEventServiceError";
+  }
+}
+
+export type CustomEventResponse = ReturnType<typeof toCustomEventResponse>;
+export type CustomEventDeliveryResponse = ReturnType<
+  typeof toCustomEventDeliveryResponse
+>;
+export type AutomationRunListItemResponse = ReturnType<
+  typeof toRunListItemResponse
+>;
+
+export type CustomEventListResponse = {
+  object: "list";
+  data: CustomEventResponse[];
+  has_more: boolean;
+};
+
+export type CustomEventDeleteResponse = {
+  object: "event";
+  id: string;
+  deleted: true;
+};
+
+export type SendCustomEventResponse = {
+  object: "event_delivery";
+  delivery: CustomEventDeliveryResponse;
+  resumed_runs: AutomationRunListItemResponse[];
+  automation_runs: AutomationRunListItemResponse[];
+};
+
+export type CustomEventBoundaryRepository = {
+  create(input: CreateCustomEventInput): Promise<CustomEventRow>;
+  list(input: {
+    limit: number;
+    after?: string;
+    userId?: string | null;
+  }): Promise<{ data: CustomEventRow[]; hasMore: boolean }>;
+  findByName(
+    name: string,
+    userId?: string | null,
+  ): Promise<CustomEventRow | undefined>;
+  deleteForUser(
+    id: string,
+    userId?: string | null,
+  ): Promise<Array<{ id: string }>>;
+  resolveContactId(input: {
+    contactId?: string;
+    email?: string;
+    userId: string | null;
+  }): Promise<string | null>;
+  recordDelivery(
+    input: RecordCustomEventDeliveryInput,
+  ): Promise<CustomEventDeliveryRow>;
+  findEnabledAutomationsByTriggerEventName(
+    eventName: string,
+    userId?: string | null,
+  ): Promise<AutomationRow[]>;
+  createRunFromTrigger(input: {
+    automationId: string;
+    triggerEventId: string;
+    contactId?: string | null;
+    userId?: string | null;
+    initialStepKey?: string;
+  }): Promise<CustomEventAutomationRunRow>;
+};
+
+export type CustomEventServiceDependencies = {
+  repository?: CustomEventBoundaryRepository;
+  resumeWaitingRunsForEvent?: (
+    delivery: CustomEventDeliveryRow,
+  ) => Promise<CustomEventAutomationRunRow[]>;
+};
+
+function defaultRepository(): CustomEventBoundaryRepository {
+  return {
+    create: (input) => customEventRepo.create(input),
+    list: (input) => customEventRepo.list(input),
+    findByName: (name, userId) => customEventRepo.findByName(name, userId),
+    deleteForUser: (id, userId) => customEventRepo.deleteForUser(id, userId),
+    resolveContactId: async (input) => {
+      if (input.contactId) return input.contactId;
+      if (!input.email) return null;
+
+      const normalizedEmail = input.email.toLowerCase().trim();
+      const existing = await db.query.contacts.findFirst({
+        where: eq(contacts.email, normalizedEmail),
+      });
+      if (existing) return existing.id;
+
+      const [created] = await db
+        .insert(contacts)
+        .values({ email: normalizedEmail, userId: input.userId })
+        .returning({ id: contacts.id });
+      return created.id;
+    },
+    recordDelivery: (input) => customEventDeliveryRepo.record(input),
+    findEnabledAutomationsByTriggerEventName: (eventName, userId) =>
+      automationRepo.findEnabledByTriggerEventName(eventName, userId),
+    createRunFromTrigger: (input) =>
+      automationRunRepo.createFromTrigger({
+        automationId: input.automationId,
+        triggerEventId: input.triggerEventId,
+        contactId: input.contactId,
+        userId: input.userId,
+        initialStepKey: input.initialStepKey,
+      }),
+  };
+}
+
+function toCustomEventResponse(event: CustomEventRow) {
+  return {
+    object: "event" as const,
+    id: event.id,
+    name: event.name,
+    schema: event.schema ?? null,
+    created_at: event.createdAt,
+    updated_at: event.updatedAt,
+  };
+}
+
+function toCustomEventDeliveryResponse(delivery: CustomEventDeliveryRow) {
+  return {
+    object: "event_delivery" as const,
+    id: delivery.id,
+    event: delivery.eventName,
+    contact_id: delivery.contactId,
+    email: delivery.email,
+    payload: delivery.payload,
+    received_at: delivery.receivedAt,
+  };
+}
+
+function findFailedStepKey(
+  stepStates: CustomEventAutomationRunRow["stepStates"],
+): string | null {
+  if (!stepStates) return null;
+  for (const [key, state] of Object.entries(stepStates) as Array<
+    [string, StepState]
+  >) {
+    if (state.status === "failed") return key;
+  }
+  return null;
+}
+
+function durationMs(run: CustomEventAutomationRunRow): number | null {
+  if (!run.startedAt || !run.completedAt) return null;
+  return Math.max(0, run.completedAt.getTime() - run.startedAt.getTime());
+}
+
+function toRunListItemResponse(run: CustomEventAutomationRunRow) {
+  return {
+    object: "automation_run" as const,
+    id: run.id,
+    automation_id: run.automationId,
+    status: run.status,
+    started_at: run.startedAt,
+    completed_at: run.completedAt,
+    duration_ms: durationMs(run),
+    current_step_key: run.currentStepKey,
+    failed_step_key: findFailedStepKey(run.stepStates),
+    failure_reason: run.failureReason,
+    next_step_at: run.nextStepAt,
+    created_at: run.createdAt,
+    updated_at: run.updatedAt,
+  };
+}
+
+function schemaValidationError(
+  details: EventSchemaIssue[],
+): CustomEventServiceError {
+  const code = details.some((detail) => detail.path.startsWith("schema"))
+    ? "event_schema_invalid"
+    : "event_payload_invalid";
+  return new CustomEventServiceError(
+    code,
+    code === "event_schema_invalid"
+      ? "Stored event schema is invalid"
+      : "Event payload does not match schema",
+    details,
+  );
+}
+
+async function noopResumeWaitingRunsForEvent(): Promise<
+  CustomEventAutomationRunRow[]
+> {
+  return [];
+}
+
+export function createCustomEventService({
+  repository = defaultRepository(),
+  resumeWaitingRunsForEvent = noopResumeWaitingRunsForEvent,
+}: CustomEventServiceDependencies = {}) {
+  return {
+    async createCustomEvent(
+      input: CreateCustomEventServiceInput,
+    ): Promise<CustomEventResponse> {
+      const event = await repository.create({
+        name: input.data.name,
+        schema: input.data.schema ?? null,
+        userId: input.userId,
+      });
+      return toCustomEventResponse(event);
+    },
+
+    async listCustomEvents(
+      input: ListCustomEventsServiceInput,
+    ): Promise<CustomEventListResponse> {
+      const { data, hasMore } = await repository.list({
+        limit: input.limit ?? 50,
+        after: input.after,
+        userId: input.userId,
+      });
+      return {
+        object: "list",
+        data: data.map(toCustomEventResponse),
+        has_more: hasMore,
+      };
+    },
+
+    async deleteCustomEvent(
+      input: DeleteCustomEventServiceInput,
+    ): Promise<CustomEventDeleteResponse> {
+      const deleted = await repository.deleteForUser(input.id, input.userId);
+      if (deleted.length === 0) {
+        throw new CustomEventServiceError("not_found", "Event not found");
+      }
+      return { object: "event", id: deleted[0].id, deleted: true };
+    },
+
+    async sendCustomEvent(
+      input: SendCustomEventServiceInput,
+    ): Promise<SendCustomEventResponse> {
+      const event = input.data;
+      const contactId = event.contact_id ?? event.contactId;
+      const customEvent = await repository.findByName(
+        event.event,
+        input.userId,
+      );
+      const payload = event.payload ?? {};
+
+      if (customEvent?.schema !== null && customEvent?.schema !== undefined) {
+        if (!isRecord(customEvent.schema)) {
+          throw new CustomEventServiceError(
+            "event_schema_invalid",
+            "Stored event schema is invalid",
+            [{ path: "schema", message: "schema must be an object" }],
+          );
+        }
+
+        const details = validateEventPayloadAgainstSchema(
+          payload,
+          customEvent.schema,
+        );
+        if (details.length > 0) throw schemaValidationError(details);
+      }
+
+      const resolvedContactId = await repository.resolveContactId({
+        contactId,
+        email: event.email,
+        userId: input.userId,
+      });
+      const delivery = await repository.recordDelivery({
+        eventName: event.event,
+        payload,
+        contactId: resolvedContactId,
+        email: event.email?.toLowerCase().trim() ?? null,
+        userId: input.userId,
+      });
+      const resumedRuns = await resumeWaitingRunsForEvent(delivery);
+
+      const matching =
+        await repository.findEnabledAutomationsByTriggerEventName(
+          event.event,
+          input.userId,
+        );
+      const runs: CustomEventAutomationRunRow[] = [];
+      for (const automation of matching) {
+        runs.push(
+          await repository.createRunFromTrigger({
+            automationId: automation.id,
+            triggerEventId: delivery.id,
+            contactId: resolvedContactId,
+            userId: input.userId,
+            initialStepKey: "trigger",
+          }),
+        );
+      }
+
+      return {
+        object: "event_delivery",
+        delivery: toCustomEventDeliveryResponse(delivery),
+        resumed_runs: resumedRuns.map(toRunListItemResponse),
+        automation_runs: runs.map(toRunListItemResponse),
+      };
+    },
+  };
+}

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,11 +1,16 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import { formatCustomEvent } from "@/lib/automations";
 import {
   createCustomEventSchema,
   listEventsQuerySchema,
 } from "@/lib/validation/events";
-import { AutomationValidationError, customEventRepo } from "@opensend/core";
+import {
+  AutomationValidationError,
+  CustomEventServiceError,
+  createCustomEventService,
+} from "@opensend/core";
+
+const customEventService = createCustomEventService();
 
 function isUniqueViolation(err: unknown): boolean {
   return (
@@ -14,6 +19,36 @@ function isUniqueViolation(err: unknown): boolean {
     "code" in err &&
     err.code === "23505"
   );
+}
+
+function mapCreateEventError(err: unknown): Response {
+  if (err instanceof AutomationValidationError) {
+    return Response.json(
+      { error: err.message, code: err.code },
+      { status: 422 },
+    );
+  }
+  if (isUniqueViolation(err)) {
+    return Response.json(
+      { error: "An event with this name already exists" },
+      { status: 409 },
+    );
+  }
+  const message = err instanceof Error ? err.message : "Failed to create event";
+  return Response.json({ error: message }, { status: 500 });
+}
+
+function mapListEventError(err: unknown): Response {
+  const message = err instanceof Error ? err.message : "Failed to list events";
+  return Response.json({ error: message }, { status: 500 });
+}
+
+function mapDeleteEventError(err: unknown): Response {
+  if (err instanceof CustomEventServiceError && err.code === "not_found") {
+    return Response.json({ error: err.message }, { status: 404 });
+  }
+  const message = err instanceof Error ? err.message : "Failed to delete event";
+  return Response.json({ error: message }, { status: 500 });
 }
 
 export async function POST(request: Request): Promise<Response> {
@@ -38,28 +73,13 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   try {
-    const event = await customEventRepo.create({
-      name: parsed.data.name,
-      schema: parsed.data.schema ?? null,
+    const event = await customEventService.createCustomEvent({
       userId: auth.userId,
+      data: parsed.data,
     });
-    return Response.json(formatCustomEvent(event), { status: 201 });
+    return Response.json(event, { status: 201 });
   } catch (err) {
-    if (err instanceof AutomationValidationError) {
-      return Response.json(
-        { error: err.message, code: err.code },
-        { status: 422 },
-      );
-    }
-    if (isUniqueViolation(err)) {
-      return Response.json(
-        { error: "An event with this name already exists" },
-        { status: 409 },
-      );
-    }
-    const message =
-      err instanceof Error ? err.message : "Failed to create event";
-    return Response.json({ error: message }, { status: 500 });
+    return mapCreateEventError(err);
   }
 }
 
@@ -82,19 +102,43 @@ export async function GET(request: Request): Promise<Response> {
   }
 
   try {
-    const { data, hasMore } = await customEventRepo.list({
-      limit: parsed.data.limit ?? 50,
-      after: parsed.data.after,
+    const list = await customEventService.listCustomEvents({
       userId: auth.userId,
+      limit: parsed.data.limit,
+      after: parsed.data.after,
     });
-    return Response.json({
-      object: "list",
-      data: data.map(formatCustomEvent),
-      has_more: hasMore,
-    });
+    return Response.json(list);
   } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to list events";
-    return Response.json({ error: message }, { status: 500 });
+    return mapListEventError(err);
+  }
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
+
+  const url = new URL(request.url);
+  const id = url.searchParams.get("id");
+  if (!id) {
+    return Response.json(
+      {
+        error: "Validation failed",
+        details: {
+          formErrors: [],
+          fieldErrors: { id: ["Required"] },
+        },
+      },
+      { status: 422 },
+    );
+  }
+
+  try {
+    return Response.json(
+      await customEventService.deleteCustomEvent({ userId: auth.userId, id }),
+    );
+  } catch (err) {
+    return mapDeleteEventError(err);
   }
 }

--- a/src/app/api/events/send/route.ts
+++ b/src/app/api/events/send/route.ts
@@ -1,45 +1,38 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
-import {
-  formatCustomEventDelivery,
-  formatRunListItem,
-} from "@/lib/automations";
-import { db } from "@/lib/db";
-import { contacts } from "@/lib/db/schema";
-import {
-  isRecord,
-  sendEventSchema,
-  validateEventPayloadAgainstSchema,
-} from "@/lib/validation/events";
+import { sendEventSchema } from "@/lib/validation/events";
 import { resumeWaitingRunsForEvent } from "@/lib/workers/automation-runner";
 import {
   AutomationValidationError,
-  automationRepo,
-  automationRunRepo,
-  customEventDeliveryRepo,
-  customEventRepo,
+  CustomEventServiceError,
+  createCustomEventService,
 } from "@opensend/core";
-import { eq } from "drizzle-orm";
 
-async function resolveContactId(input: {
-  contactId?: string;
-  email?: string;
-  userId: string | null;
-}): Promise<string | null> {
-  if (input.contactId) return input.contactId;
-  if (!input.email) return null;
+const customEventService = createCustomEventService({
+  resumeWaitingRunsForEvent,
+});
 
-  const normalizedEmail = input.email.toLowerCase().trim();
-  const existing = await db.query.contacts.findFirst({
-    where: eq(contacts.email, normalizedEmail),
-  });
-  if (existing) return existing.id;
+function mapSendEventError(err: unknown): Response {
+  if (err instanceof CustomEventServiceError) {
+    if (
+      err.code === "event_schema_invalid" ||
+      err.code === "event_payload_invalid"
+    ) {
+      return Response.json(
+        { error: err.message, code: err.code, details: err.details ?? [] },
+        { status: 422 },
+      );
+    }
+  }
 
-  const [created] = await db
-    .insert(contacts)
-    .values({ email: normalizedEmail, userId: input.userId })
-    .returning({ id: contacts.id });
-  return created.id;
+  if (err instanceof AutomationValidationError) {
+    return Response.json(
+      { error: err.message, code: err.code },
+      { status: 422 },
+    );
+  }
+  const message = err instanceof Error ? err.message : "Failed to send event";
+  return Response.json({ error: message }, { status: 500 });
 }
 
 export async function POST(request: Request): Promise<Response> {
@@ -63,97 +56,15 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  const event = parsed.data;
-  const contactId = event.contact_id ?? event.contactId;
-
   try {
-    const customEvent = await customEventRepo.findByName(
-      event.event,
-      auth.userId,
-    );
-    const payload = event.payload ?? {};
-    if (customEvent?.schema !== null && customEvent?.schema !== undefined) {
-      if (!isRecord(customEvent.schema)) {
-        return Response.json(
-          {
-            error: "Stored event schema is invalid",
-            code: "event_schema_invalid",
-            details: [{ path: "schema", message: "schema must be an object" }],
-          },
-          { status: 422 },
-        );
-      }
-
-      const details = validateEventPayloadAgainstSchema(
-        payload,
-        customEvent.schema,
-      );
-      if (details.length > 0) {
-        const code = details.some((detail) => detail.path.startsWith("schema"))
-          ? "event_schema_invalid"
-          : "event_payload_invalid";
-        return Response.json(
-          {
-            error:
-              code === "event_schema_invalid"
-                ? "Stored event schema is invalid"
-                : "Event payload does not match schema",
-            code,
-            details,
-          },
-          { status: 422 },
-        );
-      }
-    }
-
-    const resolvedContactId = await resolveContactId({
-      contactId,
-      email: event.email,
-      userId: auth.userId,
-    });
-    const delivery = await customEventDeliveryRepo.record({
-      eventName: event.event,
-      payload,
-      contactId: resolvedContactId,
-      email: event.email?.toLowerCase().trim() ?? null,
-      userId: auth.userId,
-    });
-    const resumedRuns = await resumeWaitingRunsForEvent(delivery);
-
-    const matching = await automationRepo.findEnabledByTriggerEventName(
-      event.event,
-      auth.userId,
-    );
-    const runs = [];
-    for (const automation of matching) {
-      runs.push(
-        await automationRunRepo.createFromTrigger({
-          automationId: automation.id,
-          triggerEventId: delivery.id,
-          contactId: resolvedContactId,
-          userId: auth.userId,
-          initialStepKey: "trigger",
-        }),
-      );
-    }
-
     return Response.json(
-      {
-        object: "event_delivery",
-        delivery: formatCustomEventDelivery(delivery),
-        resumed_runs: resumedRuns.map(formatRunListItem),
-        automation_runs: runs.map(formatRunListItem),
-      },
+      await customEventService.sendCustomEvent({
+        userId: auth.userId,
+        data: parsed.data,
+      }),
       { status: 202 },
     );
   } catch (err) {
-    if (err instanceof AutomationValidationError) {
-      return Response.json(
-        { error: err.message, code: err.code },
-        { status: 422 },
-      );
-    }
-    const message = err instanceof Error ? err.message : "Failed to send event";
-    return Response.json({ error: message }, { status: 500 });
+    return mapSendEventError(err);
   }
 }

--- a/src/lib/validation/events.ts
+++ b/src/lib/validation/events.ts
@@ -1,174 +1,15 @@
+import {
+  type EventSchemaIssue,
+  isRecord,
+  validateCustomEventSchemaDefinition,
+  validateEventPayloadAgainstSchema,
+} from "@opensend/core";
 import { z } from "zod";
 
 const eventNameSchema = z.string().min(1).max(255);
 const uuidSchema = z.string().uuid();
 const emailSchema = z.string().email().min(3).max(512);
 const jsonObjectSchema = z.record(z.string(), z.unknown());
-const supportedEventSchemaTypes = [
-  "string",
-  "number",
-  "boolean",
-  "object",
-  "array",
-] as const;
-
-type EventSchemaType = (typeof supportedEventSchemaTypes)[number];
-
-export interface EventSchemaIssue {
-  path: string;
-  message: string;
-}
-
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isSupportedEventSchemaType(value: unknown): value is EventSchemaType {
-  return (
-    typeof value === "string" &&
-    supportedEventSchemaTypes.includes(value as EventSchemaType)
-  );
-}
-
-function pushIssue(
-  issues: EventSchemaIssue[],
-  path: string[],
-  message: string,
-) {
-  issues.push({ path: path.join("."), message });
-}
-
-function validateRequiredList(
-  value: unknown,
-  path: string[],
-  issues: EventSchemaIssue[],
-) {
-  if (value === undefined) return;
-  if (!Array.isArray(value)) {
-    pushIssue(issues, path, `${path.join(".")} must be an array of strings`);
-    return;
-  }
-
-  value.forEach((entry, index) => {
-    if (typeof entry !== "string" || entry.trim().length === 0) {
-      pushIssue(
-        issues,
-        [...path, String(index)],
-        `${[...path, String(index)].join(".")} must be a non-empty string`,
-      );
-    }
-  });
-}
-
-function validatePropertiesObject(
-  value: unknown,
-  path: string[],
-  issues: EventSchemaIssue[],
-) {
-  if (value === undefined) return;
-  if (!isRecord(value)) {
-    pushIssue(issues, path, `${path.join(".")} must be an object`);
-    return;
-  }
-
-  for (const [propertyName, descriptor] of Object.entries(value)) {
-    if (propertyName.trim().length === 0) {
-      pushIssue(
-        issues,
-        [...path, propertyName],
-        `${path.join(".")} keys must be non-empty strings`,
-      );
-      continue;
-    }
-    validatePropertyDescriptor(descriptor, [...path, propertyName], issues);
-  }
-}
-
-function validateAllowedKeys(
-  value: Record<string, unknown>,
-  path: string[],
-  allowedKeys: ReadonlySet<string>,
-  issues: EventSchemaIssue[],
-) {
-  for (const key of Object.keys(value)) {
-    if (!allowedKeys.has(key)) {
-      pushIssue(
-        issues,
-        [...path, key],
-        `${[...path, key].join(".")} is not a supported schema keyword`,
-      );
-    }
-  }
-}
-
-function validatePropertyDescriptor(
-  value: unknown,
-  path: string[],
-  issues: EventSchemaIssue[],
-) {
-  if (!isRecord(value)) {
-    pushIssue(issues, path, `${path.join(".")} must be an object descriptor`);
-    return;
-  }
-
-  validateAllowedKeys(
-    value,
-    path,
-    new Set(["type", "properties", "required"]),
-    issues,
-  );
-
-  if (!isSupportedEventSchemaType(value.type)) {
-    pushIssue(
-      issues,
-      [...path, "type"],
-      `${[...path, "type"].join(".")} must be one of: ${supportedEventSchemaTypes.join(", ")}`,
-    );
-    return;
-  }
-
-  if (value.type !== "object") {
-    if (value.properties !== undefined) {
-      pushIssue(
-        issues,
-        [...path, "properties"],
-        `${[...path, "properties"].join(".")} is only supported when type is "object"`,
-      );
-    }
-    if (value.required !== undefined) {
-      pushIssue(
-        issues,
-        [...path, "required"],
-        `${[...path, "required"].join(".")} is only supported when type is "object"`,
-      );
-    }
-    return;
-  }
-
-  validatePropertiesObject(value.properties, [...path, "properties"], issues);
-  validateRequiredList(value.required, [...path, "required"], issues);
-}
-
-export function validateCustomEventSchemaDefinition(
-  schema: Record<string, unknown>,
-): EventSchemaIssue[] {
-  const issues: EventSchemaIssue[] = [];
-  validateAllowedKeys(
-    schema,
-    ["schema"],
-    new Set(["type", "properties", "required"]),
-    issues,
-  );
-
-  if (schema.type !== "object") {
-    pushIssue(issues, ["schema", "type"], 'schema.type must be "object"');
-    return issues;
-  }
-
-  validatePropertiesObject(schema.properties, ["schema", "properties"], issues);
-  validateRequiredList(schema.required, ["schema", "required"], issues);
-  return issues;
-}
 
 const eventSchemaDefinitionSchema = jsonObjectSchema.superRefine(
   (schema, ctx) => {
@@ -228,82 +69,11 @@ export const sendEventSchema = z
     }
   });
 
-function hasOwn(record: Record<string, unknown>, key: string): boolean {
-  return Object.prototype.hasOwnProperty.call(record, key);
-}
-
-function valueMatchesType(value: unknown, type: EventSchemaType): boolean {
-  switch (type) {
-    case "string":
-      return typeof value === "string";
-    case "number":
-      return typeof value === "number" && Number.isFinite(value);
-    case "boolean":
-      return typeof value === "boolean";
-    case "object":
-      return isRecord(value);
-    case "array":
-      return Array.isArray(value);
-  }
-}
-
-function validateObjectPayload(
-  payload: Record<string, unknown>,
-  schema: Record<string, unknown>,
-  path: string[],
-  issues: EventSchemaIssue[],
-) {
-  const required = Array.isArray(schema.required)
-    ? schema.required.filter(
-        (entry): entry is string => typeof entry === "string",
-      )
-    : [];
-
-  for (const field of required) {
-    if (!hasOwn(payload, field)) {
-      pushIssue(
-        issues,
-        [...path, field],
-        `Missing required field ${[...path, field].join(".")}`,
-      );
-    }
-  }
-
-  const properties = isRecord(schema.properties) ? schema.properties : {};
-  for (const [field, descriptor] of Object.entries(properties)) {
-    if (!hasOwn(payload, field)) continue;
-    if (!isRecord(descriptor) || !isSupportedEventSchemaType(descriptor.type)) {
-      continue;
-    }
-
-    const value = payload[field];
-    const fieldPath = [...path, field];
-    if (!valueMatchesType(value, descriptor.type)) {
-      pushIssue(
-        issues,
-        fieldPath,
-        `Expected ${fieldPath.join(".")} to be "${descriptor.type}"`,
-      );
-      continue;
-    }
-
-    if (descriptor.type === "object" && isRecord(value)) {
-      validateObjectPayload(value, descriptor, fieldPath, issues);
-    }
-  }
-}
-
-export function validateEventPayloadAgainstSchema(
-  payload: Record<string, unknown>,
-  schema: Record<string, unknown>,
-): EventSchemaIssue[] {
-  const schemaIssues = validateCustomEventSchemaDefinition(schema);
-  if (schemaIssues.length > 0) return schemaIssues;
-
-  const issues: EventSchemaIssue[] = [];
-  validateObjectPayload(payload, schema, ["payload"], issues);
-  return issues;
-}
-
 export type CreateCustomEventRequest = z.infer<typeof createCustomEventSchema>;
 export type SendEventRequest = z.infer<typeof sendEventSchema>;
+export {
+  isRecord,
+  validateCustomEventSchemaDefinition,
+  validateEventPayloadAgainstSchema,
+};
+export type { EventSchemaIssue };

--- a/tests/api-automations-events.test.ts
+++ b/tests/api-automations-events.test.ts
@@ -12,6 +12,10 @@ const mockServiceListAutomations = vi.hoisted(() => vi.fn());
 const mockServiceGetAutomation = vi.hoisted(() => vi.fn());
 const mockServiceUpdateAutomation = vi.hoisted(() => vi.fn());
 const mockServiceDeleteAutomation = vi.hoisted(() => vi.fn());
+const mockServiceCreateCustomEvent = vi.hoisted(() => vi.fn());
+const mockServiceListCustomEvents = vi.hoisted(() => vi.fn());
+const mockServiceDeleteCustomEvent = vi.hoisted(() => vi.fn());
+const mockServiceSendCustomEvent = vi.hoisted(() => vi.fn());
 const mockAutomationValidate = vi.hoisted(() => vi.fn());
 const mockAutomationDelete = vi.hoisted(() => vi.fn());
 const mockFindEnabledByTriggerEventName = vi.hoisted(() => vi.fn());
@@ -64,6 +68,22 @@ class TestAutomationServiceError extends Error {
   }
 }
 
+class TestCustomEventServiceError extends Error {
+  readonly code: string;
+  readonly details?: Array<{ path: string; message: string }>;
+
+  constructor(
+    code: string,
+    message: string,
+    details?: Array<{ path: string; message: string }>,
+  ) {
+    super(message);
+    this.name = "CustomEventServiceError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
 function queryRows<T>(rows: T[]) {
   return {
     from: vi.fn().mockReturnThis(),
@@ -113,6 +133,42 @@ vi.mock("@opensend/core", () => ({
   AutomationValidationError: TestAutomationValidationError,
   AutomationRunServiceError: TestAutomationRunServiceError,
   AutomationServiceError: TestAutomationServiceError,
+  CustomEventServiceError: TestCustomEventServiceError,
+  isRecord: (value: unknown) =>
+    typeof value === "object" && value !== null && !Array.isArray(value),
+  validateCustomEventSchemaDefinition: (schema: Record<string, unknown>) => {
+    const propertyTypes = ["string", "number", "boolean", "object", "array"];
+    const issues: Array<{ path: string; message: string }> = [];
+    if (schema.type !== "object") {
+      issues.push({
+        path: "schema.type",
+        message: 'schema.type must be "object"',
+      });
+      return issues;
+    }
+    const properties = schema.properties;
+    if (
+      typeof properties === "object" &&
+      properties !== null &&
+      !Array.isArray(properties)
+    ) {
+      for (const [name, descriptor] of Object.entries(properties)) {
+        if (
+          typeof descriptor === "object" &&
+          descriptor !== null &&
+          !Array.isArray(descriptor) &&
+          !propertyTypes.includes(String(descriptor.type))
+        ) {
+          issues.push({
+            path: `schema.properties.${name}.type`,
+            message: `schema.properties.${name}.type must be one of: ${propertyTypes.join(", ")}`,
+          });
+        }
+      }
+    }
+    return issues;
+  },
+  validateEventPayloadAgainstSchema: () => [],
   createAutomationService: () => ({
     createAutomation: mockServiceCreateAutomation,
     listAutomations: mockServiceListAutomations,
@@ -125,6 +181,12 @@ vi.mock("@opensend/core", () => ({
     getRun: mockGetRun,
     cancelRun: mockCancelRun,
     getMetrics: mockGetMetrics,
+  }),
+  createCustomEventService: () => ({
+    createCustomEvent: mockServiceCreateCustomEvent,
+    listCustomEvents: mockServiceListCustomEvents,
+    deleteCustomEvent: mockServiceDeleteCustomEvent,
+    sendCustomEvent: mockServiceSendCustomEvent,
   }),
   automationRepo: {
     create: mockAutomationCreate,
@@ -974,41 +1036,152 @@ describe("automation API routes", () => {
 });
 
 describe("events API routes", () => {
+  const eventResponse = {
+    object: "event",
+    id: "evt_1",
+    name: "user.signed_up",
+    schema: null,
+    created_at: now,
+    updated_at: now,
+  };
+  const deliveryResponse = {
+    object: "event_delivery",
+    id: "delivery_1",
+    event: "user.signed_up",
+    contact_id: "contact_1",
+    email: "user@example.com",
+    payload: { plan: "pro" },
+    received_at: now,
+  };
+  const runResponse = {
+    object: "automation_run",
+    id: "run_1",
+    automation_id: "auto_1",
+    status: "queued",
+    started_at: null,
+    completed_at: null,
+    duration_ms: null,
+    current_step_key: "trigger",
+    failed_step_key: null,
+    failure_reason: null,
+    next_step_at: null,
+    created_at: now,
+    updated_at: now,
+  };
+
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
     mockValidateApiKey.mockResolvedValue(auth);
-    mockCustomEventFindByName.mockResolvedValue(null);
-    mockResumeWaitingRunsForEvent.mockResolvedValue([]);
+    mockServiceCreateCustomEvent.mockResolvedValue(eventResponse);
+    mockServiceListCustomEvents.mockResolvedValue({
+      object: "list",
+      data: [
+        {
+          ...eventResponse,
+          created_at: now.toISOString(),
+          updated_at: now.toISOString(),
+        },
+      ],
+      has_more: false,
+    });
+    mockServiceDeleteCustomEvent.mockResolvedValue({
+      object: "event",
+      id: "evt_1",
+      deleted: true,
+    });
+    mockServiceSendCustomEvent.mockResolvedValue({
+      object: "event_delivery",
+      delivery: deliveryResponse,
+      resumed_runs: [],
+      automation_runs: [runResponse],
+    });
   });
 
-  it("creates and lists custom events", async () => {
-    mockCustomEventCreate.mockResolvedValue(customEvent);
-    mockCustomEventList.mockResolvedValue({
-      data: [customEvent],
-      hasMore: false,
-    });
+  it("creates and lists custom events through the service boundary", async () => {
     const { POST, GET } = await import("@/app/api/events/route");
 
     const created = await POST(
       jsonRequest("http://localhost/api/events", { name: "user.signed_up" }),
     );
     const listed = await GET(
-      new Request("http://localhost/api/events", {
+      new Request("http://localhost/api/events?limit=10&after=evt_0", {
         headers: { Authorization: "Bearer re_test" },
       }),
     );
 
     expect(created.status).toBe(201);
     expect(listed.status).toBe(200);
+    expect(mockServiceCreateCustomEvent).toHaveBeenCalledWith({
+      userId: "user_1",
+      data: { name: "user.signed_up" },
+    });
+    expect(mockServiceListCustomEvents).toHaveBeenCalledWith({
+      userId: "user_1",
+      limit: 10,
+      after: "evt_0",
+    });
     await expect(created.json()).resolves.toMatchObject({
-      id: "evt_1",
-      name: "user.signed_up",
+      ...eventResponse,
+      created_at: now.toISOString(),
+      updated_at: now.toISOString(),
+    });
+    await expect(listed.json()).resolves.toMatchObject({
+      object: "list",
+      data: [
+        {
+          ...eventResponse,
+          created_at: now.toISOString(),
+          updated_at: now.toISOString(),
+        },
+      ],
+      has_more: false,
     });
   });
 
-  it("rejects reserved resend event names", async () => {
-    mockCustomEventCreate.mockRejectedValue(
+  it("deletes custom events through the service boundary", async () => {
+    const { DELETE } = await import("@/app/api/events/route");
+
+    const response = await DELETE(
+      new Request("http://localhost/api/events?id=evt_1", {
+        method: "DELETE",
+        headers: { Authorization: "Bearer re_test" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockServiceDeleteCustomEvent).toHaveBeenCalledWith({
+      userId: "user_1",
+      id: "evt_1",
+    });
+    await expect(response.json()).resolves.toEqual({
+      object: "event",
+      id: "evt_1",
+      deleted: true,
+    });
+  });
+
+  it("maps missing custom event deletes to 404", async () => {
+    mockServiceDeleteCustomEvent.mockRejectedValue(
+      new TestCustomEventServiceError("not_found", "Event not found"),
+    );
+    const { DELETE } = await import("@/app/api/events/route");
+
+    const response = await DELETE(
+      new Request("http://localhost/api/events?id=missing", {
+        method: "DELETE",
+        headers: { Authorization: "Bearer re_test" },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Event not found",
+    });
+  });
+
+  it("rejects reserved resend event names with the preserved 422 envelope", async () => {
+    mockServiceCreateCustomEvent.mockRejectedValue(
       new TestAutomationValidationError("reserved", "event_name_reserved"),
     );
     const { POST } = await import("@/app/api/events/route");
@@ -1023,7 +1196,7 @@ describe("events API routes", () => {
     });
   });
 
-  it("rejects invalid custom event schema definitions with 422 details", async () => {
+  it("rejects invalid custom event schema definitions before calling the service", async () => {
     const { POST } = await import("@/app/api/events/route");
 
     const response = await POST(
@@ -1049,7 +1222,7 @@ describe("events API routes", () => {
         },
       },
     });
-    expect(mockCustomEventCreate).not.toHaveBeenCalled();
+    expect(mockServiceCreateCustomEvent).not.toHaveBeenCalled();
   });
 
   it("requires exactly one contact identifier when sending events", async () => {
@@ -1070,52 +1243,10 @@ describe("events API routes", () => {
 
     expect(none.status).toBe(422);
     expect(both.status).toBe(422);
+    expect(mockServiceSendCustomEvent).not.toHaveBeenCalled();
   });
 
-  it("resolves email contacts, records delivery, and fans out one run per matching automation", async () => {
-    mockContactFindFirst.mockResolvedValue(null);
-    mockDbInsert.mockReturnValue(insertRows([{ id: "contact_1" }]));
-    mockDeliveryRecord.mockResolvedValue({
-      id: "delivery_1",
-      eventName: "user.signed_up",
-      contactId: "contact_1",
-      email: "user@example.com",
-      payload: { plan: "pro" },
-      receivedAt: now,
-    });
-    mockFindEnabledByTriggerEventName.mockResolvedValue([
-      { ...automation, id: "auto_1" },
-      { ...automation, id: "auto_2" },
-    ]);
-    mockRunCreateFromTrigger
-      .mockResolvedValueOnce({
-        id: "run_1",
-        automationId: "auto_1",
-        status: "queued",
-        triggerEventId: "delivery_1",
-        contactId: "contact_1",
-        stepStates: {},
-        startedAt: null,
-        completedAt: null,
-        currentStepKey: "trigger",
-        failureReason: null,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .mockResolvedValueOnce({
-        id: "run_2",
-        automationId: "auto_2",
-        status: "queued",
-        triggerEventId: "delivery_1",
-        contactId: "contact_1",
-        stepStates: {},
-        startedAt: null,
-        completedAt: null,
-        currentStepKey: "trigger",
-        failureReason: null,
-        createdAt: now,
-        updatedAt: now,
-      });
+  it("sends custom events through the service boundary and preserves the 202 response shape", async () => {
     const { POST } = await import("@/app/api/events/send/route");
 
     const response = await POST(
@@ -1127,92 +1258,41 @@ describe("events API routes", () => {
     );
 
     expect(response.status).toBe(202);
-    const json = await response.json();
-    expect(json.automation_runs).toHaveLength(2);
-    expect(mockFindEnabledByTriggerEventName).toHaveBeenCalledWith(
-      "user.signed_up",
-      "user_1",
-    );
-    expect(mockResumeWaitingRunsForEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "delivery_1" }),
-    );
-    expect(mockRunCreateFromTrigger).toHaveBeenCalledTimes(2);
-  });
-
-  it("validates a payload against a stored custom event schema before recording delivery", async () => {
-    mockCustomEventFindByName.mockResolvedValue({
-      ...customEvent,
-      schema: {
-        type: "object",
-        required: ["plan", "trial"],
-        properties: {
-          plan: { type: "string" },
-          seats: { type: "number" },
-          trial: { type: "boolean" },
-        },
-      },
-    });
-    mockContactFindFirst.mockResolvedValue({ id: "contact_1" });
-    mockDeliveryRecord.mockResolvedValue({
-      id: "delivery_1",
-      eventName: "user.signed_up",
-      contactId: "contact_1",
-      email: "user@example.com",
-      payload: { plan: "pro", seats: 3, trial: false },
-      receivedAt: now,
-    });
-    mockFindEnabledByTriggerEventName.mockResolvedValue([
-      { ...automation, id: "auto_1" },
-    ]);
-    mockRunCreateFromTrigger.mockResolvedValue({
-      id: "run_1",
-      automationId: "auto_1",
-      status: "queued",
-      triggerEventId: "delivery_1",
-      contactId: "contact_1",
-      stepStates: {},
-      startedAt: null,
-      completedAt: null,
-      currentStepKey: "trigger",
-      failureReason: null,
-      createdAt: now,
-      updatedAt: now,
-    });
-    const { POST } = await import("@/app/api/events/send/route");
-
-    const response = await POST(
-      jsonRequest("http://localhost/api/events/send", {
+    expect(mockServiceSendCustomEvent).toHaveBeenCalledWith({
+      userId: "user_1",
+      data: {
         event: "user.signed_up",
-        email: "user@example.com",
-        payload: { plan: "pro", seats: 3, trial: false },
-      }),
-    );
-
-    expect(response.status).toBe(202);
-    expect(mockCustomEventFindByName).toHaveBeenCalledWith(
-      "user.signed_up",
-      "user_1",
-    );
-    expect(mockDeliveryRecord).toHaveBeenCalledWith(
-      expect.objectContaining({
-        payload: { plan: "pro", seats: 3, trial: false },
-      }),
-    );
-    expect(mockRunCreateFromTrigger).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns 422 path details and creates no delivery or runs when schema validation fails", async () => {
-    mockCustomEventFindByName.mockResolvedValue({
-      ...customEvent,
-      schema: {
-        type: "object",
-        required: ["plan", "trial"],
-        properties: {
-          plan: { type: "string" },
-          trial: { type: "boolean" },
-        },
+        email: "USER@example.com",
+        payload: { plan: "pro" },
       },
     });
+    await expect(response.json()).resolves.toEqual({
+      object: "event_delivery",
+      delivery: { ...deliveryResponse, received_at: now.toISOString() },
+      resumed_runs: [],
+      automation_runs: [
+        {
+          ...runResponse,
+          created_at: now.toISOString(),
+          updated_at: now.toISOString(),
+        },
+      ],
+    });
+  });
+
+  it("maps service payload validation errors to the preserved 422 details envelope", async () => {
+    mockServiceSendCustomEvent.mockRejectedValue(
+      new TestCustomEventServiceError(
+        "event_payload_invalid",
+        "Event payload does not match schema",
+        [
+          {
+            path: "payload.plan",
+            message: 'Expected payload.plan to be "string"',
+          },
+        ],
+      ),
+    );
     const { POST } = await import("@/app/api/events/send/route");
 
     const response = await POST(
@@ -1224,147 +1304,15 @@ describe("events API routes", () => {
     );
 
     expect(response.status).toBe(422);
-    await expect(response.json()).resolves.toMatchObject({
+    await expect(response.json()).resolves.toEqual({
+      error: "Event payload does not match schema",
       code: "event_payload_invalid",
-      details: expect.arrayContaining([
+      details: [
         {
           path: "payload.plan",
           message: 'Expected payload.plan to be "string"',
         },
-        {
-          path: "payload.trial",
-          message: "Missing required field payload.trial",
-        },
-      ]),
-    });
-    expect(mockContactFindFirst).not.toHaveBeenCalled();
-    expect(mockDbInsert).not.toHaveBeenCalled();
-    expect(mockDeliveryRecord).not.toHaveBeenCalled();
-    expect(mockResumeWaitingRunsForEvent).not.toHaveBeenCalled();
-    expect(mockFindEnabledByTriggerEventName).not.toHaveBeenCalled();
-    expect(mockRunCreateFromTrigger).not.toHaveBeenCalled();
-  });
-
-  it("keeps schema-less custom events accepting arbitrary object payloads", async () => {
-    mockCustomEventFindByName.mockResolvedValue({
-      ...customEvent,
-      schema: null,
-    });
-    mockContactFindFirst.mockResolvedValue({ id: "contact_1" });
-    mockDeliveryRecord.mockResolvedValue({
-      id: "delivery_1",
-      eventName: "user.signed_up",
-      contactId: "contact_1",
-      email: "user@example.com",
-      payload: { nested: { ok: true }, extra: ["anything"] },
-      receivedAt: now,
-    });
-    mockFindEnabledByTriggerEventName.mockResolvedValue([]);
-    const { POST } = await import("@/app/api/events/send/route");
-
-    const response = await POST(
-      jsonRequest("http://localhost/api/events/send", {
-        event: "user.signed_up",
-        email: "user@example.com",
-        payload: { nested: { ok: true }, extra: ["anything"] },
-      }),
-    );
-
-    expect(response.status).toBe(202);
-    expect(mockDeliveryRecord).toHaveBeenCalledWith(
-      expect.objectContaining({
-        payload: { nested: { ok: true }, extra: ["anything"] },
-      }),
-    );
-  });
-
-  it("documents current-compatible unknown event names as schema-less sends", async () => {
-    mockCustomEventFindByName.mockResolvedValue(null);
-    mockContactFindFirst.mockResolvedValue({ id: "contact_1" });
-    mockDeliveryRecord.mockResolvedValue({
-      id: "delivery_unknown",
-      eventName: "unknown.event",
-      contactId: "contact_1",
-      email: "user@example.com",
-      payload: { arbitrary: true },
-      receivedAt: now,
-    });
-    mockFindEnabledByTriggerEventName.mockResolvedValue([]);
-    const { POST } = await import("@/app/api/events/send/route");
-
-    const response = await POST(
-      jsonRequest("http://localhost/api/events/send", {
-        event: "unknown.event",
-        email: "user@example.com",
-        payload: { arbitrary: true },
-      }),
-    );
-
-    expect(response.status).toBe(202);
-    expect(mockCustomEventFindByName).toHaveBeenCalledWith(
-      "unknown.event",
-      "user_1",
-    );
-    expect(mockDeliveryRecord).toHaveBeenCalledWith(
-      expect.objectContaining({
-        eventName: "unknown.event",
-        payload: { arbitrary: true },
-      }),
-    );
-  });
-
-  it("includes wait_for_event resumed runs when sending a matching event", async () => {
-    mockContactFindFirst.mockResolvedValue({ id: "contact_1" });
-    mockDeliveryRecord.mockResolvedValue({
-      id: "delivery_1",
-      eventName: "invoice.paid",
-      contactId: "contact_1",
-      email: "user@example.com",
-      payload: { invoice_id: "inv_1" },
-      receivedAt: now,
-    });
-    mockResumeWaitingRunsForEvent.mockResolvedValue([
-      {
-        id: "run_wait",
-        automationId: "auto_1",
-        status: "queued",
-        triggerEventId: "trigger_delivery",
-        contactId: "contact_1",
-        stepStates: {
-          wait: {
-            status: "completed",
-            output: {
-              waited_event: {
-                delivery_id: "delivery_1",
-                payload: { invoice_id: "inv_1" },
-              },
-            },
-          },
-        },
-        startedAt: now,
-        completedAt: null,
-        currentStepKey: "send",
-        failureReason: null,
-        nextStepAt: now,
-        createdAt: now,
-        updatedAt: now,
-      },
-    ]);
-    mockFindEnabledByTriggerEventName.mockResolvedValue([]);
-    const { POST } = await import("@/app/api/events/send/route");
-
-    const response = await POST(
-      jsonRequest("http://localhost/api/events/send", {
-        event: "invoice.paid",
-        contact_id: "11111111-1111-4111-8111-111111111111",
-        payload: { invoice_id: "inv_1" },
-      }),
-    );
-
-    expect(response.status).toBe(202);
-    await expect(response.json()).resolves.toMatchObject({
-      resumed_runs: [{ id: "run_wait", current_step_key: "send" }],
-      automation_runs: [],
+      ],
     });
   });
 });

--- a/tests/custom-event-service.test.ts
+++ b/tests/custom-event-service.test.ts
@@ -1,0 +1,335 @@
+import {
+  type CustomEventAutomationRunRow,
+  type CustomEventBoundaryRepository,
+  type CustomEventDeliveryRow,
+  type CustomEventRow,
+  CustomEventServiceError,
+  createCustomEventService,
+} from "@opensend/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type AutomationRow = Awaited<
+  ReturnType<
+    CustomEventBoundaryRepository["findEnabledAutomationsByTriggerEventName"]
+  >
+>[number];
+
+type RecordDeliveryInput = Parameters<
+  CustomEventBoundaryRepository["recordDelivery"]
+>[0];
+
+type CreateRunInput = Parameters<
+  CustomEventBoundaryRepository["createRunFromTrigger"]
+>[0];
+
+const now = new Date("2026-05-02T00:00:00.000Z");
+
+const customEvent: CustomEventRow = {
+  id: "evt_1",
+  name: "user.signed_up",
+  schema: null,
+  createdAt: now,
+  updatedAt: now,
+  userId: "user_1",
+};
+
+const delivery: CustomEventDeliveryRow = {
+  id: "delivery_1",
+  eventName: "user.signed_up",
+  contactId: "contact_1",
+  email: "user@example.com",
+  payload: { plan: "pro" },
+  receivedAt: now,
+  userId: "user_1",
+};
+
+const automation: AutomationRow = {
+  id: "auto_1",
+  name: "Welcome",
+  status: "enabled",
+  triggerEventName: "user.signed_up",
+  connections: [],
+  createdAt: now,
+  updatedAt: now,
+  document: null,
+  userId: "user_1",
+};
+
+const run: CustomEventAutomationRunRow = {
+  id: "run_1",
+  automationId: "auto_1",
+  triggerEventId: "delivery_1",
+  contactId: "contact_1",
+  status: "queued",
+  currentStepKey: "trigger",
+  stepStates: {},
+  startedAt: null,
+  completedAt: null,
+  nextStepAt: null,
+  failureReason: null,
+  createdAt: now,
+  updatedAt: now,
+  userId: "user_1",
+};
+
+function makeRepository(
+  overrides: Partial<CustomEventBoundaryRepository> = {},
+): CustomEventBoundaryRepository {
+  const repository: CustomEventBoundaryRepository = {
+    create: vi.fn(async (input) => ({
+      ...customEvent,
+      name: input.name,
+      schema: input.schema ?? null,
+      userId: input.userId ?? null,
+    })),
+    list: vi.fn(async () => ({ data: [customEvent], hasMore: false })),
+    findByName: vi.fn(async () => customEvent),
+    deleteForUser: vi.fn(async (id) => [{ id }]),
+    resolveContactId: vi.fn(async (input) => input.contactId ?? "contact_1"),
+    recordDelivery: vi.fn(async (input) => ({
+      ...delivery,
+      eventName: input.eventName,
+      payload: input.payload,
+      contactId: input.contactId ?? null,
+      email: input.email ?? null,
+      userId: input.userId ?? null,
+    })),
+    findEnabledAutomationsByTriggerEventName: vi.fn(async () => [automation]),
+    createRunFromTrigger: vi.fn(async (input) => ({
+      ...run,
+      automationId: input.automationId,
+      triggerEventId: input.triggerEventId,
+      contactId: input.contactId ?? null,
+      userId: input.userId ?? null,
+    })),
+  };
+
+  return { ...repository, ...overrides };
+}
+
+describe("custom event service boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates, lists, and deletes custom events with caller scope and public response shapes", async () => {
+    const repository = makeRepository();
+    const service = createCustomEventService({ repository });
+
+    await expect(
+      service.createCustomEvent({
+        userId: "user_1",
+        data: { name: "user.signed_up", schema: { type: "object" } },
+      }),
+    ).resolves.toMatchObject({
+      object: "event",
+      id: "evt_1",
+      name: "user.signed_up",
+      schema: { type: "object" },
+    });
+
+    await expect(
+      service.listCustomEvents({ userId: "user_1", limit: 10, after: "evt_0" }),
+    ).resolves.toMatchObject({ object: "list", data: [{ id: "evt_1" }] });
+
+    await expect(
+      service.deleteCustomEvent({ userId: "user_1", id: "evt_1" }),
+    ).resolves.toEqual({ object: "event", id: "evt_1", deleted: true });
+
+    expect(repository.create).toHaveBeenCalledWith({
+      name: "user.signed_up",
+      schema: { type: "object" },
+      userId: "user_1",
+    });
+    expect(repository.list).toHaveBeenCalledWith({
+      limit: 10,
+      after: "evt_0",
+      userId: "user_1",
+    });
+    expect(repository.deleteForUser).toHaveBeenCalledWith("evt_1", "user_1");
+  });
+
+  it("reports missing deletes without leaking cross-tenant existence", async () => {
+    const service = createCustomEventService({
+      repository: makeRepository({ deleteForUser: vi.fn(async () => []) }),
+    });
+
+    await expect(
+      service.deleteCustomEvent({ userId: "user_2", id: "evt_1" }),
+    ).rejects.toMatchObject({ code: "not_found", message: "Event not found" });
+  });
+
+  it("validates stored schemas before contact resolution, records delivery, resumes waiters, and fans out runs", async () => {
+    let capturedDelivery: RecordDeliveryInput | undefined;
+    let capturedRun: CreateRunInput | undefined;
+    const resumedRun = { ...run, id: "run_wait", currentStepKey: "send" };
+    const repository = makeRepository({
+      findByName: vi.fn(async () => ({
+        ...customEvent,
+        schema: {
+          type: "object",
+          required: ["plan"],
+          properties: { plan: { type: "string" } },
+        },
+      })),
+      recordDelivery: vi.fn(async (input) => {
+        capturedDelivery = input;
+        return { ...delivery, payload: input.payload };
+      }),
+      createRunFromTrigger: vi.fn(async (input) => {
+        capturedRun = input;
+        return run;
+      }),
+    });
+    const resumeWaitingRunsForEvent = vi.fn(async () => [resumedRun]);
+    const service = createCustomEventService({
+      repository,
+      resumeWaitingRunsForEvent,
+    });
+
+    const result = await service.sendCustomEvent({
+      userId: "user_1",
+      data: {
+        event: "user.signed_up",
+        email: "USER@example.com",
+        payload: { plan: "pro" },
+      },
+    });
+
+    expect(repository.findByName).toHaveBeenCalledWith(
+      "user.signed_up",
+      "user_1",
+    );
+    expect(repository.resolveContactId).toHaveBeenCalledWith({
+      contactId: undefined,
+      email: "USER@example.com",
+      userId: "user_1",
+    });
+    expect(capturedDelivery).toMatchObject({
+      eventName: "user.signed_up",
+      payload: { plan: "pro" },
+      contactId: "contact_1",
+      email: "user@example.com",
+      userId: "user_1",
+    });
+    expect(resumeWaitingRunsForEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "delivery_1" }),
+    );
+    expect(
+      repository.findEnabledAutomationsByTriggerEventName,
+    ).toHaveBeenCalledWith("user.signed_up", "user_1");
+    expect(capturedRun).toMatchObject({
+      automationId: "auto_1",
+      triggerEventId: "delivery_1",
+      contactId: "contact_1",
+      userId: "user_1",
+      initialStepKey: "trigger",
+    });
+    expect(result).toMatchObject({
+      object: "event_delivery",
+      delivery: { event: "user.signed_up", email: "user@example.com" },
+      resumed_runs: [{ id: "run_wait", current_step_key: "send" }],
+      automation_runs: [{ id: "run_1", current_step_key: "trigger" }],
+    });
+  });
+
+  it("returns payload validation details and stops before side effects", async () => {
+    const repository = makeRepository({
+      findByName: vi.fn(async () => ({
+        ...customEvent,
+        schema: {
+          type: "object",
+          required: ["plan", "trial"],
+          properties: {
+            plan: { type: "string" },
+            trial: { type: "boolean" },
+          },
+        },
+      })),
+    });
+    const service = createCustomEventService({ repository });
+
+    await expect(
+      service.sendCustomEvent({
+        userId: "user_1",
+        data: {
+          event: "user.signed_up",
+          email: "user@example.com",
+          payload: { plan: 42 },
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "event_payload_invalid",
+      message: "Event payload does not match schema",
+      details: expect.arrayContaining([
+        {
+          path: "payload.plan",
+          message: 'Expected payload.plan to be "string"',
+        },
+        {
+          path: "payload.trial",
+          message: "Missing required field payload.trial",
+        },
+      ]),
+    });
+    expect(repository.resolveContactId).not.toHaveBeenCalled();
+    expect(repository.recordDelivery).not.toHaveBeenCalled();
+    expect(
+      repository.findEnabledAutomationsByTriggerEventName,
+    ).not.toHaveBeenCalled();
+    expect(repository.createRunFromTrigger).not.toHaveBeenCalled();
+  });
+
+  it("keeps unknown event names schema-less and accepts arbitrary object payloads", async () => {
+    const repository = makeRepository({
+      findByName: vi.fn(async () => undefined),
+      findEnabledAutomationsByTriggerEventName: vi.fn(async () => []),
+    });
+    const service = createCustomEventService({ repository });
+
+    await expect(
+      service.sendCustomEvent({
+        userId: "user_1",
+        data: {
+          event: "unknown.event",
+          contact_id: "11111111-1111-4111-8111-111111111111",
+          payload: { arbitrary: true },
+        },
+      }),
+    ).resolves.toMatchObject({
+      object: "event_delivery",
+      automation_runs: [],
+    });
+    expect(repository.recordDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventName: "unknown.event",
+        payload: { arbitrary: true },
+        contactId: "11111111-1111-4111-8111-111111111111",
+      }),
+    );
+  });
+
+  it("classifies invalid stored schema rows as event_schema_invalid", async () => {
+    const service = createCustomEventService({
+      repository: makeRepository({
+        findByName: vi.fn(async () => ({ ...customEvent, schema: [] })),
+      }),
+    });
+
+    await expect(
+      service.sendCustomEvent({
+        userId: "user_1",
+        data: { event: "user.signed_up", email: "user@example.com" },
+      }),
+    ).rejects.toBeInstanceOf(CustomEventServiceError);
+    await expect(
+      service.sendCustomEvent({
+        userId: "user_1",
+        data: { event: "user.signed_up", email: "user@example.com" },
+      }),
+    ).rejects.toMatchObject({
+      code: "event_schema_invalid",
+      details: [{ path: "schema", message: "schema must be an object" }],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extracted custom event create/list/delete/send orchestration into `packages/core/src/services/customEvents.ts`.
- Kept Next event routes as auth, Zod parse, service-call, and HTTP error/status mapping adapters.
- Moved the custom event schema/payload validator into core DTOs and re-exported it through the existing Next validation module.
- Added focused service coverage plus updated route compatibility coverage for custom events and send-event errors.

Closes #348

## Changed files
- `src/app/api/events/route.ts`
- `src/app/api/events/send/route.ts`
- `src/lib/validation/events.ts`
- `packages/core/src/services/customEvents.ts`
- `packages/core/src/db/repositories/customEventRepo.ts`
- `packages/core/src/dto/automations.ts`
- `packages/core/src/index.ts`
- `tests/api-automations-events.test.ts`
- `tests/custom-event-service.test.ts`
- `agent_docs/learnings/active/2026-05-11-issue-348-custom-events-boundary.md`

## Validation
- `make check`
- `bun run test tests/api-automations-events.test.ts tests/custom-event-service.test.ts tests/automations-schema.test.ts`
- `make test` (123 files / 1044 tests passed)

## Residual risk
- Playwright E2E not run; no dashboard/UI changes were made and backend route/service/unit coverage passed.
- `resumeWaitingRunsForEvent` remains app-worker-owned and is injected into the core custom-event service from the Next send route to avoid importing app worker code into `@opensend/core`.
