### PR TITLE
Expose Resend-compatible audiences CRUD

### DIFF
--- a/packages/core/src/dto/index.ts
+++ b/packages/core/src/dto/index.ts
@@ -274,6 +274,35 @@ export interface ContactListResponse {
   has_more: boolean;
 }
 
+export interface CreateAudiencePayload {
+  name: string;
+}
+
+export interface AudienceResponse {
+  object: "audience";
+  id: string;
+  name: string;
+  created_at?: string;
+}
+
+export interface AudienceListItem {
+  id: string;
+  name: string;
+  created_at: string;
+}
+
+export interface AudienceListResponse {
+  object: "list";
+  data: AudienceListItem[];
+  has_more: boolean;
+}
+
+export interface DeleteAudienceResponse {
+  object: "audience";
+  id: string;
+  deleted: true;
+}
+
 export * from "./automations";
 
 // ── Billing DTOs ───────────────────────────────────────────────────

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,6 +2,9 @@ import type {
   ApiKeyListItem,
   ApiKeyListResponse,
   ApiKeyResponse,
+  AudienceListItem,
+  AudienceListResponse,
+  AudienceResponse,
   BatchEmailItemError,
   BatchEmailItemResponse,
   BatchEmailResponse,
@@ -10,8 +13,10 @@ import type {
   ContactResponse,
   ContactTopicPreference,
   CreateApiKeyPayload,
+  CreateAudiencePayload,
   CreateContactPayload,
   CreateContactResponse,
+  DeleteAudienceResponse,
   DeleteContactResponse,
   DomainCapability,
   DomainListItem,
@@ -111,6 +116,10 @@ export interface CreateEventPayload {
 export interface ListOptions {
   limit?: number;
   after?: string;
+}
+
+export interface AudienceListOptions extends ListOptions {
+  search?: string;
 }
 
 export interface AutomationRunListOptions extends ListOptions {
@@ -409,6 +418,42 @@ class Contacts {
   }
 }
 
+class Audiences {
+  constructor(private readonly http: HttpClient) {}
+
+  async create(
+    payload: CreateAudiencePayload,
+  ): Promise<ApiResponse<AudienceResponse>> {
+    return this.http.request<AudienceResponse>("POST", "/audiences", payload);
+  }
+
+  async list(
+    options: AudienceListOptions = {},
+  ): Promise<ApiResponse<AudienceListResponse>> {
+    const params = new URLSearchParams();
+    if (options.limit !== undefined) params.set("limit", String(options.limit));
+    if (options.after) params.set("after", options.after);
+    if (options.search) params.set("search", options.search);
+
+    const query = params.toString();
+    return this.http.request<AudienceListResponse>(
+      "GET",
+      query ? `/audiences?${query}` : "/audiences",
+    );
+  }
+
+  async get(id: string): Promise<ApiResponse<AudienceResponse>> {
+    return this.http.request<AudienceResponse>("GET", `/audiences/${id}`);
+  }
+
+  async delete(id: string): Promise<ApiResponse<DeleteAudienceResponse>> {
+    return this.http.request<DeleteAudienceResponse>(
+      "DELETE",
+      `/audiences/${id}`,
+    );
+  }
+}
+
 class Automations {
   constructor(private readonly http: HttpClient) {}
 
@@ -532,6 +577,7 @@ class Opensend {
   public readonly domains: Domains;
   public readonly apiKeys: ApiKeys;
   public readonly contacts: Contacts;
+  public readonly audiences: Audiences;
   public readonly automations: Automations;
   public readonly events: Events;
 
@@ -546,6 +592,7 @@ class Opensend {
     this.domains = new Domains(http);
     this.apiKeys = new ApiKeys(http);
     this.contacts = new Contacts(http);
+    this.audiences = new Audiences(http);
     this.automations = new Automations(http);
     this.events = new Events(http);
   }
@@ -583,6 +630,11 @@ export type {
   ApiKeyResponse,
   ApiKeyListItem,
   ApiKeyListResponse,
+  CreateAudiencePayload,
+  AudienceResponse,
+  AudienceListItem,
+  AudienceListResponse,
+  DeleteAudienceResponse,
   CreateContactPayload,
   CreateContactResponse,
   UpdateContactPayload,

--- a/src/app/audiences/[audience_id]/route.ts
+++ b/src/app/audiences/[audience_id]/route.ts
@@ -1,0 +1,84 @@
+import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
+import {
+  AudienceMetadataServiceError,
+  createAudienceMetadataService,
+} from "@opensend/core";
+import { NextResponse } from "next/server";
+
+type SegmentDetailResult = Awaited<
+  ReturnType<ReturnType<typeof createAudienceMetadataService>["getSegment"]>
+>;
+
+type AudienceRouteContext = {
+  params: Promise<{ audience_id: string }>;
+};
+
+function audienceMetadataService() {
+  return createAudienceMetadataService();
+}
+
+function mapServiceError(error: unknown, fallback: string) {
+  if (error instanceof AudienceMetadataServiceError) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: error.status },
+    );
+  }
+
+  console.error(`${fallback}:`, error);
+  return NextResponse.json({ error: fallback }, { status: 500 });
+}
+
+function toAudienceDetailResponse(result: SegmentDetailResult) {
+  return {
+    object: "audience" as const,
+    id: result.id,
+    name: result.name,
+    created_at: result.created_at,
+  };
+}
+
+export async function GET(request: Request, context: AudienceRouteContext) {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
+  if (!auth.userId) return unauthorizedResponse();
+
+  try {
+    const { audience_id } = await context.params;
+    const result = await audienceMetadataService().getSegment({
+      userId: auth.userId,
+      id: audience_id,
+    });
+
+    return NextResponse.json(toAudienceDetailResponse(result));
+  } catch (error) {
+    return mapServiceError(error, "Failed to fetch audience");
+  }
+}
+
+export async function DELETE(request: Request, context: AudienceRouteContext) {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
+  if (!auth.userId) return unauthorizedResponse();
+
+  try {
+    const { audience_id } = await context.params;
+    await audienceMetadataService().deleteSegment({
+      userId: auth.userId,
+      id: audience_id,
+    });
+
+    return NextResponse.json({
+      object: "audience",
+      id: audience_id,
+      deleted: true,
+    });
+  } catch (error) {
+    return mapServiceError(error, "Failed to delete audience");
+  }
+}

--- a/src/app/audiences/route.ts
+++ b/src/app/audiences/route.ts
@@ -1,0 +1,110 @@
+import {
+  authorizeDashboardOrApiKey,
+  getServerSession,
+  unauthorizedResponse,
+} from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
+import {
+  AudienceMetadataServiceError,
+  createAudienceMetadataService,
+} from "@opensend/core";
+import { NextResponse } from "next/server";
+
+type AudienceRouteAuth = NonNullable<
+  Awaited<ReturnType<typeof authorizeDashboardOrApiKey>>
+>;
+
+type SegmentListResult = Awaited<
+  ReturnType<ReturnType<typeof createAudienceMetadataService>["listSegments"]>
+>;
+
+type SegmentCreateResult = Awaited<
+  ReturnType<ReturnType<typeof createAudienceMetadataService>["createSegment"]>
+>;
+
+async function resolveUserId(auth: AudienceRouteAuth): Promise<string | null> {
+  if ("userId" in auth) return auth.userId;
+
+  const session = await getServerSession();
+  return session?.user?.id ?? null;
+}
+
+function audienceMetadataService() {
+  return createAudienceMetadataService();
+}
+
+function mapServiceError(error: unknown, fallback: string) {
+  if (error instanceof AudienceMetadataServiceError) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: error.status },
+    );
+  }
+
+  console.error(`${fallback}:`, error);
+  return NextResponse.json({ error: fallback }, { status: 500 });
+}
+
+function toAudienceListResponse(result: SegmentListResult) {
+  return {
+    object: "list" as const,
+    has_more: result.has_more,
+    data: result.data,
+  };
+}
+
+function toAudienceCreateResponse(result: SegmentCreateResult) {
+  return {
+    object: "audience" as const,
+    id: result.id,
+    name: result.name,
+  };
+}
+
+export async function GET(request: Request) {
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
+  if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
+  const userId = await resolveUserId(auth);
+  if (!userId) return unauthorizedResponse();
+
+  try {
+    const url = new URL(request.url);
+    const result = await audienceMetadataService().listSegments({
+      userId,
+      limit: Number(url.searchParams.get("limit")) || undefined,
+      search: url.searchParams.get("search") || undefined,
+      after: url.searchParams.get("after") || undefined,
+    });
+
+    return NextResponse.json(toAudienceListResponse(result));
+  } catch (error) {
+    return mapServiceError(error, "Failed to fetch audiences");
+  }
+}
+
+export async function POST(request: Request) {
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
+  if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
+  const userId = await resolveUserId(auth);
+  if (!userId) return unauthorizedResponse();
+
+  try {
+    const body = await request.json();
+    const result = await audienceMetadataService().createSegment({
+      userId,
+      body,
+    });
+
+    return NextResponse.json(toAudienceCreateResponse(result), { status: 201 });
+  } catch (error) {
+    return mapServiceError(error, "Failed to create audience");
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -96,6 +96,14 @@ function isContactsAlias(pathname: string, method: string): boolean {
   return false;
 }
 
+function isAudiencesAlias(pathname: string, method: string): boolean {
+  if (pathname === "/audiences") return ["GET", "POST"].includes(method);
+  if (pathname.startsWith("/audiences/")) {
+    return ["GET", "DELETE"].includes(method);
+  }
+  return false;
+}
+
 function isSendApiPost(pathname: string, method: string): boolean {
   return (
     method === "POST" &&
@@ -113,6 +121,11 @@ function getRateLimitPathname(pathname: string, method: string): string {
     return pathname === "/contacts"
       ? "/api/contacts"
       : pathname.replace(/^\/contacts/, "/api/contacts");
+  }
+  if (isAudiencesAlias(pathname, method)) {
+    return pathname === "/audiences"
+      ? "/api/segments"
+      : pathname.replace(/^\/audiences/, "/api/segments");
   }
   return pathname;
 }
@@ -163,7 +176,13 @@ export async function middleware(request: NextRequest) {
   // aliases must bypass dashboard session redirects and use public API auth.
   const isSendAlias = isSendPostAlias(pathname, request.method);
   const isContactAlias = isContactsAlias(pathname, request.method);
-  if (!pathname.startsWith("/api/") && !isSendAlias && !isContactAlias) {
+  const isAudienceAlias = isAudiencesAlias(pathname, request.method);
+  if (
+    !pathname.startsWith("/api/") &&
+    !isSendAlias &&
+    !isContactAlias &&
+    !isAudienceAlias
+  ) {
     // Allow auth page, public landing page, and static assets
     if (
       pathname === "/" ||

--- a/tests/audience-root-api.test.ts
+++ b/tests/audience-root-api.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockAudienceMetadataService = vi.hoisted(() => ({
+  createSegment: vi.fn(),
+  listSegments: vi.fn(),
+  getSegment: vi.fn(),
+  deleteSegment: vi.fn(),
+}));
+const MockAudienceMetadataServiceError = vi.hoisted(
+  () =>
+    class AudienceMetadataServiceError extends Error {
+      constructor(
+        readonly code: "invalid_input" | "not_found",
+        message: string,
+        readonly status: number,
+      ) {
+        super(message);
+        this.name = "AudienceMetadataServiceError";
+      }
+    },
+);
+
+function makeRequest(url: string, init?: RequestInit) {
+  const request = new Request(url, init) as Request & { nextUrl: URL };
+  request.nextUrl = new URL(url);
+  return request;
+}
+
+vi.mock("@/lib/api-auth", () => ({
+  authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
+  getServerSession: mockGetServerSession,
+  validateApiKey: mockValidateApiKey,
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+
+vi.mock("@opensend/core", () => ({
+  AudienceMetadataServiceError: MockAudienceMetadataServiceError,
+  createAudienceMetadataService: () => mockAudienceMetadataService,
+}));
+
+describe("Resend-compatible root audiences API", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    const auth = {
+      apiKeyId: "key-1",
+      permission: "full_access",
+      domain: null,
+      userId: "user-1",
+    };
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue(auth);
+    mockValidateApiKey.mockResolvedValue(auth);
+    mockGetServerSession.mockResolvedValue(null);
+  });
+
+  it("creates, lists, retrieves, and deletes audiences through segment storage", async () => {
+    const createdAt = new Date("2026-05-11T00:00:00.000Z");
+    mockAudienceMetadataService.createSegment.mockResolvedValueOnce({
+      object: "segment",
+      id: "seg-1",
+      name: "Registered Users",
+    });
+    mockAudienceMetadataService.listSegments.mockResolvedValueOnce({
+      object: "list",
+      has_more: false,
+      total: 1,
+      data: [
+        {
+          id: "seg-1",
+          name: "Registered Users",
+          created_at: createdAt.toISOString(),
+        },
+      ],
+    });
+    mockAudienceMetadataService.getSegment.mockResolvedValueOnce({
+      object: "segment",
+      id: "seg-1",
+      name: "Registered Users",
+      created_at: createdAt,
+    });
+    mockAudienceMetadataService.deleteSegment.mockResolvedValueOnce(undefined);
+
+    const collectionRoute = await import("@/app/audiences/route");
+    const detailRoute = await import("@/app/audiences/[audience_id]/route");
+
+    const createResponse = await collectionRoute.POST(
+      makeRequest("http://localhost/audiences", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer key",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ name: "Registered Users" }),
+      }),
+    );
+
+    expect(createResponse.status).toBe(201);
+    await expect(createResponse.json()).resolves.toEqual({
+      object: "audience",
+      id: "seg-1",
+      name: "Registered Users",
+    });
+    expect(mockAudienceMetadataService.createSegment).toHaveBeenCalledWith({
+      userId: "user-1",
+      body: { name: "Registered Users" },
+    });
+
+    const listResponse = await collectionRoute.GET(
+      makeRequest("http://localhost/audiences?limit=10&search=registered", {
+        headers: { authorization: "Bearer key" },
+      }),
+    );
+    await expect(listResponse.json()).resolves.toEqual({
+      object: "list",
+      has_more: false,
+      data: [
+        {
+          id: "seg-1",
+          name: "Registered Users",
+          created_at: createdAt.toISOString(),
+        },
+      ],
+    });
+    expect(mockAudienceMetadataService.listSegments).toHaveBeenCalledWith({
+      userId: "user-1",
+      limit: 10,
+      search: "registered",
+      after: undefined,
+    });
+
+    const getResponse = await detailRoute.GET(
+      makeRequest("http://localhost/audiences/seg-1", {
+        headers: { authorization: "Bearer key" },
+      }),
+      { params: Promise.resolve({ audience_id: "seg-1" }) },
+    );
+    await expect(getResponse.json()).resolves.toEqual({
+      object: "audience",
+      id: "seg-1",
+      name: "Registered Users",
+      created_at: createdAt.toISOString(),
+    });
+    expect(mockAudienceMetadataService.getSegment).toHaveBeenCalledWith({
+      userId: "user-1",
+      id: "seg-1",
+    });
+
+    const deleteResponse = await detailRoute.DELETE(
+      makeRequest("http://localhost/audiences/seg-1", {
+        method: "DELETE",
+        headers: { authorization: "Bearer key" },
+      }),
+      { params: Promise.resolve({ audience_id: "seg-1" }) },
+    );
+    await expect(deleteResponse.json()).resolves.toEqual({
+      object: "audience",
+      id: "seg-1",
+      deleted: true,
+    });
+    expect(mockAudienceMetadataService.deleteSegment).toHaveBeenCalledWith({
+      userId: "user-1",
+      id: "seg-1",
+    });
+  });
+
+  it("preserves full-access API key enforcement for send-only audience calls", async () => {
+    mockValidateApiKey.mockResolvedValueOnce({
+      apiKeyId: "send-key",
+      permission: "sending_access",
+      domain: null,
+      userId: "user-1",
+    });
+
+    const detailRoute = await import("@/app/audiences/[audience_id]/route");
+    const response = await detailRoute.GET(
+      makeRequest("http://localhost/audiences/seg-1", {
+        headers: { authorization: "Bearer send-key" },
+      }),
+      { params: Promise.resolve({ audience_id: "seg-1" }) },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      name: "insufficient_api_key_permission",
+      code: "insufficient_api_key_permission",
+      statusCode: 403,
+    });
+    expect(mockAudienceMetadataService.getSegment).not.toHaveBeenCalled();
+  });
+
+  it("maps segment service errors without leaking segment object responses", async () => {
+    mockAudienceMetadataService.getSegment.mockRejectedValueOnce(
+      new MockAudienceMetadataServiceError(
+        "not_found",
+        "Segment not found",
+        404,
+      ),
+    );
+
+    const detailRoute = await import("@/app/audiences/[audience_id]/route");
+    const response = await detailRoute.GET(
+      makeRequest("http://localhost/audiences/missing", {
+        headers: { authorization: "Bearer key" },
+      }),
+      { params: Promise.resolve({ audience_id: "missing" }) },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Segment not found",
+    });
+  });
+});

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -92,7 +92,7 @@ The fixture provides:
 
 | Spec | Classification | Notes |
 | --- | --- | --- |
-| `tenant-isolation.spec.ts` | Real Playwright API E2E | Canonical issue #229 proof: real app routes, API keys, Postgres users/contacts, cross-tenant list/detail/mutation/delete denial. |
+| `tenant-isolation.spec.ts`, `audiences-api.spec.ts` | Real Playwright API E2E | Canonical issue #229 proof for contacts plus issue #360 proof for Resend-compatible `/audiences` CRUD backed by Postgres segment rows. |
 | `domain-create-auth.spec.ts` | Real browser E2E | Uses `authenticatedPage`, real Better Auth rows, dashboard UI, and Postgres domain assertion. |
 | `domains-page.spec.ts` | Real browser E2E | Uses `authenticatedPage`; mostly page rendering/navigation over current DB state. |
 | `landing-page.spec.ts` | Real browser E2E | Public landing page plus signed-in redirect through real auth fixture. |

--- a/tests/e2e/audiences-api.spec.ts
+++ b/tests/e2e/audiences-api.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "./fixtures/auth";
+
+test.describe("Resend-compatible /audiences API", () => {
+  test("creates, lists, retrieves, and deletes an audience through segment storage", async ({
+    e2eApiRequest,
+    e2eDb,
+    e2eRunId,
+    e2eTenant,
+  }) => {
+    const name = `Registered Users ${e2eRunId}`;
+
+    const createResponse = await e2eApiRequest.post("/audiences", {
+      data: { name },
+    });
+    expect(createResponse.status()).toBe(201);
+    const created = (await createResponse.json()) as {
+      object: string;
+      id: string;
+      name: string;
+    };
+    expect(created).toEqual({
+      object: "audience",
+      id: expect.any(String),
+      name,
+    });
+
+    const segmentRows = await e2eDb.query<{
+      name: string;
+      user_id: string;
+    }>("select name, user_id from segments where id = $1", [created.id]);
+    expect(segmentRows.rows).toEqual([{ name, user_id: e2eTenant.user.id }]);
+
+    const listResponse = await e2eApiRequest.get(
+      `/audiences?search=${encodeURIComponent(name)}&limit=10`,
+    );
+    expect(listResponse.status()).toBe(200);
+    const listed = (await listResponse.json()) as {
+      object: string;
+      has_more: boolean;
+      data: Array<{ id: string; name: string; created_at: string }>;
+      total?: number;
+    };
+    expect(listed).toEqual({
+      object: "list",
+      has_more: false,
+      data: [
+        {
+          id: created.id,
+          name,
+          created_at: expect.any(String),
+        },
+      ],
+    });
+    expect(listed.total).toBeUndefined();
+
+    const getResponse = await e2eApiRequest.get(`/audiences/${created.id}`);
+    expect(getResponse.status()).toBe(200);
+    await expect(getResponse.json()).resolves.toEqual({
+      object: "audience",
+      id: created.id,
+      name,
+      created_at: expect.any(String),
+    });
+
+    const deleteResponse = await e2eApiRequest.delete(
+      `/audiences/${created.id}`,
+    );
+    expect(deleteResponse.status()).toBe(200);
+    await expect(deleteResponse.json()).resolves.toEqual({
+      object: "audience",
+      id: created.id,
+      deleted: true,
+    });
+
+    const deletedGetResponse = await e2eApiRequest.get(
+      `/audiences/${created.id}`,
+    );
+    expect(deletedGetResponse.status()).toBe(404);
+  });
+});

--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -109,6 +109,14 @@ export async function cleanupE2ERun(
     [`${userPrefix}%`, emailPattern, runId],
   );
   await client.query(
+    "delete from contacts_to_segments where segment_id in (select id from segments where user_id like $1 or document->>'test_run_id' = $2)",
+    [`${userPrefix}%`, runId],
+  );
+  await client.query(
+    "delete from segments where user_id like $1 or document->>'test_run_id' = $2",
+    [`${userPrefix}%`, runId],
+  );
+  await client.query(
     "delete from api_keys where user_id like $1 or name like $2 or document->>'test_run_id' = $3",
     [`${userPrefix}%`, `${apiKeyPrefix}%`, runId],
   );

--- a/tests/middleware-rate-limit.test.ts
+++ b/tests/middleware-rate-limit.test.ts
@@ -140,6 +140,22 @@ describe("middleware rate limiting", () => {
     expect(response.headers.get("x-ratelimit-backend")).toBe("disabled");
   });
 
+  it("allows root audiences API aliases without requiring a dashboard session", async () => {
+    mockGetSessionCookie.mockReturnValue(null);
+    const { middleware } = await import("@/middleware");
+
+    const response = await middleware(
+      makeRequest("https://example.com/audiences/aud_123", {
+        method: "DELETE",
+        headers: { authorization: "Bearer test-api-key" },
+      }),
+    );
+
+    expect(mockGetSessionCookie).not.toHaveBeenCalled();
+    expect(response.status).not.toBe(307);
+    expect(response.headers.get("x-ratelimit-backend")).toBe("disabled");
+  });
+
   it("enforces Redis-backed limits for API routes", async () => {
     process.env.RATE_LIMIT_BACKEND = "redis";
     mockIncrCache.mockResolvedValue(1);
@@ -232,6 +248,29 @@ describe("middleware rate limiting", () => {
 
     expect(mockIncrCache).toHaveBeenCalledWith(
       "ratelimit:203.0.113.10:Bearer test-api-key:/api/contacts/user@example.com",
+      60,
+    );
+    expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
+  });
+
+  it("shares rate-limit buckets between root audiences aliases and /api/segments", async () => {
+    process.env.RATE_LIMIT_BACKEND = "redis";
+    mockGetSessionCookie.mockReturnValue(null);
+    mockIncrCache.mockResolvedValue(1);
+
+    const { middleware } = await import("@/middleware");
+    const response = await middleware(
+      makeRequest("https://example.com/audiences/aud_123", {
+        method: "DELETE",
+        headers: {
+          "x-forwarded-for": "203.0.113.10",
+          authorization: "Bearer test-api-key",
+        },
+      }),
+    );
+
+    expect(mockIncrCache).toHaveBeenCalledWith(
+      "ratelimit:203.0.113.10:Bearer test-api-key:/api/segments/aud_123",
       60,
     );
     expect(response.headers.get("x-ratelimit-backend")).toBe("redis");

--- a/tests/sdk-client.test.tsx
+++ b/tests/sdk-client.test.tsx
@@ -3,9 +3,12 @@ import { DEFAULT_BASE_URL, Opensend, Resend } from "../packages/sdk/src";
 import type {
   ApiError,
   ApiResponse,
+  AudienceListResponse,
+  AudienceResponse,
   BatchEmailResponse,
   ContactListResponse,
   ContactResponse,
+  DeleteAudienceResponse,
   DeleteContactResponse,
   EmailOptions,
   EmailResponse,
@@ -149,6 +152,24 @@ describe("Opensend SDK", () => {
       error: ApiError | null;
     }>();
     expectTypeOf<BatchEmailResponse>().toMatchTypeOf<{ data: unknown[] }>();
+    expectTypeOf<AudienceListResponse>().toMatchTypeOf<{
+      object: "list";
+      data: Array<{
+        id: string;
+        name: string;
+        created_at: string;
+      }>;
+      has_more: boolean;
+    }>();
+    expectTypeOf<AudienceResponse>().toMatchTypeOf<{
+      object: "audience";
+      id: string;
+      name: string;
+    }>();
+    expectTypeOf<DeleteAudienceResponse>().toMatchTypeOf<{
+      object: "audience";
+      deleted: true;
+    }>();
     expectTypeOf<ContactListResponse>().toMatchTypeOf<{
       object: "list";
       data: Array<{
@@ -310,6 +331,53 @@ describe("Opensend SDK", () => {
     expect(fetchMock).toHaveBeenNthCalledWith(
       5,
       "https://api.example.com/contacts/user@example.com",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("uses Resend-compatible root audiences endpoints for CRUD", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({ object: "audience", id: "aud_123", name: "VIP" }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new Opensend("re_test", {
+      baseUrl: "https://api.example.com",
+    });
+    const resend = new Resend("re_test", {
+      baseUrl: "https://api.example.com",
+    });
+
+    await client.audiences.create({ name: "Registered Users" });
+    await client.audiences.list({ limit: 10, after: "aud_100", search: "vip" });
+    await resend.audiences.get("aud_123");
+    await resend.audiences.delete("aud_123");
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example.com/audiences",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.example.com/audiences?limit=10&after=aud_100&search=vip",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "https://api.example.com/audiences/aud_123",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      "https://api.example.com/audiences/aud_123",
       expect.objectContaining({ method: "DELETE" }),
     );
   });


### PR DESCRIPTION
## Summary
- Adds Resend-compatible root `/audiences` create/list/retrieve/delete routes backed by the existing tenant-scoped segment service.
- Maps segment responses to Resend audience envelopes, including deletion `{ object: "audience", id, deleted: true }`, while preserving existing `/api/segments` behavior.
- Exposes `audiences.create/list/get/delete` on both `Opensend` and `Resend` TypeScript SDK clients with typed DTO aliases.
- Adds middleware alias handling so `/audiences` API calls bypass dashboard auth redirects and share rate-limit buckets with `/api/segments`.

Closes #360

## Validation
- `make check`
- `make test`
- `bun run test -- tests/audience-root-api.test.ts tests/audience-metadata-routes.test.ts tests/audience-metadata-service.test.ts tests/middleware-rate-limit.test.ts tests/sdk-client.test.tsx`
- `DATABASE_URL=<temp migrated postgres> .scratch/audiences-parity-scenario.sh`

## Notes
- Full `make test-e2e` was not run; the focused Playwright API scenario for `/audiences` passed against a temporary migrated Postgres database.
