### PR TITLE
Enable dashboard webhook replay

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-375-webhook-replay-boundary.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-375-webhook-replay-boundary.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-11
+issue: "#375"
+type: decision
+promoted_to: null
+---
+
+## Webhook replay should create a new delivery row, then reuse dispatcher signing
+
+Dashboard replay stays tenant-safe by resolving the caller-owned webhook before reading the original delivery. A replay does not mutate the old delivery or reuse its Svix message id; it creates a new pending `webhook_deliveries` row with the same `event_id` and `webhook_id`, then dispatches that new id through the existing webhook dispatcher so endpoint URL, event payload, and Svix-compatible signing stay on the same path as normal delivery.
+
+Disabled endpoints are rejected before creating the replay row. Deleted or foreign endpoints are reported as not found before any delivery lookup to avoid leaking cross-tenant delivery existence.

--- a/packages/core/src/services/webhook.ts
+++ b/packages/core/src/services/webhook.ts
@@ -56,6 +56,10 @@ export type UpdateWebhookInput = {
 };
 
 export type WebhookDeliveryRepository = {
+  findById(id: string): Promise<WebhookDeliveryRow | undefined>;
+  create(
+    data: typeof webhookDeliveries.$inferInsert,
+  ): Promise<WebhookDeliveryRow>;
   listByWebhookId(
     webhookId: string,
     options?: { limit?: number; after?: string },
@@ -64,6 +68,15 @@ export type WebhookDeliveryRepository = {
     hasMore: boolean;
   }>;
 };
+
+export type WebhookReplayResult = {
+  originalDelivery: WebhookDeliveryListItem;
+  replayDelivery: WebhookDeliveryListItem;
+};
+
+export type WebhookDispatchDelivery = (
+  deliveryId: string,
+) => Promise<WebhookDeliveryRow | null | undefined>;
 
 export type WebhookRepository = {
   list(options: { userId: string; limit?: number; after?: string }): Promise<{
@@ -83,8 +96,24 @@ export type WebhookRepository = {
 export type WebhookServiceDependencies = {
   repository?: WebhookRepository;
   deliveryRepository?: WebhookDeliveryRepository;
+  dispatchDelivery?: WebhookDispatchDelivery;
   generateSigningSecret?: () => string;
 };
+
+export type WebhookServiceErrorCode =
+  | "not_found"
+  | "disabled"
+  | "dispatch_failed";
+
+export class WebhookServiceError extends Error {
+  constructor(
+    readonly code: WebhookServiceErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "WebhookServiceError";
+  }
+}
 
 function normalizeLimit(limit: number | undefined): number {
   return Math.min(Math.max(limit || 20, 1), 100);
@@ -163,6 +192,7 @@ function buildUpdateData(input: UpdateWebhookInput): Partial<WebhookInsert> {
 export function createWebhookService({
   repository = webhookRepo,
   deliveryRepository = webhookDeliveryRepo,
+  dispatchDelivery,
   generateSigningSecret = generateSecureSigningSecret,
 }: WebhookServiceDependencies = {}) {
   return {
@@ -227,6 +257,64 @@ export function createWebhookService({
       const [deleted] = await repository.delete(id, userId);
       return deleted;
     },
+
+    async replayWebhookDelivery(input: {
+      webhookId: string;
+      deliveryId: string;
+      userId: string;
+    }): Promise<WebhookReplayResult> {
+      const webhook = await repository.findById(input.webhookId, input.userId);
+      if (!webhook) {
+        throw new WebhookServiceError(
+          "not_found",
+          "Webhook endpoint not found or deleted",
+        );
+      }
+
+      if (webhook.status !== "active") {
+        throw new WebhookServiceError(
+          "disabled",
+          "Webhook endpoint is disabled and cannot replay deliveries",
+        );
+      }
+
+      const originalDelivery = await deliveryRepository.findById(
+        input.deliveryId,
+      );
+      if (!originalDelivery || originalDelivery.webhookId !== input.webhookId) {
+        throw new WebhookServiceError(
+          "not_found",
+          "Webhook delivery not found for this endpoint",
+        );
+      }
+
+      const replayDelivery = await deliveryRepository.create({
+        webhookId: webhook.id,
+        eventId: originalDelivery.eventId,
+        status: "pending",
+        attempt: 0,
+        statusCode: null,
+        responseBody: null,
+        attemptedAt: null,
+        nextRetryAt: null,
+      });
+
+      const dispatchedDelivery = dispatchDelivery
+        ? await dispatchDelivery(replayDelivery.id)
+        : replayDelivery;
+
+      if (!dispatchedDelivery) {
+        throw new WebhookServiceError(
+          "dispatch_failed",
+          "Webhook replay delivery could not be dispatched",
+        );
+      }
+
+      return {
+        originalDelivery: toWebhookDeliveryListItem(originalDelivery),
+        replayDelivery: toWebhookDeliveryListItem(dispatchedDelivery),
+      };
+    },
   };
 }
 
@@ -255,6 +343,14 @@ export class WebhookService {
 
   async delete(id: string, userId: string) {
     return await this.service.deleteWebhook(id, userId);
+  }
+
+  async replayDelivery(input: {
+    webhookId: string;
+    deliveryId: string;
+    userId: string;
+  }) {
+    return await this.service.replayWebhookDelivery(input);
   }
 }
 

--- a/src/app/(dashboard)/webhooks/[id]/page.tsx
+++ b/src/app/(dashboard)/webhooks/[id]/page.tsx
@@ -1,0 +1,39 @@
+import { WebhookDetail } from "@/components/webhook-detail";
+import { getServerSession } from "@/lib/api-auth";
+import { createWebhookService } from "@opensend/core";
+import { notFound, redirect } from "next/navigation";
+
+export default async function WebhookDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const session = await getServerSession();
+  if (!session?.user?.id) redirect("/auth");
+
+  const { id } = await params;
+  const webhook = await createWebhookService().getWebhook(id, session.user.id);
+
+  if (!webhook) notFound();
+
+  return (
+    <WebhookDetail
+      webhook={{
+        id: webhook.id,
+        endpoint: webhook.endpoint,
+        events: webhook.events,
+        status: webhook.status,
+        createdAt: webhook.createdAt.toISOString(),
+        recentDeliveries: webhook.recentDeliveries.map((delivery) => ({
+          id: delivery.id,
+          status: delivery.status,
+          attempt: delivery.attempt,
+          statusCode: delivery.statusCode,
+          attemptedAt: delivery.attemptedAt?.toISOString() ?? null,
+          nextRetryAt: delivery.nextRetryAt?.toISOString() ?? null,
+          createdAt: delivery.createdAt.toISOString(),
+        })),
+      }}
+    />
+  );
+}

--- a/src/app/api/webhooks/[id]/deliveries/[deliveryId]/replay/route.ts
+++ b/src/app/api/webhooks/[id]/deliveries/[deliveryId]/replay/route.ts
@@ -1,0 +1,9 @@
+import { handleReplayWebhookDeliveryRequest } from "@/lib/api/webhooks";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string; deliveryId: string }> },
+): Promise<Response> {
+  const { id, deliveryId } = await params;
+  return await handleReplayWebhookDeliveryRequest(request, id, deliveryId);
+}

--- a/src/components/webhook-detail.tsx
+++ b/src/components/webhook-detail.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { StatusBadge } from "@/components/status-badge";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useState } from "react";
+
+export interface WebhookDeliveryDetailData {
+  id: string;
+  status: string;
+  attempt: number;
+  statusCode: number | null;
+  attemptedAt: string | null;
+  nextRetryAt: string | null;
+  createdAt: string;
+}
+
+export interface WebhookDetailData {
+  id: string;
+  endpoint: string;
+  events: string[];
+  status: "enabled" | "disabled";
+  createdAt: string;
+  recentDeliveries: WebhookDeliveryDetailData[];
+}
+
+interface WebhookReplayResponse {
+  replay_delivery?: {
+    id?: string;
+    status?: string;
+  };
+  error?: string;
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return "—";
+  return new Date(value).toLocaleString();
+}
+
+function formatStatusLabel(status: string): string {
+  return status
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function deliveryBadgeStatus(
+  status: string,
+): "success" | "error" | "warning" | "default" {
+  if (status === "success") return "success";
+  if (status === "pending") return "warning";
+  if (status === "failed" || status === "dead_letter") return "error";
+  return "default";
+}
+
+async function parseReplayResponse(response: Response) {
+  try {
+    return (await response.json()) as WebhookReplayResponse;
+  } catch {
+    return {} satisfies WebhookReplayResponse;
+  }
+}
+
+export function WebhookDetail({ webhook }: { webhook: WebhookDetailData }) {
+  const router = useRouter();
+  const [replayingId, setReplayingId] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<{
+    tone: "success" | "error";
+    message: string;
+  } | null>(null);
+
+  const replayDelivery = useCallback(
+    async (deliveryId: string) => {
+      if (replayingId) return;
+      setReplayingId(deliveryId);
+      setFeedback(null);
+
+      try {
+        const response = await fetch(
+          `/api/webhooks/${webhook.id}/deliveries/${deliveryId}/replay`,
+          { method: "POST" },
+        );
+        const body = await parseReplayResponse(response);
+
+        if (!response.ok) {
+          throw new Error(body.error ?? "Failed to replay webhook delivery");
+        }
+
+        const replayId = body.replay_delivery?.id ?? "new delivery";
+        const replayStatus = body.replay_delivery?.status ?? "pending";
+        setFeedback({
+          tone: "success",
+          message: `Replay triggered as ${replayId} (${formatStatusLabel(
+            replayStatus,
+          )}).`,
+        });
+        router.refresh();
+      } catch (error) {
+        setFeedback({
+          tone: "error",
+          message:
+            error instanceof Error
+              ? error.message
+              : "Failed to replay webhook delivery",
+        });
+      } finally {
+        setReplayingId(null);
+      }
+    },
+    [replayingId, router, webhook.id],
+  );
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center gap-2 text-[13px] text-[#A1A4A5]">
+        <Link
+          href="/webhooks"
+          className="transition-colors hover:text-[#F0F0F0]"
+        >
+          Webhooks
+        </Link>
+        <span>/</span>
+        <span className="text-[#F0F0F0]">Endpoint</span>
+      </div>
+
+      <div className="mb-8 flex items-start justify-between gap-6">
+        <div>
+          <p className="text-[13px] text-[#A1A4A5]">Webhook endpoint</p>
+          <h1 className="mt-1 break-all text-2xl font-semibold text-[#F0F0F0]">
+            {webhook.endpoint}
+          </h1>
+          <div className="mt-3 flex flex-wrap items-center gap-2 text-sm text-white/40">
+            <StatusBadge
+              status={webhook.status === "enabled" ? "active" : "failed"}
+            />
+            <span>Created {formatDateTime(webhook.createdAt)}</span>
+          </div>
+        </div>
+      </div>
+
+      <section className="mb-6 rounded-lg border border-white/5 bg-black p-6">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-white/40">
+          Subscribed events
+        </h2>
+        <div className="mt-4 flex flex-wrap gap-2">
+          {webhook.events.map((event) => (
+            <span
+              key={event}
+              className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 text-xs text-[#F0F0F0]"
+            >
+              {event}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-white/5 bg-black">
+        <div className="flex items-center justify-between border-b border-white/5 px-6 py-4">
+          <div>
+            <h2 className="text-sm font-medium uppercase tracking-wider text-white/40">
+              Recent deliveries
+            </h2>
+            <p className="mt-1 text-sm text-white/40">
+              Replay any recent message to send the same event payload again.
+            </p>
+          </div>
+        </div>
+
+        {feedback && (
+          <output
+            className={`mx-6 mt-4 block rounded-md border px-4 py-3 text-sm ${
+              feedback.tone === "success"
+                ? "border-green-500/30 bg-green-500/10 text-green-300"
+                : "border-red-500/30 bg-red-500/10 text-red-300"
+            }`}
+          >
+            {feedback.message}
+          </output>
+        )}
+
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-white/5">
+            <thead>
+              <tr>
+                <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-white/40">
+                  ID
+                </th>
+                <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-white/40">
+                  Status
+                </th>
+                <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-white/40">
+                  Attempt
+                </th>
+                <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-white/40">
+                  Status code
+                </th>
+                <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-white/40">
+                  Attempted at
+                </th>
+                <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-white/40">
+                  Next retry
+                </th>
+                <th className="px-6 py-4 text-right text-xs font-medium uppercase tracking-wider text-white/40">
+                  Action
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5">
+              {webhook.recentDeliveries.map((delivery) => (
+                <tr key={delivery.id} className="hover:bg-white/[0.02]">
+                  <td className="whitespace-nowrap px-6 py-4 font-mono text-xs text-[#F0F0F0]">
+                    {delivery.id}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm">
+                    <StatusBadge
+                      status={delivery.status}
+                      variant={deliveryBadgeStatus(delivery.status)}
+                    />
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-white/40">
+                    {delivery.attempt}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-white/40">
+                    {delivery.statusCode ?? "—"}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-white/40">
+                    {formatDateTime(delivery.attemptedAt)}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-white/40">
+                    {formatDateTime(delivery.nextRetryAt)}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-right text-sm">
+                    <button
+                      type="button"
+                      className="rounded-md border border-white/10 px-3 py-1.5 text-xs font-medium text-[#F0F0F0] transition-colors hover:bg-white/[0.06] disabled:cursor-not-allowed disabled:opacity-50"
+                      disabled={replayingId !== null}
+                      onClick={() => void replayDelivery(delivery.id)}
+                    >
+                      {replayingId === delivery.id ? "Replaying…" : "Replay"}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {webhook.recentDeliveries.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={7}
+                    className="px-6 py-12 text-center text-sm text-white/40"
+                  >
+                    No webhook deliveries yet.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/webhooks-list.tsx
+++ b/src/components/webhooks-list.tsx
@@ -2,6 +2,7 @@
 
 import { StatusBadge } from "@/components/status-badge";
 import type { SupportedWebhookEventType } from "@opensend/core/src/webhook-events";
+import Link from "next/link";
 
 interface Webhook {
   id: string;
@@ -69,7 +70,12 @@ export function WebhooksList({
             {webhooks.map((webhook) => (
               <tr key={webhook.id} className="hover:bg-white/[0.02]">
                 <td className="whitespace-nowrap px-6 py-4 text-sm text-[#F0F0F0]">
-                  {webhook.url}
+                  <Link
+                    href={`/webhooks/${webhook.id}`}
+                    className="hover:underline"
+                  >
+                    {webhook.url}
+                  </Link>
                 </td>
                 <td className="whitespace-nowrap px-6 py-4 text-sm">
                   <StatusBadge

--- a/src/lib/api/webhooks/handlers.ts
+++ b/src/lib/api/webhooks/handlers.ts
@@ -1,9 +1,14 @@
 import {
   type AuthResult,
+  authorizeDashboardOrApiKey,
+  getServerSession,
   unauthorizedResponse,
   validateApiKey,
 } from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
+import {
+  requireFullAccessApiKey,
+  requireFullAccessForApiKeyCaller,
+} from "@/lib/api-key-permissions";
 import {
   createWebhookSchema,
   updateWebhookSchema,
@@ -12,6 +17,7 @@ import {
   type WebhookDeliveryListItem,
   type WebhookServiceCreateResult,
   type WebhookServiceDetail,
+  WebhookServiceError,
   type WebhookServiceListItem,
   createWebhookService,
 } from "@opensend/core";
@@ -70,6 +76,10 @@ type WebhookAuthResult =
   | { ok: true; auth: WebhookAuth }
   | { ok: false; response: Response };
 
+type DashboardOrApiKeyAuth = NonNullable<
+  Awaited<ReturnType<typeof authorizeDashboardOrApiKey>>
+>;
+
 async function requireWebhookAuth(
   request: Request,
 ): Promise<WebhookAuthResult> {
@@ -80,6 +90,49 @@ async function requireWebhookAuth(
   if (permissionError) return { ok: false, response: permissionError };
 
   return { ok: true, auth: { ...auth, userId: auth.userId } };
+}
+
+async function resolveDashboardOrApiKeyUserId(
+  auth: DashboardOrApiKeyAuth,
+): Promise<string | null> {
+  if ("userId" in auth) return auth.userId;
+
+  const session = await getServerSession();
+  return session?.user?.id ?? null;
+}
+
+async function requireWebhookReplayAuth(
+  request: Request,
+): Promise<{ ok: true; userId: string } | { ok: false; response: Response }> {
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
+  if (!auth) return { ok: false, response: unauthorizedResponse() };
+
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return { ok: false, response: permissionError };
+
+  const userId = await resolveDashboardOrApiKeyUserId(auth);
+  if (!userId) return { ok: false, response: unauthorizedResponse() };
+
+  return { ok: true, userId };
+}
+
+function mapWebhookServiceError(error: unknown, fallback: string): Response {
+  if (error instanceof WebhookServiceError) {
+    const status =
+      error.code === "not_found" ? 404 : error.code === "disabled" ? 409 : 500;
+    return Response.json({ error: error.message }, { status });
+  }
+
+  return mapWebhookError(error, fallback);
+}
+
+async function dispatchWebhookDelivery(deliveryId: string) {
+  const { webhookDispatcher } = await import(
+    "@opensend/ingester/src/dispatcher"
+  );
+  return await webhookDispatcher.dispatchDelivery(deliveryId);
 }
 
 export async function handleListWebhooksRequest(
@@ -249,5 +302,35 @@ export async function handleDeleteWebhookRequest(
     });
   } catch (error) {
     return mapWebhookError(error, "Failed to delete webhook");
+  }
+}
+
+export async function handleReplayWebhookDeliveryRequest(
+  request: Request,
+  id: string,
+  deliveryId: string,
+): Promise<Response> {
+  const authResult = await requireWebhookReplayAuth(request);
+  if (!authResult.ok) return authResult.response;
+
+  try {
+    const result = await createWebhookService({
+      dispatchDelivery: dispatchWebhookDelivery,
+    }).replayWebhookDelivery({
+      webhookId: id,
+      deliveryId,
+      userId: authResult.userId,
+    });
+
+    return Response.json(
+      {
+        object: "webhook_delivery_replay",
+        original_delivery: mapDelivery(result.originalDelivery),
+        replay_delivery: mapDelivery(result.replayDelivery),
+      },
+      { status: 202 },
+    );
+  } catch (error) {
+    return mapWebhookServiceError(error, "Failed to replay webhook delivery");
   }
 }

--- a/src/lib/api/webhooks/index.ts
+++ b/src/lib/api/webhooks/index.ts
@@ -3,5 +3,6 @@ export {
   handleDeleteWebhookRequest,
   handleGetWebhookRequest,
   handleListWebhooksRequest,
+  handleReplayWebhookDeliveryRequest,
   handleUpdateWebhookRequest,
 } from "./handlers";

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -257,6 +257,15 @@ describe("route smoke coverage", () => {
           this.name = "AudienceMetadataServiceError";
         }
       }
+      class WebhookServiceError extends Error {
+        constructor(
+          readonly code: string,
+          message: string,
+        ) {
+          super(message);
+          this.name = "WebhookServiceError";
+        }
+      }
 
       const notFound = (message: string) =>
         new AudienceMetadataServiceError("not_found", message, 404);
@@ -270,6 +279,7 @@ describe("route smoke coverage", () => {
         ContactOperationsServiceError,
         BroadcastServiceError,
         AudienceMetadataServiceError,
+        WebhookServiceError,
         createDashboardAggregateService: () => ({
           async getMetrics() {
             await mockSelect().from().where();

--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -97,9 +97,21 @@ export async function cleanupE2ERun(
      )`,
     [`${userPrefix}%`],
   );
+  await client.query(
+    `delete from webhook_deliveries
+     where webhook_id in (
+       select id from webhooks
+       where user_id like $1 or document->>'test_run_id' = $2
+     )`,
+    [`${userPrefix}%`, runId],
+  );
   await client.query("delete from email_events where user_id like $1", [
     `${userPrefix}%`,
   ]);
+  await client.query(
+    "delete from webhooks where user_id like $1 or document->>'test_run_id' = $2",
+    [`${userPrefix}%`, runId],
+  );
   await client.query(
     "delete from contacts_to_segments where contact_id in (select id from contacts where user_id like $1 or email like $2 or document->>'test_run_id' = $3)",
     [`${userPrefix}%`, emailPattern, runId],

--- a/tests/e2e/webhook-replay.spec.ts
+++ b/tests/e2e/webhook-replay.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "./fixtures/auth";
+
+test("dashboard webhook delivery row exposes replay and calls replay route", async ({
+  authenticatedPage,
+  e2eDb,
+  e2eRunId,
+  e2eUser,
+}) => {
+  const eventResult = await e2eDb.query<{ id: string }>(
+    `insert into email_events (type, payload, user_id)
+     values ('delivered', $1::jsonb, $2)
+     returning id`,
+    [JSON.stringify({ smtp_response: "250 ok" }), e2eUser.id],
+  );
+  const eventId = eventResult.rows[0]?.id;
+  expect(eventId).toBeTruthy();
+
+  const webhookResult = await e2eDb.query<{ id: string }>(
+    `insert into webhooks (url, event_types, status, signing_secret, user_id, document)
+     values ($1, $2::jsonb, 'active', 'whsec_e2e', $3, $4::jsonb)
+     returning id`,
+    [
+      "https://example.com/e2e-webhook",
+      JSON.stringify(["email.delivered"]),
+      e2eUser.id,
+      JSON.stringify({ test_run_id: e2eRunId }),
+    ],
+  );
+  const webhookId = webhookResult.rows[0]?.id;
+  expect(webhookId).toBeTruthy();
+
+  const deliveryResult = await e2eDb.query<{ id: string }>(
+    `insert into webhook_deliveries
+       (webhook_id, event_id, attempt, status_code, response_body, status, attempted_at, next_retry_at)
+     values ($1, $2, 1, 200, 'accepted', 'success', now(), null)
+     returning id`,
+    [webhookId, eventId],
+  );
+  const deliveryId = deliveryResult.rows[0]?.id;
+  expect(deliveryId).toBeTruthy();
+
+  let replayCalled = false;
+  await authenticatedPage.route(
+    `**/api/webhooks/${webhookId}/deliveries/${deliveryId}/replay`,
+    async (route) => {
+      replayCalled = true;
+      await route.fulfill({
+        status: 202,
+        contentType: "application/json",
+        body: JSON.stringify({
+          object: "webhook_delivery_replay",
+          replay_delivery: {
+            id: "delivery-replay-e2e",
+            status: "success",
+          },
+        }),
+      });
+    },
+  );
+
+  await authenticatedPage.goto(`/webhooks/${webhookId}`);
+
+  await expect(
+    authenticatedPage.getByRole("heading", {
+      name: "https://example.com/e2e-webhook",
+    }),
+  ).toBeVisible();
+  await expect(authenticatedPage.getByText(deliveryId)).toBeVisible();
+  await expect(authenticatedPage.getByText("200")).toBeVisible();
+
+  const replayButton = authenticatedPage.getByRole("button", {
+    name: "Replay",
+  });
+  await expect(replayButton).toBeVisible();
+  await replayButton.click();
+
+  expect(replayCalled).toBe(true);
+  await expect(authenticatedPage.getByRole("status")).toContainText(
+    "Replay triggered as delivery-replay-e2e",
+  );
+});

--- a/tests/webhook-service.test.ts
+++ b/tests/webhook-service.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  type WebhookDeliveryRepository,
   type WebhookRepository,
+  WebhookServiceError,
   createWebhookService,
 } from "../packages/core/src/services/webhook";
 
@@ -8,6 +10,10 @@ type WebhookRow = NonNullable<
   Awaited<ReturnType<WebhookRepository["findById"]>>
 >;
 type WebhookInsert = Parameters<WebhookRepository["create"]>[0];
+type WebhookDeliveryRow = NonNullable<
+  Awaited<ReturnType<WebhookDeliveryRepository["findById"]>>
+>;
+type WebhookDeliveryInsert = Parameters<WebhookDeliveryRepository["create"]>[0];
 
 function webhookRow(overrides: Partial<WebhookRow> = {}): WebhookRow {
   return {
@@ -39,6 +45,43 @@ function createRepository(overrides: Partial<WebhookRepository> = {}) {
     },
     async delete(id: string) {
       return [{ id }];
+    },
+    ...overrides,
+  };
+
+  return repository;
+}
+
+function deliveryRow(
+  overrides: Partial<WebhookDeliveryRow> = {},
+): WebhookDeliveryRow {
+  return {
+    id: "delivery-1",
+    webhookId: "webhook-1",
+    eventId: "event-1",
+    attempt: 2,
+    statusCode: 503,
+    responseBody: "unavailable",
+    status: "pending",
+    attemptedAt: new Date("2026-05-06T00:00:00.000Z"),
+    nextRetryAt: new Date("2026-05-06T00:05:00.000Z"),
+    createdAt: new Date("2026-05-05T23:59:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createDeliveryRepository(
+  overrides: Partial<WebhookDeliveryRepository> = {},
+) {
+  const repository: WebhookDeliveryRepository = {
+    async findById(id) {
+      return deliveryRow({ id });
+    },
+    async create(data: WebhookDeliveryInsert) {
+      return deliveryRow({ ...data, id: "delivery-replay" });
+    },
+    async listByWebhookId() {
+      return { data: [], hasMore: false };
     },
     ...overrides,
   };
@@ -171,7 +214,7 @@ describe("webhook service", () => {
           return webhookRow({ id });
         },
       }),
-      deliveryRepository: {
+      deliveryRepository: createDeliveryRepository({
         async listByWebhookId(webhookId, options) {
           expect(webhookId).toBe("webhook-1");
           expect(options).toEqual({ limit: 20 });
@@ -193,7 +236,7 @@ describe("webhook service", () => {
             hasMore: false,
           };
         },
-      },
+      }),
     });
 
     const result = await service.getWebhook("webhook-1", "user-1");
@@ -236,5 +279,197 @@ describe("webhook service", () => {
     await expect(
       service.deleteWebhook("missing", "user-1"),
     ).resolves.toBeUndefined();
+  });
+
+  it("replays a failed delivery through a fresh dispatched delivery", async () => {
+    const created: WebhookDeliveryInsert[] = [];
+    const dispatchDelivery = vi.fn(async (deliveryId: string) =>
+      deliveryRow({
+        id: deliveryId,
+        attempt: 1,
+        status: "success",
+        statusCode: 200,
+        responseBody: "accepted",
+        attemptedAt: new Date("2026-05-06T00:10:00.000Z"),
+        nextRetryAt: null,
+      }),
+    );
+    const service = createWebhookService({
+      repository: createRepository({
+        async findById(id, userId) {
+          expect(id).toBe("webhook-1");
+          expect(userId).toBe("user-1");
+          return webhookRow({ id, userId });
+        },
+      }),
+      deliveryRepository: createDeliveryRepository({
+        async findById(id) {
+          return deliveryRow({
+            id,
+            status: "dead_letter",
+            attempt: 8,
+            statusCode: 500,
+          });
+        },
+        async create(data) {
+          created.push(data);
+          return deliveryRow({
+            ...data,
+            id: "delivery-replay",
+            createdAt: new Date("2026-05-06T00:09:59.000Z"),
+          });
+        },
+      }),
+      dispatchDelivery,
+    });
+
+    const result = await service.replayWebhookDelivery({
+      webhookId: "webhook-1",
+      deliveryId: "delivery-original",
+      userId: "user-1",
+    });
+
+    expect(created).toEqual([
+      {
+        webhookId: "webhook-1",
+        eventId: "event-1",
+        status: "pending",
+        attempt: 0,
+        statusCode: null,
+        responseBody: null,
+        attemptedAt: null,
+        nextRetryAt: null,
+      },
+    ]);
+    expect(dispatchDelivery).toHaveBeenCalledWith("delivery-replay");
+    expect(result.originalDelivery).toMatchObject({
+      id: "delivery-original",
+      status: "dead_letter",
+      attempt: 8,
+    });
+    expect(result.replayDelivery).toMatchObject({
+      id: "delivery-replay",
+      status: "success",
+      attempt: 1,
+      statusCode: 200,
+    });
+  });
+
+  it("replays an already successful delivery", async () => {
+    const service = createWebhookService({
+      repository: createRepository(),
+      deliveryRepository: createDeliveryRepository({
+        async findById(id) {
+          return deliveryRow({
+            id,
+            status: "success",
+            attempt: 1,
+            statusCode: 200,
+            nextRetryAt: null,
+          });
+        },
+      }),
+      dispatchDelivery: async (deliveryId) =>
+        deliveryRow({ id: deliveryId, status: "success", attempt: 1 }),
+    });
+
+    const result = await service.replayWebhookDelivery({
+      webhookId: "webhook-1",
+      deliveryId: "delivery-success",
+      userId: "user-1",
+    });
+
+    expect(result.originalDelivery).toMatchObject({
+      id: "delivery-success",
+      status: "success",
+    });
+    expect(result.replayDelivery).toMatchObject({
+      id: "delivery-replay",
+      status: "success",
+      attempt: 1,
+    });
+  });
+
+  it("prevents replaying another user's delivery by resolving the owned webhook first", async () => {
+    const findDelivery = vi.fn();
+    const service = createWebhookService({
+      repository: createRepository({
+        async findById() {
+          return undefined;
+        },
+      }),
+      deliveryRepository: createDeliveryRepository({
+        findById: findDelivery,
+      }),
+    });
+
+    await expect(
+      service.replayWebhookDelivery({
+        webhookId: "webhook-user-a",
+        deliveryId: "delivery-user-a",
+        userId: "user-b",
+      }),
+    ).rejects.toMatchObject({
+      code: "not_found",
+      message: "Webhook endpoint not found or deleted",
+    });
+    expect(findDelivery).not.toHaveBeenCalled();
+  });
+
+  it("rejects disabled endpoints before creating a replay delivery", async () => {
+    const createDelivery = vi.fn();
+    const service = createWebhookService({
+      repository: createRepository({
+        async findById() {
+          return webhookRow({ status: "disabled" });
+        },
+      }),
+      deliveryRepository: createDeliveryRepository({
+        create: createDelivery,
+      }),
+    });
+
+    await expect(
+      service.replayWebhookDelivery({
+        webhookId: "webhook-1",
+        deliveryId: "delivery-1",
+        userId: "user-1",
+      }),
+    ).rejects.toBeInstanceOf(WebhookServiceError);
+    await expect(
+      service.replayWebhookDelivery({
+        webhookId: "webhook-1",
+        deliveryId: "delivery-1",
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({
+      code: "disabled",
+      message: "Webhook endpoint is disabled and cannot replay deliveries",
+    });
+    expect(createDelivery).not.toHaveBeenCalled();
+  });
+
+  it("rejects deleted endpoints with a clear not found error", async () => {
+    const service = createWebhookService({
+      repository: createRepository({
+        async findById() {
+          return undefined;
+        },
+      }),
+      deliveryRepository: createDeliveryRepository({
+        create: vi.fn(),
+      }),
+    });
+
+    await expect(
+      service.replayWebhookDelivery({
+        webhookId: "deleted-webhook",
+        deliveryId: "delivery-1",
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({
+      code: "not_found",
+      message: "Webhook endpoint not found or deleted",
+    });
   });
 });

--- a/tests/webhooks-api-keys-tenant-isolation.test.ts
+++ b/tests/webhooks-api-keys-tenant-isolation.test.ts
@@ -6,10 +6,12 @@ const mockCreateWebhook = vi.hoisted(() => vi.fn());
 const mockGetWebhook = vi.hoisted(() => vi.fn());
 const mockUpdateWebhook = vi.hoisted(() => vi.fn());
 const mockDeleteWebhook = vi.hoisted(() => vi.fn());
+const mockReplayWebhookDelivery = vi.hoisted(() => vi.fn());
 const mockListApiKeys = vi.hoisted(() => vi.fn());
 const mockCreateApiKey = vi.hoisted(() => vi.fn());
 const mockGetApiKey = vi.hoisted(() => vi.fn());
 const mockDeleteApiKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
 const MockApiKeyServiceError = vi.hoisted(
   () =>
     class ApiKeyServiceError extends Error {
@@ -22,6 +24,18 @@ const MockApiKeyServiceError = vi.hoisted(
       }
     },
 );
+const MockWebhookServiceError = vi.hoisted(
+  () =>
+    class WebhookServiceError extends Error {
+      constructor(
+        readonly code: string,
+        message: string,
+      ) {
+        super(message);
+        this.name = "WebhookServiceError";
+      }
+    },
+);
 
 vi.mock("@/lib/api-auth", () => ({
   invalidateApiKeyAuthCache: vi.fn(),
@@ -29,7 +43,7 @@ vi.mock("@/lib/api-auth", () => ({
     Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
   validateApiKey: mockValidateApiKey,
   authorizeDashboardOrApiKey: mockValidateApiKey,
-  getServerSession: vi.fn(),
+  getServerSession: mockGetServerSession,
 }));
 
 vi.mock("@/lib/billing/quota", () => ({
@@ -39,6 +53,7 @@ vi.mock("@/lib/billing/quota", () => ({
 
 vi.mock("@opensend/core", () => ({
   ApiKeyServiceError: MockApiKeyServiceError,
+  WebhookServiceError: MockWebhookServiceError,
   createApiKeyService: () => ({
     listApiKeys: mockListApiKeys,
     createApiKey: mockCreateApiKey,
@@ -107,6 +122,7 @@ vi.mock("@opensend/core", () => ({
     getWebhook: mockGetWebhook,
     updateWebhook: mockUpdateWebhook,
     deleteWebhook: mockDeleteWebhook,
+    replayWebhookDelivery: mockReplayWebhookDelivery,
   }),
 }));
 
@@ -129,6 +145,9 @@ beforeEach(() => {
     permission: "full_access",
     domain: null,
     userId: "user-b",
+  });
+  mockGetServerSession.mockResolvedValue({
+    user: { id: "dashboard-user-b" },
   });
 });
 
@@ -235,6 +254,91 @@ describe("webhook API tenant isolation", () => {
 
     expect(response.status).toBe(401);
     expect(mockListWebhooks).not.toHaveBeenCalled();
+  });
+
+  it("lets a signed-in dashboard user replay an owned webhook delivery", async () => {
+    mockValidateApiKey.mockResolvedValueOnce({ dashboard: true });
+    mockGetServerSession.mockResolvedValueOnce({
+      user: { id: "dashboard-user-b" },
+    });
+    mockReplayWebhookDelivery.mockResolvedValue({
+      originalDelivery: {
+        id: "delivery-original",
+        status: "success",
+        attempt: 1,
+        statusCode: 200,
+        responseBody: "accepted",
+        attemptedAt: "2026-05-11T00:00:00.000Z",
+        nextRetryAt: null,
+        createdAt: "2026-05-11T00:00:00.000Z",
+      },
+      replayDelivery: {
+        id: "delivery-replay",
+        status: "success",
+        attempt: 1,
+        statusCode: 200,
+        responseBody: "accepted",
+        attemptedAt: "2026-05-11T00:01:00.000Z",
+        nextRetryAt: null,
+        createdAt: "2026-05-11T00:01:00.000Z",
+      },
+    });
+
+    const route = await import(
+      "@/app/api/webhooks/[id]/deliveries/[deliveryId]/replay/route"
+    );
+    const response = await route.POST(
+      request("http://localhost/api/webhooks/wh-b/deliveries/delivery/replay", {
+        method: "POST",
+      }),
+      {
+        params: Promise.resolve({
+          id: "wh-b",
+          deliveryId: "delivery-original",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      object: "webhook_delivery_replay",
+      original_delivery: { id: "delivery-original", status: "success" },
+      replay_delivery: { id: "delivery-replay", status: "success" },
+    });
+    expect(mockReplayWebhookDelivery).toHaveBeenCalledWith({
+      webhookId: "wh-b",
+      deliveryId: "delivery-original",
+      userId: "dashboard-user-b",
+    });
+  });
+
+  it("maps disabled webhook replay rejection to a clear conflict response", async () => {
+    mockReplayWebhookDelivery.mockRejectedValue(
+      new MockWebhookServiceError(
+        "disabled",
+        "Webhook endpoint is disabled and cannot replay deliveries",
+      ),
+    );
+
+    const route = await import(
+      "@/app/api/webhooks/[id]/deliveries/[deliveryId]/replay/route"
+    );
+    const response = await route.POST(
+      request("http://localhost/api/webhooks/wh-b/deliveries/delivery/replay", {
+        method: "POST",
+      }),
+      {
+        params: Promise.resolve({
+          id: "wh-b",
+          deliveryId: "delivery-original",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Webhook endpoint is disabled and cannot replay deliveries",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds tenant-scoped webhook delivery replay for dashboard/API-key callers via `POST /api/webhooks/:id/deliveries/:deliveryId/replay`.
- Creates a fresh `webhook_deliveries` row for the original event and dispatches that new delivery through the existing Svix-compatible dispatcher/signing path.
- Adds a minimal dashboard webhook detail page with recent delivery rows and Replay actions for both successful and failed/dead-letter messages.

Closes #375

## Validation
- `bun run vitest run tests/webhook-service.test.ts tests/webhooks-api-keys-tenant-isolation.test.ts tests/webhook-event-types.test.tsx`
- `bun run playwright test tests/e2e/webhook-replay.spec.ts` (skipped locally: existing auth-backed E2E fixture requires `DATABASE_URL`, which is unset in this worktree)
- `make check`
- `make test`

## Notes / risk
- Replay intentionally does not alter retry cadence and does not add a queue provider; it reuses the existing immediate dispatcher path for the newly-created delivery row.
- Disabled endpoints return a clear conflict before creating a replay row; deleted/foreign endpoints are resolved as not found before delivery lookup to avoid tenant leakage.
