### PR TITLE
Add tag-filtered delivery metrics

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-378-dashboard-tag-metrics.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-378-dashboard-tag-metrics.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-11
+issue: "#378"
+type: decision
+promoted_to: null
+---
+
+## Dashboard metric tag filters stay read-only over stored email tags
+
+**What:** `/api/metrics` now treats `tag_name` plus optional `tag_value` as read-only filters over the existing `emails.tags` JSONB send contract, and the dashboard response exposes tenant-scoped tag options separately from the filtered aggregate rows.
+
+**Why:** The issue only needs dashboard/API filtering parity. Changing send-time tag validation or ingestion would widen the contract and risk breaking existing Resend-compatible callers.
+
+**Fix:** Future metric dimensions should flow through the dashboard aggregate service input/cache key and preserve tenant predicates in every aggregate query before adding UI controls.

--- a/packages/core/src/services/dashboardAggregates.ts
+++ b/packages/core/src/services/dashboardAggregates.ts
@@ -70,11 +70,23 @@ export type DashboardDomainBreakdownRow = {
   delivered: number;
 };
 
+export type DashboardTagOption = {
+  name: string;
+  values: string[];
+};
+
+export type DashboardStoredEmailTag = {
+  name: string;
+  value: string;
+};
+
 export type DashboardMetricsBaseInput = {
   userId: string;
   start: Date;
   end: Date;
   domain: string | null;
+  tagName: string | null;
+  tagValue: string | null;
 };
 
 export type DashboardDailyCountsInput = DashboardMetricsBaseInput & {
@@ -110,6 +122,7 @@ export type DashboardAggregateRepository = {
   listDomainBreakdown(
     input: DashboardMetricsBaseInput,
   ): Promise<DashboardDomainBreakdownRow[]>;
+  listTagOptions(userId: string): Promise<DashboardTagOption[]>;
   countUsage(input: DashboardUsageCountInput): Promise<DashboardUsageCounts>;
 };
 
@@ -128,6 +141,7 @@ export type DashboardMetricsPayload = {
   bounceRate: number;
   complainRate: number;
   domains: string[];
+  tagOptions: DashboardTagOption[];
   dailyData: DashboardDailyCountRow[];
   domainBreakdown: Array<{
     domain: string;
@@ -187,7 +201,49 @@ function metricConditions(input: DashboardMetricsBaseInput): SQL<unknown>[] {
     conditions.push(eq(senderDomainSql, input.domain));
   }
 
+  if (input.tagName) {
+    const tagPredicate: Array<{ name: string; value?: string }> = [
+      input.tagValue === null
+        ? { name: input.tagName }
+        : { name: input.tagName, value: input.tagValue },
+    ];
+    conditions.push(
+      sql`${emails.tags} @> ${JSON.stringify(tagPredicate)}::jsonb`,
+    );
+  }
+
   return conditions;
+}
+
+function isStoredEmailTag(value: unknown): value is DashboardStoredEmailTag {
+  if (!value || typeof value !== "object") return false;
+  const tag = value as Record<string, unknown>;
+  return typeof tag.name === "string" && typeof tag.value === "string";
+}
+
+function collectTagOptions(
+  rows: Array<{ tags: DashboardStoredEmailTag[] | null }>,
+): DashboardTagOption[] {
+  const valuesByName = new Map<string, Set<string>>();
+
+  for (const row of rows) {
+    if (!Array.isArray(row.tags)) continue;
+    for (const tag of row.tags) {
+      if (!isStoredEmailTag(tag) || tag.name === "") continue;
+      const values = valuesByName.get(tag.name) ?? new Set<string>();
+      values.add(tag.value);
+      valuesByName.set(tag.name, values);
+    }
+  }
+
+  return Array.from(valuesByName.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, values]) => ({
+      name,
+      values: Array.from(values).sort((left, right) =>
+        left.localeCompare(right),
+      ),
+    }));
 }
 
 const emptyMetricsStats: DashboardMetricsStats = {
@@ -274,6 +330,15 @@ const defaultDashboardAggregateRepository: DashboardAggregateRepository = {
       .orderBy(sql`count(*) desc`);
   },
 
+  async listTagOptions(userId) {
+    const rows = await db
+      .select({ tags: emails.tags })
+      .from(emails)
+      .where(eq(emails.userId, userId));
+
+    return collectTagOptions(rows);
+  },
+
   async countUsage(input) {
     const [
       monthlyEmails,
@@ -329,18 +394,27 @@ export function createDashboardAggregateService({
         start: input.start,
         end: input.end,
         domain: input.domain,
+        tagName: input.tagName,
+        tagValue: input.tagValue,
       };
-      const [stats, dailyRows, dailyBounceRows, dailyComplainRows, domainRows] =
-        await Promise.all([
-          repository.aggregateMetrics(baseInput),
-          repository.listDailyCounts({
-            ...baseInput,
-            statuses: getEventStatuses(input.eventType),
-          }),
-          repository.listDailyBounceRates(baseInput),
-          repository.listDailyComplainRates(baseInput),
-          repository.listDomainBreakdown(baseInput),
-        ]);
+      const [
+        stats,
+        dailyRows,
+        dailyBounceRows,
+        dailyComplainRows,
+        domainRows,
+        tagOptions,
+      ] = await Promise.all([
+        repository.aggregateMetrics(baseInput),
+        repository.listDailyCounts({
+          ...baseInput,
+          statuses: getEventStatuses(input.eventType),
+        }),
+        repository.listDailyBounceRates(baseInput),
+        repository.listDailyComplainRates(baseInput),
+        repository.listDomainBreakdown(baseInput),
+        repository.listTagOptions(input.userId),
+      ]);
 
       const totalEmails = stats.total;
       const domainBreakdown = domainRows
@@ -360,6 +434,7 @@ export function createDashboardAggregateService({
         bounceRate: roundRate(stats.bounced, totalEmails),
         complainRate: roundRate(stats.complained, totalEmails),
         domains: domainBreakdown.map((item) => item.domain),
+        tagOptions,
         dailyData: dailyRows.map((row) => ({
           date: row.date,
           count: row.count,

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -24,6 +24,12 @@ function getMetricsDateRange(range: string): { start: Date; end: Date } {
   return getDateRangeBounds(RANGE_TO_PRESET[range] || "Last 15 days");
 }
 
+function normalizeOptionalQueryParam(value: string | null): string | null {
+  if (value === null) return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
 const dashboardAggregateService = createDashboardAggregateService();
 
 // Dashboard-only internal endpoint
@@ -36,12 +42,18 @@ export async function GET(request: NextRequest) {
     const range = searchParams.get("range") || "last_15_days";
     const domain = searchParams.get("domain");
     const eventType = searchParams.get("event_type");
+    const tagName = normalizeOptionalQueryParam(searchParams.get("tag_name"));
+    const rawTagValue = searchParams.get("tag_value");
+    const tagValue =
+      tagName && rawTagValue !== null ? rawTagValue.trim() : null;
     const userId = session.user.id;
     const cacheKey = getMetricsAggregateCacheKey({
       userId,
       range,
       domain,
       eventType,
+      tagName,
+      tagValue,
     });
 
     const cached = await readDashboardAggregateCache<unknown>(cacheKey);
@@ -58,6 +70,8 @@ export async function GET(request: NextRequest) {
       end,
       domain,
       eventType,
+      tagName,
+      tagValue,
     });
 
     await writeDashboardAggregateCache(

--- a/src/components/metrics-page.tsx
+++ b/src/components/metrics-page.tsx
@@ -23,6 +23,9 @@ const DATE_RANGE_TO_API: Record<string, string> = {
   "Last 30 days": "last_30_days",
 };
 
+const TAG_NAME_PREFIX = "name:";
+const TAG_VALUE_PREFIX = "value:";
+
 // ── Types ───────────────────────────────────────────────────────────
 
 interface DailyDataPoint {
@@ -52,6 +55,11 @@ interface DailyComplainPoint {
   rate: number;
 }
 
+interface TagOption {
+  name: string;
+  values: string[];
+}
+
 interface MetricsData {
   totalEmails: number;
   deliverabilityRate: number;
@@ -59,12 +67,41 @@ interface MetricsData {
   complainRate: number;
   complained: number;
   domains: string[];
+  tagOptions: TagOption[];
   dailyData: DailyDataPoint[];
   domainBreakdown: DomainBreakdownEntry[];
   bounceBreakdown: BounceBreakdown;
   dailyBounceData: DailyBouncePoint[];
   dailyComplainData: DailyComplainPoint[];
   lastUpdated: string;
+}
+
+function tagNameFilterValue(name: string): string {
+  return `${TAG_NAME_PREFIX}${name}`;
+}
+
+function tagValueFilterValue(name: string, value: string): string {
+  return `${TAG_VALUE_PREFIX}${name}:${value}`;
+}
+
+function getTagLabel(name: string, value: string): string {
+  return `${name}: ${value === "" ? "(empty)" : value}`;
+}
+
+function appendTagParams(params: URLSearchParams, tagFilter: string): void {
+  if (tagFilter.startsWith(TAG_VALUE_PREFIX)) {
+    const raw = tagFilter.slice(TAG_VALUE_PREFIX.length);
+    const separatorIndex = raw.indexOf(":");
+    if (separatorIndex <= 0) return;
+    params.set("tag_name", raw.slice(0, separatorIndex));
+    params.set("tag_value", raw.slice(separatorIndex + 1));
+    return;
+  }
+
+  if (tagFilter.startsWith(TAG_NAME_PREFIX)) {
+    const name = tagFilter.slice(TAG_NAME_PREFIX.length);
+    if (name) params.set("tag_name", name);
+  }
 }
 
 // ── MetricSection (collapsible) ─────────────────────────────────────
@@ -146,6 +183,7 @@ export function MetricSection({
 export function MetricsPage() {
   const [dateRange, setDateRange] = useState("Last 15 days");
   const [domain, setDomain] = useState("all");
+  const [tagFilter, setTagFilter] = useState("all");
   const [eventType, setEventType] = useState("all");
   const [data, setData] = useState<MetricsData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -160,6 +198,9 @@ export function MetricsPage() {
     if (eventType !== "all") {
       params.set("event_type", eventType);
     }
+    if (tagFilter !== "all") {
+      appendTagParams(params, tagFilter);
+    }
     try {
       const res = await fetch(`/api/metrics?${params.toString()}`);
       if (res.ok) {
@@ -169,7 +210,7 @@ export function MetricsPage() {
     } finally {
       setLoading(false);
     }
-  }, [dateRange, domain, eventType]);
+  }, [dateRange, domain, eventType, tagFilter]);
 
   useEffect(() => {
     fetchMetrics();
@@ -182,6 +223,17 @@ export function MetricsPage() {
       value: d,
       label: d,
     })),
+  ];
+
+  const tagOptions: ComboboxOption[] = [
+    { value: "all", label: "All Tags" },
+    ...(data?.tagOptions ?? []).flatMap((tag) => [
+      { value: tagNameFilterValue(tag.name), label: `${tag.name}: Any value` },
+      ...tag.values.map((value) => ({
+        value: tagValueFilterValue(tag.name, value),
+        label: getTagLabel(tag.name, value),
+      })),
+    ]),
   ];
 
   const lastUpdatedStr = data?.lastUpdated
@@ -201,6 +253,11 @@ export function MetricsPage() {
             options={domainOptions}
             value={domain}
             onChange={setDomain}
+          />
+          <ComboboxFilter
+            options={tagOptions}
+            value={tagFilter}
+            onChange={setTagFilter}
           />
           <DateRangePicker value={dateRange} onChange={setDateRange} />
         </div>

--- a/src/lib/cache/dashboard-aggregates.ts
+++ b/src/lib/cache/dashboard-aggregates.ts
@@ -6,8 +6,10 @@ export const DASHBOARD_METRICS_CACHE_TTL_SECONDS = 60;
 export const BROADCAST_METRICS_CACHE_TTL_SECONDS = 120;
 
 function normalizeCacheSegment(value: string | null | undefined): string {
-  if (!value || value.trim() === "") return "all";
-  return encodeURIComponent(value.trim());
+  if (value === null || value === undefined) return "all";
+  const trimmed = value.trim();
+  if (trimmed === "") return "empty";
+  return encodeURIComponent(trimmed);
 }
 
 export function getMetricsAggregateCacheKey(params: {
@@ -15,6 +17,8 @@ export function getMetricsAggregateCacheKey(params: {
   range: string;
   domain: string | null;
   eventType: string | null;
+  tagName: string | null;
+  tagValue: string | null;
 }): string {
   return [
     DASHBOARD_AGGREGATE_CACHE_PREFIX,
@@ -23,6 +27,8 @@ export function getMetricsAggregateCacheKey(params: {
     normalizeCacheSegment(params.range),
     normalizeCacheSegment(params.domain),
     normalizeCacheSegment(params.eventType),
+    normalizeCacheSegment(params.tagName),
+    normalizeCacheSegment(params.tagValue),
   ].join(":");
 }
 

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -293,6 +293,7 @@ describe("route smoke coverage", () => {
               bounceRate: 20,
               complainRate: 10,
               domains: ["example.com"],
+              tagOptions: [{ name: "campaign", values: ["launch"] }],
               dailyData: [{ date: "2026-04-23", count: 7 }],
               domainBreakdown: [{ domain: "example.com", count: 10, rate: 70 }],
               bounceBreakdown: {

--- a/tests/dashboard-aggregates-cache.test.ts
+++ b/tests/dashboard-aggregates-cache.test.ts
@@ -1,0 +1,41 @@
+import { getMetricsAggregateCacheKey } from "@/lib/cache/dashboard-aggregates";
+import { describe, expect, it } from "vitest";
+
+describe("dashboard aggregate cache keys", () => {
+  it("partitions metrics cache entries by tag filter combinations", () => {
+    const base = {
+      userId: "user-1",
+      range: "last_7_days",
+      domain: "example.com",
+      eventType: "delivered",
+    };
+
+    expect(
+      getMetricsAggregateCacheKey({
+        ...base,
+        tagName: null,
+        tagValue: null,
+      }),
+    ).toBe(
+      "dashboard-aggregate:v1:metrics:user-1:last_7_days:example.com:delivered:all:all",
+    );
+    expect(
+      getMetricsAggregateCacheKey({
+        ...base,
+        tagName: "campaign",
+        tagValue: null,
+      }),
+    ).toBe(
+      "dashboard-aggregate:v1:metrics:user-1:last_7_days:example.com:delivered:campaign:all",
+    );
+    expect(
+      getMetricsAggregateCacheKey({
+        ...base,
+        tagName: "campaign",
+        tagValue: "launch",
+      }),
+    ).toBe(
+      "dashboard-aggregate:v1:metrics:user-1:last_7_days:example.com:delivered:campaign:launch",
+    );
+  });
+});

--- a/tests/dashboard-aggregates-service.test.ts
+++ b/tests/dashboard-aggregates-service.test.ts
@@ -41,6 +41,9 @@ function makeRepository(
     async listDomainBreakdown() {
       return [];
     },
+    async listTagOptions() {
+      return [];
+    },
     async countUsage() {
       return {
         monthlyEmails: 0,
@@ -99,6 +102,8 @@ describe("dashboard aggregate service", () => {
       start,
       end,
       domain: "example.com",
+      tagName: "campaign",
+      tagValue: "launch",
       eventType: "opened",
       now: new Date("2026-04-23T06:45:30.000Z"),
     });
@@ -108,12 +113,16 @@ describe("dashboard aggregate service", () => {
       start,
       end,
       domain: "example.com",
+      tagName: "campaign",
+      tagValue: "launch",
     });
     expect(dailyInput).toEqual({
       userId: "user-1",
       start,
       end,
       domain: "example.com",
+      tagName: "campaign",
+      tagValue: "launch",
       statuses: ["opened"],
     });
     expect(payload).toEqual({
@@ -122,6 +131,7 @@ describe("dashboard aggregate service", () => {
       bounceRate: 20,
       complainRate: 10,
       domains: ["example.com"],
+      tagOptions: [],
       dailyData: [{ date: "2026-04-23", count: 7 }],
       domainBreakdown: [{ domain: "example.com", count: 10, rate: 70 }],
       bounceBreakdown: {
@@ -134,6 +144,83 @@ describe("dashboard aggregate service", () => {
       dailyComplainData: [{ date: "2026-04-23", rate: 10 }],
       lastUpdated: "2026-04-23T06:45:30.000Z",
     });
+  });
+
+  it("applies tenant and tag filters consistently across metric aggregate reads", async () => {
+    const start = new Date("2026-05-01T00:00:00.000Z");
+    const end = new Date("2026-05-11T23:59:59.999Z");
+    const metricInputs: MetricsBaseInput[] = [];
+    const dailyInputs: DailyCountsInput[] = [];
+    let tagOptionsUserId: string | undefined;
+
+    const service = createDashboardAggregateService({
+      repository: makeRepository({
+        async aggregateMetrics(input) {
+          metricInputs.push(input);
+          return {
+            total: 0,
+            delivered: 0,
+            bounced: 0,
+            hard_bounced: 0,
+            soft_bounced: 0,
+            undetermined_bounced: 0,
+            complained: 0,
+          };
+        },
+        async listDailyCounts(input) {
+          dailyInputs.push(input);
+          return [];
+        },
+        async listDailyBounceRates(input) {
+          metricInputs.push(input);
+          return [];
+        },
+        async listDailyComplainRates(input) {
+          metricInputs.push(input);
+          return [];
+        },
+        async listDomainBreakdown(input) {
+          metricInputs.push(input);
+          return [];
+        },
+        async listTagOptions(userId) {
+          tagOptionsUserId = userId;
+          return [{ name: "campaign", values: ["launch"] }];
+        },
+      }),
+    });
+
+    const payload = await service.getMetrics({
+      userId: "tenant-1",
+      start,
+      end,
+      domain: "example.com",
+      tagName: "campaign",
+      tagValue: "launch",
+      eventType: "delivered",
+    });
+
+    const expectedBase = {
+      userId: "tenant-1",
+      start,
+      end,
+      domain: "example.com",
+      tagName: "campaign",
+      tagValue: "launch",
+    };
+    expect(metricInputs).toEqual([
+      expectedBase,
+      expectedBase,
+      expectedBase,
+      expectedBase,
+    ]);
+    expect(dailyInputs).toEqual([{ ...expectedBase, statuses: ["delivered"] }]);
+    expect(tagOptionsUserId).toBe("tenant-1");
+    expect(payload.tagOptions).toEqual([
+      { name: "campaign", values: ["launch"] },
+    ]);
+    expect(payload.totalEmails).toBe(0);
+    expect(payload.dailyData).toEqual([]);
   });
 
   it("leaves daily counts unfiltered for all or unknown event types", async () => {
@@ -152,6 +239,8 @@ describe("dashboard aggregate service", () => {
       start: new Date("2026-04-01T00:00:00.000Z"),
       end: new Date("2026-04-02T00:00:00.000Z"),
       domain: null,
+      tagName: null,
+      tagValue: null,
     };
 
     await service.getMetrics({ ...base, eventType: "all" });

--- a/tests/metrics-page.test.ts
+++ b/tests/metrics-page.test.ts
@@ -1,6 +1,12 @@
 // ABOUTME: Unit tests for the Metrics page layout — component structure, collapsible sections
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -144,6 +150,81 @@ describe("Metrics Page Layout", () => {
       // Info icon (circle with i) should be present
       const infoSvgs = container.querySelectorAll("svg");
       expect(infoSvgs.length).toBeGreaterThanOrEqual(2); // chevron + info icon
+    });
+  });
+
+  describe("MetricsPage tag filter behavior", () => {
+    let originalFetch: typeof globalThis.fetch;
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+      const payload = {
+        totalEmails: 3,
+        deliverabilityRate: 100,
+        bounceRate: 0,
+        complainRate: 0,
+        complained: 0,
+        domains: ["example.com"],
+        tagOptions: [
+          { name: "campaign", values: ["launch", ""] },
+          { name: "workflow", values: ["reset"] },
+        ],
+        dailyData: [{ date: "2026-05-11", count: 3 }],
+        domainBreakdown: [{ domain: "example.com", count: 3, rate: 100 }],
+        bounceBreakdown: {
+          permanent: 0,
+          transient: 0,
+          undetermined: 0,
+        },
+        dailyBounceData: [],
+        dailyComplainData: [],
+        lastUpdated: "2026-05-11T00:00:00.000Z",
+      };
+      globalThis.fetch = vi.fn(
+        async () =>
+          new Response(JSON.stringify(payload), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      );
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it("renders tenant tag options and sends tag_name/tag_value query params", async () => {
+      const { MetricsPage } = await import("../src/components/metrics-page");
+      render(React.createElement(MetricsPage));
+
+      await waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledWith(
+          "/api/metrics?range=last_15_days",
+        );
+      });
+
+      fireEvent.click(await screen.findByText("All Tags"));
+      fireEvent.click(screen.getByText("campaign: launch"));
+
+      await waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenLastCalledWith(
+          "/api/metrics?range=last_15_days&tag_name=campaign&tag_value=launch",
+        );
+      });
+    });
+
+    it("can request a tag-name-only filter", async () => {
+      const { MetricsPage } = await import("../src/components/metrics-page");
+      render(React.createElement(MetricsPage));
+
+      fireEvent.click(await screen.findByText("All Tags"));
+      fireEvent.click(screen.getByText("workflow: Any value"));
+
+      await waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenLastCalledWith(
+          "/api/metrics?range=last_15_days&tag_name=workflow",
+        );
+      });
     });
   });
 });

--- a/tests/metrics-route.test.ts
+++ b/tests/metrics-route.test.ts
@@ -21,13 +21,17 @@ vi.mock("@/lib/cache/dashboard-aggregates", () => ({
     range,
     domain,
     eventType,
+    tagName,
+    tagValue,
   }: {
     userId: string;
     range: string;
     domain: string | null;
     eventType: string | null;
+    tagName: string | null;
+    tagValue: string | null;
   }) =>
-    `dashboard-aggregate:v1:metrics:${userId}:${range}:${domain ?? "all"}:${eventType ?? "all"}`,
+    `dashboard-aggregate:v1:metrics:${userId}:${range}:${domain ?? "all"}:${eventType ?? "all"}:${tagName ?? "all"}:${tagValue ?? "all"}`,
   readDashboardAggregateCache: mockReadDashboardAggregateCache,
   writeDashboardAggregateCache: mockWriteDashboardAggregateCache,
 }));
@@ -77,6 +81,7 @@ const freshPayload = {
   complainRate: 10,
   complained: 1,
   domains: ["example.com"],
+  tagOptions: [{ name: "campaign", values: ["launch"] }],
   dailyData: [{ date: "2026-04-23", count: 7 }],
   domainBreakdown: [{ domain: "example.com", count: 10, rate: 70 }],
   bounceBreakdown: {
@@ -117,7 +122,7 @@ describe("metrics route adapter", () => {
     const metricsRoute = await import("@/app/api/metrics/route");
     const response = await metricsRoute.GET(
       makeNextRequest(
-        "http://localhost/api/metrics?range=last_7_days&domain=example.com&event_type=delivered",
+        "http://localhost/api/metrics?range=last_7_days&domain=example.com&event_type=delivered&tag_name=campaign&tag_value=launch",
       ) as never,
     );
 
@@ -127,7 +132,7 @@ describe("metrics route adapter", () => {
     expect(mockWriteDashboardAggregateCache).not.toHaveBeenCalled();
     await expect(response.json()).resolves.toMatchObject({ totalEmails: 99 });
     expect(mockReadDashboardAggregateCache).toHaveBeenCalledWith(
-      "dashboard-aggregate:v1:metrics:user-1:last_7_days:example.com:delivered",
+      "dashboard-aggregate:v1:metrics:user-1:last_7_days:example.com:delivered:campaign:launch",
     );
   });
 
@@ -135,7 +140,7 @@ describe("metrics route adapter", () => {
     const metricsRoute = await import("@/app/api/metrics/route");
     const response = await metricsRoute.GET(
       makeNextRequest(
-        "http://localhost/api/metrics?range=last_7_days&domain=example.com&event_type=opened",
+        "http://localhost/api/metrics?range=last_7_days&domain=example.com&event_type=opened&tag_name=campaign",
       ) as never,
     );
 
@@ -146,6 +151,8 @@ describe("metrics route adapter", () => {
     expect(input.userId).toBe("user-1");
     expect(input.domain).toBe("example.com");
     expect(input.eventType).toBe("opened");
+    expect(input.tagName).toBe("campaign");
+    expect(input.tagValue).toBeNull();
     expectLocalDateParts(requireDate(input.start), {
       year: 2026,
       month: 3,
@@ -165,7 +172,7 @@ describe("metrics route adapter", () => {
       millisecond: 999,
     });
     expect(mockWriteDashboardAggregateCache).toHaveBeenCalledWith(
-      "dashboard-aggregate:v1:metrics:user-1:last_7_days:example.com:opened",
+      "dashboard-aggregate:v1:metrics:user-1:last_7_days:example.com:opened:campaign:all",
       freshPayload,
       60,
     );


### PR DESCRIPTION
## Summary
- Adds `tag_name` plus optional `tag_value` support to `/api/metrics` while preserving range/domain/event filters.
- Threads tag predicates through dashboard aggregate totals, daily data, bounce/complaint rates, and domain breakdowns.
- Partitions metrics cache keys by tag filters and exposes tenant-scoped `tagOptions` for the dashboard.
- Adds a Metrics page tag combobox that sends name-only and name/value filters without changing the send API tag contract.

Closes #378

## Validation
- `make check`
- `bun run test tests/dashboard-aggregates-service.test.ts tests/metrics-route.test.ts tests/dashboard-aggregates-cache.test.ts tests/metrics-page.test.ts`
- `make test` — 133 files / 1088 tests passed

## Notes / Risk
- Tag options are derived from existing tenant email tags only; no send-time tag contract changes.
- Playwright E2E not run because the route/component/unit coverage exercises the new request params and UI control without requiring the dev server.
