### PR TITLE
Extract dashboard aggregate service boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-350-dashboard-aggregates-boundary.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-350-dashboard-aggregates-boundary.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-11
+issue: "#350"
+type: pattern
+promoted_to: null
+---
+
+## Dashboard aggregate service boundary
+
+Issue #350 moved `/api/metrics` and `/api/usage` DB orchestration into `packages/core/src/services/dashboardAggregates.ts`. Keep dashboard session auth and dashboard aggregate cache reads/writes in the Next.js route adapter, but put metrics SQL aggregation, event-type-to-status mapping, payload shaping, usage period-bound calculations, and usage limit constants in the core service.
+
+For metrics date ranges, the Next.js adapter still calls `src/lib/date-range.ts` and passes concrete `start`/`end` bounds into the core service. This preserves the dashboard picker preset semantics without making `@opensend/core` import app-local modules.
+
+Shared smoke tests that mock `@opensend/core` need a `createDashboardAggregateService` mock; otherwise route-boundary extractions can pass focused tests but fail broad route smoke coverage.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,5 +55,6 @@ export * from "./services/audience-metadata";
 export * from "./services/automations";
 export * from "./services/automationRuns";
 export * from "./services/customEvents";
+export * from "./services/dashboardAggregates";
 export * from "./jobs/background-jobs";
 export * from "./observability/telemetry";

