### PR TITLE
Make React Email first-class in the TypeScript SDK

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -73,9 +73,21 @@
     "packages/sdk": {
       "name": "opensend",
       "version": "1.0.0",
+      "dependencies": {
+        "@types/react": "^19.2.14",
+      },
       "devDependencies": {
+        "@types/react-dom": "^19.2.3",
         "typescript": "^5.0.0",
       },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18",
+      },
+      "optionalPeers": [
+        "react",
+        "react-dom",
+      ],
     },
     "services/api": {
       "name": "@opensend/api",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -65,6 +65,49 @@ returns after the API persists the row and queues background delivery work. Poll
 
 ### With React components
 
+Install React and ReactDOM alongside the SDK when you use the `react` payload.
+They are optional peer dependencies so plain `html`/`text` sends do not pull
+React into non-React applications.
+
+```bash
+bun add opensend react react-dom @react-email/components
+```
+
+```tsx
+import { Html, Text } from "@react-email/components";
+import { Resend } from "opensend";
+
+function EmailTemplate({ name }: { name: string }) {
+  return (
+    <Html>
+      <Text>Hello {name}, welcome to OpenSend.</Text>
+    </Html>
+  );
+}
+
+const resend = new Resend(process.env.OPENSEND_API_KEY);
+
+export async function POST() {
+  const { data, error } = await resend.emails.send({
+    from: "hello@updates.example.com",
+    to: "user@example.com",
+    subject: "Welcome!",
+    react: <EmailTemplate name="Ada" />,
+  });
+
+  if (error) {
+    return Response.json({ error: error.message }, { status: error.statusCode });
+  }
+
+  return Response.json(data);
+}
+```
+
+The SDK renders the React element to HTML locally with `react-dom/server` and
+sends only JSON/HTML to the OpenSend REST API. If ReactDOM is missing or the
+component throws while rendering, `emails.send()` returns a
+`react_render_error` SDK error and does not call the API.
+
 ```tsx
 const { data } = await resend.emails.send({
   from: "hello@updates.example.com",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -17,7 +17,23 @@
   },
   "keywords": ["email", "api", "sdk", "resend"],
   "license": "MIT",
+  "dependencies": {
+    "@types/react": "^19.2.14"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@types/react-dom": "^19.2.3",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type {
   ApiKeyListItem,
   ApiKeyListResponse,
@@ -63,7 +64,7 @@ interface ApiResponse<T> {
 }
 
 export type SendEmailPayload = EmailOptions & {
-  react?: unknown;
+  react?: ReactNode;
 };
 export type CreateDomainPayload = DomainOptions;
 
@@ -314,14 +315,49 @@ function toBroadcastPayload<T extends BroadcastPayloadAliases>(
   return normalized;
 }
 
-async function renderReactToHtml(element: unknown): Promise<string | null> {
+interface ReactRenderSuccess {
+  html: string;
+  error: null;
+}
+
+interface ReactRenderFailure {
+  html: null;
+  error: ApiError;
+}
+
+type ReactRenderResult = ReactRenderSuccess | ReactRenderFailure;
+
+function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function createReactRenderError(error: unknown): ApiError {
+  const cause = formatUnknownError(error);
+
+  return {
+    message:
+      "Unable to render React email in the OpenSend SDK. Install react and react-dom in your application, then pass a renderable React element to emails.send({ react }).",
+    statusCode: 500,
+    name: "react_render_error",
+    code: "react_render_error",
+    details: { cause },
+  };
+}
+
+async function renderReactToHtml(
+  element: ReactNode,
+): Promise<ReactRenderResult> {
   try {
-    const { renderToStaticMarkup } = await import("react-dom/server");
-    return renderToStaticMarkup(
-      element as Parameters<typeof renderToStaticMarkup>[0],
-    );
-  } catch {
-    return null;
+    const renderer = await import("react-dom/server");
+    if (typeof renderer.renderToStaticMarkup !== "function") {
+      throw new Error(
+        "react-dom/server is unavailable: renderToStaticMarkup export was not found.",
+      );
+    }
+
+    return { html: renderer.renderToStaticMarkup(element), error: null };
+  } catch (error) {
+    return { html: null, error: createReactRenderError(error) };
   }
 }
 
@@ -388,9 +424,10 @@ class Emails {
 
     if (react != null) {
       const rendered = await renderReactToHtml(react);
-      if (rendered) {
-        rest.html = rendered;
+      if (rendered.error) {
+        return { data: null, error: rendered.error };
       }
+      rest.html = rendered.html;
     }
 
     return this.http.request<EmailResponse>("POST", "/emails", rest, options);

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -442,6 +442,56 @@ Content-Type: application/json
               contact properties, API-key management, and public npx packaging.
             </p>
           </div>
+
+          <div className="mt-5 rounded-lg border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.5)] p-4 space-y-3">
+            <h2 className="text-[15px] font-semibold text-[#F0F0F0]">
+              React Email with the TypeScript SDK
+            </h2>
+            <p className="text-[13px] text-[#A1A4A5]">
+              Use the Resend-compatible SDK path when you want to author emails
+              as React components. Install{" "}
+              <code className="font-mono text-[#F0F0F0]">react</code> and{" "}
+              <code className="font-mono text-[#F0F0F0]">react-dom</code>{" "}
+              alongside{" "}
+              <code className="font-mono text-[#F0F0F0]">opensend</code>; the
+              SDK renders the component to HTML locally and posts JSON to the
+              email API.
+            </p>
+            <pre className="text-[12px] text-[#A1A4A5] font-mono bg-[rgba(24,25,28,0.88)] border border-[rgba(176,199,217,0.145)] rounded-lg p-4 overflow-x-auto whitespace-pre-wrap">
+              {`import { Html, Text } from "@react-email/components";
+import { Resend } from "opensend";
+
+function EmailTemplate({ name }: { name: string }) {
+  return (
+    <Html>
+      <Text>Hello {name}, welcome to OpenSend.</Text>
+    </Html>
+  );
+}
+
+const resend = new Resend(process.env.OPENSEND_API_KEY);
+
+export async function POST() {
+  const { data, error } = await resend.emails.send({
+    from: "hello@updates.example.com",
+    to: "user@example.com",
+    subject: "Welcome!",
+    react: <EmailTemplate name="Ada" />,
+  });
+
+  if (error) {
+    return Response.json({ error: error.message }, { status: error.statusCode });
+  }
+
+  return Response.json(data);
+}`}
+            </pre>
+            <p className="text-[12px] text-[#A1A4A5]">
+              The REST API remains JSON-only: send React components through the
+              TypeScript SDK, or send pre-rendered{" "}
+              <code className="font-mono text-[#F0F0F0]">html</code> directly.
+            </p>
+          </div>
         </div>
 
         {/* Groups */}

--- a/tests/sdk-client.test.tsx
+++ b/tests/sdk-client.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { DEFAULT_BASE_URL, Opensend, Resend } from "../packages/sdk/src";
 import type {
@@ -26,6 +27,8 @@ import type {
 describe("Opensend SDK", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.doUnmock("react-dom/server");
   });
 
   it("constructs Resend and Opensend clients with the hosted default baseUrl", async () => {
@@ -151,7 +154,7 @@ describe("Opensend SDK", () => {
     expectTypeOf<SDKOptions>().toMatchTypeOf<{ baseUrl?: string }>();
     expectTypeOf<RequestOptions>().toMatchTypeOf<{ idempotencyKey?: string }>();
     expectTypeOf<SendEmailPayload>().toMatchTypeOf<
-      EmailOptions & { react?: unknown }
+      EmailOptions & { react?: ReactNode }
     >();
     expectTypeOf<ApiResponse<EmailResponse>>().toEqualTypeOf<{
       data: EmailResponse | null;
@@ -242,7 +245,88 @@ describe("Opensend SDK", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, options] = fetchMock.mock.calls[0] ?? [];
-    expect(options?.body).toContain("<strong>Hello</strong>");
+    const outgoingBody = JSON.parse(String(options?.body)) as Record<
+      string,
+      unknown
+    >;
+    expect(outgoingBody).toMatchObject({
+      from: "hello@example.com",
+      to: "user@example.com",
+      subject: "Hello",
+      html: "<strong>Hello</strong>",
+    });
+    expect(outgoingBody).not.toHaveProperty("react");
+  });
+
+  it("returns a clear SDK error when the React renderer cannot load", async () => {
+    vi.resetModules();
+    vi.doMock("react-dom/server", () => ({
+      renderToStaticMarkup: "missing renderer",
+    }));
+
+    const { Opensend: MockedOpensend } = await import("../packages/sdk/src");
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new MockedOpensend("re_test", {
+      baseUrl: "https://api.example.com",
+    });
+
+    const response = await client.emails.send({
+      from: "hello@example.com",
+      to: "user@example.com",
+      subject: "Hello",
+      react: <strong>Hello</strong>,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response).toEqual({
+      data: null,
+      error: {
+        name: "react_render_error",
+        code: "react_render_error",
+        statusCode: 500,
+        message:
+          "Unable to render React email in the OpenSend SDK. Install react and react-dom in your application, then pass a renderable React element to emails.send({ react }).",
+        details: {
+          cause:
+            "react-dom/server is unavailable: renderToStaticMarkup export was not found.",
+        },
+      },
+    });
+
+    vi.doUnmock("react-dom/server");
+    vi.resetModules();
+  });
+
+  it("returns a clear SDK error when React rendering throws", async () => {
+    function BrokenEmail(): ReactNode {
+      throw new Error("template exploded");
+    }
+
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new Opensend("re_test", {
+      baseUrl: "https://api.example.com",
+    });
+
+    const response = await client.emails.send({
+      from: "hello@example.com",
+      to: "user@example.com",
+      subject: "Hello",
+      react: <BrokenEmail />,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.error).toMatchObject({
+      name: "react_render_error",
+      code: "react_render_error",
+      statusCode: 500,
+      message:
+        "Unable to render React email in the OpenSend SDK. Install react and react-dom in your application, then pass a renderable React element to emails.send({ react }).",
+      details: { cause: "template exploded" },
+    });
   });
 
   it("passes email lifecycle status filters when listing emails", async () => {


### PR DESCRIPTION
## Summary
- Makes the TypeScript SDK `react` send payload a typed `ReactNode` path instead of `unknown`.
- Renders React payloads to outgoing HTML locally and returns `react_render_error` without calling the API when the renderer is missing/invalid or component rendering throws.
- Declares the SDK React/ReactDOM optional peer contract and documents React Email / Next.js-style usage with `import { Resend } from "opensend"`.

Closes #372

## Validation
- `make check` → passed (`TypeCheck passed`; `Lint & Format passed`; 497 files checked)
- `bunx vitest run tests/sdk-client.test.tsx` → passed (1 file, 17 tests)
- `make test` → passed (131 files, 1074 tests)
- `bun run --cwd packages/sdk build` → passed (`tsc`)

## Notes
- REST API remains JSON-only; React components are rendered client/SDK-side and stripped before the `/emails` request.
- Playwright E2E not run because this is an SDK/docs-only slice with no browser interaction change; full unit suite, typecheck, lint, and SDK build passed.
