### PR TITLE
Enable open and click tracking for outbound email

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-382-worker-time-tracking.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-382-worker-time-tracking.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-11
+issue: "#382"
+type: decision
+promoted_to: null
+---
+
+## Render open/click tracking at worker delivery time
+
+**What:** Open/click tracking rewrites are applied in the queue worker immediately before provider delivery instead of mutating accepted email rows.
+**Why:** The send API has already completed validation, template interpolation, and managed-unsubscribe rendering by the time rows are queued; rendering tracking at worker-time preserves stored body parity when tracking is disabled and also covers scheduled, batch, and broadcast sends that share the worker delivery path.
+**Fix:** Future per-recipient tracking should preserve this provider-payload boundary unless the data model changes to store personalized rendered bodies intentionally.

--- a/packages/core/src/db/repositories/domainRepo.ts
+++ b/packages/core/src/db/repositories/domainRepo.ts
@@ -17,6 +17,12 @@ export const domainRepo = {
     });
   },
 
+  async findByNameForUser(name: string, userId: string) {
+    return await db.query.domains.findFirst({
+      where: and(eq(domains.name, name), eq(domains.userId, userId)),
+    });
+  },
+
   async create(data: typeof domains.$inferInsert) {
     return await db.insert(domains).values(data).returning();
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,7 @@ export * from "./services/receivedEmail";
 export * from "./services/logs";
 export * from "./services/suppressions";
 export * from "./services/emailProvider";
+export * from "./services/tracking";
 export * from "./services/sandboxTestRecipients";
 export * from "./services/storage";
 export * from "./services/template";

--- a/packages/core/src/services/tracking.ts
+++ b/packages/core/src/services/tracking.ts
@@ -1,0 +1,335 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  createHmac,
+  randomBytes,
+  timingSafeEqual,
+} from "node:crypto";
+
+const TOKEN_VERSION = "opensend.tracking.v1";
+const OPEN_PIXEL_MARKER = 'data-opensend-open-tracking="true"';
+
+export type EmailTrackingKind = "open" | "click";
+
+export type EmailTrackingTokenPayload = {
+  v: 1;
+  kind: EmailTrackingKind;
+  userId: string;
+  emailId: string;
+  domainId: string;
+  recipient?: string;
+  targetUrl?: string;
+};
+
+export type VerifiedEmailTrackingToken = EmailTrackingTokenPayload;
+
+export type ApplyEmailTrackingInput = {
+  html: string | null | undefined;
+  clickTracking: boolean;
+  openTracking: boolean;
+  trackingBaseUrl: string;
+  createClickToken: (targetUrl: string) => string;
+  createOpenToken: () => string;
+};
+
+export type ApplyEmailTrackingResult = {
+  html: string;
+  rewroteLinks: number;
+  insertedOpenPixel: boolean;
+};
+
+function getTrackingSecret(): string {
+  const secret =
+    process.env.TRACKING_SECRET ??
+    process.env.UNSUBSCRIBE_SECRET ??
+    process.env.BETTER_AUTH_SECRET ??
+    process.env.AUTH_SECRET ??
+    process.env.DASHBOARD_KEY;
+
+  if (secret) return secret;
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("TRACKING_SECRET or DASHBOARD_KEY is required");
+  }
+  return "opensend-local-tracking-secret";
+}
+
+function signPayload(encodedPayload: string): string {
+  return createHmac("sha256", getTrackingSecret())
+    .update(`${TOKEN_VERSION}:${encodedPayload}`)
+    .digest("base64url");
+}
+
+function getEncryptionKey(): Buffer {
+  return createHash("sha256").update(getTrackingSecret()).digest();
+}
+
+function safeCompare(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  return (
+    leftBuffer.length === rightBuffer.length &&
+    timingSafeEqual(leftBuffer, rightBuffer)
+  );
+}
+
+function encodePayload(payload: EmailTrackingTokenPayload): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", getEncryptionKey(), iv);
+  cipher.setAAD(Buffer.from(TOKEN_VERSION));
+  const encrypted = Buffer.concat([
+    cipher.update(JSON.stringify(payload), "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, encrypted]).toString("base64url");
+}
+
+function decodePayload(encodedPayload: string): unknown {
+  try {
+    const blob = Buffer.from(encodedPayload, "base64url");
+    if (blob.length <= 28) return null;
+    const iv = blob.subarray(0, 12);
+    const tag = blob.subarray(12, 28);
+    const encrypted = blob.subarray(28);
+    const decipher = createDecipheriv("aes-256-gcm", getEncryptionKey(), iv);
+    decipher.setAAD(Buffer.from(TOKEN_VERSION));
+    decipher.setAuthTag(tag);
+    const plaintext = Buffer.concat([
+      decipher.update(encrypted),
+      decipher.final(),
+    ]).toString("utf8");
+    return JSON.parse(plaintext);
+  } catch {
+    return null;
+  }
+}
+
+function isPayloadRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function normalizePayload(value: unknown): EmailTrackingTokenPayload | null {
+  if (!isPayloadRecord(value)) return null;
+  if (value.v !== 1) return null;
+  if (value.kind !== "open" && value.kind !== "click") return null;
+  if (typeof value.userId !== "string" || value.userId.length === 0) {
+    return null;
+  }
+  if (typeof value.emailId !== "string" || value.emailId.length === 0) {
+    return null;
+  }
+  if (typeof value.domainId !== "string" || value.domainId.length === 0) {
+    return null;
+  }
+
+  const payload: EmailTrackingTokenPayload = {
+    v: 1,
+    kind: value.kind,
+    userId: value.userId,
+    emailId: value.emailId,
+    domainId: value.domainId,
+  };
+
+  if (typeof value.recipient === "string" && value.recipient.length > 0) {
+    payload.recipient = value.recipient;
+  }
+  if (typeof value.targetUrl === "string" && value.targetUrl.length > 0) {
+    payload.targetUrl = value.targetUrl;
+  }
+
+  if (payload.kind === "click" && !isHttpUrl(payload.targetUrl)) {
+    return null;
+  }
+
+  return payload;
+}
+
+export function createEmailTrackingToken(
+  payload: Omit<EmailTrackingTokenPayload, "v">,
+): string {
+  const normalizedPayload: EmailTrackingTokenPayload = { v: 1, ...payload };
+  const encodedPayload = encodePayload(normalizedPayload);
+  return `${encodedPayload}.${signPayload(encodedPayload)}`;
+}
+
+export function verifyEmailTrackingToken(
+  token: string | null | undefined,
+): VerifiedEmailTrackingToken | null {
+  if (!token) return null;
+  const [encodedPayload, signature, extra] = token.split(".");
+  if (!encodedPayload || !signature || extra !== undefined) return null;
+  const expectedSignature = signPayload(encodedPayload);
+  if (!safeCompare(signature, expectedSignature)) return null;
+  return normalizePayload(decodePayload(encodedPayload));
+}
+
+export function getEmailAddressDomain(address: string): string {
+  const trimmed = address.trim();
+  const match = trimmed.match(/<([^<>\s]+@[^<>\s]+)>$/);
+  const emailAddress = match?.[1] ?? trimmed;
+  return emailAddress.split("@").pop()?.trim().toLowerCase() ?? "";
+}
+
+export function getEmailTrackingBaseUrl(input: {
+  trackingSubdomain?: string | null;
+  fallbackBaseUrl?: string | null;
+}): string {
+  const fallback =
+    input.fallbackBaseUrl ??
+    process.env.TRACKING_BASE_URL ??
+    process.env.NEXT_PUBLIC_APP_URL ??
+    process.env.APP_URL ??
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null) ??
+    "http://localhost:3015";
+  const fallbackOrigin =
+    normalizeTrackingOrigin(fallback) ?? "http://localhost:3015";
+
+  const trackingSubdomain = input.trackingSubdomain?.trim();
+  if (!trackingSubdomain) return fallbackOrigin;
+
+  return (
+    normalizeTrackingOrigin(
+      /^https?:\/\//i.test(trackingSubdomain)
+        ? trackingSubdomain
+        : `https://${trackingSubdomain}`,
+    ) ?? fallbackOrigin
+  );
+}
+
+function normalizeTrackingOrigin(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function applyEmailTracking(
+  input: ApplyEmailTrackingInput,
+): ApplyEmailTrackingResult {
+  let html = input.html ?? "";
+  let rewroteLinks = 0;
+
+  if (input.clickTracking) {
+    const result = rewriteHtmlLinks({
+      html,
+      trackingBaseUrl: input.trackingBaseUrl,
+      createClickToken: input.createClickToken,
+    });
+    html = result.html;
+    rewroteLinks = result.rewroteLinks;
+  }
+
+  let insertedOpenPixel = false;
+  if (input.openTracking && !html.includes(OPEN_PIXEL_MARKER)) {
+    const token = input.createOpenToken();
+    html = insertOpenPixel(
+      html,
+      buildTrackingUrl(input.trackingBaseUrl, "open", token),
+    );
+    insertedOpenPixel = true;
+  }
+
+  return { html, rewroteLinks, insertedOpenPixel };
+}
+
+function rewriteHtmlLinks(input: {
+  html: string;
+  trackingBaseUrl: string;
+  createClickToken: (targetUrl: string) => string;
+}): { html: string; rewroteLinks: number } {
+  let rewroteLinks = 0;
+  const html = input.html.replace(
+    /<a\b([^>]*?)\bhref\s*=\s*(["'])(.*?)\2([^>]*)>/gi,
+    (
+      fullMatch: string,
+      beforeHref: string,
+      quote: string,
+      rawHref: string,
+      afterHref: string,
+    ) => {
+      const href = decodeHtmlAttribute(rawHref.trim());
+      if (!shouldRewriteHref(href, `${beforeHref} ${afterHref}`)) {
+        return fullMatch;
+      }
+
+      const token = input.createClickToken(href);
+      const trackingUrl = buildTrackingUrl(
+        input.trackingBaseUrl,
+        "click",
+        token,
+      );
+      rewroteLinks++;
+      return `<a${beforeHref}href=${quote}${escapeHtmlAttribute(trackingUrl)}${quote}${afterHref}>`;
+    },
+  );
+
+  return { html, rewroteLinks };
+}
+
+function buildTrackingUrl(
+  trackingBaseUrl: string,
+  kind: EmailTrackingKind,
+  token: string,
+): string {
+  return `${trackingBaseUrl.replace(/\/$/, "")}/api/track/${kind}/${encodeURIComponent(token)}`;
+}
+
+function shouldRewriteHref(href: string, anchorAttributes: string): boolean {
+  if (!isHttpUrl(href)) return false;
+  const lowerHref = href.toLowerCase();
+  const lowerAttributes = anchorAttributes.toLowerCase();
+  if (
+    lowerHref.includes("/unsubscribe/") ||
+    lowerHref.includes("unsubscribe")
+  ) {
+    return false;
+  }
+  if (lowerAttributes.includes("list-unsubscribe")) return false;
+  if (lowerAttributes.includes("unsubscribe")) return false;
+
+  try {
+    const url = new URL(href);
+    if (url.pathname.startsWith("/api/track/")) return false;
+  } catch {
+    return false;
+  }
+
+  return true;
+}
+
+function insertOpenPixel(html: string, pixelUrl: string): string {
+  const pixel = `<img src="${escapeHtmlAttribute(pixelUrl)}" width="1" height="1" alt="" style="display:none!important;width:1px;height:1px;opacity:0" ${OPEN_PIXEL_MARKER} />`;
+  if (/<\/body>/i.test(html)) {
+    return html.replace(/<\/body>/i, `${pixel}</body>`);
+  }
+  return `${html}${pixel}`;
+}
+
+function isHttpUrl(value: string | undefined): value is string {
+  if (!value) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function decodeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/packages/ingester/src/queue-worker.ts
+++ b/packages/ingester/src/queue-worker.ts
@@ -9,13 +9,18 @@ import {
   type BackgroundJob,
   type SandboxTestOutcome,
   type TelemetryContext,
+  applyEmailTracking,
   createBackgroundJob,
+  createEmailTrackingToken,
   createTelemetryContext,
+  domainRepo,
   emailEventRepo,
   emailProvider,
   emailRepo,
   emitCloudWatchMetric,
   finishTelemetrySpan,
+  getEmailAddressDomain,
+  getEmailTrackingBaseUrl,
   getSandboxTestOutcomeForRecipients,
   getTelemetryCarrier,
   logTelemetry,
@@ -426,11 +431,17 @@ export class QueueWorker {
       attributes: { email_id: email.id },
     });
     try {
+      // Tracking is intentionally rendered at worker-time: validation, template,
+      // and managed-unsubscribe rendering already happened when the email row was
+      // accepted, while stored bodies remain unchanged for disabled parity and
+      // auditability. The provider payload is the only mutated boundary.
+      const trackedHtml = await renderTrackedHtmlForDelivery(email);
+
       await emailProvider.sendEmail({
         from: email.from,
         to: email.to,
         subject: email.subject,
-        html: email.html ?? undefined,
+        html: trackedHtml ?? undefined,
         text: email.text ?? undefined,
         cc: email.cc ?? undefined,
         bcc: email.bcc ?? undefined,
@@ -506,6 +517,50 @@ export class QueueWorker {
       throw error;
     }
   }
+}
+
+async function renderTrackedHtmlForDelivery(
+  email: SandboxEmailRecord,
+): Promise<string | null | undefined> {
+  if (!email.html || !email.userId) return email.html;
+
+  const userId = email.userId;
+  const fromDomain = getEmailAddressDomain(email.from);
+  if (!fromDomain) return email.html;
+
+  const domain = await domainRepo.findByNameForUser(fromDomain, userId);
+  if (!domain || (!domain.trackClicks && !domain.trackOpens)) {
+    return email.html;
+  }
+
+  const recipient = email.to.length === 1 ? email.to[0] : undefined;
+  const trackingBaseUrl = getEmailTrackingBaseUrl({
+    trackingSubdomain: domain.trackingSubdomain,
+  });
+
+  return applyEmailTracking({
+    html: email.html,
+    clickTracking: domain.trackClicks,
+    openTracking: domain.trackOpens,
+    trackingBaseUrl,
+    createClickToken: (targetUrl) =>
+      createEmailTrackingToken({
+        kind: "click",
+        userId,
+        emailId: email.id,
+        domainId: domain.id,
+        recipient,
+        targetUrl,
+      }),
+    createOpenToken: () =>
+      createEmailTrackingToken({
+        kind: "open",
+        userId,
+        emailId: email.id,
+        domainId: domain.id,
+        recipient,
+      }),
+  }).html;
 }
 
 function getTerminalEmailSkipReason(status: string): string | null {

--- a/src/app/api/track/click/[token]/route.ts
+++ b/src/app/api/track/click/[token]/route.ts
@@ -1,0 +1,45 @@
+import { queueEvent } from "@/lib/events";
+import { verifyEmailTrackingToken } from "@opensend/core";
+import { findTrackingContext, getRequestMetadata } from "../../tracking-route";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ token: string }> },
+): Promise<Response> {
+  const { token } = await params;
+  const payload = verifyEmailTrackingToken(token);
+  if (!payload || payload.kind !== "click" || !payload.targetUrl) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  let target: URL;
+  try {
+    target = new URL(payload.targetUrl);
+  } catch {
+    return new Response("Not found", { status: 404 });
+  }
+
+  if (target.protocol !== "http:" && target.protocol !== "https:") {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const context = await findTrackingContext(payload);
+  if (!context) return new Response("Not found", { status: 404 });
+
+  await queueEvent({
+    type: "email.clicked",
+    userId: payload.userId,
+    emailId: payload.emailId,
+    payload: {
+      email_id: payload.emailId,
+      domain_id: payload.domainId,
+      recipient: payload.recipient ?? null,
+      url: target.toString(),
+      ...getRequestMetadata(request),
+    },
+  });
+
+  return Response.redirect(target.toString(), 302);
+}

--- a/src/app/api/track/open/[token]/route.ts
+++ b/src/app/api/track/open/[token]/route.ts
@@ -1,0 +1,47 @@
+import { queueEvent } from "@/lib/events";
+import { verifyEmailTrackingToken } from "@opensend/core";
+import { findTrackingContext, getRequestMetadata } from "../../tracking-route";
+
+export const runtime = "nodejs";
+
+const TRANSPARENT_GIF = Uint8Array.from([
+  71, 73, 70, 56, 57, 97, 1, 0, 1, 0, 128, 0, 0, 0, 0, 0, 255, 255, 255, 33,
+  249, 4, 1, 0, 0, 0, 0, 44, 0, 0, 0, 0, 1, 0, 1, 0, 0, 2, 2, 68, 1, 0, 59,
+]);
+
+function pixelResponse(status = 200): Response {
+  return new Response(TRANSPARENT_GIF, {
+    status,
+    headers: {
+      "Content-Type": "image/gif",
+      "Content-Length": String(TRANSPARENT_GIF.length),
+      "Cache-Control": "no-store, max-age=0",
+    },
+  });
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ token: string }> },
+): Promise<Response> {
+  const { token } = await params;
+  const payload = verifyEmailTrackingToken(token);
+  if (!payload || payload.kind !== "open") return pixelResponse(404);
+
+  const context = await findTrackingContext(payload);
+  if (!context) return pixelResponse(404);
+
+  await queueEvent({
+    type: "email.opened",
+    userId: payload.userId,
+    emailId: payload.emailId,
+    payload: {
+      email_id: payload.emailId,
+      domain_id: payload.domainId,
+      recipient: payload.recipient ?? null,
+      ...getRequestMetadata(request),
+    },
+  });
+
+  return pixelResponse();
+}

--- a/src/app/api/track/tracking-route.ts
+++ b/src/app/api/track/tracking-route.ts
@@ -1,0 +1,37 @@
+import { db } from "@/lib/db";
+import { domains, emails } from "@/lib/db/schema";
+import type { VerifiedEmailTrackingToken } from "@opensend/core";
+import { and, eq } from "drizzle-orm";
+
+export async function findTrackingContext(payload: VerifiedEmailTrackingToken) {
+  const [email, domain] = await Promise.all([
+    db.query.emails.findFirst({
+      where: and(
+        eq(emails.id, payload.emailId),
+        eq(emails.userId, payload.userId),
+      ),
+    }),
+    db.query.domains.findFirst({
+      where: and(
+        eq(domains.id, payload.domainId),
+        eq(domains.userId, payload.userId),
+      ),
+    }),
+  ]);
+
+  if (!email || !domain) return null;
+  if (payload.kind === "click" && !domain.trackClicks) return null;
+  if (payload.kind === "open" && !domain.trackOpens) return null;
+  return { email, domain };
+}
+
+export function getRequestMetadata(
+  request: Request,
+): Record<string, string | null> {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  const ip = forwardedFor?.split(",")[0]?.trim() ?? null;
+  return {
+    user_agent: request.headers.get("user-agent"),
+    ip,
+  };
+}

--- a/tests/queue-worker.test.ts
+++ b/tests/queue-worker.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFindById = vi.hoisted(() => vi.fn());
 const mockFindDueScheduled = vi.hoisted(() => vi.fn());
+const mockFindDomainByNameForUser = vi.hoisted(() => vi.fn());
 const mockUpdateEmail = vi.hoisted(() => vi.fn());
 const mockCreateEmailEvent = vi.hoisted(() => vi.fn());
 const mockSendEmail = vi.hoisted(() => vi.fn());
@@ -14,12 +15,15 @@ const mockDispatchPendingDeliveries = vi.hoisted(() => vi.fn());
 const mockEmitCloudWatchMetric = vi.hoisted(() => vi.fn());
 const mockLogTelemetry = vi.hoisted(() => vi.fn());
 const mockRecordTelemetryError = vi.hoisted(() => vi.fn());
+const mockApplyEmailTracking = vi.hoisted(() => vi.fn());
+const mockCreateEmailTrackingToken = vi.hoisted(() => vi.fn());
 
 vi.mock("@opensend/core", () => ({
   createBackgroundJob: (job: Record<string, unknown>) => ({
     ...job,
     requestedAt: "2026-04-28T00:00:00.000Z",
   }),
+  createEmailTrackingToken: mockCreateEmailTrackingToken,
   createTelemetryContext: (input: {
     service: string;
     operation: string;
@@ -36,6 +40,9 @@ vi.mock("@opensend/core", () => ({
       "00-11111111111111111111111111111111-2222222222222222-01",
     correlationId: input.carrier?.correlationId ?? "corr-worker-test",
   }),
+  domainRepo: {
+    findByNameForUser: mockFindDomainByNameForUser,
+  },
   emailEventRepo: {
     create: mockCreateEmailEvent,
   },
@@ -47,6 +54,12 @@ vi.mock("@opensend/core", () => ({
     findDueScheduled: mockFindDueScheduled,
     update: mockUpdateEmail,
   },
+  getEmailAddressDomain: (address: string) =>
+    address.split("@").pop()?.replace(">", "").trim().toLowerCase() ?? "",
+  getEmailTrackingBaseUrl: (input: { trackingSubdomain?: string | null }) =>
+    input.trackingSubdomain
+      ? `https://${input.trackingSubdomain}`
+      : "http://localhost:3015",
   getSandboxTestOutcomeForRecipients: (recipients: string[]) => {
     const outcomes = recipients.map((recipient) => {
       const [local, domain] = recipient.trim().toLowerCase().split("@");
@@ -74,6 +87,7 @@ vi.mock("@opensend/core", () => ({
   }),
   logTelemetry: mockLogTelemetry,
   parseBackgroundJob: (raw: string) => JSON.parse(raw),
+  applyEmailTracking: mockApplyEmailTracking,
   publishBackgroundJob: mockPublishBackgroundJob,
   recordTelemetryError: mockRecordTelemetryError,
   suppressionRepo: {
@@ -109,6 +123,18 @@ describe("QueueWorker", () => {
     vi.clearAllMocks();
     mockListWebhooksForDispatch.mockResolvedValue({ data: [] });
     mockEnqueueWebhookDelivery.mockResolvedValue({ id: "delivery-1" });
+    mockFindDomainByNameForUser.mockResolvedValue(null);
+    mockApplyEmailTracking.mockImplementation((input: { html: string }) => ({
+      html: input.html,
+      rewroteLinks: 0,
+      insertedOpenPixel: false,
+    }));
+    mockCreateEmailTrackingToken.mockImplementation(
+      (payload: { kind: string; targetUrl?: string }) =>
+        payload.targetUrl
+          ? `${payload.kind}:${payload.targetUrl}`
+          : payload.kind,
+    );
   });
 
   afterEach(() => {
@@ -163,6 +189,123 @@ describe("QueueWorker", () => {
       providerNextRetryAt: null,
       providerDeadLetteredAt: null,
     });
+  });
+
+  it("applies domain tracking only to the provider payload", async () => {
+    mockFindById.mockResolvedValue({
+      id: "email-track",
+      from: "sender@example.com",
+      to: ["user@example.com"],
+      cc: [],
+      bcc: [],
+      replyTo: [],
+      subject: "Hello",
+      html: '<p><a href="https://example.com">Hello</a></p>',
+      text: "",
+      headers: {},
+      attachments: [],
+      status: "queued",
+      scheduledAt: null,
+      userId: "user-1",
+    });
+    mockFindDomainByNameForUser.mockResolvedValue({
+      id: "domain-1",
+      name: "example.com",
+      userId: "user-1",
+      trackClicks: true,
+      trackOpens: true,
+      trackingSubdomain: "track.example.com",
+    });
+    mockApplyEmailTracking.mockReturnValue({
+      html: '<p><a href="https://track.example.com/api/track/click/token">Hello</a></p><img data-opensend-open-tracking="true" />',
+      rewroteLinks: 1,
+      insertedOpenPixel: true,
+    });
+
+    const { QueueWorker } = await import(
+      "../packages/ingester/src/queue-worker"
+    );
+    const worker = new QueueWorker({ queueUrl: null });
+
+    await expect(
+      worker.processJob({
+        id: "email.send:email-track",
+        type: "email.send",
+        source: "api",
+        requestedAt: "2026-04-28T00:00:00.000Z",
+        emailId: "email-track",
+      }),
+    ).resolves.toEqual({ status: "sent" });
+
+    expect(mockFindDomainByNameForUser).toHaveBeenCalledWith(
+      "example.com",
+      "user-1",
+    );
+    expect(mockApplyEmailTracking).toHaveBeenCalledWith(
+      expect.objectContaining({
+        html: '<p><a href="https://example.com">Hello</a></p>',
+        clickTracking: true,
+        openTracking: true,
+        trackingBaseUrl: "https://track.example.com",
+      }),
+    );
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        html: expect.stringContaining("data-opensend-open-tracking"),
+      }),
+    );
+    expect(mockUpdateEmail).not.toHaveBeenCalledWith(
+      "email-track",
+      expect.objectContaining({ html: expect.any(String) }),
+    );
+  });
+
+  it("preserves provider HTML when domain tracking is disabled", async () => {
+    const html = '<p><a href="https://example.com">Hello</a></p>';
+    mockFindById.mockResolvedValue({
+      id: "email-no-track",
+      from: "sender@example.com",
+      to: ["user@example.com"],
+      cc: [],
+      bcc: [],
+      replyTo: [],
+      subject: "Hello",
+      html,
+      text: "",
+      headers: {},
+      attachments: [],
+      status: "queued",
+      scheduledAt: null,
+      userId: "user-1",
+    });
+    mockFindDomainByNameForUser.mockResolvedValue({
+      id: "domain-1",
+      name: "example.com",
+      userId: "user-1",
+      trackClicks: false,
+      trackOpens: false,
+      trackingSubdomain: "track.example.com",
+    });
+
+    const { QueueWorker } = await import(
+      "../packages/ingester/src/queue-worker"
+    );
+    const worker = new QueueWorker({ queueUrl: null });
+
+    await expect(
+      worker.processJob({
+        id: "email.send:email-no-track",
+        type: "email.send",
+        source: "api",
+        requestedAt: "2026-04-28T00:00:00.000Z",
+        emailId: "email-no-track",
+      }),
+    ).resolves.toEqual({ status: "sent" });
+
+    expect(mockApplyEmailTracking).not.toHaveBeenCalled();
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ html }),
+    );
   });
 
   it("simulates delivered resend.dev recipients without calling the provider", async () => {

--- a/tests/tracking-routes.test.ts
+++ b/tests/tracking-routes.test.ts
@@ -1,0 +1,164 @@
+import { createEmailTrackingToken } from "@opensend/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFindEmail = vi.hoisted(() => vi.fn());
+const mockFindDomain = vi.hoisted(() => vi.fn());
+const mockQueueEvent = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      emails: { findFirst: mockFindEmail },
+      domains: { findFirst: mockFindDomain },
+    },
+  },
+}));
+
+vi.mock("@/lib/events", () => ({
+  queueEvent: mockQueueEvent,
+}));
+
+function trackingToken(kind: "open" | "click", targetUrl?: string) {
+  return createEmailTrackingToken({
+    kind,
+    userId: "user-1",
+    emailId: "email-1",
+    domainId: "domain-1",
+    recipient: "person@example.com",
+    targetUrl,
+  });
+}
+
+describe("tracking routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindEmail.mockResolvedValue({
+      id: "email-1",
+      userId: "user-1",
+    });
+    mockFindDomain.mockResolvedValue({
+      id: "domain-1",
+      userId: "user-1",
+      trackClicks: true,
+      trackOpens: true,
+    });
+    mockQueueEvent.mockResolvedValue({ eventId: "event-1", deliveryIds: [] });
+  });
+
+  it("records click events and redirects only to the signed target URL", async () => {
+    const { GET } = await import("../src/app/api/track/click/[token]/route");
+    const token = trackingToken(
+      "click",
+      "https://destination.example.com/welcome?utm=1",
+    );
+
+    const response = await GET(
+      new Request("https://track.example.com/api/track/click/token", {
+        headers: {
+          "user-agent": "vitest-agent",
+          "x-forwarded-for": "203.0.113.10, 10.0.0.1",
+        },
+      }),
+      { params: Promise.resolve({ token }) },
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://destination.example.com/welcome?utm=1",
+    );
+    expect(mockQueueEvent).toHaveBeenCalledWith({
+      type: "email.clicked",
+      userId: "user-1",
+      emailId: "email-1",
+      payload: {
+        email_id: "email-1",
+        domain_id: "domain-1",
+        recipient: "person@example.com",
+        url: "https://destination.example.com/welcome?utm=1",
+        user_agent: "vitest-agent",
+        ip: "203.0.113.10",
+      },
+    });
+  });
+
+  it("rejects forged click tokens without using a redirect query parameter", async () => {
+    const { GET } = await import("../src/app/api/track/click/[token]/route");
+    const token = `${trackingToken("click", "https://safe.example.com")}forged`;
+
+    const response = await GET(
+      new Request(
+        "https://track.example.com/api/track/click/token?url=https://evil.example.com",
+      ),
+      { params: Promise.resolve({ token }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("location")).toBeNull();
+    expect(mockQueueEvent).not.toHaveBeenCalled();
+  });
+
+  it("records open events and returns a no-store transparent image", async () => {
+    const { GET } = await import("../src/app/api/track/open/[token]/route");
+    const token = trackingToken("open");
+
+    const response = await GET(
+      new Request("https://track.example.com/api/track/open/token", {
+        headers: { "user-agent": "pixel-agent" },
+      }),
+      { params: Promise.resolve({ token }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/gif");
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    expect((await response.arrayBuffer()).byteLength).toBeGreaterThan(0);
+    expect(mockQueueEvent).toHaveBeenCalledWith({
+      type: "email.opened",
+      userId: "user-1",
+      emailId: "email-1",
+      payload: {
+        email_id: "email-1",
+        domain_id: "domain-1",
+        recipient: "person@example.com",
+        user_agent: "pixel-agent",
+        ip: null,
+      },
+    });
+  });
+
+  it("does not create events when the domain toggle is disabled", async () => {
+    mockFindDomain.mockResolvedValue({
+      id: "domain-1",
+      userId: "user-1",
+      trackClicks: false,
+      trackOpens: true,
+    });
+    const { GET } = await import("../src/app/api/track/click/[token]/route");
+
+    const response = await GET(
+      new Request("https://track.example.com/api/track/click/token"),
+      {
+        params: Promise.resolve({
+          token: trackingToken("click", "https://destination.example.com"),
+        }),
+      },
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("location")).toBeNull();
+    expect(mockQueueEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not create events when token tenant context is missing", async () => {
+    mockFindDomain.mockResolvedValue(null);
+    const { GET } = await import("../src/app/api/track/open/[token]/route");
+
+    const response = await GET(
+      new Request("https://track.example.com/api/track/open/token"),
+      { params: Promise.resolve({ token: trackingToken("open") }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockQueueEvent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tracking.test.ts
+++ b/tests/tracking.test.ts
@@ -1,0 +1,136 @@
+import {
+  applyEmailTracking,
+  createEmailTrackingToken,
+  getEmailAddressDomain,
+  getEmailTrackingBaseUrl,
+  verifyEmailTrackingToken,
+} from "@opensend/core";
+import { describe, expect, it } from "vitest";
+
+function tokenFor(kind: "open" | "click", targetUrl?: string) {
+  return createEmailTrackingToken({
+    kind,
+    userId: "user-1",
+    emailId: "email-1",
+    domainId: "domain-1",
+    recipient: "person@example.com",
+    targetUrl,
+  });
+}
+
+describe("email tracking helpers", () => {
+  it("creates tenant-scoped opaque signed tokens and rejects tampering", () => {
+    const token = tokenFor("click", "https://example.com/path?a=1");
+
+    expect(token).not.toContain("https://example.com");
+    expect(verifyEmailTrackingToken(token)).toMatchObject({
+      kind: "click",
+      userId: "user-1",
+      emailId: "email-1",
+      domainId: "domain-1",
+      recipient: "person@example.com",
+      targetUrl: "https://example.com/path?a=1",
+    });
+    expect(verifyEmailTrackingToken(`${token}tampered`)).toBeNull();
+  });
+
+  it("rewrites accepted HTTP links while preserving unsubscribe and non-web links", () => {
+    const html = `<html><body>
+      <a href="https://example.com/welcome?x=1&amp;y=2">Welcome</a>
+      <a href='http://example.net/next'>Next</a>
+      <a href="mailto:support@example.com">Mail</a>
+      <a href="https://app.opensend.dev/unsubscribe/contact-1?token=u">Unsubscribe</a>
+      <a data-role="list-unsubscribe" href="https://example.com/list">List unsubscribe</a>
+    </body></html>`;
+
+    const result = applyEmailTracking({
+      html,
+      clickTracking: true,
+      openTracking: false,
+      trackingBaseUrl: "https://track.example.com",
+      createClickToken: (targetUrl) => tokenFor("click", targetUrl),
+      createOpenToken: () => tokenFor("open"),
+    });
+
+    expect(result.rewroteLinks).toBe(2);
+    expect(result.insertedOpenPixel).toBe(false);
+    expect(result.html.match(/\/api\/track\/click\//g)).toHaveLength(2);
+    expect(result.html).toContain("mailto:support@example.com");
+    expect(result.html).toContain("/unsubscribe/contact-1?token=u");
+    expect(result.html).toContain('data-role="list-unsubscribe"');
+  });
+
+  it("inserts exactly one 1x1 open pixel before body close", () => {
+    const result = applyEmailTracking({
+      html: "<html><body><p>Hello</p></body></html>",
+      clickTracking: false,
+      openTracking: true,
+      trackingBaseUrl: "https://track.example.com/",
+      createClickToken: (targetUrl) => tokenFor("click", targetUrl),
+      createOpenToken: () => tokenFor("open"),
+    });
+
+    expect(result.rewroteLinks).toBe(0);
+    expect(result.insertedOpenPixel).toBe(true);
+    expect(result.html.match(/data-opensend-open-tracking/g)).toHaveLength(1);
+    expect(result.html).toContain('width="1" height="1"');
+    expect(result.html).toContain("/api/track/open/");
+    expect(result.html.indexOf("data-opensend-open-tracking")).toBeLessThan(
+      result.html.indexOf("</body>"),
+    );
+
+    const secondPass = applyEmailTracking({
+      html: result.html,
+      clickTracking: false,
+      openTracking: true,
+      trackingBaseUrl: "https://track.example.com",
+      createClickToken: (targetUrl) => tokenFor("click", targetUrl),
+      createOpenToken: () => tokenFor("open"),
+    });
+    expect(secondPass.html.match(/data-opensend-open-tracking/g)).toHaveLength(
+      1,
+    );
+    expect(secondPass.insertedOpenPixel).toBe(false);
+  });
+
+  it("preserves HTML exactly when both toggles are disabled", () => {
+    const html = '<p><a href="https://example.com">No tracking</a></p>';
+    const result = applyEmailTracking({
+      html,
+      clickTracking: false,
+      openTracking: false,
+      trackingBaseUrl: "https://track.example.com",
+      createClickToken: (targetUrl) => tokenFor("click", targetUrl),
+      createOpenToken: () => tokenFor("open"),
+    });
+
+    expect(result).toEqual({
+      html,
+      rewroteLinks: 0,
+      insertedOpenPixel: false,
+    });
+  });
+
+  it("derives configured tracking subdomains and fallback app origins", () => {
+    expect(
+      getEmailTrackingBaseUrl({ trackingSubdomain: "track.example.com" }),
+    ).toBe("https://track.example.com");
+    expect(
+      getEmailTrackingBaseUrl({
+        trackingSubdomain: "http://localhost:3015/",
+      }),
+    ).toBe("http://localhost:3015");
+    expect(
+      getEmailTrackingBaseUrl({
+        trackingSubdomain: "https://track.example.com/path?ignored=1",
+      }),
+    ).toBe("https://track.example.com");
+    expect(
+      getEmailTrackingBaseUrl({ fallbackBaseUrl: "https://app.example.com/" }),
+    ).toBe("https://app.example.com");
+    expect(getEmailAddressDomain("sender@example.com")).toBe("example.com");
+    expect(getEmailAddressDomain("Sender <sender@example.com>")).toBe(
+      "example.com",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Implements bounded Resend-parity open/click tracking for enabled domains.
- Applies tracking at queue-worker delivery time after validation/template/managed-unsubscribe rendering and before SES/provider delivery, leaving stored email bodies unchanged.
- Adds encrypted + HMAC-signed tenant/domain/email-scoped tracking tokens and public open/click routes that only resolve target URLs from signed token payloads.

Closes #382

## Changed files
- `packages/core/src/services/tracking.ts` — token creation/verification, tracking base URL normalization, HTML link rewrite, open pixel insertion, unsubscribe/list-unsubscribe skipping.
- `packages/core/src/db/repositories/domainRepo.ts` — tenant-scoped domain lookup by sender domain for worker tracking decisions.
- `packages/core/src/index.ts` — exports tracking helpers to the ingester worker.
- `packages/ingester/src/queue-worker.ts` — applies tracking only to provider HTML payloads when the sending tenant domain has `trackClicks` and/or `trackOpens` enabled.
- `src/app/api/track/click/[token]/route.ts` — validates click token/context, records `email.clicked`, redirects to signed target URL.
- `src/app/api/track/open/[token]/route.ts` — validates open token/context, records `email.opened`, returns no-store transparent GIF.
- `src/app/api/track/tracking-route.ts` — shared tenant/domain/email context validation and toggle gate.
- `tests/tracking.test.ts` — token, rewrite, pixel, disabled no-op, base URL coverage.
- `tests/tracking-routes.test.ts` — click/open route event behavior, forged token/open-redirect guard, disabled toggle guard.
- `tests/queue-worker.test.ts` — worker boundary coverage for enabled tracking and disabled provider-payload no-op.
- `agent_docs/learnings/active/2026-05-11-issue-382-worker-time-tracking.md` — records the worker-time rendering boundary decision.

## Behavior covered
- Click tracking rewrites only HTTP/HTTPS anchor hrefs, skips unsubscribe/list-unsubscribe/non-web links, and uses `/api/track/click/<token>` URLs.
- Open tracking inserts exactly one 1x1 transparent pixel.
- Disabled tracking leaves provider HTML unchanged and does not call the tracking renderer.
- Tracking routes require valid signed tokens, tenant-scoped email/domain context, and the matching domain toggle still enabled.
- Click redirects ignore query-string redirect targets and redirect only to the signed token target URL.

## Validation
- `bun run test tests/tracking.test.ts tests/tracking-routes.test.ts tests/queue-worker.test.ts` — passed: 3 files, 22 tests.
- `make check` — passed: TypeScript + Biome.
- `make test` — passed: 135 files, 1100 tests.
- `git push` pre-push `bun run check` — passed: full-project typecheck + changed-file Biome.

## Residual risks
- No live SES/DNS custom tracking-subdomain smoke was run; this is covered by unit/route/worker behavior tests only.
- HTML rewriting is intentionally bounded to quoted `<a href="...">` / `<a href='...'>` patterns rather than a full HTML parser.
- Multi-recipient sends share an email-level token with no per-recipient attribution unless the send has a single recipient.
