### PR TITLE
Extract invites API service boundary

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,5 +57,6 @@ export * from "./services/automationRuns";
 export * from "./services/customEvents";
 export * from "./services/dashboardAggregates";
 export * from "./services/health";
+export * from "./services/invites";
 export * from "./jobs/background-jobs";
 export * from "./observability/telemetry";

--- a/packages/core/src/services/invites.ts
+++ b/packages/core/src/services/invites.ts
@@ -1,0 +1,72 @@
+import { db } from "../db/client";
+import { user } from "../db/schema";
+
+type UserRow = typeof user.$inferSelect;
+
+export type InviteMemberRow = Pick<
+  UserRow,
+  "id" | "name" | "email" | "createdAt"
+>;
+
+export type InviteMember = {
+  id: string;
+  name: string;
+  email: string;
+  role: "admin";
+  created_at: InviteMemberRow["createdAt"];
+};
+
+export type InviteListResponse = {
+  object: "list";
+  data: InviteMember[];
+};
+
+export type InviteMemberRepository = {
+  listMembers(): Promise<InviteMemberRow[]>;
+};
+
+const inviteMemberRepository: InviteMemberRepository = {
+  async listMembers() {
+    // In a real multi-tenant setup, we'd filter by orgId.
+    // For now, we return all users as a base implementation of the 'Team' view.
+    return db
+      .select({
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        createdAt: user.createdAt,
+      })
+      .from(user);
+  },
+};
+
+export type InvitesServiceDependencies = {
+  repository?: InviteMemberRepository;
+};
+
+function toInviteMember(row: InviteMemberRow): InviteMember {
+  return {
+    id: row.id,
+    name: row.name,
+    email: row.email,
+    role: "admin",
+    created_at: row.createdAt,
+  };
+}
+
+export function createInvitesService({
+  repository = inviteMemberRepository,
+}: InvitesServiceDependencies = {}) {
+  return {
+    async listMembers(): Promise<InviteListResponse> {
+      const members = await repository.listMembers();
+
+      return {
+        object: "list",
+        data: members.map(toInviteMember),
+      };
+    },
+  };
+}
+
+export const invitesService = createInvitesService();

--- a/src/app/api/invites/route.ts
+++ b/src/app/api/invites/route.ts
@@ -1,9 +1,9 @@
 import { auth } from "@/lib/auth";
