### PR TITLE
Fix Settings Usage quota and upgrade affordances

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-369-usage-billing-limits.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-369-usage-billing-limits.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-11
+issue: 369
+type: decision
+promoted_to: null
+---
+
+## Usage tab limits must come from billing when billing is enabled
+
+Settings `/api/usage` still uses the dashboard aggregate service for dashboard counters, but when Stripe billing is enabled the route adapter enriches the payload from `loadBillingSummary(userId)`. That makes the Usage tab's plan label, monthly email quota, domain usage count, and domain limit match the active billing plan source of truth.
+
+The aggregate-service fallback now uses `FREE_PLAN_DEFAULTS` exported from core DTOs instead of duplicating Free plan literals. Keep future dashboard fallback limits tied to the same defaults used by `planRepo.ensureFreePlan()` and billing quota fallback creation so the disabled/missing-billing path cannot drift independently.

--- a/packages/core/src/db/repositories/planRepo.ts
+++ b/packages/core/src/db/repositories/planRepo.ts
@@ -1,5 +1,5 @@
 import { asc, eq } from "drizzle-orm";
-import { FREE_PLAN_SLUG } from "../../dto";
+import { FREE_PLAN_DEFAULTS, FREE_PLAN_SLUG } from "../../dto";
 import { db } from "../client";
 import { plans } from "../schema";
 