--- a/packages/core/src/services/dashboardAggregates.ts
+++ b/packages/core/src/services/dashboardAggregates.ts
@@ -1,0 +1,405 @@
+import { type SQL, and, eq, gte, inArray, lte, sql } from "drizzle-orm";
+import { db } from "../db/client";
+import { contacts, domains, emails, segments } from "../db/schema";
+
+export const DASHBOARD_USAGE_LIMITS = {
+  transactional: {
+    monthlyLimit: 3000,
+    dailyLimit: 100,
+  },
+  marketing: {
+    contactsLimit: 1000,
+    segmentsLimit: 3,
+    broadcastsLimit: "Unlimited",
+  },
+  team: {
+    domainsLimit: 3,
+    rateLimit: 2,
+  },
+} as const;
+
+const EVENT_TYPE_TO_STATUS: Record<string, string[]> = {
+  received: ["delivered", "opened", "clicked"],
+  delivered: ["delivered"],
+  opened: ["opened"],
+  clicked: ["clicked"],
+  bounced: ["bounced", "hard_bounced", "soft_bounced"],
+  complained: ["complained"],
+  unsubscribed: ["unsubscribed"],
+  delivery_delayed: ["delivery_delayed"],
+  failed: ["failed"],
+  suppressed: ["suppressed"],
+};
+
+const senderDomainSql = sql<string>`substring(${emails.from} from '@([^>]+)')`;
+
+export type DashboardMetricsStats = {
+  total: number;
+  delivered: number;
+  bounced: number;
+  hard_bounced: number;
+  soft_bounced: number;
+  undetermined_bounced: number;
+  complained: number;
+};
+
+export type DashboardDailyCountRow = {
+  date: string;
+  count: number;
+};
+
+export type DashboardDailyBounceRow = {
+  date: string;
+  total: number;
+  bounced: number;
+};
+
+export type DashboardDailyComplainRow = {
+  date: string;
+  total: number;
+  complained: number;
+};
+
+export type DashboardDomainBreakdownRow = {
+  domain: string | null;
+  total: number;
+  delivered: number;
+};
+
+export type DashboardMetricsBaseInput = {
+  userId: string;
+  start: Date;
+  end: Date;
+  domain: string | null;
+};
+
+export type DashboardDailyCountsInput = DashboardMetricsBaseInput & {
+  statuses?: string[];
+};
+
+export type DashboardUsageCountInput = {
+  startOfMonth: Date;
+  startOfDay: Date;
+};
+
+export type DashboardUsageCounts = {
+  monthlyEmails: number;
+  dailyEmails: number;
+  contacts: number;
+  segments: number;
+  domains: number;
+};
+
+export type DashboardAggregateRepository = {
+  aggregateMetrics(
+    input: DashboardMetricsBaseInput,
+  ): Promise<DashboardMetricsStats>;
+  listDailyCounts(
+    input: DashboardDailyCountsInput,
+  ): Promise<DashboardDailyCountRow[]>;
+  listDailyBounceRates(
+    input: DashboardMetricsBaseInput,
+  ): Promise<DashboardDailyBounceRow[]>;
+  listDailyComplainRates(
+    input: DashboardMetricsBaseInput,
+  ): Promise<DashboardDailyComplainRow[]>;
+  listDomainBreakdown(
+    input: DashboardMetricsBaseInput,
+  ): Promise<DashboardDomainBreakdownRow[]>;
+  countUsage(input: DashboardUsageCountInput): Promise<DashboardUsageCounts>;
+};
+
+export type DashboardAggregateServiceDependencies = {
+  repository?: DashboardAggregateRepository;
+};
+
+export type GetDashboardMetricsInput = DashboardMetricsBaseInput & {
+  eventType: string | null;
+  now?: Date;
+};
+
+export type DashboardMetricsPayload = {
+  totalEmails: number;
+  deliverabilityRate: number;
+  bounceRate: number;
+  complainRate: number;
+  domains: string[];
+  dailyData: DashboardDailyCountRow[];
+  domainBreakdown: Array<{
+    domain: string;
+    count: number;
+    rate: number;
+  }>;
+  bounceBreakdown: {
+    permanent: number;
+    transient: number;
+    undetermined: number;
+  };
+  dailyBounceData: Array<{
+    date: string;
+    rate: number;
+  }>;
+  complained: number;
+  dailyComplainData: Array<{
+    date: string;
+    rate: number;
+  }>;
+  lastUpdated: string;
+};
+
+export type DashboardUsagePayload = {
+  transactional: {
+    monthlyUsed: number;
+    monthlyLimit: typeof DASHBOARD_USAGE_LIMITS.transactional.monthlyLimit;
+    dailyUsed: number;
+    dailyLimit: typeof DASHBOARD_USAGE_LIMITS.transactional.dailyLimit;
+  };
+  marketing: {
+    contactsUsed: number;
+    contactsLimit: typeof DASHBOARD_USAGE_LIMITS.marketing.contactsLimit;
+    segmentsUsed: number;
+    segmentsLimit: typeof DASHBOARD_USAGE_LIMITS.marketing.segmentsLimit;
+    broadcastsLimit: typeof DASHBOARD_USAGE_LIMITS.marketing.broadcastsLimit;
+  };
+  team: {
+    domainsUsed: number;
+    domainsLimit: typeof DASHBOARD_USAGE_LIMITS.team.domainsLimit;
+    rateLimit: typeof DASHBOARD_USAGE_LIMITS.team.rateLimit;
+  };
+};
+
+function metricConditions(input: DashboardMetricsBaseInput): SQL<unknown>[] {
+  const conditions: SQL<unknown>[] = [
+    eq(emails.userId, input.userId),
+    gte(emails.createdAt, input.start),
+    lte(emails.createdAt, input.end),
+  ];
+
+  if (input.domain) {
+    conditions.push(eq(senderDomainSql, input.domain));
+  }
+
+  return conditions;
+}
+
+const emptyMetricsStats: DashboardMetricsStats = {
+  total: 0,
+  delivered: 0,
+  bounced: 0,
+  hard_bounced: 0,
+  soft_bounced: 0,
+  undetermined_bounced: 0,
+  complained: 0,
+};
+
+const defaultDashboardAggregateRepository: DashboardAggregateRepository = {
+  async aggregateMetrics(input) {
+    const [stats] = await db
+      .select({
+        total: sql<number>`count(*)::int`,
+        delivered: sql<number>`count(*) filter (where ${emails.status} = 'delivered')::int`,
+        bounced: sql<number>`count(*) filter (where ${emails.status} in ('bounced', 'hard_bounced', 'soft_bounced'))::int`,
+        hard_bounced: sql<number>`count(*) filter (where ${emails.status} = 'hard_bounced')::int`,
+        soft_bounced: sql<number>`count(*) filter (where ${emails.status} = 'soft_bounced')::int`,
+        undetermined_bounced: sql<number>`count(*) filter (where ${emails.status} = 'bounced')::int`,
+        complained: sql<number>`count(*) filter (where ${emails.status} = 'complained')::int`,
+      })
+      .from(emails)
+      .where(and(...metricConditions(input)));
+
+    return stats ?? emptyMetricsStats;
+  },
+
+  async listDailyCounts(input) {
+    const conditions = metricConditions(input);
+    if (input.statuses && input.statuses.length > 0) {
+      conditions.push(inArray(emails.status, input.statuses));
+    }
+
+    return await db
+      .select({
+        date: sql<string>`to_char(${emails.createdAt}::date, 'YYYY-MM-DD')`,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(emails)
+      .where(and(...conditions))
+      .groupBy(sql`${emails.createdAt}::date`)
+      .orderBy(sql`${emails.createdAt}::date`);
+  },
+
+  async listDailyBounceRates(input) {
+    return await db
+      .select({
+        date: sql<string>`to_char(${emails.createdAt}::date, 'YYYY-MM-DD')`,
+        total: sql<number>`count(*)::int`,
+        bounced: sql<number>`count(*) filter (where ${emails.status} in ('bounced', 'hard_bounced', 'soft_bounced'))::int`,
+      })
+      .from(emails)
+      .where(and(...metricConditions(input)))
+      .groupBy(sql`${emails.createdAt}::date`)
+      .orderBy(sql`${emails.createdAt}::date`);
+  },
+
+  async listDailyComplainRates(input) {
+    return await db
+      .select({
+        date: sql<string>`to_char(${emails.createdAt}::date, 'YYYY-MM-DD')`,
+        total: sql<number>`count(*)::int`,
+        complained: sql<number>`count(*) filter (where ${emails.status} = 'complained')::int`,
+      })
+      .from(emails)
+      .where(and(...metricConditions(input)))
+      .groupBy(sql`${emails.createdAt}::date`)
+      .orderBy(sql`${emails.createdAt}::date`);
+  },
+
+  async listDomainBreakdown(input) {
+    return await db
+      .select({
+        domain: senderDomainSql,
+        total: sql<number>`count(*)::int`,
+        delivered: sql<number>`count(*) filter (where ${emails.status} = 'delivered')::int`,
+      })
+      .from(emails)
+      .where(and(...metricConditions(input)))
+      .groupBy(senderDomainSql)
+      .orderBy(sql`count(*) desc`);
+  },
+
+  async countUsage(input) {
+    const [
+      monthlyEmails,
+      dailyEmails,
+      contactCount,
+      segmentCount,
+      domainCount,
+    ] = await Promise.all([
+      db.$count(emails, gte(emails.createdAt, input.startOfMonth)),
+      db.$count(emails, gte(emails.createdAt, input.startOfDay)),
+      db.$count(contacts),
+      db.$count(segments),
+      db.$count(domains),
+    ]);
+
+    return {
+      monthlyEmails: Number(monthlyEmails),
+      dailyEmails: Number(dailyEmails),
+      contacts: Number(contactCount),
+      segments: Number(segmentCount),
+      domains: Number(domainCount),
+    };
+  },
+};
+
+function roundRate(numerator: number, denominator: number): number {
+  return denominator > 0
+    ? Math.round((numerator / denominator) * 10000) / 100
+    : 0;
+}
+
+function getEventStatuses(eventType: string | null): string[] | undefined {
+  if (!eventType || eventType === "all") return undefined;
+  return EVENT_TYPE_TO_STATUS[eventType];
+}
+
+function getUsageBounds(now: Date): DashboardUsageCountInput {
+  return {
+    startOfMonth: new Date(now.getFullYear(), now.getMonth(), 1),
+    startOfDay: new Date(now.getFullYear(), now.getMonth(), now.getDate()),
+  };
+}
+
+export function createDashboardAggregateService({
+  repository = defaultDashboardAggregateRepository,
+}: DashboardAggregateServiceDependencies = {}) {
+  return {
+    async getMetrics(
+      input: GetDashboardMetricsInput,
+    ): Promise<DashboardMetricsPayload> {
+      const baseInput: DashboardMetricsBaseInput = {
+        userId: input.userId,
+        start: input.start,
+        end: input.end,
+        domain: input.domain,
+      };
+      const [stats, dailyRows, dailyBounceRows, dailyComplainRows, domainRows] =
+        await Promise.all([
+          repository.aggregateMetrics(baseInput),
+          repository.listDailyCounts({
+            ...baseInput,
+            statuses: getEventStatuses(input.eventType),
+          }),
+          repository.listDailyBounceRates(baseInput),
+          repository.listDailyComplainRates(baseInput),
+          repository.listDomainBreakdown(baseInput),
+        ]);
+
+      const totalEmails = stats.total;
+      const domainBreakdown = domainRows
+        .filter(
+          (row): row is DashboardDomainBreakdownRow & { domain: string } =>
+            row.domain !== null && row.domain !== "",
+        )
+        .map((row) => ({
+          domain: row.domain,
+          count: row.total,
+          rate: roundRate(row.delivered, row.total),
+        }));
+
+      return {
+        totalEmails,
+        deliverabilityRate: roundRate(stats.delivered, totalEmails),
+        bounceRate: roundRate(stats.bounced, totalEmails),
+        complainRate: roundRate(stats.complained, totalEmails),
+        domains: domainBreakdown.map((item) => item.domain),
+        dailyData: dailyRows.map((row) => ({
+          date: row.date,
+          count: row.count,
+        })),
+        domainBreakdown,
+        bounceBreakdown: {
+          permanent: stats.hard_bounced,
+          transient: stats.soft_bounced,
+          undetermined: stats.undetermined_bounced,
+        },
+        dailyBounceData: dailyBounceRows.map((row) => ({
+          date: row.date,
+          rate: roundRate(row.bounced, row.total),
+        })),
+        complained: stats.complained,
+        dailyComplainData: dailyComplainRows.map((row) => ({
+          date: row.date,
+          rate: roundRate(row.complained, row.total),
+        })),
+        lastUpdated: (input.now ?? new Date()).toISOString(),
+      };
+    },
+
+    async getUsage(now = new Date()): Promise<DashboardUsagePayload> {
+      const counts = await repository.countUsage(getUsageBounds(now));
+
+      return {
+        transactional: {
+          monthlyUsed: counts.monthlyEmails,
+          monthlyLimit: DASHBOARD_USAGE_LIMITS.transactional.monthlyLimit,
+          dailyUsed: counts.dailyEmails,
+          dailyLimit: DASHBOARD_USAGE_LIMITS.transactional.dailyLimit,
+        },
+        marketing: {
+          contactsUsed: counts.contacts,
+          contactsLimit: DASHBOARD_USAGE_LIMITS.marketing.contactsLimit,
+          segmentsUsed: counts.segments,
+          segmentsLimit: DASHBOARD_USAGE_LIMITS.marketing.segmentsLimit,
+          broadcastsLimit: DASHBOARD_USAGE_LIMITS.marketing.broadcastsLimit,
+        },
+        team: {
+          domainsUsed: counts.domains,
+          domainsLimit: DASHBOARD_USAGE_LIMITS.team.domainsLimit,
+          rateLimit: DASHBOARD_USAGE_LIMITS.team.rateLimit,
+        },
+      };
+    },
+  };
+}
+
+export const dashboardAggregateService = createDashboardAggregateService();

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -8,9 +8,7 @@ import {
   writeDashboardAggregateCache,
 } from "@/lib/cache/dashboard-aggregates";
 import { getDateRangeBounds } from "@/lib/date-range";
-import { db } from "@/lib/db";
-import { emails } from "@/lib/db/schema";
-import { and, eq, gte, inArray, lte, sql } from "drizzle-orm";
+import { createDashboardAggregateService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 
 const RANGE_TO_PRESET: Record<string, string> = {
@@ -22,25 +20,11 @@ const RANGE_TO_PRESET: Record<string, string> = {
   last_30_days: "Last 30 days",
 };
 
-// Map event type filter values to email status values
-const EVENT_TYPE_TO_STATUS: Record<string, string[]> = {
-  received: ["delivered", "opened", "clicked"],
-  delivered: ["delivered"],
-  opened: ["opened"],
-  clicked: ["clicked"],
-  bounced: ["bounced", "hard_bounced", "soft_bounced"],
-  complained: ["complained"],
-  unsubscribed: ["unsubscribed"],
-  delivery_delayed: ["delivery_delayed"],
-  failed: ["failed"],
-  suppressed: ["suppressed"],
-};
-
 function getMetricsDateRange(range: string): { start: Date; end: Date } {
   return getDateRangeBounds(RANGE_TO_PRESET[range] || "Last 15 days");
 }
 
-const senderDomainSql = sql<string>`substring(${emails.from} from '@([^>]+)')`;
+const dashboardAggregateService = createDashboardAggregateService();
 
 // Dashboard-only internal endpoint
 export async function GET(request: NextRequest) {
@@ -68,145 +52,13 @@ export async function GET(request: NextRequest) {
     }
 
     const { start, end } = getMetricsDateRange(range);
-
-    const conditions = [
-      eq(emails.userId, userId),
-      gte(emails.createdAt, start),
-      lte(emails.createdAt, end),
-    ];
-    if (domain) {
-      conditions.push(eq(senderDomainSql, domain));
-    }
-
-    const result = await db
-      .select({
-        total: sql<number>`count(*)::int`,
-        delivered: sql<number>`count(*) filter (where ${emails.status} = 'delivered')::int`,
-        bounced: sql<number>`count(*) filter (where ${emails.status} in ('bounced', 'hard_bounced', 'soft_bounced'))::int`,
-        hard_bounced: sql<number>`count(*) filter (where ${emails.status} = 'hard_bounced')::int`,
-        soft_bounced: sql<number>`count(*) filter (where ${emails.status} = 'soft_bounced')::int`,
-        undetermined_bounced: sql<number>`count(*) filter (where ${emails.status} = 'bounced')::int`,
-        complained: sql<number>`count(*) filter (where ${emails.status} = 'complained')::int`,
-      })
-      .from(emails)
-      .where(and(...conditions));
-
-    const stats = result[0] || {
-      total: 0,
-      delivered: 0,
-      bounced: 0,
-      hard_bounced: 0,
-      soft_bounced: 0,
-      undetermined_bounced: 0,
-      complained: 0,
-    };
-
-    const totalEmails = stats.total;
-    const deliverabilityRate =
-      totalEmails > 0
-        ? Math.round((stats.delivered / totalEmails) * 10000) / 100
-        : 0;
-    const bounceRate =
-      totalEmails > 0
-        ? Math.round((stats.bounced / totalEmails) * 10000) / 100
-        : 0;
-    const complainRate =
-      totalEmails > 0
-        ? Math.round((stats.complained / totalEmails) * 10000) / 100
-        : 0;
-
-    const dailyConditions = [...conditions];
-    if (eventType && eventType !== "all" && EVENT_TYPE_TO_STATUS[eventType]) {
-      const statuses = EVENT_TYPE_TO_STATUS[eventType];
-      dailyConditions.push(inArray(emails.status, statuses));
-    }
-
-    const dailyRows = await db
-      .select({
-        date: sql<string>`to_char(${emails.createdAt}::date, 'YYYY-MM-DD')`,
-        count: sql<number>`count(*)::int`,
-      })
-      .from(emails)
-      .where(and(...dailyConditions))
-      .groupBy(sql`${emails.createdAt}::date`)
-      .orderBy(sql`${emails.createdAt}::date`);
-
-    const dailyData = dailyRows.map((r) => ({
-      date: r.date,
-      count: r.count,
-    }));
-
-    const dailyBounceRows = await db
-      .select({
-        date: sql<string>`to_char(${emails.createdAt}::date, 'YYYY-MM-DD')`,
-        total: sql<number>`count(*)::int`,
-        bounced: sql<number>`count(*) filter (where ${emails.status} in ('bounced', 'hard_bounced', 'soft_bounced'))::int`,
-      })
-      .from(emails)
-      .where(and(...conditions))
-      .groupBy(sql`${emails.createdAt}::date`)
-      .orderBy(sql`${emails.createdAt}::date`);
-
-    const dailyBounceData = dailyBounceRows.map((r) => ({
-      date: r.date,
-      rate: r.total > 0 ? Math.round((r.bounced / r.total) * 10000) / 100 : 0,
-    }));
-
-    const dailyComplainRows = await db
-      .select({
-        date: sql<string>`to_char(${emails.createdAt}::date, 'YYYY-MM-DD')`,
-        total: sql<number>`count(*)::int`,
-        complained: sql<number>`count(*) filter (where ${emails.status} = 'complained')::int`,
-      })
-      .from(emails)
-      .where(and(...conditions))
-      .groupBy(sql`${emails.createdAt}::date`)
-      .orderBy(sql`${emails.createdAt}::date`);
-
-    const dailyComplainData = dailyComplainRows.map((r) => ({
-      date: r.date,
-      rate:
-        r.total > 0 ? Math.round((r.complained / r.total) * 10000) / 100 : 0,
-    }));
-
-    const domainBreakdownRows = await db
-      .select({
-        domain: senderDomainSql,
-        total: sql<number>`count(*)::int`,
-        delivered: sql<number>`count(*) filter (where ${emails.status} = 'delivered')::int`,
-      })
-      .from(emails)
-      .where(and(...conditions))
-      .groupBy(senderDomainSql)
-      .orderBy(sql`count(*) desc`);
-
-    const domainBreakdown = domainBreakdownRows
-      .filter((r) => r.domain !== null && r.domain !== "")
-      .map((r) => ({
-        domain: r.domain,
-        count: r.total,
-        rate:
-          r.total > 0 ? Math.round((r.delivered / r.total) * 10000) / 100 : 0,
-      }));
-
-    const payload = {
-      totalEmails,
-      deliverabilityRate,
-      bounceRate,
-      complainRate,
-      domains: domainBreakdown.map((d) => d.domain),
-      dailyData,
-      domainBreakdown,
-      bounceBreakdown: {
-        permanent: stats.hard_bounced,
-        transient: stats.soft_bounced,
-        undetermined: stats.undetermined_bounced,
-      },
-      dailyBounceData,
-      complained: stats.complained,
-      dailyComplainData,
-      lastUpdated: new Date().toISOString(),
-    };
+    const payload = await dashboardAggregateService.getMetrics({
+      userId,
+      start,
+      end,
+      domain,
+      eventType,
+    });
 
     await writeDashboardAggregateCache(
       cacheKey,

--- a/src/app/api/usage/route.ts
+++ b/src/app/api/usage/route.ts
@@ -1,8 +1,8 @@
 import { getServerSession, unauthorizedResponse } from "@/lib/api-auth";
-import { db } from "@/lib/db";
-import { contacts, domains, emails, segments } from "@/lib/db/schema";
-import { gte } from "drizzle-orm";
+import { createDashboardAggregateService } from "@opensend/core";
 import { NextResponse } from "next/server";
+
+const dashboardAggregateService = createDashboardAggregateService();
 
 // Dashboard-only internal endpoint
 export async function GET() {
@@ -10,48 +10,8 @@ export async function GET() {
   if (!session) return unauthorizedResponse();
 
   try {
-    const now = new Date();
-    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-    const startOfDay = new Date(
-      now.getFullYear(),
-      now.getMonth(),
-      now.getDate(),
-    );
-
-    const [
-      monthlyEmails,
-      dailyEmails,
-      contactCount,
-      segmentCount,
-      domainCount,
-    ] = await Promise.all([
-      db.$count(emails, gte(emails.createdAt, startOfMonth)),
-      db.$count(emails, gte(emails.createdAt, startOfDay)),
-      db.$count(contacts),
-      db.$count(segments),
-      db.$count(domains),
-    ]);
-
-    return NextResponse.json({
-      transactional: {
-        monthlyUsed: Number(monthlyEmails),
-        monthlyLimit: 3000,
-        dailyUsed: Number(dailyEmails),
-        dailyLimit: 100,
-      },
-      marketing: {
-        contactsUsed: Number(contactCount),
-        contactsLimit: 1000,
-        segmentsUsed: Number(segmentCount),
-        segmentsLimit: 3,
-        broadcastsLimit: "Unlimited",
-      },
-      team: {
-        domainsUsed: Number(domainCount),
-        domainsLimit: 3,
-        rateLimit: 2,
-      },
-    });
+    const payload = await dashboardAggregateService.getUsage();
+    return NextResponse.json(payload);
   } catch (error) {
     console.error("Failed to fetch usage:", error);
     return NextResponse.json(

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -270,6 +270,68 @@ describe("route smoke coverage", () => {
         ContactOperationsServiceError,
         BroadcastServiceError,
         AudienceMetadataServiceError,
+        createDashboardAggregateService: () => ({
+          async getMetrics() {
+            await mockSelect().from().where();
+            await mockSelect().from().where().groupBy().orderBy();
+            await mockSelect().from().where().groupBy().orderBy();
+            await mockSelect().from().where().groupBy().orderBy();
+            await mockSelect().from().where().groupBy().orderBy();
+            return {
+              totalEmails: 10,
+              deliverabilityRate: 70,
+              bounceRate: 20,
+              complainRate: 10,
+              domains: ["example.com"],
+              dailyData: [{ date: "2026-04-23", count: 7 }],
+              domainBreakdown: [{ domain: "example.com", count: 10, rate: 70 }],
+              bounceBreakdown: {
+                permanent: 1,
+                transient: 1,
+                undetermined: 0,
+              },
+              dailyBounceData: [{ date: "2026-04-23", rate: 20 }],
+              complained: 1,
+              dailyComplainData: [{ date: "2026-04-23", rate: 10 }],
+              lastUpdated: new Date().toISOString(),
+            };
+          },
+          async getUsage() {
+            const [
+              monthlyEmails,
+              dailyEmails,
+              contactCount,
+              segmentCount,
+              domainCount,
+            ] = await Promise.all([
+              mockCountFn(),
+              mockCountFn(),
+              mockCountFn(),
+              mockCountFn(),
+              mockCountFn(),
+            ]);
+            return {
+              transactional: {
+                monthlyUsed: Number(monthlyEmails),
+                monthlyLimit: 3000,
+                dailyUsed: Number(dailyEmails),
+                dailyLimit: 100,
+              },
+              marketing: {
+                contactsUsed: Number(contactCount),
+                contactsLimit: 1000,
+                segmentsUsed: Number(segmentCount),
+                segmentsLimit: 3,
+                broadcastsLimit: "Unlimited",
+              },
+              team: {
+                domainsUsed: Number(domainCount),
+                domainsLimit: 3,
+                rateLimit: 2,
+              },
+            };
+          },
+        }),
         createBroadcastService: () => ({
           async listBroadcasts() {
             const rows = await mockSelect().from().where().orderBy().limit();

--- a/tests/dashboard-aggregates-service.test.ts
+++ b/tests/dashboard-aggregates-service.test.ts
@@ -1,0 +1,207 @@
+import {
+  type DashboardAggregateRepository,
+  createDashboardAggregateService,
+} from "@opensend/core";
+import { describe, expect, it } from "vitest";
+
+type MetricsBaseInput = Parameters<
+  DashboardAggregateRepository["aggregateMetrics"]
+>[0];
+type DailyCountsInput = Parameters<
+  DashboardAggregateRepository["listDailyCounts"]
+>[0];
+type UsageCountInput = Parameters<
+  DashboardAggregateRepository["countUsage"]
+>[0];
+
+function makeRepository(
+  overrides: Partial<DashboardAggregateRepository> = {},
+): DashboardAggregateRepository {
+  return {
+    async aggregateMetrics() {
+      return {
+        total: 0,
+        delivered: 0,
+        bounced: 0,
+        hard_bounced: 0,
+        soft_bounced: 0,
+        undetermined_bounced: 0,
+        complained: 0,
+      };
+    },
+    async listDailyCounts() {
+      return [];
+    },
+    async listDailyBounceRates() {
+      return [];
+    },
+    async listDailyComplainRates() {
+      return [];
+    },
+    async listDomainBreakdown() {
+      return [];
+    },
+    async countUsage() {
+      return {
+        monthlyEmails: 0,
+        dailyEmails: 0,
+        contacts: 0,
+        segments: 0,
+        domains: 0,
+      };
+    },
+    ...overrides,
+  };
+}
+
+describe("dashboard aggregate service", () => {
+  it("computes the compatible metrics payload and keeps sender-domain filtering exact", async () => {
+    const start = new Date("2026-04-17T00:00:00.000Z");
+    const end = new Date("2026-04-23T23:59:59.999Z");
+    let aggregateInput: MetricsBaseInput | undefined;
+    let dailyInput: DailyCountsInput | undefined;
+    const service = createDashboardAggregateService({
+      repository: makeRepository({
+        async aggregateMetrics(input) {
+          aggregateInput = input;
+          return {
+            total: 10,
+            delivered: 7,
+            bounced: 2,
+            hard_bounced: 1,
+            soft_bounced: 1,
+            undetermined_bounced: 0,
+            complained: 1,
+          };
+        },
+        async listDailyCounts(input) {
+          dailyInput = input;
+          return [{ date: "2026-04-23", count: 7 }];
+        },
+        async listDailyBounceRates() {
+          return [{ date: "2026-04-23", total: 10, bounced: 2 }];
+        },
+        async listDailyComplainRates() {
+          return [{ date: "2026-04-23", total: 10, complained: 1 }];
+        },
+        async listDomainBreakdown() {
+          return [
+            { domain: "example.com", total: 10, delivered: 7 },
+            { domain: null, total: 1, delivered: 1 },
+            { domain: "", total: 1, delivered: 0 },
+          ];
+        },
+      }),
+    });
+
+    const payload = await service.getMetrics({
+      userId: "user-1",
+      start,
+      end,
+      domain: "example.com",
+      eventType: "opened",
+      now: new Date("2026-04-23T06:45:30.000Z"),
+    });
+
+    expect(aggregateInput).toEqual({
+      userId: "user-1",
+      start,
+      end,
+      domain: "example.com",
+    });
+    expect(dailyInput).toEqual({
+      userId: "user-1",
+      start,
+      end,
+      domain: "example.com",
+      statuses: ["opened"],
+    });
+    expect(payload).toEqual({
+      totalEmails: 10,
+      deliverabilityRate: 70,
+      bounceRate: 20,
+      complainRate: 10,
+      domains: ["example.com"],
+      dailyData: [{ date: "2026-04-23", count: 7 }],
+      domainBreakdown: [{ domain: "example.com", count: 10, rate: 70 }],
+      bounceBreakdown: {
+        permanent: 1,
+        transient: 1,
+        undetermined: 0,
+      },
+      dailyBounceData: [{ date: "2026-04-23", rate: 20 }],
+      complained: 1,
+      dailyComplainData: [{ date: "2026-04-23", rate: 10 }],
+      lastUpdated: "2026-04-23T06:45:30.000Z",
+    });
+  });
+
+  it("leaves daily counts unfiltered for all or unknown event types", async () => {
+    const dailyInputs: DailyCountsInput[] = [];
+    const service = createDashboardAggregateService({
+      repository: makeRepository({
+        async listDailyCounts(input) {
+          dailyInputs.push(input);
+          return [];
+        },
+      }),
+    });
+
+    const base = {
+      userId: "user-1",
+      start: new Date("2026-04-01T00:00:00.000Z"),
+      end: new Date("2026-04-02T00:00:00.000Z"),
+      domain: null,
+    };
+
+    await service.getMetrics({ ...base, eventType: "all" });
+    await service.getMetrics({ ...base, eventType: "unknown" });
+
+    expect(dailyInputs).toHaveLength(2);
+    expect(dailyInputs[0]?.statuses).toBeUndefined();
+    expect(dailyInputs[1]?.statuses).toBeUndefined();
+  });
+
+  it("keeps the current usage envelope, limits, and local period boundaries", async () => {
+    let countInput: UsageCountInput | undefined;
+    const service = createDashboardAggregateService({
+      repository: makeRepository({
+        async countUsage(input) {
+          countInput = input;
+          return {
+            monthlyEmails: 42,
+            dailyEmails: 3,
+            contacts: 120,
+            segments: 4,
+            domains: 2,
+          };
+        },
+      }),
+    });
+
+    const payload = await service.getUsage(new Date(2026, 3, 23, 15, 45, 30));
+
+    expect(countInput?.startOfMonth).toEqual(new Date(2026, 3, 1));
+    expect(countInput?.startOfDay).toEqual(new Date(2026, 3, 23));
+    expect(payload).toEqual({
+      transactional: {
+        monthlyUsed: 42,
+        monthlyLimit: 3000,
+        dailyUsed: 3,
+        dailyLimit: 100,
+      },
+      marketing: {
+        contactsUsed: 120,
+        contactsLimit: 1000,
+        segmentsUsed: 4,
+        segmentsLimit: 3,
+        broadcastsLimit: "Unlimited",
+      },
+      team: {
+        domainsUsed: 2,
+        domainsLimit: 3,
+        rateLimit: 2,
+      },
+    });
+  });
+});

--- a/tests/metrics-route.test.ts
+++ b/tests/metrics-route.test.ts
@@ -1,47 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockSelect = vi.hoisted(() => vi.fn());
 const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockReadDashboardAggregateCache = vi.hoisted(() => vi.fn());
 const mockWriteDashboardAggregateCache = vi.hoisted(() => vi.fn());
-const mockGte = vi.hoisted(() =>
-  vi.fn((left, right) => ({ kind: "gte", left, right })),
-);
-const mockLte = vi.hoisted(() =>
-  vi.fn((left, right) => ({ kind: "lte", left, right })),
-);
-const mockEq = vi.hoisted(() =>
-  vi.fn((left, right) => ({ kind: "eq", left, right })),
-);
-const mockLike = vi.hoisted(() =>
-  vi.fn((left, right) => ({ kind: "like", left, right })),
-);
-const mockAnd = vi.hoisted(() => vi.fn((...conds) => ({ kind: "and", conds })));
-const mockInArray = vi.hoisted(() =>
-  vi.fn((left, right) => ({ kind: "inArray", left, right })),
-);
-
-function makeQueryChain<T>(rows: T[], whereArgs: unknown[]) {
-  const chain = {
-    from: vi.fn().mockReturnThis(),
-    where: vi.fn((arg: unknown) => {
-      whereArgs.push(arg);
-      return chain;
-    }),
-    groupBy: vi.fn().mockReturnThis(),
-    orderBy: vi.fn().mockReturnThis(),
-    // biome-ignore lint/suspicious/noThenProperty: mocks Drizzle's thenable query builder
-    then: (resolve: (value: T[]) => unknown) => Promise.resolve(resolve(rows)),
-  };
-
-  return chain;
-}
-
-vi.mock("@/lib/db", () => ({
-  db: {
-    select: mockSelect,
-  },
-}));
+const mockGetMetrics = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/api-auth", () => ({
   getServerSession: mockGetServerSession,
@@ -70,66 +32,16 @@ vi.mock("@/lib/cache/dashboard-aggregates", () => ({
   writeDashboardAggregateCache: mockWriteDashboardAggregateCache,
 }));
 
-vi.mock("drizzle-orm", async () => {
-  const actual =
-    await vi.importActual<typeof import("drizzle-orm")>("drizzle-orm");
-
-  return {
-    ...actual,
-    and: mockAnd,
-    eq: mockEq,
-    gte: mockGte,
-    inArray: mockInArray,
-    like: mockLike,
-    lte: mockLte,
-  };
-});
+vi.mock("@opensend/core", () => ({
+  createDashboardAggregateService: () => ({
+    getMetrics: mockGetMetrics,
+  }),
+}));
 
 function makeNextRequest(url: string, init?: RequestInit) {
   const request = new Request(url, init) as Request & { nextUrl: URL };
   request.nextUrl = new URL(url);
   return request;
-}
-
-function queueMetricsQueries(whereArgs: unknown[]) {
-  mockSelect
-    .mockReturnValueOnce(
-      makeQueryChain(
-        [
-          {
-            total: 10,
-            delivered: 7,
-            bounced: 2,
-            hard_bounced: 1,
-            soft_bounced: 1,
-            undetermined_bounced: 0,
-            complained: 1,
-          },
-        ],
-        whereArgs,
-      ),
-    )
-    .mockReturnValueOnce(
-      makeQueryChain([{ date: "2026-04-23", count: 7 }], whereArgs),
-    )
-    .mockReturnValueOnce(
-      makeQueryChain(
-        [{ date: "2026-04-23", total: 10, bounced: 2 }],
-        whereArgs,
-      ),
-    )
-    .mockReturnValueOnce(
-      makeQueryChain(
-        [{ date: "2026-04-23", total: 10, complained: 1 }],
-        whereArgs,
-      ),
-    )
-    .mockReturnValueOnce(
-      makeQueryChain(
-        [{ domain: "example.com", total: 10, delivered: 7 }],
-        whereArgs,
-      ),
-    );
 }
 
 function expectLocalDateParts(
@@ -153,12 +65,31 @@ function expectLocalDateParts(
   expect(date.getMilliseconds()).toBe(expected.millisecond);
 }
 
-function requireCondition<T>(value: T | undefined): T {
-  expect(value).toBeDefined();
-  return value as T;
+function requireDate(value: unknown): Date {
+  expect(value).toBeInstanceOf(Date);
+  return value as Date;
 }
 
-describe("metrics route filters", () => {
+const freshPayload = {
+  totalEmails: 10,
+  deliverabilityRate: 70,
+  bounceRate: 20,
+  complainRate: 10,
+  complained: 1,
+  domains: ["example.com"],
+  dailyData: [{ date: "2026-04-23", count: 7 }],
+  domainBreakdown: [{ domain: "example.com", count: 10, rate: 70 }],
+  bounceBreakdown: {
+    permanent: 1,
+    transient: 1,
+    undetermined: 0,
+  },
+  dailyBounceData: [{ date: "2026-04-23", rate: 20 }],
+  dailyComplainData: [{ date: "2026-04-23", rate: 10 }],
+  lastUpdated: "2026-04-23T06:45:30.000Z",
+};
+
+describe("metrics route adapter", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
@@ -170,168 +101,17 @@ describe("metrics route filters", () => {
     });
     mockReadDashboardAggregateCache.mockResolvedValue(null);
     mockWriteDashboardAggregateCache.mockResolvedValue(undefined);
+    mockGetMetrics.mockResolvedValue(freshPayload);
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("scopes every aggregate query and cache key to the dashboard user", async () => {
-    const whereArgs: unknown[] = [];
-    queueMetricsQueries(whereArgs);
-
-    const metricsRoute = await import("@/app/api/metrics/route");
-    const response = await metricsRoute.GET(
-      makeNextRequest(
-        "http://localhost/api/metrics?range=last_7_days",
-      ) as never,
-    );
-
-    expect(response.status).toBe(200);
-    expect(mockReadDashboardAggregateCache).toHaveBeenCalledWith(
-      "dashboard-aggregate:v1:metrics:user-1:last_7_days:all:all",
-    );
-    expect(mockEq.mock.calls.some(([, right]) => right === "user-1")).toBe(
-      true,
-    );
-    expect(whereArgs).toHaveLength(5);
-    for (const whereArg of whereArgs) {
-      const condition = whereArg as {
-        kind: string;
-        conds: Array<{ kind: string; right: unknown }>;
-      };
-      expect(condition.conds.some((cond) => cond.right === "user-1")).toBe(
-        true,
-      );
-    }
-  });
-
-  it("matches Yesterday exactly instead of leaking into today", async () => {
-    const whereArgs: unknown[] = [];
-    queueMetricsQueries(whereArgs);
-
-    const metricsRoute = await import("@/app/api/metrics/route");
-    const response = await metricsRoute.GET(
-      makeNextRequest("http://localhost/api/metrics?range=yesterday") as never,
-    );
-
-    expect(response.status).toBe(200);
-    expect(response.headers.get("x-opensend-cache")).toBe("miss");
-
-    const firstWhere = whereArgs[0] as {
-      kind: string;
-      conds: Array<{ kind: string; right: Date }>;
-    };
-
-    const lowerBound = firstWhere.conds.find((cond) => cond.kind === "gte");
-    const upperBound = firstWhere.conds.find((cond) => cond.kind === "lte");
-
-    expectLocalDateParts(requireCondition(lowerBound).right, {
-      year: 2026,
-      month: 3,
-      day: 22,
-      hour: 0,
-      minute: 0,
-      second: 0,
-      millisecond: 0,
-    });
-    expectLocalDateParts(requireCondition(upperBound).right, {
-      year: 2026,
-      month: 3,
-      day: 22,
-      hour: 23,
-      minute: 59,
-      second: 59,
-      millisecond: 999,
-    });
-  });
-
-  it("uses inclusive rolling preset bounds that match date-range.ts", async () => {
-    const whereArgs: unknown[] = [];
-    queueMetricsQueries(whereArgs);
-
-    const metricsRoute = await import("@/app/api/metrics/route");
-    const response = await metricsRoute.GET(
-      makeNextRequest(
-        "http://localhost/api/metrics?range=last_7_days",
-      ) as never,
-    );
-
-    expect(response.status).toBe(200);
-
-    const firstWhere = whereArgs[0] as {
-      kind: string;
-      conds: Array<{ kind: string; right: Date }>;
-    };
-
-    const lowerBound = firstWhere.conds.find((cond) => cond.kind === "gte");
-    const upperBound = firstWhere.conds.find((cond) => cond.kind === "lte");
-
-    expectLocalDateParts(requireCondition(lowerBound).right, {
-      year: 2026,
-      month: 3,
-      day: 17,
-      hour: 0,
-      minute: 0,
-      second: 0,
-      millisecond: 0,
-    });
-    expectLocalDateParts(requireCondition(upperBound).right, {
-      year: 2026,
-      month: 3,
-      day: 23,
-      hour: 23,
-      minute: 59,
-      second: 59,
-      millisecond: 999,
-    });
-  });
-
-  it("filters by exact sender domain instead of raw from substring matches", async () => {
-    const whereArgs: unknown[] = [];
-    queueMetricsQueries(whereArgs);
-
-    const metricsRoute = await import("@/app/api/metrics/route");
-    const response = await metricsRoute.GET(
-      makeNextRequest(
-        "http://localhost/api/metrics?range=last_7_days&domain=example.com",
-      ) as never,
-    );
-
-    expect(response.status).toBe(200);
-    expect(mockEq.mock.calls.some(([, right]) => right === "user-1")).toBe(
-      true,
-    );
-    expect(mockEq.mock.calls.some(([, right]) => right === "example.com")).toBe(
-      true,
-    );
-    expect(mockLike).not.toHaveBeenCalled();
-
-    const firstWhere = whereArgs[0] as {
-      kind: string;
-      conds: Array<{ kind: string }>;
-    };
-    expect(firstWhere.conds.some((cond) => cond.kind === "eq")).toBe(true);
-  });
-
-  it("returns cached metrics payloads without hitting the database", async () => {
+  it("returns cached metrics payloads without calling the service", async () => {
     mockReadDashboardAggregateCache.mockResolvedValue({
+      ...freshPayload,
       totalEmails: 99,
-      deliverabilityRate: 98,
-      bounceRate: 1,
-      complainRate: 0,
-      complained: 0,
-      domains: ["example.com"],
-      dailyData: [],
-      domainBreakdown: [],
-      bounceBreakdown: {
-        permanent: 0,
-        transient: 0,
-        undetermined: 0,
-      },
-      dailyBounceData: [],
-      dailyComplainData: [],
-      lastUpdated: "2026-04-23T06:45:30.000Z",
     });
 
     const metricsRoute = await import("@/app/api/metrics/route");
@@ -343,32 +123,103 @@ describe("metrics route filters", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("x-opensend-cache")).toBe("hit");
-    expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockGetMetrics).not.toHaveBeenCalled();
     expect(mockWriteDashboardAggregateCache).not.toHaveBeenCalled();
-
-    const json = await response.json();
-    expect(json.totalEmails).toBe(99);
+    await expect(response.json()).resolves.toMatchObject({ totalEmails: 99 });
     expect(mockReadDashboardAggregateCache).toHaveBeenCalledWith(
       "dashboard-aggregate:v1:metrics:user-1:last_7_days:example.com:delivered",
     );
   });
 
-  it("writes a fresh aggregate response to cache with a short ttl", async () => {
-    const whereArgs: unknown[] = [];
-    queueMetricsQueries(whereArgs);
-
+  it("passes user, query filters, and inclusive rolling bounds to the core service", async () => {
     const metricsRoute = await import("@/app/api/metrics/route");
     const response = await metricsRoute.GET(
       makeNextRequest(
-        "http://localhost/api/metrics?range=last_7_days&event_type=opened",
+        "http://localhost/api/metrics?range=last_7_days&domain=example.com&event_type=opened",
       ) as never,
     );
 
     expect(response.status).toBe(200);
-    expect(mockWriteDashboardAggregateCache).toHaveBeenCalledOnce();
-    expect(mockWriteDashboardAggregateCache.mock.calls[0]?.[0]).toBe(
-      "dashboard-aggregate:v1:metrics:user-1:last_7_days:all:opened",
+    expect(response.headers.get("x-opensend-cache")).toBe("miss");
+    expect(mockGetMetrics).toHaveBeenCalledOnce();
+    const input = mockGetMetrics.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(input.userId).toBe("user-1");
+    expect(input.domain).toBe("example.com");
+    expect(input.eventType).toBe("opened");
+    expectLocalDateParts(requireDate(input.start), {
+      year: 2026,
+      month: 3,
+      day: 17,
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+    });
+    expectLocalDateParts(requireDate(input.end), {
+      year: 2026,
+      month: 3,
+      day: 23,
+      hour: 23,
+      minute: 59,
+      second: 59,
+      millisecond: 999,
+    });
+    expect(mockWriteDashboardAggregateCache).toHaveBeenCalledWith(
+      "dashboard-aggregate:v1:metrics:user-1:last_7_days:example.com:opened",
+      freshPayload,
+      60,
     );
-    expect(mockWriteDashboardAggregateCache.mock.calls[0]?.[2]).toBe(60);
+    await expect(response.json()).resolves.toEqual(freshPayload);
+  });
+
+  it("matches Yesterday exactly instead of leaking into today", async () => {
+    const metricsRoute = await import("@/app/api/metrics/route");
+    const response = await metricsRoute.GET(
+      makeNextRequest("http://localhost/api/metrics?range=yesterday") as never,
+    );
+
+    expect(response.status).toBe(200);
+    const input = mockGetMetrics.mock.calls[0]?.[0] as Record<string, unknown>;
+    expectLocalDateParts(requireDate(input.start), {
+      year: 2026,
+      month: 3,
+      day: 22,
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+    });
+    expectLocalDateParts(requireDate(input.end), {
+      year: 2026,
+      month: 3,
+      day: 22,
+      hour: 23,
+      minute: 59,
+      second: 59,
+      millisecond: 999,
+    });
+  });
+
+  it("keeps dashboard auth and error mapping in the adapter", async () => {
+    mockGetServerSession.mockResolvedValueOnce(null);
+    const metricsRoute = await import("@/app/api/metrics/route");
+
+    const unauthorized = await metricsRoute.GET(
+      makeNextRequest("http://localhost/api/metrics") as never,
+    );
+    expect(unauthorized.status).toBe(401);
+
+    mockGetServerSession.mockResolvedValueOnce({
+      session: { id: "session-1" },
+      user: { id: "user-1" },
+    });
+    mockGetMetrics.mockRejectedValueOnce(new Error("db down"));
+    const failed = await metricsRoute.GET(
+      makeNextRequest("http://localhost/api/metrics") as never,
+    );
+    expect(failed.status).toBe(500);
+    await expect(failed.json()).resolves.toEqual({
+      error: "Failed to fetch metrics data",
+    });
   });
 });

--- a/tests/usage-route.test.ts
+++ b/tests/usage-route.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockGetUsage = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api-auth", () => ({
+  getServerSession: mockGetServerSession,
+  unauthorizedResponse: () =>
+    new Response(JSON.stringify({ error: "Missing or invalid API key" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    }),
+}));
+
+vi.mock("@opensend/core", () => ({
+  createDashboardAggregateService: () => ({
+    getUsage: mockGetUsage,
+  }),
+}));
+
+const usagePayload = {
+  transactional: {
+    monthlyUsed: 42,
+    monthlyLimit: 3000,
+    dailyUsed: 3,
+    dailyLimit: 100,
+  },
+  marketing: {
+    contactsUsed: 120,
+    contactsLimit: 1000,
+    segmentsUsed: 4,
+    segmentsLimit: 3,
+    broadcastsLimit: "Unlimited",
+  },
+  team: {
+    domainsUsed: 2,
+    domainsLimit: 3,
+    rateLimit: 2,
+  },
+};
+
+describe("usage route adapter", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue({
+      session: { id: "session-1" },
+      user: { id: "user-1" },
+    });
+    mockGetUsage.mockResolvedValue(usagePayload);
+  });
+
+  it("keeps dashboard auth adapter-side and returns the core usage envelope", async () => {
+    const usageRoute = await import("@/app/api/usage/route");
+    const response = await usageRoute.GET();
+
+    expect(response.status).toBe(200);
+    expect(mockGetUsage).toHaveBeenCalledOnce();
+    await expect(response.json()).resolves.toEqual(usagePayload);
+  });
+
+  it("maps missing sessions and service failures to existing responses", async () => {
+    mockGetServerSession.mockResolvedValueOnce(null);
+    const usageRoute = await import("@/app/api/usage/route");
+
+    const unauthorized = await usageRoute.GET();
+    expect(unauthorized.status).toBe(401);
+
+    mockGetServerSession.mockResolvedValueOnce({
+      session: { id: "session-1" },
+      user: { id: "user-1" },
+    });
+    mockGetUsage.mockRejectedValueOnce(new Error("db down"));
+    const failed = await usageRoute.GET();
+    expect(failed.status).toBe(500);
+    await expect(failed.json()).resolves.toEqual({
+      error: "Failed to fetch usage data",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extracted `/api/metrics` and `/api/usage` aggregation/business logic into `packages/core/src/services/dashboardAggregates.ts`.
- Kept Next.js route handlers thin: dashboard session auth, query/date parsing, cache read/write, and HTTP response/error mapping stay adapter-side.
- Preserved metrics payload shape, event-type status mapping, exact sender-domain filtering, usage envelope, and limit constants.
- Added service tests plus metrics/usage route adapter compatibility tests; updated shared route smoke mocks for the new core service surface.

Closes #350

## Changed files
- `packages/core/src/services/dashboardAggregates.ts`
- `packages/core/src/index.ts`
- `src/app/api/metrics/route.ts`
- `src/app/api/usage/route.ts`
- `tests/dashboard-aggregates-service.test.ts`
- `tests/metrics-route.test.ts`
- `tests/usage-route.test.ts`
- `tests/api-auth-date-range-routes.test.ts`
- `agent_docs/learnings/active/2026-05-11-issue-350-dashboard-aggregates-boundary.md`

## Validation
- `make check`
- `bun run test tests/dashboard-aggregates-service.test.ts tests/metrics-route.test.ts tests/usage-route.test.ts tests/api-auth-date-range-routes.test.ts`
- `make test` — 125 files / 1047 tests passed
- Push guardrails: typecheck + changed-file Biome passed

## Residual risk
- Playwright E2E not run because this slice does not change dashboard UI.
- Core service still receives date bounds from the Next adapter to preserve existing `src/lib/date-range.ts` preset behavior without coupling `@opensend/core` to app-local modules.
