### PR TITLE
Add first-party Go send SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ That's it. Open **http://localhost:3015** and sign in with Google (configure `GO
 - **Idempotency Keys** — Opt-in `Idempotency-Key` header (or per-row keys on batch sends) so retries collapse safely
 - **TypeScript SDK** — [`opensend`](./packages/sdk) npm package with full type safety
 - **Python SDK** — [`opensend`](./packages/python-sdk) package with a Resend-shaped transactional email surface
+- **Go SDK** — [`github.com/namuh-eng/opensend/packages/go-sdk`](./packages/go-sdk) package for the first transactional send slice
 - **React Email Templates** — Pass React components via the SDK's `react` prop
 - **Domain Verification** — DKIM, SPF, DMARC records auto-written to Cloudflare DNS, with click-tracking subdomains and custom return paths supported
 - **API Key Management** — `full_access` and `sending_access` permission scopes
@@ -180,6 +181,46 @@ print("Queued email", email["id"])
 
 Full Python SDK docs: [`packages/python-sdk/README.md`](./packages/python-sdk/README.md) and [`docs/sdk/python.md`](./docs/sdk/python.md)
 
+### Go SDK
+
+```bash
+go get github.com/namuh-eng/opensend/packages/go-sdk
+```
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	opensend "github.com/namuh-eng/opensend/packages/go-sdk"
+)
+
+func main() {
+	client, err := opensend.NewClient(os.Getenv("OPENSEND_API_KEY"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	email, err := client.Send(context.Background(), opensend.SendRequest{
+		From:    "hello@yourdomain.com",
+		To:      []string{"recipient@example.com"},
+		Subject: "Hello from Opensend",
+		HTML:    "<h1>It works!</h1>",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Queued email", email.ID)
+}
+```
+
+Full Go SDK docs: [`packages/go-sdk/README.md`](./packages/go-sdk/README.md) and [`docs/sdk/go.md`](./docs/sdk/go.md)
+
 ## Self-Hosting
 
 ### Requirements
@@ -258,7 +299,8 @@ packages/
 ├── ingester/        # @opensend/ingester — Hono service for SES/SNS events,
 │                    #   scheduled-email worker, webhook retry scan (port 3016)
 ├── sdk/             # opensend — published TypeScript SDK
-└── python-sdk/      # opensend — first-party Python SDK package
+├── python-sdk/      # opensend — first-party Python SDK package
+└── go-sdk/          # github.com/namuh-eng/opensend/packages/go-sdk — first send Go SDK
 
 services/
 ├── api/             # Bun + Hono control-plane skeleton (port 3026)

--- a/agent_docs/learnings/active/2026-05-11-issue-356-go-sdk-send-endpoint.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-356-go-sdk-send-endpoint.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-11
+issue: 356
+type: decision
+promoted_to: null
+---
+
+## Go SDK first send slice uses the Resend-compatible root endpoint
+
+**What:** The first-party Go client SDK posts send requests to `POST /emails` from a separate `packages/go-sdk` module.
+**Why:** The existing TypeScript and Python SDKs already target the Resend-compatible root send alias, while `services/api` owns the shared Hono route and Next.js keeps `/api/emails` as the compatibility adapter. Matching the published SDK shape avoids making Go callers special-case the Next.js adapter path.
+**Boundary:** Keep `services/ingester-go` shadow-only and unrelated to client SDK packaging; do not wire it into Compose or reuse it for SDK code.

--- a/docs/sdk/go.md
+++ b/docs/sdk/go.md
@@ -1,0 +1,67 @@
+# Go SDK
+
+OpenSend includes a minimal first-party Go SDK package at
+[`packages/go-sdk`](../../packages/go-sdk) for Resend-shaped transactional email
+sends.
+
+## Install
+
+```bash
+go get github.com/namuh-eng/opensend/packages/go-sdk
+```
+
+## Configure
+
+Store API keys in environment variables; do not hardcode real keys.
+
+```bash
+export OPENSEND_API_KEY="re_your_api_key"
+export OPENSEND_BASE_URL="http://localhost:3026" # optional for self-hosting
+```
+
+If `OPENSEND_BASE_URL` is unset, the SDK targets `https://api.opensend.com`.
+
+## Send
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	opensend "github.com/namuh-eng/opensend/packages/go-sdk"
+)
+
+func main() {
+	options := []opensend.Option{}
+	if baseURL := os.Getenv("OPENSEND_BASE_URL"); baseURL != "" {
+		options = append(options, opensend.WithBaseURL(baseURL))
+	}
+
+	client, err := opensend.NewClient(os.Getenv("OPENSEND_API_KEY"), options...)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	email, err := client.Send(context.Background(), opensend.SendRequest{
+		From:    "hello@yourdomain.com",
+		To:      []string{"recipient@example.com"},
+		Subject: "Hello from OpenSend",
+		HTML:    "<h1>It works!</h1>",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(email.ID)
+}
+```
+
+## Errors
+
+Non-2xx responses return `*opensend.APIError` with `StatusCode` and raw `Body`.
+When the OpenSend API error envelope is present, `Name`, `Code`, `Message`, and
+`Details` are populated as well.

--- a/packages/go-sdk/README.md
+++ b/packages/go-sdk/README.md
@@ -1,0 +1,118 @@
+# opensend Go SDK
+
+Minimal first-party Go SDK for OpenSend transactional email sends with a
+Resend-shaped first send surface.
+
+## Installation
+
+From a Go module, install the package from this repository:
+
+```bash
+go get github.com/namuh-eng/opensend/packages/go-sdk
+```
+
+## Setup
+
+Use environment variables instead of hardcoding API keys:
+
+```bash
+export OPENSEND_API_KEY="re_your_api_key"
+```
+
+For self-hosted OpenSend, point the SDK at your deployment origin. The default
+hosted origin is `https://api.opensend.com`.
+
+```bash
+export OPENSEND_BASE_URL="http://localhost:3026"
+```
+
+## Send an email
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	opensend "github.com/namuh-eng/opensend/packages/go-sdk"
+)
+
+func main() {
+	options := []opensend.Option{}
+	if baseURL := os.Getenv("OPENSEND_BASE_URL"); baseURL != "" {
+		options = append(options, opensend.WithBaseURL(baseURL))
+	}
+
+	client, err := opensend.NewClient(os.Getenv("OPENSEND_API_KEY"), options...)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	email, err := client.Send(context.Background(), opensend.SendRequest{
+		From:    "hello@yourdomain.com",
+		To:      []string{"recipient@example.com"},
+		Subject: "Hello from OpenSend",
+		HTML:    "<h1>It works!</h1>",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(email.ID)
+}
+```
+
+`Send` posts to OpenSend's Resend-compatible `POST /emails` endpoint and returns
+the accepted email id.
+
+## Custom HTTP client
+
+```go
+httpClient := &http.Client{Timeout: 10 * time.Second}
+client, err := opensend.NewClient(
+	os.Getenv("OPENSEND_API_KEY"),
+	opensend.WithHTTPClient(httpClient),
+)
+```
+
+## Errors
+
+Non-2xx API responses return `*opensend.APIError`. The error keeps the HTTP
+status and raw response body so callers can branch on validation/auth failures.
+When OpenSend returns its public error envelope, `Name`, `Code`, `Message`, and
+`Details` are populated too.
+
+```go
+email, err := client.Send(ctx, params)
+if err != nil {
+	var apiErr *opensend.APIError
+	if errors.As(err, &apiErr) {
+		fmt.Println(apiErr.StatusCode, apiErr.Code, apiErr.Body)
+		return
+	}
+	return
+}
+fmt.Println(email.ID)
+```
+
+## Supported first slice
+
+- `client.Send(ctx, opensend.SendRequest{...})` → `POST /emails`
+- Bearer API key auth
+- Configurable base URL
+- Optional custom `*http.Client`
+- Typed request fields for `from`, `to`, `subject`, `html`, `text`, `cc`, `bcc`, and `reply_to`
+
+This first package intentionally does not implement attachments, templates,
+audiences, domains, framework examples, provider infrastructure, or the full
+Resend resource surface yet.
+
+## Tests
+
+```bash
+cd packages/go-sdk
+go test ./...
+```

--- a/packages/go-sdk/go.mod
+++ b/packages/go-sdk/go.mod
@@ -1,0 +1,3 @@
+module github.com/namuh-eng/opensend/packages/go-sdk
+
+go 1.23

--- a/packages/go-sdk/opensend.go
+++ b/packages/go-sdk/opensend.go
@@ -1,0 +1,239 @@
+package opensend
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	// DefaultBaseURL is the hosted OpenSend API origin used when no base URL is configured.
+	DefaultBaseURL = "https://api.opensend.com"
+	userAgent      = "opensend-go/0.1.0"
+)
+
+// Client is a small first-party client for OpenSend's transactional send API.
+type Client struct {
+	apiKey     string
+	baseURL    *url.URL
+	httpClient *http.Client
+}
+
+// Option configures a Client.
+type Option func(*Client) error
+
+// WithBaseURL points the client at a self-hosted or alternate OpenSend API origin.
+// The value must be an absolute http or https URL. Any trailing slash is ignored.
+func WithBaseURL(baseURL string) Option {
+	return func(c *Client) error {
+		parsed, err := normalizeBaseURL(baseURL)
+		if err != nil {
+			return err
+		}
+		c.baseURL = parsed
+		return nil
+	}
+}
+
+// WithHTTPClient sets the HTTP client used for requests. It is useful for custom
+// transports, timeouts, instrumentation, and tests.
+func WithHTTPClient(httpClient *http.Client) Option {
+	return func(c *Client) error {
+		if httpClient == nil {
+			return errors.New("http client must not be nil")
+		}
+		c.httpClient = httpClient
+		return nil
+	}
+}
+
+// NewClient creates a Client using the provided API key.
+func NewClient(apiKey string, options ...Option) (*Client, error) {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return nil, errors.New("API key is required")
+	}
+
+	baseURL, err := normalizeBaseURL(DefaultBaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &Client{
+		apiKey:     apiKey,
+		baseURL:    baseURL,
+		httpClient: http.DefaultClient,
+	}
+
+	for _, option := range options {
+		if option == nil {
+			continue
+		}
+		if err := option(client); err != nil {
+			return nil, err
+		}
+	}
+
+	return client, nil
+}
+
+// New is an alias for NewClient.
+func New(apiKey string, options ...Option) (*Client, error) {
+	return NewClient(apiKey, options...)
+}
+
+// SendRequest is the first OpenSend Go SDK request surface. It maps to
+// POST /emails and intentionally excludes later-slice resources like
+// attachments, templates, audiences, domains, or provider infrastructure.
+type SendRequest struct {
+	From    string   `json:"from"`
+	To      []string `json:"to"`
+	Subject string   `json:"subject"`
+	HTML    string   `json:"html,omitempty"`
+	Text    string   `json:"text,omitempty"`
+	CC      []string `json:"cc,omitempty"`
+	BCC     []string `json:"bcc,omitempty"`
+	ReplyTo []string `json:"reply_to,omitempty"`
+}
+
+// SendResponse is returned when OpenSend accepts an email for processing.
+type SendResponse struct {
+	ID string `json:"id"`
+}
+
+// APIError represents a non-2xx response from OpenSend. StatusCode and Body are
+// always populated so callers can branch on validation/auth failures even when
+// the server returns an unexpected error shape.
+type APIError struct {
+	StatusCode int
+	Body       string
+	Message    string
+	Name       string
+	Code       string
+	Details    json.RawMessage
+}
+
+func (e *APIError) Error() string {
+	if e == nil {
+		return "opensend: api error"
+	}
+	if e.Message != "" {
+		return fmt.Sprintf("opensend: API request failed with status %d: %s", e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("opensend: API request failed with status %d", e.StatusCode)
+}
+
+// Send posts req to OpenSend's Resend-compatible transactional send endpoint.
+func (c *Client) Send(ctx context.Context, req SendRequest) (*SendResponse, error) {
+	if c == nil {
+		return nil, errors.New("opensend client is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	encoded, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("opensend: encode send request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint("/emails"), bytes.NewReader(encoded))
+	if err != nil {
+		return nil, fmt.Errorf("opensend: build send request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("User-Agent", userAgent)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("opensend: send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("opensend: read response body: %w", err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, parseAPIError(resp, body)
+	}
+
+	var parsed SendResponse
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			return nil, fmt.Errorf("opensend: decode send response: %w", err)
+		}
+	}
+
+	return &parsed, nil
+}
+
+func normalizeBaseURL(raw string) (*url.URL, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, errors.New("base URL must be a non-empty string when provided")
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, errors.New("base URL must be a valid absolute URL")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, errors.New("base URL must use http or https")
+	}
+
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed, nil
+}
+
+func (c *Client) endpoint(path string) string {
+	base := *c.baseURL
+	basePath := strings.TrimRight(base.Path, "/")
+	requestPath := "/" + strings.TrimLeft(path, "/")
+	if basePath == "" {
+		base.Path = requestPath
+	} else {
+		base.Path = basePath + requestPath
+	}
+	base.RawQuery = ""
+	base.Fragment = ""
+	return base.String()
+}
+
+func parseAPIError(resp *http.Response, body []byte) *APIError {
+	apiError := &APIError{
+		StatusCode: resp.StatusCode,
+		Body:       string(body),
+		Message:    resp.Status,
+	}
+
+	var envelope struct {
+		Message string          `json:"message"`
+		Error   string          `json:"error"`
+		Name    string          `json:"name"`
+		Code    string          `json:"code"`
+		Details json.RawMessage `json:"details"`
+	}
+	if len(body) > 0 && json.Unmarshal(body, &envelope) == nil {
+		if envelope.Message != "" {
+			apiError.Message = envelope.Message
+		} else if envelope.Error != "" {
+			apiError.Message = envelope.Error
+		}
+		apiError.Name = envelope.Name
+		apiError.Code = envelope.Code
+		apiError.Details = envelope.Details
+	}
+
+	return apiError
+}

--- a/packages/go-sdk/opensend_test.go
+++ b/packages/go-sdk/opensend_test.go
@@ -1,0 +1,219 @@
+package opensend
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func testHTTPClient(t *testing.T, fn roundTripFunc) *http.Client {
+	t.Helper()
+	return &http.Client{Transport: fn}
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestSendConstructsRequestWithAuthAndConfiguredBaseURL(t *testing.T) {
+	var called bool
+	client, err := NewClient(
+		"re_test",
+		WithBaseURL("https://api.example.test/base/"),
+		WithHTTPClient(testHTTPClient(t, func(req *http.Request) (*http.Response, error) {
+			called = true
+			if req.Method != http.MethodPost {
+				t.Fatalf("method = %s, want POST", req.Method)
+			}
+			if got := req.URL.String(); got != "https://api.example.test/base/emails" {
+				t.Fatalf("url = %s, want https://api.example.test/base/emails", got)
+			}
+			if got := req.Header.Get("Authorization"); got != "Bearer re_test" {
+				t.Fatalf("authorization = %q", got)
+			}
+			if got := req.Header.Get("Content-Type"); got != "application/json" {
+				t.Fatalf("content-type = %q", got)
+			}
+			if got := req.Header.Get("Accept"); got != "application/json" {
+				t.Fatalf("accept = %q", got)
+			}
+			if got := req.Header.Get("User-Agent"); got != userAgent {
+				t.Fatalf("user-agent = %q", got)
+			}
+
+			var body map[string]any
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			want := map[string]any{
+				"from":     "hello@example.com",
+				"to":       []any{"user@example.com"},
+				"subject":  "Hello",
+				"html":     "<p>Hello</p>",
+				"cc":       []any{"cc@example.com"},
+				"bcc":      []any{"bcc@example.com"},
+				"reply_to": []any{"reply@example.com"},
+			}
+			for key, wantValue := range want {
+				if got := body[key]; !equalJSONValue(got, wantValue) {
+					t.Fatalf("body[%s] = %#v, want %#v; full body %#v", key, got, wantValue, body)
+				}
+			}
+			if _, ok := body["replyTo"]; ok {
+				t.Fatalf("body unexpectedly included replyTo: %#v", body)
+			}
+
+			return jsonResponse(http.StatusOK, `{"id":"email_123"}`), nil
+		})),
+	)
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+
+	response, err := client.Send(context.Background(), SendRequest{
+		From:    "hello@example.com",
+		To:      []string{"user@example.com"},
+		Subject: "Hello",
+		HTML:    "<p>Hello</p>",
+		CC:      []string{"cc@example.com"},
+		BCC:     []string{"bcc@example.com"},
+		ReplyTo: []string{"reply@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("Send returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("HTTP client was not called")
+	}
+	if response.ID != "email_123" {
+		t.Fatalf("response id = %q, want email_123", response.ID)
+	}
+}
+
+func TestNewClientDefaultsToHostedBaseURL(t *testing.T) {
+	client, err := NewClient(
+		"re_default",
+		WithHTTPClient(testHTTPClient(t, func(req *http.Request) (*http.Response, error) {
+			if got := req.URL.String(); got != "https://api.opensend.com/emails" {
+				t.Fatalf("url = %s, want https://api.opensend.com/emails", got)
+			}
+			return jsonResponse(http.StatusOK, `{"id":"email_default"}`), nil
+		})),
+	)
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+
+	response, err := client.Send(context.Background(), SendRequest{
+		From:    "hello@example.com",
+		To:      []string{"user@example.com"},
+		Subject: "Hello",
+		Text:    "Hello",
+	})
+	if err != nil {
+		t.Fatalf("Send returned error: %v", err)
+	}
+	if response.ID != "email_default" {
+		t.Fatalf("response id = %q", response.ID)
+	}
+}
+
+func TestSendParsesAcceptedEmailID(t *testing.T) {
+	client, err := NewClient(
+		"re_parse",
+		WithHTTPClient(testHTTPClient(t, func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusAccepted, `{"id":"email_accepted"}`), nil
+		})),
+	)
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+
+	response, err := client.Send(context.Background(), SendRequest{
+		From:    "hello@example.com",
+		To:      []string{"user@example.com"},
+		Subject: "Hello",
+		Text:    "Hello",
+	})
+	if err != nil {
+		t.Fatalf("Send returned error: %v", err)
+	}
+	if response.ID != "email_accepted" {
+		t.Fatalf("response id = %q", response.ID)
+	}
+}
+
+func TestSendNon2xxReturnsAPIErrorWithStatusBodyAndEnvelope(t *testing.T) {
+	body := `{"name":"validation_error","code":"validation_error","message":"Validation failed.","details":{"fieldErrors":{"to":["Required"]},"formErrors":[]}}`
+	client, err := NewClient(
+		"re_error",
+		WithHTTPClient(testHTTPClient(t, func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusUnprocessableEntity, body), nil
+		})),
+	)
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+
+	_, err = client.Send(context.Background(), SendRequest{
+		From:    "hello@example.com",
+		To:      []string{"user@example.com"},
+		Subject: "Hello",
+		HTML:    "<p>Hello</p>",
+	})
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %T %v, want *APIError", err, err)
+	}
+	if apiErr.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d", apiErr.StatusCode)
+	}
+	if apiErr.Body != body {
+		t.Fatalf("body = %q", apiErr.Body)
+	}
+	if apiErr.Name != "validation_error" || apiErr.Code != "validation_error" || apiErr.Message != "Validation failed." {
+		t.Fatalf("parsed envelope = name %q code %q message %q", apiErr.Name, apiErr.Code, apiErr.Message)
+	}
+	if !strings.Contains(string(apiErr.Details), "fieldErrors") {
+		t.Fatalf("details = %s", apiErr.Details)
+	}
+}
+
+func TestClientValidation(t *testing.T) {
+	if _, err := NewClient(""); err == nil || !strings.Contains(err.Error(), "API key") {
+		t.Fatalf("NewClient blank key error = %v", err)
+	}
+	if _, err := NewClient("re_test", WithBaseURL("ftp://example.com")); err == nil || !strings.Contains(err.Error(), "http or https") {
+		t.Fatalf("NewClient ftp base url error = %v", err)
+	}
+	if _, err := NewClient("re_test", WithHTTPClient(nil)); err == nil || !strings.Contains(err.Error(), "http client") {
+		t.Fatalf("NewClient nil http client error = %v", err)
+	}
+}
+
+func equalJSONValue(got any, want any) bool {
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		return false
+	}
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		return false
+	}
+	return string(gotJSON) == string(wantJSON)
+}


### PR DESCRIPTION
Closes #356

## Summary
- Added a first-party Go client SDK module at `packages/go-sdk` for the first transactional send slice only.
- Supports API-key client creation, configurable base URL, custom `*http.Client`, typed `SendRequest`, parsed `SendResponse.ID`, and `APIError` with status/body/envelope fields for non-2xx responses.
- Added no-network Go unit tests using a mock `RoundTripper` for request construction, auth/base URL behavior, response id parsing, and non-2xx errors.
- Added Go quickstart docs in `packages/go-sdk/README.md`, `docs/sdk/go.md`, and the root README.
- Preserved `services/ingester-go` as a separate shadow service; no Compose or ingester wiring changes.

## Changed files
- `packages/go-sdk/go.mod`
- `packages/go-sdk/opensend.go`
- `packages/go-sdk/opensend_test.go`
- `packages/go-sdk/README.md`
- `docs/sdk/go.md`
- `README.md`
- `agent_docs/learnings/active/2026-05-11-issue-356-go-sdk-send-endpoint.md`

## Checks
- `cd packages/go-sdk && go test ./...` ✅
- `cd packages/go-sdk && go vet ./...` ✅
- `make check` ✅
- `make test` ✅ (`129 passed`, `1055 passed`)

## Residual risk
- No live send was attempted against a deployed OpenSend API; coverage is via no-network unit tests and existing repo checks.
