### PR TITLE
Expose broadcasts root API parity

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-365-broadcast-root-alias-collision.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-365-broadcast-root-alias-collision.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-11
+issue: "#365"
+type: decision
+promoted_to: null
+---
+
+## Broadcast collection root aliases must preserve the dashboard page
+
+Next.js cannot build both `src/app/broadcasts/route.ts` and the dashboard page at `src/app/(dashboard)/broadcasts/page.tsx`; the route/page conflict fails `next build` at `/broadcasts`.
+
+For Resend-compatible collection aliases that collide with dashboard pages, keep `GET/POST /broadcasts` as API-like middleware rewrites to `/api/broadcasts` and gate `GET /broadcasts` by API-like headers (`Authorization`, JSON content/accept, or non-HTML clients). Browser HTML navigations should continue through the dashboard session flow.
+
+Detail aliases such as `/broadcasts/[id]` and `/broadcasts/[id]/send` can remain App Router route handlers because they do not occupy the dashboard list page path.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -135,6 +135,88 @@ export interface AutomationRunMetricsOptions {
   to?: string;
 }
 
+type BroadcastStatus = "draft" | "scheduled" | "queued" | "sent" | "failed";
+
+interface BroadcastPayloadAliases {
+  segment_id?: string;
+  segmentId?: string;
+  topic_id?: string;
+  topicId?: string;
+  reply_to?: string;
+  replyTo?: string;
+  preview_text?: string;
+  previewText?: string;
+  scheduled_at?: string;
+  scheduledAt?: string;
+}
+
+interface CreateBroadcastPayload extends BroadcastPayloadAliases {
+  name?: string;
+  from: string;
+  subject: string;
+  html?: string;
+  text?: string;
+  send?: boolean;
+}
+
+type UpdateBroadcastPayload = Partial<
+  Omit<CreateBroadcastPayload, "from" | "subject">
+> &
+  Partial<Pick<CreateBroadcastPayload, "from" | "subject">>;
+
+type SendBroadcastPayload = Pick<
+  BroadcastPayloadAliases,
+  "scheduled_at" | "scheduledAt"
+>;
+
+interface BroadcastListOptions extends ListOptions {
+  search?: string;
+  status?: BroadcastStatus;
+  segmentId?: string;
+}
+
+interface BroadcastListItem {
+  id: string;
+  name: string;
+  status: BroadcastStatus;
+  audience_id: string | null;
+  topic_id: string | null;
+  created_at: string;
+  scheduled_at: string | null;
+}
+
+interface BroadcastListResponse {
+  object: "list";
+  data: BroadcastListItem[];
+  has_more: boolean;
+}
+
+interface BroadcastResponse extends BroadcastListItem {
+  object: "broadcast";
+  from?: string | null;
+  subject?: string | null;
+  html?: string | null;
+  text?: string | null;
+  reply_to?: string | null;
+  preview_text?: string | null;
+}
+
+type CreateBroadcastResponse = Pick<
+  BroadcastResponse,
+  "object" | "id" | "name" | "status" | "created_at"
+>;
+
+interface DeleteBroadcastResponse {
+  object: "broadcast";
+  id: string;
+  deleted: true;
+}
+
+type SendBroadcastResponse = Pick<
+  BroadcastResponse,
+  "object" | "id" | "status" | "scheduled_at"
+>;
+
 function normalizeBaseUrl(baseUrl: string = DEFAULT_BASE_URL): string {
   if (!baseUrl.trim()) {
     throw new Error("baseUrl must be a non-empty string when provided");
@@ -201,6 +283,35 @@ function parseApiErrorBody(parsedBody: unknown, response: Response): ApiError {
     ...(code ? { code } : {}),
     ...(details ? { details } : {}),
   };
+}
+
+function toBroadcastPayload<T extends BroadcastPayloadAliases>(
+  payload: T,
+): Omit<
+  T,
+  "segmentId" | "topicId" | "replyTo" | "previewText" | "scheduledAt"
+> {
+  const { segmentId, topicId, replyTo, previewText, scheduledAt, ...rest } =
+    payload;
+  const normalized = { ...rest };
+
+  if (normalized.segment_id === undefined && segmentId !== undefined) {
+    normalized.segment_id = segmentId;
+  }
+  if (normalized.topic_id === undefined && topicId !== undefined) {
+    normalized.topic_id = topicId;
+  }
+  if (normalized.reply_to === undefined && replyTo !== undefined) {
+    normalized.reply_to = replyTo;
+  }
+  if (normalized.preview_text === undefined && previewText !== undefined) {
+    normalized.preview_text = previewText;
+  }
+  if (normalized.scheduled_at === undefined && scheduledAt !== undefined) {
+    normalized.scheduled_at = scheduledAt;
+  }
+
+  return normalized;
 }
 
 async function renderReactToHtml(element: unknown): Promise<string | null> {
@@ -454,6 +565,74 @@ class Audiences {
   }
 }
 
+class Broadcasts {
+  constructor(private readonly http: HttpClient) {}
+
+  async create(
+    payload: CreateBroadcastPayload,
+    options: RequestOptions = {},
+  ): Promise<ApiResponse<CreateBroadcastResponse>> {
+    return this.http.request<CreateBroadcastResponse>(
+      "POST",
+      "/broadcasts",
+      toBroadcastPayload(payload),
+      options,
+    );
+  }
+
+  async list(
+    options: BroadcastListOptions = {},
+  ): Promise<ApiResponse<BroadcastListResponse>> {
+    const params = new URLSearchParams();
+    if (options.limit !== undefined) params.set("limit", String(options.limit));
+    if (options.after) params.set("after", options.after);
+    if (options.search) params.set("search", options.search);
+    if (options.status) params.set("status", options.status);
+    if (options.segmentId) params.set("segmentId", options.segmentId);
+
+    const query = params.toString();
+    return this.http.request<BroadcastListResponse>(
+      "GET",
+      query ? `/broadcasts?${query}` : "/broadcasts",
+    );
+  }
+
+  async get(id: string): Promise<ApiResponse<BroadcastResponse>> {
+    return this.http.request<BroadcastResponse>("GET", `/broadcasts/${id}`);
+  }
+
+  async update(
+    id: string,
+    payload: UpdateBroadcastPayload,
+  ): Promise<ApiResponse<BroadcastResponse>> {
+    return this.http.request<BroadcastResponse>(
+      "PATCH",
+      `/broadcasts/${id}`,
+      toBroadcastPayload(payload),
+    );
+  }
+
+  async delete(id: string): Promise<ApiResponse<DeleteBroadcastResponse>> {
+    return this.http.request<DeleteBroadcastResponse>(
+      "DELETE",
+      `/broadcasts/${id}`,
+    );
+  }
+
+  async send(
+    id: string,
+    payload: SendBroadcastPayload = {},
+    options: RequestOptions = {},
+  ): Promise<ApiResponse<SendBroadcastResponse>> {
+    return this.http.request<SendBroadcastResponse>(
+      "POST",
+      `/broadcasts/${id}/send`,
+      toBroadcastPayload(payload),
+      options,
+    );
+  }
+}
+
 class Automations {
   constructor(private readonly http: HttpClient) {}
 
@@ -578,6 +757,7 @@ class Opensend {
   public readonly apiKeys: ApiKeys;
   public readonly contacts: Contacts;
   public readonly audiences: Audiences;
+  public readonly broadcasts: Broadcasts;
   public readonly automations: Automations;
   public readonly events: Events;
 
@@ -593,6 +773,7 @@ class Opensend {
     this.apiKeys = new ApiKeys(http);
     this.contacts = new Contacts(http);
     this.audiences = new Audiences(http);
+    this.broadcasts = new Broadcasts(http);
     this.automations = new Automations(http);
     this.events = new Events(http);
   }
@@ -635,6 +816,17 @@ export type {
   AudienceListItem,
   AudienceListResponse,
   DeleteAudienceResponse,
+  BroadcastStatus,
+  CreateBroadcastPayload,
+  UpdateBroadcastPayload,
+  SendBroadcastPayload,
+  BroadcastListOptions,
+  BroadcastListItem,
+  BroadcastListResponse,
+  BroadcastResponse,
+  CreateBroadcastResponse,
+  DeleteBroadcastResponse,
+  SendBroadcastResponse,
   CreateContactPayload,
   CreateContactResponse,
   UpdateContactPayload,

--- a/src/app/broadcasts/[id]/route.ts
+++ b/src/app/broadcasts/[id]/route.ts
@@ -1,0 +1,1 @@
+export { DELETE, GET, PATCH } from "@/app/api/broadcasts/[id]/route";

--- a/src/app/broadcasts/[id]/send/route.ts
+++ b/src/app/broadcasts/[id]/send/route.ts
@@ -1,0 +1,1 @@
+export { POST } from "@/app/api/broadcasts/[id]/send/route";

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -204,26 +204,49 @@ const API_GROUPS: EndpointGroup[] = [
     endpoints: [
       {
         method: "POST",
-        path: "/api/broadcasts",
+        path: "/broadcasts",
         description: "Create a new broadcast",
-        curl: `curl -X POST https://api.opensend.com/api/broadcasts \\
+        curl: `curl -X POST https://api.opensend.com/broadcasts \\
   -H "Authorization: Bearer re_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
-  -d '{ "name": "March Newsletter" }'`,
+  -d '{ "name": "March Newsletter", "from": "Acme <news@example.com>", "subject": "March updates", "segment_id": "SEGMENT_ID" }'
+
+// SDK
+await client.broadcasts.create({
+  name: "March Newsletter",
+  from: "Acme <news@example.com>",
+  subject: "March updates",
+  segmentId: "SEGMENT_ID",
+  previewText: "A quick monthly update"
+});`,
       },
       {
         method: "GET",
-        path: "/api/broadcasts",
+        path: "/broadcasts",
         description: "List all broadcasts",
-        curl: `curl https://api.opensend.com/api/broadcasts \\
+        curl: `curl https://api.opensend.com/broadcasts \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
       },
       {
         method: "GET",
-        path: "/api/broadcasts/:id",
+        path: "/broadcasts/:id",
         description: "Retrieve a broadcast by ID",
-        curl: `curl https://api.opensend.com/api/broadcasts/BROADCAST_ID \\
+        curl: `curl https://api.opensend.com/broadcasts/BROADCAST_ID \\
   -H "Authorization: Bearer re_YOUR_API_KEY"`,
+      },
+      {
+        method: "POST",
+        path: "/broadcasts/:id/send",
+        description: "Send or schedule a broadcast",
+        curl: `curl -X POST https://api.opensend.com/broadcasts/BROADCAST_ID/send \\
+  -H "Authorization: Bearer re_YOUR_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{ "scheduled_at": "in 1 min" }'
+
+// SDK
+await client.broadcasts.send("BROADCAST_ID", {
+  scheduledAt: "in 1 min"
+});`,
       },
     ],
   },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -104,6 +104,46 @@ function isAudiencesAlias(pathname: string, method: string): boolean {
   return false;
 }
 
+function isBroadcastsAlias(pathname: string, method: string): boolean {
+  if (pathname === "/broadcasts") return ["GET", "POST"].includes(method);
+  const parts = pathname.split("/").filter(Boolean);
+  if (parts[0] !== "broadcasts") return false;
+  if (parts.length === 2) {
+    return ["GET", "PATCH", "DELETE"].includes(method);
+  }
+  if (parts.length === 3 && parts[2] === "send") {
+    return method === "POST";
+  }
+  return false;
+}
+
+function isBroadcastsCollectionAlias(
+  pathname: string,
+  method: string,
+): boolean {
+  return pathname === "/broadcasts" && ["GET", "POST"].includes(method);
+}
+
+function isApiLikeRequest(request: NextRequest): boolean {
+  const accept = request.headers.get("accept") ?? "";
+  const contentType = request.headers.get("content-type") ?? "";
+  return (
+    request.headers.has("authorization") ||
+    accept.includes("application/json") ||
+    contentType.includes("application/json") ||
+    !accept.includes("text/html")
+  );
+}
+
+function shouldHandleBroadcastsAlias(request: NextRequest): boolean {
+  const { pathname } = request.nextUrl;
+  if (!isBroadcastsAlias(pathname, request.method)) return false;
+  if (pathname === "/broadcasts" && request.method === "GET") {
+    return isApiLikeRequest(request);
+  }
+  return true;
+}
+
 function isSendApiPost(pathname: string, method: string): boolean {
   return (
     method === "POST" &&
@@ -126,6 +166,11 @@ function getRateLimitPathname(pathname: string, method: string): string {
     return pathname === "/audiences"
       ? "/api/segments"
       : pathname.replace(/^\/audiences/, "/api/segments");
+  }
+  if (isBroadcastsAlias(pathname, method)) {
+    return pathname === "/broadcasts"
+      ? "/api/broadcasts"
+      : pathname.replace(/^\/broadcasts/, "/api/broadcasts");
   }
   return pathname;
 }
@@ -177,11 +222,13 @@ export async function middleware(request: NextRequest) {
   const isSendAlias = isSendPostAlias(pathname, request.method);
   const isContactAlias = isContactsAlias(pathname, request.method);
   const isAudienceAlias = isAudiencesAlias(pathname, request.method);
+  const isBroadcastAlias = shouldHandleBroadcastsAlias(request);
   if (
     !pathname.startsWith("/api/") &&
     !isSendAlias &&
     !isContactAlias &&
-    !isAudienceAlias
+    !isAudienceAlias &&
+    !isBroadcastAlias
   ) {
     // Allow auth page, public landing page, and static assets
     if (
@@ -219,6 +266,11 @@ export async function middleware(request: NextRequest) {
     }
     if (isBatchSendPostAlias(pathname, request.method)) {
       return NextResponse.rewrite(new URL("/api/emails/batch", request.url), {
+        headers: responseHeaders,
+      });
+    }
+    if (isBroadcastsCollectionAlias(pathname, request.method)) {
+      return NextResponse.rewrite(new URL("/api/broadcasts", request.url), {
         headers: responseHeaders,
       });
     }
@@ -277,6 +329,11 @@ export async function middleware(request: NextRequest) {
   }
   if (isBatchSendPostAlias(pathname, request.method)) {
     return NextResponse.rewrite(new URL("/api/emails/batch", request.url), {
+      headers: responseHeaders,
+    });
+  }
+  if (isBroadcastsCollectionAlias(pathname, request.method)) {
+    return NextResponse.rewrite(new URL("/api/broadcasts", request.url), {
       headers: responseHeaders,
     });
   }

--- a/tests/broadcast-tenant-routes.test.ts
+++ b/tests/broadcast-tenant-routes.test.ts
@@ -88,6 +88,45 @@ beforeEach(() => {
 });
 
 describe("broadcast tenant isolation", () => {
+  it("exposes root broadcast aliases as JSON API routes instead of dashboard fallthrough", async () => {
+    mockAuthorizeDashboardOrApiKey.mockResolvedValueOnce(null);
+
+    const { middleware } = await import("@/middleware");
+    const rewrite = await middleware(
+      makeNextRequest("http://localhost:3015/broadcasts", {
+        headers: { accept: "application/json" },
+      }),
+    );
+    expect(rewrite.headers.get("x-middleware-rewrite")).toBe(
+      "http://localhost:3015/api/broadcasts",
+    );
+
+    const apiRoute = await import("@/app/api/broadcasts/route");
+    const response = await apiRoute.GET(
+      makeNextRequest("http://localhost:3015/api/broadcasts", {
+        headers: { accept: "application/json" },
+      }),
+    );
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    await expect(response.json()).resolves.toEqual({
+      error: "Missing or invalid API key",
+    });
+    expect(mockBroadcastService.listBroadcasts).not.toHaveBeenCalled();
+  });
+
+  it("keeps browser navigations to the broadcasts dashboard out of API rewrites", async () => {
+    const { middleware } = await import("@/middleware");
+    const response = await middleware(
+      makeNextRequest("http://localhost:3015/broadcasts", {
+        headers: { accept: "text/html" },
+      }),
+    );
+
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(response.headers.get("location")).toBe("http://localhost:3015/auth");
+  });
+
   it("passes tenant and list filters to the broadcast service", async () => {
     const createdAt = new Date("2026-01-01T00:00:00Z");
     mockBroadcastService.listBroadcasts.mockResolvedValueOnce({
@@ -175,6 +214,72 @@ describe("broadcast tenant isolation", () => {
     });
   });
 
+  it("delegates root broadcast collection aliases to existing service behavior", async () => {
+    const createdAt = new Date("2026-01-01T00:00:00Z");
+    const body = {
+      name: "Launch",
+      from: "team@example.com",
+      subject: "Hello",
+      segment_id: "segment-1",
+    };
+    mockBroadcastService.createBroadcast.mockResolvedValueOnce({
+      id: "broadcast-1",
+      name: "Launch",
+      status: "draft",
+      createdAt,
+    });
+    mockBroadcastService.listBroadcasts.mockResolvedValueOnce({
+      data: [
+        {
+          id: "broadcast-1",
+          name: "Launch",
+          status: "draft",
+          audienceId: "segment-1",
+          topicId: null,
+          createdAt,
+          scheduledAt: null,
+        },
+      ],
+      hasMore: false,
+    });
+
+    const { middleware } = await import("@/middleware");
+    const postRewrite = await middleware(
+      jsonRequest("http://localhost:3015/broadcasts", body),
+    );
+    const getRewrite = await middleware(
+      makeNextRequest("http://localhost:3015/broadcasts?limit=5", {
+        headers: { Authorization: "Bearer re_test" },
+      }),
+    );
+    expect(postRewrite.headers.get("x-middleware-rewrite")).toBe(
+      "http://localhost:3015/api/broadcasts",
+    );
+    expect(getRewrite.headers.get("x-middleware-rewrite")).toBe(
+      "http://localhost:3015/api/broadcasts",
+    );
+
+    const apiRoute = await import("@/app/api/broadcasts/route");
+    const createResponse = await apiRoute.POST(
+      jsonRequest("http://localhost:3015/api/broadcasts", body),
+    );
+    const listResponse = await apiRoute.GET(
+      makeNextRequest("http://localhost:3015/api/broadcasts?limit=5", {
+        headers: { Authorization: "Bearer re_test" },
+      }),
+    );
+
+    expect(createResponse.status).toBe(201);
+    expect(listResponse.status).toBe(200);
+    expect(mockBroadcastService.createBroadcast).toHaveBeenCalledWith({
+      userId: "user-b",
+      body,
+    });
+    expect(mockBroadcastService.listBroadcasts).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-b", limit: 5 }),
+    );
+  });
+
   it("returns 404 for broadcast detail reads outside the tenant", async () => {
     mockBroadcastService.getBroadcast.mockRejectedValueOnce(
       new MockBroadcastServiceError("not_found", "Broadcast not found"),
@@ -248,6 +353,60 @@ describe("broadcast tenant isolation", () => {
       "user-b",
       "broadcast-1",
     );
+  });
+
+  it("delegates root broadcast detail and send aliases with route params", async () => {
+    const createdAt = new Date("2026-01-01T00:00:00Z");
+    const scheduledAt = new Date("2026-06-01T00:00:00Z");
+    mockBroadcastService.getBroadcast.mockResolvedValueOnce({
+      id: "broadcast-1",
+      name: "Launch",
+      status: "draft",
+      from: "team@example.com",
+      subject: "Hello",
+      html: null,
+      text: null,
+      replyTo: null,
+      previewText: null,
+      audienceId: "segment-1",
+      topicId: null,
+      scheduledAt: null,
+      createdAt,
+    });
+    mockBroadcastService.sendBroadcast.mockResolvedValueOnce({
+      id: "broadcast-1",
+      status: "scheduled",
+      scheduledAt,
+    });
+
+    const detailRoute = await import("@/app/broadcasts/[id]/route");
+    const sendRoute = await import("@/app/broadcasts/[id]/send/route");
+    const detailResponse = await detailRoute.GET(
+      makeNextRequest("http://localhost:3015/broadcasts/broadcast-1", {
+        headers: { Authorization: "Bearer re_test" },
+      }),
+      { params: Promise.resolve({ id: "broadcast-1" }) },
+    );
+    const sendBody = { scheduled_at: scheduledAt.toISOString() };
+    const sendResponse = await sendRoute.POST(
+      jsonRequest(
+        "http://localhost:3015/broadcasts/broadcast-1/send",
+        sendBody,
+      ),
+      { params: Promise.resolve({ id: "broadcast-1" }) },
+    );
+
+    expect(detailResponse.status).toBe(200);
+    expect(sendResponse.status).toBe(200);
+    expect(mockBroadcastService.getBroadcast).toHaveBeenCalledWith(
+      "user-b",
+      "broadcast-1",
+    );
+    expect(mockBroadcastService.sendBroadcast).toHaveBeenCalledWith({
+      userId: "user-b",
+      id: "broadcast-1",
+      body: sendBody,
+    });
   });
 
   it("passes broadcast send requests through the service with tenant scope", async () => {

--- a/tests/sdk-client.test.tsx
+++ b/tests/sdk-client.test.tsx
@@ -6,15 +6,21 @@ import type {
   AudienceListResponse,
   AudienceResponse,
   BatchEmailResponse,
+  BroadcastListResponse,
+  BroadcastResponse,
   ContactListResponse,
   ContactResponse,
+  CreateBroadcastPayload,
   DeleteAudienceResponse,
+  DeleteBroadcastResponse,
   DeleteContactResponse,
   EmailOptions,
   EmailResponse,
   RequestOptions,
   SDKOptions,
+  SendBroadcastPayload,
   SendEmailPayload,
+  UpdateBroadcastPayload,
 } from "../packages/sdk/src";
 
 describe("Opensend SDK", () => {
@@ -168,6 +174,33 @@ describe("Opensend SDK", () => {
     }>();
     expectTypeOf<DeleteAudienceResponse>().toMatchTypeOf<{
       object: "audience";
+      deleted: true;
+    }>();
+    expectTypeOf<CreateBroadcastPayload>().toMatchTypeOf<{
+      from: string;
+      subject: string;
+      segmentId?: string;
+      scheduledAt?: string;
+    }>();
+    expectTypeOf<UpdateBroadcastPayload>().toMatchTypeOf<{
+      previewText?: string;
+      replyTo?: string;
+    }>();
+    expectTypeOf<SendBroadcastPayload>().toMatchTypeOf<{
+      scheduledAt?: string;
+    }>();
+    expectTypeOf<BroadcastListResponse>().toMatchTypeOf<{
+      object: "list";
+      data: Array<{ id: string; scheduled_at: string | null }>;
+      has_more: boolean;
+    }>();
+    expectTypeOf<BroadcastResponse>().toMatchTypeOf<{
+      object: "broadcast";
+      id: string;
+      reply_to?: string | null;
+    }>();
+    expectTypeOf<DeleteBroadcastResponse>().toMatchTypeOf<{
+      object: "broadcast";
       deleted: true;
     }>();
     expectTypeOf<ContactListResponse>().toMatchTypeOf<{
@@ -379,6 +412,125 @@ describe("Opensend SDK", () => {
       4,
       "https://api.example.com/audiences/aud_123",
       expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("uses Resend-compatible root broadcasts endpoints and maps camelCase payload aliases", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({ object: "broadcast", id: "broadcast_123" }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new Opensend("re_test", {
+      baseUrl: "https://api.example.com",
+    });
+    const resend = new Resend("re_test", {
+      baseUrl: "https://api.example.com",
+    });
+
+    await client.broadcasts.create(
+      {
+        name: "Newsletter",
+        from: "Acme <news@example.com>",
+        subject: "Updates",
+        html: "<p>Hello</p>",
+        segmentId: "seg_123",
+        topicId: "topic_123",
+        replyTo: "reply@example.com",
+        previewText: "Preview",
+        scheduledAt: "in 1 min",
+        send: true,
+      },
+      { idempotencyKey: "broadcast-create-key" },
+    );
+    await client.broadcasts.list({
+      limit: 10,
+      after: "broadcast_100",
+      search: "news",
+      status: "draft",
+      segmentId: "seg_123",
+    });
+    await resend.broadcasts.get("broadcast_123");
+    await resend.broadcasts.update("broadcast_123", {
+      previewText: "Updated preview",
+      replyTo: "support@example.com",
+      scheduledAt: "2026-06-01T00:00:00.000Z",
+    });
+    await resend.broadcasts.delete("broadcast_123");
+    await resend.broadcasts.send(
+      "broadcast_123",
+      { scheduledAt: "in 1 min" },
+      { idempotencyKey: "broadcast-send-key" },
+    );
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example.com/broadcasts",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Idempotency-Key": "broadcast-create-key",
+        }),
+      }),
+    );
+    const createCallOptions = fetchMock.mock.calls[0]?.[1];
+    expect(JSON.parse(String(createCallOptions?.body))).toEqual({
+      name: "Newsletter",
+      from: "Acme <news@example.com>",
+      subject: "Updates",
+      html: "<p>Hello</p>",
+      send: true,
+      segment_id: "seg_123",
+      topic_id: "topic_123",
+      reply_to: "reply@example.com",
+      preview_text: "Preview",
+      scheduled_at: "in 1 min",
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.example.com/broadcasts?limit=10&after=broadcast_100&search=news&status=draft&segmentId=seg_123",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "https://api.example.com/broadcasts/broadcast_123",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      "https://api.example.com/broadcasts/broadcast_123",
+      expect.objectContaining({
+        method: "PATCH",
+      }),
+    );
+    const updateCallOptions = fetchMock.mock.calls[3]?.[1];
+    expect(JSON.parse(String(updateCallOptions?.body))).toEqual({
+      preview_text: "Updated preview",
+      reply_to: "support@example.com",
+      scheduled_at: "2026-06-01T00:00:00.000Z",
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      5,
+      "https://api.example.com/broadcasts/broadcast_123",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      6,
+      "https://api.example.com/broadcasts/broadcast_123/send",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Idempotency-Key": "broadcast-send-key",
+        }),
+        body: JSON.stringify({ scheduled_at: "in 1 min" }),
+      }),
     );
   });
 


### PR DESCRIPTION
Closes #365

## Summary
- Expose Resend-compatible broadcasts root API aliases while preserving the dashboard `/broadcasts` page.
- Add `client.broadcasts.create/list/get/update/delete/send` with camelCase alias mapping (`segmentId`, `topicId`, `replyTo`, `previewText`, `scheduledAt`) to the existing snake_case HTTP payload shape.
- Update public docs examples to show root `/broadcasts` HTTP calls and SDK create/send usage.
- Add route-level and SDK tests for API alias behavior, dashboard fallthrough protection, and SDK path/payload mapping.

## Validation
- `bun run test tests/sdk-client.test.tsx tests/broadcast-tenant-routes.test.ts`
- `bun run typecheck`
- `bun run build` (passed after clearing stale `.next`; emitted existing Better Auth default-secret warnings during page-data collection)
- `make check`
- `make test`
- Push guardrails: change-scoped check, full-project typecheck, and changed-file Biome lint passed during `git push`.

## Residual risk
- Playwright e2e smoke was not run; route-level middleware/adapter tests cover the root aliases and dashboard navigation protection instead.
- `GET /broadcasts` collection API uses API-like request detection in middleware so browser HTML navigation continues to the dashboard while SDK/API requests rewrite to `/api/broadcasts`.
