### PR TITLE
Fix dashboard automations session auth

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-363-automation-dashboard-session-auth.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-363-automation-dashboard-session-auth.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-11
+issue: "#363"
+type: pattern
+promoted_to: null
+---
+
+## Automations dashboard routes accept session auth, public callers still need full-access API keys
+
+Dashboard automations UI should call same-origin `/api/automations/**` endpoints without reading or sending a stored client API key. The route adapter resolves either a signed-in Better Auth dashboard session or a bearer API key, then preserves the existing full-access permission gate only for API-key callers.
+
+Keep public SDK/API behavior covered with bearer-key tests, but add dashboard-session tests for list/detail/create/update/delete/run flows so dashboard regressions do not reintroduce `localStorage.api_key` requirements.

--- a/src/app/api/automations/[id]/route.ts
+++ b/src/app/api/automations/[id]/route.ts
@@ -1,11 +1,10 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { updateAutomationSchema } from "@/lib/validation/automations";
 import {
   AutomationServiceError,
   AutomationValidationError,
   createAutomationService,
 } from "@opensend/core";
+import { authorizeAutomationRoute } from "../route-helpers";
 
 const automationService = createAutomationService();
 
@@ -31,10 +30,8 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
+  const auth = await authorizeAutomationRoute(request);
+  if ("response" in auth) return auth.response;
 
   const { id } = await params;
   try {
@@ -54,10 +51,8 @@ export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
+  const auth = await authorizeAutomationRoute(request);
+  if ("response" in auth) return auth.response;
 
   let body: unknown;
   try {
@@ -102,10 +97,8 @@ export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
+  const auth = await authorizeAutomationRoute(request);
+  if ("response" in auth) return auth.response;
 
   const { id } = await params;
   try {

--- a/src/app/api/automations/[id]/runs/route-helpers.ts
+++ b/src/app/api/automations/[id]/runs/route-helpers.ts
@@ -1,22 +1,15 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import {
   AutomationRunServiceError,
   createAutomationRunService,
 } from "@opensend/core";
+import { authorizeAutomationRoute } from "../../route-helpers";
 
 export const automationRunService = createAutomationRunService();
 
 export async function authorizeAutomationRunRoute(
   request: Request,
-): Promise<{ userId?: string | null } | { response: Response }> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return { response: unauthorizedResponse() };
-
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return { response: permissionError };
-
-  return { userId: auth.userId };
+): Promise<{ userId: string } | { response: Response }> {
+  return authorizeAutomationRoute(request);
 }
 
 export function mapAutomationRunServiceError(

--- a/src/app/api/automations/route-helpers.ts
+++ b/src/app/api/automations/route-helpers.ts
@@ -1,0 +1,36 @@
+import {
+  authorizeDashboardOrApiKey,
+  getServerSession,
+  unauthorizedResponse,
+} from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
+
+type AutomationRouteAuth = NonNullable<
+  Awaited<ReturnType<typeof authorizeDashboardOrApiKey>>
+>;
+
+async function getUserIdFromAuth(
+  auth: AutomationRouteAuth,
+): Promise<string | null> {
+  if ("userId" in auth) return auth.userId;
+
+  const session = await getServerSession();
+  return session?.user?.id ?? null;
+}
+
+export async function authorizeAutomationRoute(
+  request: Request,
+): Promise<{ userId: string } | { response: Response }> {
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
+  if (!auth) return { response: unauthorizedResponse() };
+
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return { response: permissionError };
+
+  const userId = await getUserIdFromAuth(auth);
+  if (!userId) return { response: unauthorizedResponse() };
+
+  return { userId };
+}

--- a/src/app/api/automations/route.ts
+++ b/src/app/api/automations/route.ts
@@ -1,5 +1,3 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import {
   createAutomationSchema,
   listAutomationsQuerySchema,
@@ -8,14 +6,13 @@ import {
   AutomationValidationError,
   createAutomationService,
 } from "@opensend/core";
+import { authorizeAutomationRoute } from "./route-helpers";
 
 const automationService = createAutomationService();
 
 export async function POST(request: Request): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
+  const auth = await authorizeAutomationRoute(request);
+  if ("response" in auth) return auth.response;
 
   let body: unknown;
   try {
@@ -53,10 +50,8 @@ export async function POST(request: Request): Promise<Response> {
 }
 
 export async function GET(request: Request): Promise<Response> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
+  const auth = await authorizeAutomationRoute(request);
+  if ("response" in auth) return auth.response;
 
   const url = new URL(request.url);
   const parsed = listAutomationsQuerySchema.safeParse({

--- a/src/components/automation-builder-form.tsx
+++ b/src/components/automation-builder-form.tsx
@@ -57,15 +57,6 @@ interface FieldErrorProps {
   field: keyof AutomationFormState;
 }
 
-function getApiKey(): string | null {
-  if (typeof window === "undefined") return null;
-  try {
-    return localStorage?.getItem?.("api_key") ?? null;
-  } catch {
-    return null;
-  }
-}
-
 function findError(
   errors: AutomationFormValidationError[],
   field: keyof AutomationFormState,
@@ -366,18 +357,11 @@ export function AutomationBuilderForm({
       setTemplatesLoading(true);
       setTemplatesError(null);
       try {
-        const apiKey = getApiKey();
-        const headers: Record<string, string> = {};
-        if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
-        const res = await fetch("/api/templates?status=published", { headers });
+        const res = await fetch("/api/templates?status=published");
         if (!res.ok) {
           if (!cancelled) {
             setTemplates([]);
-            setTemplatesError(
-              res.status === 401
-                ? "Set an API key to load published templates."
-                : "Could not load templates.",
-            );
+            setTemplatesError("Could not load templates.");
           }
           return;
         }

--- a/src/components/automation-builder.tsx
+++ b/src/components/automation-builder.tsx
@@ -16,15 +16,6 @@ interface Props {
   mode: "create";
 }
 
-function getApiKey(): string | null {
-  if (typeof window === "undefined") return null;
-  try {
-    return localStorage?.getItem?.("api_key") ?? null;
-  } catch {
-    return null;
-  }
-}
-
 export function AutomationBuilder({ mode }: Props) {
   const router = useRouter();
   const [state, setState] = useState<AutomationFormState>(DEFAULT_FORM_STATE);
@@ -39,11 +30,9 @@ export function AutomationBuilder({ mode }: Props) {
     setSubmitting(true);
     setError(null);
     try {
-      const apiKey = getApiKey();
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
       };
-      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
       const res = await fetch("/api/automations", {
         method: "POST",
         headers,

--- a/src/components/automation-detail.tsx
+++ b/src/components/automation-detail.tsx
@@ -22,15 +22,6 @@ interface Props {
 
 type Tab = "steps" | "runs";
 
-function getApiKey(): string | null {
-  if (typeof window === "undefined") return null;
-  try {
-    return localStorage?.getItem?.("api_key") ?? null;
-  } catch {
-    return null;
-  }
-}
-
 function capitalize(s: string): string {
   return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
 }
@@ -50,20 +41,13 @@ export function AutomationDetail({ automationId }: Props) {
     setError(null);
     setNotFound(false);
     try {
-      const apiKey = getApiKey();
-      const headers: Record<string, string> = {};
-      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
-      const res = await fetch(`/api/automations/${automationId}`, { headers });
+      const res = await fetch(`/api/automations/${automationId}`);
       if (res.status === 404) {
         setNotFound(true);
         return;
       }
       if (!res.ok) {
-        setError(
-          res.status === 401
-            ? "Set an API key to view this automation."
-            : "Failed to load automation.",
-        );
+        setError("Failed to load automation.");
         return;
       }
       const data: ApiAutomation = await res.json();
@@ -88,11 +72,9 @@ export function AutomationDetail({ automationId }: Props) {
     setSaving(true);
     setError(null);
     try {
-      const apiKey = getApiKey();
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
       };
-      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
       const res = await fetch(`/api/automations/${automationId}`, {
         method: "PATCH",
         headers,
@@ -122,12 +104,8 @@ export function AutomationDetail({ automationId }: Props) {
   const handleDelete = async () => {
     setError(null);
     try {
-      const apiKey = getApiKey();
-      const headers: Record<string, string> = {};
-      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
       const res = await fetch(`/api/automations/${automationId}`, {
         method: "DELETE",
-        headers,
       });
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));

--- a/src/components/automation-run-detail.tsx
+++ b/src/components/automation-run-detail.tsx
@@ -49,20 +49,9 @@ const SENSITIVE_OUTPUT_KEYS = [
   "body",
 ];
 
-function getApiKey(): string | null {
-  if (typeof window === "undefined") return null;
-  try {
-    return localStorage?.getItem?.("api_key") ?? null;
-  } catch {
-    return null;
-  }
-}
-
 function apiHeaders(contentType = false): Record<string, string> {
   const headers: Record<string, string> = {};
   if (contentType) headers["Content-Type"] = "application/json";
-  const apiKey = getApiKey();
-  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
   return headers;
 }
 
@@ -152,11 +141,7 @@ export function AutomationRunDetail({ automationId, runId }: Props) {
         return;
       }
       if (!res.ok) {
-        setError(
-          res.status === 401
-            ? "Set an API key to view this run."
-            : "Failed to load run.",
-        );
+        setError("Failed to load run.");
         return;
       }
       setRun((await res.json()) as AutomationRunDetailPayload);

--- a/src/components/automation-runs-list.tsx
+++ b/src/components/automation-runs-list.tsx
@@ -39,20 +39,9 @@ const RUN_STATUSES = [
 ] as const;
 const CANCELLABLE_RUN_STATUSES = new Set(["queued", "waiting"]);
 
-function getApiKey(): string | null {
-  if (typeof window === "undefined") return null;
-  try {
-    return localStorage?.getItem?.("api_key") ?? null;
-  } catch {
-    return null;
-  }
-}
-
 function apiHeaders(contentType = false): Record<string, string> {
   const headers: Record<string, string> = {};
   if (contentType) headers["Content-Type"] = "application/json";
-  const apiKey = getApiKey();
-  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
   return headers;
 }
 
@@ -113,11 +102,7 @@ export function AutomationRunsList({ automationId }: Props) {
       });
       if (!res.ok) {
         setMetrics(null);
-        setMetricsError(
-          res.status === 401
-            ? "Set an API key to view run metrics."
-            : "Failed to load run metrics.",
-        );
+        setMetricsError("Failed to load run metrics.");
         return;
       }
       setMetrics((await res.json()) as AutomationRunMetrics);
@@ -142,11 +127,7 @@ export function AutomationRunsList({ automationId }: Props) {
       );
       if (!res.ok) {
         setRuns([]);
-        setError(
-          res.status === 401
-            ? "Set an API key to view runs."
-            : "Failed to load runs.",
-        );
+        setError("Failed to load runs.");
         return;
       }
       const data = await res.json();

--- a/src/components/automations-list.tsx
+++ b/src/components/automations-list.tsx
@@ -22,15 +22,6 @@ function capitalize(s: string): string {
   return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
 }
 
-function getApiKey(): string | null {
-  if (typeof window === "undefined") return null;
-  try {
-    return localStorage?.getItem?.("api_key") ?? null;
-  } catch {
-    return null;
-  }
-}
-
 export function AutomationsList() {
   const router = useRouter();
   const [automations, setAutomations] = useState<AutomationListItem[]>([]);
@@ -52,20 +43,12 @@ export function AutomationsList() {
       const params = new URLSearchParams();
       if (search) params.set("search", search);
       if (statusFilter) params.set("status", statusFilter);
-      const apiKey = getApiKey();
-      const headers: Record<string, string> = {};
-      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
-      const res = await fetch(`/api/automations?${params.toString()}`, {
-        headers,
-      });
+      const query = params.toString();
+      const res = await fetch(`/api/automations${query ? `?${query}` : ""}`);
       if (!res.ok) {
         setAutomations([]);
         setTotal(0);
-        if (res.status === 401) {
-          setError("Unauthorized — set an API key to view automations.");
-        } else {
-          setError("Failed to load automations.");
-        }
+        setError("Failed to load automations.");
         return;
       }
       const data = await res.json();
@@ -108,12 +91,8 @@ export function AutomationsList() {
   const handleDelete = async (item: AutomationListItem) => {
     setActionMenuId(null);
     try {
-      const apiKey = getApiKey();
-      const headers: Record<string, string> = {};
-      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
       await fetch(`/api/automations/${item.id}`, {
         method: "DELETE",
-        headers,
       });
       fetchAutomations();
     } catch {
@@ -125,11 +104,9 @@ export function AutomationsList() {
     setActionMenuId(null);
     const nextStatus = item.status === "enabled" ? "disabled" : "enabled";
     try {
-      const apiKey = getApiKey();
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
       };
-      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
       const res = await fetch(`/api/automations/${item.id}`, {
         method: "PATCH",
         headers,

--- a/tests/api-automations-events.test.ts
+++ b/tests/api-automations-events.test.ts
@@ -5,6 +5,8 @@ import type {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockAutomationCreate = vi.hoisted(() => vi.fn());
 const mockAutomationList = vi.hoisted(() => vi.fn());
 const mockServiceCreateAutomation = vi.hoisted(() => vi.fn());
@@ -106,6 +108,8 @@ function insertRows<T>(rows: T[]) {
 
 vi.mock("@/lib/api-auth", () => ({
   validateApiKey: mockValidateApiKey,
+  authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
+  getServerSession: mockGetServerSession,
   unauthorizedResponse: () =>
     Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
 }));
@@ -299,11 +303,26 @@ function jsonRequest(url: string, body: unknown, method = "POST") {
   });
 }
 
+function dashboardJsonRequest(url: string, body: unknown, method = "POST") {
+  return new Request(url, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
 describe("automation API routes", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
     mockValidateApiKey.mockResolvedValue(auth);
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue(auth);
+    mockGetServerSession.mockResolvedValue({
+      session: { id: "session_1" },
+      user: { id: "user_1" },
+    });
     mockResumeWaitingRunsForEvent.mockResolvedValue([]);
     mockDbSelect.mockReturnValue(queryRows([triggerStep]));
     mockServiceCreateAutomation.mockImplementation(
@@ -398,12 +417,199 @@ describe("automation API routes", () => {
   });
 
   it("returns 401 for missing API auth", async () => {
-    mockValidateApiKey.mockResolvedValue(null);
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue(null);
     const { GET } = await import("@/app/api/automations/route");
 
     const response = await GET(new Request("http://localhost/api/automations"));
 
     expect(response.status).toBe(401);
+  });
+
+  it("preserves full-access enforcement for bearer API-key callers", async () => {
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue({
+      ...auth,
+      permission: "sending_access",
+    });
+    const { GET } = await import("@/app/api/automations/route");
+
+    const response = await GET(
+      new Request("http://localhost/api/automations", {
+        headers: { Authorization: "Bearer re_sending" },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockAutomationList).not.toHaveBeenCalled();
+  });
+
+  it("allows dashboard-session auth for automation CRUD and run routes without a bearer key", async () => {
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue({ dashboard: true });
+    mockAutomationCreate.mockResolvedValue({
+      automation,
+      steps: [triggerStep],
+    });
+    mockAutomationList.mockResolvedValue({
+      data: [automation],
+      hasMore: false,
+    });
+    mockAutomationFindFirst.mockResolvedValue(automation);
+    mockServiceUpdateAutomation.mockResolvedValue({
+      object: "automation",
+      id: "auto_1",
+      name: "Welcome",
+      status: "disabled",
+      trigger_event_name: "user.signed_up",
+      connections: [],
+      steps: [{ id: "step_1", key: "trigger", type: "trigger", position: 0 }],
+      created_at: now,
+      updated_at: now,
+    });
+    mockServiceDeleteAutomation.mockResolvedValue({
+      object: "automation",
+      id: "auto_1",
+      deleted: true,
+    });
+    mockListRuns.mockResolvedValue({
+      object: "list",
+      data: [{ object: "automation_run", id: "run_1", status: "queued" }],
+      has_more: false,
+    });
+    mockGetRun.mockResolvedValue({
+      object: "automation_run",
+      id: "run_1",
+      automation_id: "auto_1",
+      status: "queued",
+    });
+    mockCancelRun.mockResolvedValue({
+      object: "automation_run",
+      id: "run_1",
+      automation_id: "auto_1",
+      status: "cancelled",
+    });
+    mockGetMetrics.mockResolvedValue({
+      object: "automation_run_metrics",
+      automation_id: "auto_1",
+      total_runs: 1,
+      by_status: { queued: 1 },
+      completion_rate: 0,
+      failure_rate: 0,
+      average_duration_ms: null,
+      waiting_count: 0,
+      failed_steps: [],
+      range: { from: null, to: null },
+    });
+
+    const listRoute = await import("@/app/api/automations/route");
+    const detailRoute = await import("@/app/api/automations/[id]/route");
+    const runsRoute = await import("@/app/api/automations/[id]/runs/route");
+    const runDetailRoute = await import(
+      "@/app/api/automations/[id]/runs/[runId]/route"
+    );
+    const runCancelRoute = await import(
+      "@/app/api/automations/[id]/runs/[runId]/cancel/route"
+    );
+    const metricsRoute = await import(
+      "@/app/api/automations/[id]/runs/metrics/route"
+    );
+
+    const create = await listRoute.POST(
+      dashboardJsonRequest("http://localhost/api/automations", {
+        name: "Welcome",
+        status: "enabled",
+        steps: [
+          {
+            key: "trigger",
+            type: "trigger",
+            config: { eventName: "user.signed_up" },
+          },
+        ],
+      }),
+    );
+    const list = await listRoute.GET(
+      new Request("http://localhost/api/automations?status=enabled"),
+    );
+    const detail = await detailRoute.GET(
+      new Request("http://localhost/api/automations/auto_1"),
+      { params: Promise.resolve({ id: "auto_1" }) },
+    );
+    const update = await detailRoute.PATCH(
+      dashboardJsonRequest(
+        "http://localhost/api/automations/auto_1",
+        { status: "disabled" },
+        "PATCH",
+      ),
+      { params: Promise.resolve({ id: "auto_1" }) },
+    );
+    const runList = await runsRoute.GET(
+      new Request("http://localhost/api/automations/auto_1/runs"),
+      { params: Promise.resolve({ id: "auto_1" }) },
+    );
+    const runDetail = await runDetailRoute.GET(
+      new Request("http://localhost/api/automations/auto_1/runs/run_1"),
+      { params: Promise.resolve({ id: "auto_1", runId: "run_1" }) },
+    );
+    const runCancel = await runCancelRoute.POST(
+      dashboardJsonRequest(
+        "http://localhost/api/automations/auto_1/runs/run_1/cancel",
+        { reason: "cancelled_from_dashboard" },
+      ),
+      { params: Promise.resolve({ id: "auto_1", runId: "run_1" }) },
+    );
+    const metrics = await metricsRoute.GET(
+      new Request("http://localhost/api/automations/auto_1/runs/metrics"),
+      { params: Promise.resolve({ id: "auto_1" }) },
+    );
+    const deleted = await detailRoute.DELETE(
+      new Request("http://localhost/api/automations/auto_1", {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ id: "auto_1" }) },
+    );
+
+    expect([
+      create.status,
+      list.status,
+      detail.status,
+      update.status,
+      runList.status,
+      runDetail.status,
+      runCancel.status,
+      metrics.status,
+      deleted.status,
+    ]).toEqual([201, 200, 200, 200, 200, 200, 200, 200, 200]);
+    expect(mockAutomationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user_1" }),
+    );
+    expect(mockAutomationList).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user_1" }),
+    );
+    expect(mockServiceUpdateAutomation).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user_1", id: "auto_1" }),
+    );
+    expect(mockServiceDeleteAutomation).toHaveBeenCalledWith(
+      "user_1",
+      "auto_1",
+    );
+    expect(mockListRuns).toHaveBeenCalledWith(
+      expect.objectContaining({ automationId: "auto_1", userId: "user_1" }),
+    );
+    expect(mockGetRun).toHaveBeenCalledWith({
+      automationId: "auto_1",
+      runId: "run_1",
+      userId: "user_1",
+    });
+    expect(mockCancelRun).toHaveBeenCalledWith({
+      automationId: "auto_1",
+      runId: "run_1",
+      userId: "user_1",
+      reason: "cancelled_from_dashboard",
+    });
+    expect(mockGetMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        automationId: "auto_1",
+        userId: "user_1",
+      }),
+    );
   });
 
   it("creates an automation through zod validation and repository validation", async () => {

--- a/tests/automations-list.test.tsx
+++ b/tests/automations-list.test.tsx
@@ -1,0 +1,51 @@
+import { AutomationsList } from "@/components/automations-list";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPush = vi.hoisted(() => vi.fn());
+const mockFetch = vi.hoisted(() => vi.fn());
+
+vi.stubGlobal("fetch", mockFetch);
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("AutomationsList", () => {
+  beforeEach(() => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ object: "list", data: [], total: 0 }),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows the empty state for signed-in dashboard users without requiring a client API key", async () => {
+    render(<AutomationsList />);
+
+    expect(await screen.findByText("No automations")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.queryByText(/api key/i)).toBeNull();
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith("/api/automations");
+    });
+  });
+});

--- a/tests/e2e/automations-dashboard.spec.ts
+++ b/tests/e2e/automations-dashboard.spec.ts
@@ -174,6 +174,31 @@ async function mockAutomationApis(page: Page) {
   };
 }
 
+async function mockEmptyAutomationApis(page: Page) {
+  const automationAuthorizationHeaders: Array<string | undefined> = [];
+
+  await page.route("**/api/auth/get-session", async (route) => {
+    await route.fulfill({
+      json: {
+        session: { id: "e2e-session", token: "e2e-session-token" },
+        user: { id: "e2e-user", email: "e2e@example.com", name: "E2E User" },
+      },
+    });
+  });
+  await page.route(/.*\/api\/automations(?:\?.*)?$/, async (route) => {
+    automationAuthorizationHeaders.push(
+      route.request().headers().authorization,
+    );
+    await route.fulfill({
+      json: { object: "list", data: [], has_more: false, total: 0 },
+    });
+  });
+
+  return {
+    getAutomationAuthorizationHeaders: () => automationAuthorizationHeaders,
+  };
+}
+
 test("automations dashboard lists automations and shows run failure fields", async ({
   context,
   page,
@@ -205,6 +230,27 @@ test("automations dashboard lists automations and shows run failure fields", asy
   await expect(page.getByRole("link", { name: "Failed" })).toBeVisible();
   await expect(page.getByRole("cell", { name: "send_email" })).toBeVisible();
   await expect(page.getByText("Template render failed")).toBeVisible();
+});
+
+test("empty automations dashboard uses session auth without a client API key", async ({
+  context,
+  page,
+}) => {
+  await signIn(context);
+  const mocks = await mockEmptyAutomationApis(page);
+  await page.addInitScript(() => {
+    window.localStorage.setItem("api_key", "re_should_not_be_sent");
+  });
+
+  await page.goto("/automations");
+
+  await expect(
+    page.getByRole("heading", { name: "Automations" }),
+  ).toBeVisible();
+  await expect(page.getByText("No automations")).toBeVisible();
+  await expect(page.locator("p[role='alert']")).toHaveCount(0);
+  await expect(page.getByText(/set an api key/i)).toHaveCount(0);
+  expect(mocks.getAutomationAuthorizationHeaders()).toEqual([undefined]);
 });
 
 test("automation create form submits an advanced condition flow", async ({


### PR DESCRIPTION
## Summary
- Fixes the dashboard Automations auth path so signed-in dashboard users call `/api/automations/**` with session cookies instead of a manually stored client API key.
- Adds shared automations route auth that accepts dashboard sessions or full-access bearer API keys, preserving public API/SDK bearer behavior.
- Adds regression coverage for dashboard no-API-key empty state and session-backed automation CRUD/run routes.

Closes #363

## Changes
- **API auth**: add `authorizeAutomationRoute()` and reuse it for automation CRUD plus run list/detail/cancel/metrics routes.
- **Dashboard UI**: remove `localStorage.api_key` reads and `Authorization` headers from automation list/detail/create/update/delete/toggle/run fetches.
- **Tests**: cover dashboard-session route access, full-access API-key enforcement, no unauthorized empty-state alert, and no dashboard Authorization header from the E2E flow.

## How to Test
- `make check`
- `make test`
- `bun run test -- tests/api-automations-events.test.ts tests/automations-list.test.tsx tests/automation-run-detail.test.tsx`
- `bun run test:e2e -- automations-dashboard.spec.ts`
- Ever signed-session smoke on `http://localhost:3015/automations`: rendered `No automations`; `alerts: []`; `bodyHasSetApiKey: false`.

## Notes
- Do not merge this PR yourself.
- PR #359 remains blocked until this lands on `staging` and the release PR is refreshed.
- Residual risk: the automation builder no longer sends an API key when loading published templates, but this PR does not broadly convert dashboard template APIs to session auth.