@@ -33,13 +33,13 @@ export const planRepo = {
     const [row] = await db
       .insert(plans)
       .values({
-        slug: FREE_PLAN_SLUG,
-        name: "Free",
-        monthlyPriceCents: 0,
-        monthlyEmailQuota: 3000,
-        maxDomains: 1,
-        maxApiKeys: 3,
-        isPublic: true,
+        slug: FREE_PLAN_DEFAULTS.slug,
+        name: FREE_PLAN_DEFAULTS.name,
+        monthlyPriceCents: FREE_PLAN_DEFAULTS.monthlyPriceCents,
+        monthlyEmailQuota: FREE_PLAN_DEFAULTS.monthlyEmailQuota,
+        maxDomains: FREE_PLAN_DEFAULTS.maxDomains,
+        maxApiKeys: FREE_PLAN_DEFAULTS.maxApiKeys,
+        isPublic: FREE_PLAN_DEFAULTS.isPublic,
       })
       .onConflictDoNothing({ target: plans.slug })
       .returning();

--- a/packages/core/src/dto/index.ts
+++ b/packages/core/src/dto/index.ts
@@ -366,3 +366,12 @@ export interface UsagePeriodResponse {
 }
 
 export const FREE_PLAN_SLUG = "free";
+export const FREE_PLAN_DEFAULTS = {
+  slug: FREE_PLAN_SLUG,
+  name: "Free",
+  monthlyPriceCents: 0,
+  monthlyEmailQuota: 3000,
+  maxDomains: 1,
+  maxApiKeys: 3,
+  isPublic: true,
+} as const;

--- a/packages/core/src/services/dashboardAggregates.ts
+++ b/packages/core/src/services/dashboardAggregates.ts
@@ -1,10 +1,14 @@
 import { type SQL, and, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import { db } from "../db/client";
 import { contacts, domains, emails, segments } from "../db/schema";
+import { FREE_PLAN_DEFAULTS } from "../dto";
 
+// Fallback display limits for installations without an active billing summary.
+// Keep plan-backed values tied to FREE_PLAN_DEFAULTS so the fallback cannot
+// drift from the Free plan rows created by quota enforcement and planRepo.
 export const DASHBOARD_USAGE_LIMITS = {
   transactional: {
-    monthlyLimit: 3000,
+    monthlyLimit: FREE_PLAN_DEFAULTS.monthlyEmailQuota,
     dailyLimit: 100,
   },
   marketing: {
@@ -13,7 +17,7 @@ export const DASHBOARD_USAGE_LIMITS = {
     broadcastsLimit: "Unlimited",
   },
   team: {
-    domainsLimit: 3,
+    domainsLimit: FREE_PLAN_DEFAULTS.maxDomains,
     rateLimit: 2,
   },
 } as const;
@@ -148,23 +152,27 @@ export type DashboardMetricsPayload = {
 };
 
 export type DashboardUsagePayload = {
+  plan: {
+    name: string;
+    slug: string;
+  };
   transactional: {
     monthlyUsed: number;
-    monthlyLimit: typeof DASHBOARD_USAGE_LIMITS.transactional.monthlyLimit;
+    monthlyLimit: number;
     dailyUsed: number;
-    dailyLimit: typeof DASHBOARD_USAGE_LIMITS.transactional.dailyLimit;
+    dailyLimit: number;
   };
   marketing: {
     contactsUsed: number;
-    contactsLimit: typeof DASHBOARD_USAGE_LIMITS.marketing.contactsLimit;
+    contactsLimit: number;
     segmentsUsed: number;
-    segmentsLimit: typeof DASHBOARD_USAGE_LIMITS.marketing.segmentsLimit;
+    segmentsLimit: number;
     broadcastsLimit: typeof DASHBOARD_USAGE_LIMITS.marketing.broadcastsLimit;
   };
   team: {
     domainsUsed: number;
-    domainsLimit: typeof DASHBOARD_USAGE_LIMITS.team.domainsLimit;
-    rateLimit: typeof DASHBOARD_USAGE_LIMITS.team.rateLimit;
+    domainsLimit: number;
+    rateLimit: number;
   };
 };
 
@@ -379,6 +387,10 @@ export function createDashboardAggregateService({
       const counts = await repository.countUsage(getUsageBounds(now));
 
       return {
+        plan: {
+          name: FREE_PLAN_DEFAULTS.name,
+          slug: FREE_PLAN_DEFAULTS.slug,
+        },
         transactional: {
           monthlyUsed: counts.monthlyEmails,
           monthlyLimit: DASHBOARD_USAGE_LIMITS.transactional.monthlyLimit,

--- a/src/app/api/usage/route.ts
+++ b/src/app/api/usage/route.ts
@@ -1,4 +1,6 @@
 import { getServerSession, unauthorizedResponse } from "@/lib/api-auth";
+import { isBillingEnabled } from "@/lib/billing";
+import { loadBillingSummary } from "@/lib/billing/summary";
 import { createDashboardAggregateService } from "@opensend/core";
 import { NextResponse } from "next/server";
 
@@ -11,7 +13,30 @@ export async function GET() {
 
   try {
     const payload = await dashboardAggregateService.getUsage();
-    return NextResponse.json(payload);
+
+    if (!isBillingEnabled() || !session.user?.id) {
+      return NextResponse.json(payload);
+    }
+
+    const billingSummary = await loadBillingSummary(session.user.id);
+    if (!billingSummary) return NextResponse.json(payload);
+
+    return NextResponse.json({
+      ...payload,
+      plan: {
+        name: billingSummary.plan.name,
+        slug: billingSummary.plan.slug,
+      },
+      transactional: {
+        ...payload.transactional,
+        monthlyLimit: billingSummary.plan.monthlyEmailQuota,
+      },
+      team: {
+        ...payload.team,
+        domainsUsed: billingSummary.usage.domains.used,
+        domainsLimit: billingSummary.usage.domains.limit,
+      },
+    });
   } catch (error) {
     console.error("Failed to fetch usage:", error);
     return NextResponse.json(

--- a/src/components/settings-page.tsx
+++ b/src/components/settings-page.tsx
@@ -13,6 +13,10 @@ function isUsageData(value: unknown): value is UsageData {
   const candidate = value as Partial<UsageData> & Record<string, unknown>;
 
   return (
+    typeof candidate.plan === "object" &&
+    candidate.plan !== null &&
+    typeof candidate.plan.name === "string" &&
+    typeof candidate.plan.slug === "string" &&
     typeof candidate.transactional === "object" &&
     candidate.transactional !== null &&
     typeof candidate.transactional.monthlyUsed === "number" &&
@@ -42,6 +46,7 @@ const SMTP_CREDENTIALS = [
 ];
 
 const DEFAULT_USAGE: UsageData = {
+  plan: { name: "Free", slug: "free" },
   transactional: {
     monthlyUsed: 0,
     monthlyLimit: 3000,
@@ -55,7 +60,7 @@ const DEFAULT_USAGE: UsageData = {
     segmentsLimit: 3,
     broadcastsLimit: "Unlimited",
   },
-  team: { domainsUsed: 0, domainsLimit: 3, rateLimit: 2 },
+  team: { domainsUsed: 0, domainsLimit: 1, rateLimit: 2 },
 };
 
 interface SettingsPageProps {
@@ -121,7 +126,9 @@ export function SettingsPage({
       </div>
 
       {/* Usage Tab */}
-      {activeTab === "usage" && <UsageTab usage={usage} />}
+      {activeTab === "usage" && (
+        <UsageTab usage={usage} billingEnabled={billingEnabled} />
+      )}
 
       {/* SMTP Tab */}
       {activeTab === "smtp" && (

--- a/src/components/settings-usage.tsx
+++ b/src/components/settings-usage.tsx
@@ -2,7 +2,13 @@
 
 "use client";
 
+import Link from "next/link";
+
 export interface UsageData {
+  plan: {
+    name: string;
+    slug: string;
+  };
   transactional: {
     monthlyUsed: number;
     monthlyLimit: number;
@@ -25,6 +31,10 @@ export interface UsageData {
 
 function formatNumber(n: number): string {
   return n.toLocaleString("en-US");
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`) {
+  return count === 1 ? singular : plural;
 }
 
 function QuotaIndicator({
@@ -113,39 +123,79 @@ function QuotaRow({
   );
 }
 
+function UpgradeAffordance({ billingEnabled }: { billingEnabled: boolean }) {
+  if (billingEnabled) {
+    return (
+      <Link
+        href="/pricing"
+        className="inline-flex rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] px-3 py-1.5 text-[13px] font-medium text-[#F0F0F0] hover:bg-[rgba(24,25,28,1)]"
+      >
+        Upgrade
+      </Link>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        disabled
+        className="rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.5)] px-3 py-1.5 text-[13px] font-medium text-[#A1A4A5] opacity-70"
+      >
+        Upgrade unavailable
+      </button>
+      <p className="text-[12px] text-[#A1A4A5]">
+        Billing is disabled for this installation, so plan upgrades are not
+        available here.
+      </p>
+    </div>
+  );
+}
+
 function QuotaSection({
   title,
   description,
+  planName,
+  billingEnabled,
+  overLimitMessage,
   children,
 }: {
   title: string;
   description: string;
+  planName: string;
+  billingEnabled: boolean;
+  overLimitMessage?: string;
   children: React.ReactNode;
 }) {
   return (
-    <div className="border-b border-[rgba(176,199,217,0.145)] pb-8 mb-8 last:border-b-0 last:mb-0 last:pb-0">
+    <div className="mb-8 border-b border-[rgba(176,199,217,0.145)] pb-8 last:mb-0 last:border-b-0 last:pb-0">
       <div className="flex items-start justify-between gap-12">
         {/* Left side — title, description, upgrade */}
         <div className="max-w-[340px] shrink-0">
-          <h2 className="text-[18px] font-semibold text-[#F0F0F0] mb-2">
+          <h2 className="mb-2 text-[18px] font-semibold text-[#F0F0F0]">
             {title}
           </h2>
-          <p className="text-[14px] text-[#A1A4A5] leading-relaxed mb-4">
+          <p className="mb-4 text-[14px] leading-relaxed text-[#A1A4A5]">
             {description}
           </p>
-          <button
-            type="button"
-            className="px-3 py-1.5 text-[13px] font-medium text-[#F0F0F0] bg-[rgba(24,25,28,0.88)] border border-[rgba(176,199,217,0.145)] rounded-md hover:bg-[rgba(24,25,28,1)]"
-          >
-            Upgrade
-          </button>
+          <UpgradeAffordance billingEnabled={billingEnabled} />
         </div>
 
         {/* Right side — plan badge + quota rows */}
         <div className="flex-1">
-          <div className="flex justify-end mb-4">
-            <span className="text-[14px] font-medium text-[#F0F0F0]">Free</span>
+          <div className="mb-4 flex justify-end">
+            <span className="text-[14px] font-medium text-[#F0F0F0]">
+              {planName}
+            </span>
           </div>
+          {overLimitMessage ? (
+            <p
+              className="mb-2 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-[13px] text-red-200"
+              role="alert"
+            >
+              {overLimitMessage}
+            </p>
+          ) : null}
           <div>{children}</div>
         </div>
       </div>
@@ -153,12 +203,32 @@ function QuotaSection({
   );
 }
 
-export function UsageTab({ usage }: { usage: UsageData }) {
+function getTeamOverLimitMessage(usage: UsageData): string | undefined {
+  const overBy = usage.team.domainsUsed - usage.team.domainsLimit;
+  if (overBy <= 0) return undefined;
+
+  return `You are ${formatNumber(overBy)} ${pluralize(
+    overBy,
+    "domain",
+  )} over the ${usage.plan.name} plan domain limit.`;
+}
+
+export function UsageTab({
+  usage,
+  billingEnabled = false,
+}: {
+  usage: UsageData;
+  billingEnabled?: boolean;
+}) {
+  const planName = usage.plan.name;
+
   return (
     <div>
       <QuotaSection
         title="Transactional"
         description="Integrate email into your app using the Resend API or SMTP interface."
+        planName={planName}
+        billingEnabled={billingEnabled}
       >
         <QuotaRow
           label="Monthly limit"
@@ -177,6 +247,8 @@ export function UsageTab({ usage }: { usage: UsageData }) {
       <QuotaSection
         title="Marketing"
         description="Design and send marketing emails using Broadcasts and Audiences."
+        planName={planName}
+        billingEnabled={billingEnabled}
       >
         <QuotaRow
           label="Contacts limit"
@@ -196,6 +268,9 @@ export function UsageTab({ usage }: { usage: UsageData }) {
       <QuotaSection
         title="Team"
         description="Manage your team settings, domains, and sending rate limits."
+        planName={planName}
+        billingEnabled={billingEnabled}
+        overLimitMessage={getTeamOverLimitMessage(usage)}
       >
         <QuotaRow
           label="Domains limit"

--- a/src/lib/billing/quota.ts
+++ b/src/lib/billing/quota.ts
@@ -7,7 +7,7 @@ import {
   subscriptions,
   usagePeriods,
 } from "@/lib/db/schema";
-import { FREE_PLAN_SLUG } from "@opensend/core";
+import { FREE_PLAN_DEFAULTS, FREE_PLAN_SLUG } from "@opensend/core";
 import { and, count, eq, sql } from "drizzle-orm";
 import { getBillingBackend } from "./index";
 
@@ -76,13 +76,13 @@ async function ensureFreePlan(database: BillingDb): Promise<PlanLike> {
   const [created] = await database
     .insert(plans)
     .values({
-      slug: FREE_PLAN_SLUG,
-      name: "Free",
-      monthlyPriceCents: 0,
-      monthlyEmailQuota: 3000,
-      maxDomains: 1,
-      maxApiKeys: 3,
-      isPublic: true,
+      slug: FREE_PLAN_DEFAULTS.slug,
+      name: FREE_PLAN_DEFAULTS.name,
+      monthlyPriceCents: FREE_PLAN_DEFAULTS.monthlyPriceCents,
+      monthlyEmailQuota: FREE_PLAN_DEFAULTS.monthlyEmailQuota,
+      maxDomains: FREE_PLAN_DEFAULTS.maxDomains,
+      maxApiKeys: FREE_PLAN_DEFAULTS.maxApiKeys,
+      isPublic: FREE_PLAN_DEFAULTS.isPublic,
     })
     .onConflictDoNothing({ target: plans.slug })
     .returning();

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -311,6 +311,7 @@ describe("route smoke coverage", () => {
               mockCountFn(),
             ]);
             return {
+              plan: { name: "Free", slug: "free" },
               transactional: {
                 monthlyUsed: Number(monthlyEmails),
                 monthlyLimit: 3000,
@@ -326,7 +327,7 @@ describe("route smoke coverage", () => {
               },
               team: {
                 domainsUsed: Number(domainCount),
-                domainsLimit: 3,
+                domainsLimit: 1,
                 rateLimit: 2,
               },
             };

--- a/tests/dashboard-aggregates-service.test.ts
+++ b/tests/dashboard-aggregates-service.test.ts
@@ -184,6 +184,7 @@ describe("dashboard aggregate service", () => {
     expect(countInput?.startOfMonth).toEqual(new Date(2026, 3, 1));
     expect(countInput?.startOfDay).toEqual(new Date(2026, 3, 23));
     expect(payload).toEqual({
+      plan: { name: "Free", slug: "free" },
       transactional: {
         monthlyUsed: 42,
         monthlyLimit: 3000,
@@ -199,7 +200,7 @@ describe("dashboard aggregate service", () => {
       },
       team: {
         domainsUsed: 2,
-        domainsLimit: 3,
+        domainsLimit: 1,
         rateLimit: 2,
       },
     });

--- a/tests/e2e/settings-usage.spec.ts
+++ b/tests/e2e/settings-usage.spec.ts
@@ -1,39 +1,66 @@
-// ABOUTME: E2E test for Settings Usage tab — verifies all 3 quota sections render with correct labels and values
+// ABOUTME: E2E test for Settings Usage tab — verifies quota sections and billing-aware upgrade affordances
 
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures/auth";
+
+const billingEnabled =
+  process.env.BILLING_BACKEND?.toLowerCase() === "stripe" &&
+  Boolean(process.env.STRIPE_SECRET_KEY?.trim());
 
 test.describe("Settings Usage Page", () => {
-  test("displays all quota sections with correct labels", async ({ page }) => {
-    await page.goto("/settings");
+  test("displays all quota sections with correct labels", async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto("/settings");
 
     // Usage tab should be active by default
-    const usageTab = page.locator('button:has-text("Usage")');
+    const usageTab = authenticatedPage.locator('button:has-text("Usage")');
     await expect(usageTab).toBeVisible();
     await expect(usageTab).toHaveAttribute("data-state", "active");
 
     // Transactional section
-    await expect(page.locator("text=Transactional")).toBeVisible();
-    await expect(page.locator("text=Monthly limit")).toBeVisible();
-    await expect(page.locator("text=Daily limit")).toBeVisible();
+    await expect(authenticatedPage.locator("text=Transactional")).toBeVisible();
+    await expect(authenticatedPage.locator("text=Monthly limit")).toBeVisible();
+    await expect(authenticatedPage.locator("text=Daily limit")).toBeVisible();
 
     // Marketing section
-    await expect(page.locator("text=Marketing")).toBeVisible();
-    await expect(page.locator("text=Contacts limit")).toBeVisible();
-    await expect(page.locator("text=Segments limit")).toBeVisible();
-    await expect(page.locator("text=Broadcasts limit")).toBeVisible();
-    await expect(page.locator("text=Unlimited")).toBeVisible();
+    await expect(authenticatedPage.locator("text=Marketing")).toBeVisible();
+    await expect(
+      authenticatedPage.locator("text=Contacts limit"),
+    ).toBeVisible();
+    await expect(
+      authenticatedPage.locator("text=Segments limit"),
+    ).toBeVisible();
+    await expect(
+      authenticatedPage.locator("text=Broadcasts limit"),
+    ).toBeVisible();
+    await expect(authenticatedPage.locator("text=Unlimited")).toBeVisible();
 
     // Team section
-    await expect(page.locator("text=Team")).toBeVisible();
-    await expect(page.locator("text=Domains limit")).toBeVisible();
-    await expect(page.locator("text=Rate limit")).toBeVisible();
+    await expect(authenticatedPage.locator("text=Team")).toBeVisible();
+    await expect(authenticatedPage.locator("text=Domains limit")).toBeVisible();
+    await expect(authenticatedPage.locator("text=Rate limit")).toBeVisible();
 
     // Free badges
-    const freeBadges = page.locator("text=Free");
+    const freeBadges = authenticatedPage.locator("text=Free");
     await expect(freeBadges.first()).toBeVisible();
 
-    // Upgrade buttons
-    const upgradeButtons = page.locator("text=Upgrade");
-    expect(await upgradeButtons.count()).toBeGreaterThanOrEqual(2);
+    if (billingEnabled) {
+      const upgradeLinks = authenticatedPage.getByRole("link", {
+        name: "Upgrade",
+      });
+      await expect(upgradeLinks.first()).toHaveAttribute("href", "/pricing");
+      expect(await upgradeLinks.count()).toBe(3);
+    } else {
+      const unavailableButtons = authenticatedPage.getByRole("button", {
+        name: "Upgrade unavailable",
+      });
+      await expect(unavailableButtons.first()).toBeDisabled();
+      expect(await unavailableButtons.count()).toBe(3);
+      await expect(
+        authenticatedPage
+          .getByText("Billing is disabled for this installation")
+          .first(),
+      ).toBeVisible();
+    }
   });
 });

--- a/tests/settings-page.test.tsx
+++ b/tests/settings-page.test.tsx
@@ -17,6 +17,7 @@ describe("SettingsPage", () => {
       ok: true,
       json: () =>
         Promise.resolve({
+          plan: { name: "Free", slug: "free" },
           transactional: {
             monthlyUsed: 12,
             monthlyLimit: 3000,

--- a/tests/settings-usage.test.tsx
+++ b/tests/settings-usage.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from "vitest";
 afterEach(cleanup);
 
 const defaultUsage = {
+  plan: { name: "Free", slug: "free" },
   transactional: {
     monthlyUsed: 3,
     monthlyLimit: 3000,
@@ -75,10 +76,30 @@ describe("UsageTab", () => {
     expect(screen.getByText(/Design and send marketing emails/)).toBeDefined();
   });
 
-  it("shows upgrade buttons for each section", () => {
-    render(<UsageTab usage={defaultUsage} />);
-    const upgradeButtons = screen.getAllByText("Upgrade");
-    expect(upgradeButtons.length).toBeGreaterThanOrEqual(2);
+  it("links upgrade affordances to pricing when billing is enabled", () => {
+    render(<UsageTab usage={defaultUsage} billingEnabled={true} />);
+
+    const upgradeLinks = screen.getAllByRole("link", { name: "Upgrade" });
+    expect(upgradeLinks).toHaveLength(3);
+    for (const link of upgradeLinks) {
+      expect(link.getAttribute("href")).toBe("/pricing");
+    }
+  });
+
+  it("renders disabled explanatory upgrade affordances when billing is disabled", () => {
+    render(<UsageTab usage={defaultUsage} billingEnabled={false} />);
+
+    expect(screen.queryByRole("link", { name: "Upgrade" })).toBeNull();
+    const unavailableButtons = screen.getAllByRole("button", {
+      name: "Upgrade unavailable",
+    });
+    expect(unavailableButtons).toHaveLength(3);
+    for (const button of unavailableButtons) {
+      expect(button).toHaveProperty("disabled", true);
+    }
+    expect(
+      screen.getAllByText(/Billing is disabled for this installation/),
+    ).toHaveLength(3);
   });
 
   it("renders circular progress indicators for quota rows", () => {
@@ -102,6 +123,24 @@ describe("UsageTab", () => {
       "svg.quota-indicator.at-limit",
     );
     expect(warningIndicators.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("explains over-limit team domain usage with the active plan name", () => {
+    const overLimitUsage = {
+      ...defaultUsage,
+      team: {
+        ...defaultUsage.team,
+        domainsUsed: 4,
+        domainsLimit: 3,
+      },
+    };
+
+    render(<UsageTab usage={overLimitUsage} billingEnabled={true} />);
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "You are 1 domain over the Free plan domain limit.",
+    );
+    expect(screen.getByText("4 / 3")).toBeDefined();
   });
 
   it("formats numbers with commas", () => {

--- a/tests/usage-route.test.ts
+++ b/tests/usage-route.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockGetUsage = vi.hoisted(() => vi.fn());
+const mockIsBillingEnabled = vi.hoisted(() => vi.fn());
+const mockLoadBillingSummary = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/api-auth", () => ({
   getServerSession: mockGetServerSession,
@@ -12,6 +14,14 @@ vi.mock("@/lib/api-auth", () => ({
     }),
 }));
 
+vi.mock("@/lib/billing", () => ({
+  isBillingEnabled: mockIsBillingEnabled,
+}));
+
+vi.mock("@/lib/billing/summary", () => ({
+  loadBillingSummary: mockLoadBillingSummary,
+}));
+
 vi.mock("@opensend/core", () => ({
   createDashboardAggregateService: () => ({
     getUsage: mockGetUsage,
@@ -19,6 +29,7 @@ vi.mock("@opensend/core", () => ({
 }));
 
 const usagePayload = {
+  plan: { name: "Free", slug: "free" },
   transactional: {
     monthlyUsed: 42,
     monthlyLimit: 3000,
@@ -34,7 +45,7 @@ const usagePayload = {
   },
   team: {
     domainsUsed: 2,
-    domainsLimit: 3,
+    domainsLimit: 1,
     rateLimit: 2,
   },
 };
@@ -48,6 +59,8 @@ describe("usage route adapter", () => {
       user: { id: "user-1" },
     });
     mockGetUsage.mockResolvedValue(usagePayload);
+    mockIsBillingEnabled.mockReturnValue(false);
+    mockLoadBillingSummary.mockResolvedValue(null);
   });
 
   it("keeps dashboard auth adapter-side and returns the core usage envelope", async () => {
@@ -56,7 +69,52 @@ describe("usage route adapter", () => {
 
     expect(response.status).toBe(200);
     expect(mockGetUsage).toHaveBeenCalledOnce();
+    expect(mockLoadBillingSummary).not.toHaveBeenCalled();
     await expect(response.json()).resolves.toEqual(usagePayload);
+  });
+
+  it("uses the billing summary as the source of truth for active plan domain limits", async () => {
+    mockIsBillingEnabled.mockReturnValue(true);
+    mockLoadBillingSummary.mockResolvedValueOnce({
+      plan: {
+        id: "plan-pro",
+        slug: "pro",
+        name: "Pro",
+        monthlyPriceCents: 2900,
+        monthlyEmailQuota: 50000,
+        maxDomains: 10,
+        maxApiKeys: 10,
+        isPublic: true,
+      },
+      subscription: null,
+      usage: {
+        emails: { used: 123, limit: 50000 },
+        domains: { used: 4, limit: 10 },
+        apiKeys: { used: 1, limit: 10 },
+        periodStart: null,
+        periodEnd: null,
+        hasUsagePeriod: false,
+      },
+    });
+
+    const usageRoute = await import("@/app/api/usage/route");
+    const response = await usageRoute.GET();
+
+    expect(response.status).toBe(200);
+    expect(mockLoadBillingSummary).toHaveBeenCalledWith("user-1");
+    await expect(response.json()).resolves.toEqual({
+      ...usagePayload,
+      plan: { name: "Pro", slug: "pro" },
+      transactional: {
+        ...usagePayload.transactional,
+        monthlyLimit: 50000,
+      },
+      team: {
+        ...usagePayload.team,
+        domainsUsed: 4,
+        domainsLimit: 10,
+      },
+    });
   });
 
   it("maps missing sessions and service failures to existing responses", async () => {


### PR DESCRIPTION
## Summary
- Routes Settings > Usage upgrade affordances to `/pricing` when billing is enabled and renders disabled explanatory copy when billing is unavailable.
- Enriches `/api/usage` from `loadBillingSummary(userId)` so active plan label, monthly email quota, domain usage, and domain limit come from the billing source of truth.
- Centralizes Free plan fallback limits in `FREE_PLAN_DEFAULTS` so dashboard fallback, quota fallback, and plan repo defaults do not drift.
- Adds over-limit Team domain copy and coverage for enabled/disabled upgrade states.

Closes #369

## Tests
- `make check && make test`
- `.scratch/issue-369-usage-ui-scenario.sh`
- `bunx vitest run tests/settings-usage.test.tsx tests/settings-page.test.tsx tests/usage-route.test.ts tests/dashboard-aggregates-service.test.ts`
- `bunx vitest run tests/api-auth-date-range-routes.test.ts tests/billing-quota.test.ts tests/billing-plan-repo.test.ts tests/billing-usage.test.ts`
- `bunx playwright test tests/e2e/settings-usage.spec.ts` (skipped locally because `DATABASE_URL` is required for auth-backed E2E)

## Residual risk
- Live Stripe checkout was not exercised locally; Usage links intentionally hand off to the existing `/pricing` checkout flow.