-import { db } from "@/lib/db";
-import { user } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { createInvitesService } from "@opensend/core";
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
+
+const invitesService = createInvitesService();
 
 /**
  * GET /api/invites
@@ -17,27 +17,8 @@ export async function GET() {
   }
 
   try {
-    // In a real multi-tenant setup, we'd filter by orgId.
-    // For now, we return all users as a base implementation of the 'Team' view.
-    const members = await db
-      .select({
-        id: user.id,
-        name: user.name,
-        email: user.email,
-        createdAt: user.createdAt,
-      })
-      .from(user);
-
-    return NextResponse.json({
-      object: "list",
-      data: members.map((m) => ({
-        id: m.id,
-        name: m.name,
-        email: m.email,
-        role: "admin", // Default role for now
-        created_at: m.createdAt,
-      })),
-    });
+    const members = await invitesService.listMembers();
+    return NextResponse.json(members);
   } catch (error) {
     console.error("Failed to fetch members:", error);
     return NextResponse.json(

--- a/tests/invites-route.test.ts
+++ b/tests/invites-route.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetSession = vi.hoisted(() => vi.fn());
+const mockHeaders = vi.hoisted(() => vi.fn());
+const mockCreateInvitesService = vi.hoisted(() => vi.fn());
+const mockListMembers = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: mockGetSession,
+    },
+  },
+}));
+
+vi.mock("next/headers", () => ({
+  headers: mockHeaders,
+}));
+
+vi.mock("@opensend/core", () => ({
+  createInvitesService: mockCreateInvitesService,
+}));
+
+const createdAt = new Date("2026-05-10T12:00:00.000Z");
+
+async function importRoute() {
+  return import("@/app/api/invites/route");
+}
+
+describe("invites route adapter", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockHeaders.mockResolvedValue(new Headers({ cookie: "session=test" }));
+    mockGetSession.mockResolvedValue({
+      session: { id: "session-1" },
+      user: { id: "user-1" },
+    });
+    mockListMembers.mockResolvedValue({
+      object: "list",
+      data: [],
+    });
+    mockCreateInvitesService.mockReturnValue({
+      listMembers: mockListMembers,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps dashboard session auth in the adapter and returns the service envelope", async () => {
+    mockListMembers.mockResolvedValue({
+      object: "list",
+      data: [
+        {
+          id: "user-1",
+          name: "Ada Lovelace",
+          email: "ada@example.com",
+          role: "admin",
+          created_at: createdAt,
+        },
+      ],
+    });
+
+    const route = await importRoute();
+    const response = await route.GET();
+
+    expect(response.status).toBe(200);
+    expect(mockHeaders).toHaveBeenCalledOnce();
+    expect(mockGetSession).toHaveBeenCalledWith({
+      headers: expect.any(Headers),
+    });
+    expect(mockCreateInvitesService).toHaveBeenCalledOnce();
+    expect(mockListMembers).toHaveBeenCalledOnce();
+    await expect(response.json()).resolves.toEqual({
+      object: "list",
+      data: [
+        {
+          id: "user-1",
+          name: "Ada Lovelace",
+          email: "ada@example.com",
+          role: "admin",
+          created_at: "2026-05-10T12:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("returns the existing unauthorized response without calling the service", async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const route = await importRoute();
+    const response = await route.GET();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(mockListMembers).not.toHaveBeenCalled();
+  });
+
+  it("keeps service failure logging and HTTP 500 mapping in the adapter", async () => {
+    const error = new Error("db down");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mockListMembers.mockRejectedValue(error);
+
+    const route = await importRoute();
+    const response = await route.GET();
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "Internal server error",
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to fetch members:",
+      error,
+    );
+  });
+});

--- a/tests/invites-service.test.ts
+++ b/tests/invites-service.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  type InviteMemberRepository,
+  createInvitesService,
+} from "../packages/core/src/services/invites";
+
+const createdAt = new Date("2026-05-10T12:00:00.000Z");
+
+describe("invites service", () => {
+  it("lists all users through the member repository using the existing Team member response shape", async () => {
+    let calls = 0;
+    const repository: InviteMemberRepository = {
+      async listMembers() {
+        calls += 1;
+        return [
+          {
+            id: "user-1",
+            name: "Ada Lovelace",
+            email: "ada@example.com",
+            createdAt,
+          },
+        ];
+      },
+    };
+
+    const service = createInvitesService({ repository });
+    const response = await service.listMembers();
+
+    expect(calls).toBe(1);
+    expect(response).toEqual({
+      object: "list",
+      data: [
+        {
+          id: "user-1",
+          name: "Ada Lovelace",
+          email: "ada@example.com",
+          role: "admin",
+          created_at: createdAt,
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary\n- Extracted the /api/invites all-user read and Team member response shaping into packages/core/src/services/invites.ts.\n- Kept the Next route responsible for Better Auth dashboard session auth, service invocation, logging, and 401/500 HTTP mapping.\n- Exported the invites service from @opensend/core and added focused service/route tests for success, unauthorized, and service failure behavior.\n\nCloses #354\n\n## Checks\n- bun run test -- tests/invites-service.test.ts tests/invites-route.test.ts\n- make check\n- make test\n\n## Residual risk\n- Existing broad/non-org-filtered member listing is intentionally preserved; tenant/org filtering remains a future product decision.\n- Playwright E2E not run because this slice changes only the API route/service boundary and full Vitest coverage passed.