### PR TITLE
Extract health API service boundary

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,5 +56,6 @@ export * from "./services/automations";
 export * from "./services/automationRuns";
 export * from "./services/customEvents";
 export * from "./services/dashboardAggregates";
+export * from "./services/health";
 export * from "./jobs/background-jobs";
 export * from "./observability/telemetry";

--- a/packages/core/src/services/health.ts
+++ b/packages/core/src/services/health.ts
@@ -1,0 +1,40 @@
+import { type SQL, sql } from "drizzle-orm";
+
+export type HealthStatusOk = {
+  status: "ok";
+  db: "connected";
+};
+
+export type HealthStatusError = {
+  status: "error";
+  db: "unreachable";
+};
+
+export type HealthStatus = HealthStatusOk | HealthStatusError;
+
+export type HealthProbeDatabase = {
+  execute(query: SQL): Promise<unknown>;
+};
+
+export type HealthServiceDependencies = {
+  database: HealthProbeDatabase;
+};
+
+export type HealthService = {
+  check(): Promise<HealthStatus>;
+};
+
+export function createHealthService(
+  dependencies: HealthServiceDependencies,
+): HealthService {
+  return {
+    async check() {
+      try {
+        await dependencies.database.execute(sql`SELECT 1`);
+        return { status: "ok", db: "connected" };
+      } catch {
+        return { status: "error", db: "unreachable" };
+      }
+    },
+  };
+}

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,16 +1,22 @@
 // ABOUTME: Healthcheck endpoint — confirms the app is running and the database is reachable.
 
 import { db } from "@/lib/db";
-import { sql } from "drizzle-orm";
+import { createHealthService } from "@opensend/core";
+
+const healthService = createHealthService({
+  database: {
+    execute(query) {
+      return db.execute(query);
+    },
+  },
+});
 
 export async function GET() {
-  try {
-    await db.execute(sql`SELECT 1`);
-    return Response.json({ status: "ok", db: "connected" });
-  } catch {
-    return Response.json(
-      { status: "error", db: "unreachable" },
-      { status: 503 },
-    );
+  const health = await healthService.check();
+
+  if (health.status === "error") {
+    return Response.json(health, { status: 503 });
   }
+
+  return Response.json(health);
 }

--- a/tests/health-route.test.ts
+++ b/tests/health-route.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockDbExecute = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    execute: mockDbExecute,
+  },
+}));
+
+vi.mock("@opensend/core", async () => {
+  const healthServiceModule = await vi.importActual<
+    typeof import("../packages/core/src/services/health")
+  >("../packages/core/src/services/health");
+
+  return {
+    createHealthService: healthServiceModule.createHealthService,
+  };
+});
+
+describe("GET /api/health", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockDbExecute.mockReset();
+  });
+
+  it("returns 200 and connected status when the database probe succeeds", async () => {
+    mockDbExecute.mockResolvedValueOnce([]);
+
+    const { GET } = await import("@/app/api/health/route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "ok",
+      db: "connected",
+    });
+    expect(mockDbExecute).toHaveBeenCalledOnce();
+  });
+
+  it("returns 503 and unreachable status when the database probe fails", async () => {
+    mockDbExecute.mockRejectedValueOnce(new Error("connection refused"));
+
+    const { GET } = await import("@/app/api/health/route");
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      status: "error",
+      db: "unreachable",
+    });
+    expect(mockDbExecute).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/health-service.test.ts
+++ b/tests/health-service.test.ts
@@ -1,0 +1,38 @@
+import { type SQL, sql } from "drizzle-orm";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type HealthProbeDatabase,
+  createHealthService,
+} from "../packages/core/src/services/health";
+
+describe("createHealthService", () => {
+  it("returns ok when the SELECT 1 database probe succeeds", async () => {
+    const execute = vi
+      .fn<(query: SQL) => Promise<unknown>>()
+      .mockResolvedValue([]);
+    const database: HealthProbeDatabase = { execute };
+    const service = createHealthService({ database });
+
+    await expect(service.check()).resolves.toEqual({
+      status: "ok",
+      db: "connected",
+    });
+    expect(execute).toHaveBeenCalledOnce();
+    expect(execute).toHaveBeenCalledWith(sql`SELECT 1`);
+  });
+
+  it("returns error when the SELECT 1 database probe fails", async () => {
+    const execute = vi
+      .fn<(query: SQL) => Promise<unknown>>()
+      .mockRejectedValue(new Error("database unavailable"));
+    const database: HealthProbeDatabase = { execute };
+    const service = createHealthService({ database });
+
+    await expect(service.check()).resolves.toEqual({
+      status: "error",
+      db: "unreachable",
+    });
+    expect(execute).toHaveBeenCalledOnce();
+    expect(execute).toHaveBeenCalledWith(sql`SELECT 1`);
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts the `/api/health` database probe into a small reusable core health service.
- Keeps the Next route as a thin adapter: database dependency wiring, service call, HTTP status mapping.
- Adds focused service and route tests for connected/unreachable health responses and the `SELECT 1` probe.

Closes #352

## Validation
- `make check`
- `bun run test tests/health-service.test.ts tests/health-route.test.ts`
- `make test` (127 files, 1051 tests passed)

## Notes
- No dashboard UI, platform healthcheck, auth, schema, invite, or unrelated route changes.
