### PR TITLE
Enrich email detail trace evidence

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-391-email-trace-sanitizer.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-391-email-trace-sanitizer.md
@@ -1,0 +1,19 @@
+---
+date: 2026-05-11
+issue: "#391"
+type: decision
+promoted_to: null
+---
+
+## Email detail trace shares a bounded provider-payload sanitizer
+
+Issue #391 adds dashboard event trace details without rendering raw
+`email_events.payload`. The shared mapper lives in
+`packages/core/src/services/emailEventTrace.ts` so `EmailLifecycleService` and
+the dashboard use the same event id/type/order/detail semantics while the legacy
+API event payload remains present for compatibility.
+
+Future trace fields should be added as explicit allowlisted extracts with small
+string/array bounds. Do not render generic payload JSON in the dashboard: auth
+headers, body/html/text, cookies, tokens, and provider payload drift can expose
+too much context.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,7 @@ export * from "./services/contact";
 export * from "./services/contact-operations";
 export * from "./services/email";
 export * from "./services/deliveryFailureExport";
+export * from "./services/emailEventTrace";
 export * from "./services/emailLifecycle";
 export * from "./services/emailRead";
 export * from "./services/emailDetail";

--- a/packages/core/src/services/emailEventTrace.ts
+++ b/packages/core/src/services/emailEventTrace.ts
@@ -1,0 +1,362 @@
+export type EmailEventTraceDetailValue = string | number | boolean | string[];
+
+export type EmailEventTraceDetails = Record<string, EmailEventTraceDetailValue>;
+
+export type EmailEventTraceRow = {
+  id: string;
+  type: string;
+  payload: unknown;
+  receivedAt: Date;
+};
+
+export type EmailEventTraceItem = {
+  object: "email_event";
+  id: string;
+  type: string;
+  created_at: Date;
+  summary: string;
+  details: EmailEventTraceDetails;
+};
+
+const MAX_STRING_LENGTH = 180;
+const MAX_RECIPIENTS = 3;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readRecord(
+  source: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | null {
+  const value = source[key];
+  return isRecord(value) ? value : null;
+}
+
+function truncate(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= MAX_STRING_LENGTH) return trimmed;
+  return `${trimmed.slice(0, MAX_STRING_LENGTH - 1)}…`;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? truncate(value) : null;
+}
+
+function readNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function readBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+function firstString(
+  sources: Array<Record<string, unknown> | null>,
+  keys: readonly string[],
+): string | null {
+  for (const source of sources) {
+    if (!source) continue;
+    for (const key of keys) {
+      const value = readString(source[key]);
+      if (value) return value;
+    }
+  }
+  return null;
+}
+
+function firstNumber(
+  sources: Array<Record<string, unknown> | null>,
+  keys: readonly string[],
+): number | null {
+  for (const source of sources) {
+    if (!source) continue;
+    for (const key of keys) {
+      const value = readNumber(source[key]);
+      if (value !== null) return value;
+    }
+  }
+  return null;
+}
+
+function firstBoolean(
+  sources: Array<Record<string, unknown> | null>,
+  keys: readonly string[],
+): boolean | null {
+  for (const source of sources) {
+    if (!source) continue;
+    for (const key of keys) {
+      const value = readBoolean(source[key]);
+      if (value !== null) return value;
+    }
+  }
+  return null;
+}
+
+function addString(
+  details: EmailEventTraceDetails,
+  key: string,
+  value: string | null,
+) {
+  if (value) details[key] = value;
+}
+
+function addNumber(
+  details: EmailEventTraceDetails,
+  key: string,
+  value: number | null,
+) {
+  if (value !== null) details[key] = value;
+}
+
+function addBoolean(
+  details: EmailEventTraceDetails,
+  key: string,
+  value: boolean | null,
+) {
+  if (value !== null) details[key] = value;
+}
+
+function readRecipientAddress(value: unknown): string | null {
+  if (typeof value === "string") return readString(value);
+  if (!isRecord(value)) return null;
+  return firstString([value], ["emailAddress", "email_address", "email"]);
+}
+
+function readRecipientRecords(
+  source: Record<string, unknown>,
+  key: string,
+): Record<string, unknown>[] {
+  const value = source[key];
+  if (!Array.isArray(value)) return [];
+  return value.filter(isRecord);
+}
+
+function readRecipientStrings(
+  source: Record<string, unknown>,
+  key: string,
+): string[] {
+  const value = source[key];
+  if (!Array.isArray(value)) return [];
+  return value
+    .map(readRecipientAddress)
+    .filter((recipient): recipient is string => Boolean(recipient));
+}
+
+function extractRecipients(
+  payload: Record<string, unknown>,
+  mail: Record<string, unknown> | null,
+): {
+  recipients: string[];
+  total: number;
+  firstRecord: Record<string, unknown> | null;
+} {
+  const recipientRecords = [
+    ...readRecipientRecords(payload, "bouncedRecipients"),
+    ...readRecipientRecords(payload, "complainedRecipients"),
+  ];
+
+  const recipients = [
+    ...readRecipientStrings(payload, "recipients"),
+    ...readRecipientStrings(payload, "bouncedRecipients"),
+    ...readRecipientStrings(payload, "complainedRecipients"),
+    ...(mail ? readRecipientStrings(mail, "destination") : []),
+  ];
+
+  const uniqueRecipients = Array.from(new Set(recipients));
+  return {
+    recipients: uniqueRecipients.slice(0, MAX_RECIPIENTS),
+    total: uniqueRecipients.length,
+    firstRecord: recipientRecords[0] ?? null,
+  };
+}
+
+function addRecipients(
+  details: EmailEventTraceDetails,
+  extracted: ReturnType<typeof extractRecipients>,
+) {
+  if (extracted.recipients.length > 0) {
+    details.recipients = extracted.recipients;
+  }
+  if (extracted.total > extracted.recipients.length) {
+    details.recipients_count = extracted.total;
+  }
+}
+
+function stringDetail(
+  details: EmailEventTraceDetails,
+  key: string,
+): string | null {
+  const value = details[key];
+  return typeof value === "string" ? value : null;
+}
+
+function recipientsDetail(details: EmailEventTraceDetails): string | null {
+  const value = details.recipients;
+  if (!Array.isArray(value) || value.length === 0) return null;
+
+  const count = details.recipients_count;
+  const suffix =
+    typeof count === "number" && count > value.length
+      ? ` (+${count - value.length} more)`
+      : "";
+  return `${value.join(", ")}${suffix}`;
+}
+
+function buildSummary(type: string, details: EmailEventTraceDetails): string {
+  const recipients = recipientsDetail(details);
+  const reason =
+    stringDetail(details, "reason") ??
+    stringDetail(details, "error_message") ??
+    stringDetail(details, "diagnostic_code");
+
+  switch (type) {
+    case "sent": {
+      const messageId = stringDetail(details, "message_id");
+      return messageId
+        ? `Accepted by provider as ${messageId}`
+        : "Accepted by provider";
+    }
+    case "delivered": {
+      const smtp = stringDetail(details, "smtp_response");
+      return [recipients ? `Delivered to ${recipients}` : "Delivered", smtp]
+        .filter(Boolean)
+        .join(" — ");
+    }
+    case "bounced": {
+      const bounceType = stringDetail(details, "bounce_type");
+      return [
+        bounceType ? `${bounceType} bounce` : "Bounce recorded",
+        recipients ? `for ${recipients}` : null,
+        reason,
+      ]
+        .filter(Boolean)
+        .join(" — ");
+    }
+    case "complained": {
+      const feedbackType = stringDetail(details, "complaint_feedback_type");
+      return [
+        feedbackType ? `Complaint: ${feedbackType}` : "Complaint recorded",
+        recipients ? `from ${recipients}` : null,
+      ]
+        .filter(Boolean)
+        .join(" — ");
+    }
+    case "delivery_delayed":
+      return [
+        recipients ? `Delivery delayed for ${recipients}` : "Delivery delayed",
+        reason,
+      ]
+        .filter(Boolean)
+        .join(" — ");
+    case "failed":
+      return reason ? `Failed: ${reason}` : "Provider failure recorded";
+    case "opened":
+      return recipients ? `Opened by ${recipients}` : "Open recorded";
+    case "clicked":
+      return recipients ? `Clicked by ${recipients}` : "Click recorded";
+    default:
+      return reason ?? "Provider event recorded";
+  }
+}
+
+export function toEmailEventTraceItem(
+  event: EmailEventTraceRow,
+): EmailEventTraceItem {
+  const payload = isRecord(event.payload) ? event.payload : {};
+  const mail = readRecord(payload, "mail");
+  const error = readRecord(payload, "error");
+  const lastError = readRecord(payload, "last_error");
+  const extractedRecipients = extractRecipients(payload, mail);
+  const details: EmailEventTraceDetails = {};
+  const searchSources = [
+    payload,
+    mail,
+    error,
+    lastError,
+    extractedRecipients.firstRecord,
+  ];
+
+  addString(
+    details,
+    "message_id",
+    firstString(searchSources, [
+      "sourceMessageId",
+      "messageId",
+      "message_id",
+      "feedbackId",
+    ]),
+  );
+  addString(details, "provider", firstString(searchSources, ["provider"]));
+  addString(
+    details,
+    "reason",
+    firstString(searchSources, ["reason", "code", "type"]),
+  );
+  addString(
+    details,
+    "error_message",
+    firstString(searchSources, ["message", "errorMessage", "error_message"]),
+  );
+  addString(
+    details,
+    "bounce_type",
+    firstString(searchSources, ["bounceType", "bounce_type"]),
+  );
+  addString(
+    details,
+    "bounce_subtype",
+    firstString(searchSources, ["bounceSubType", "bounce_subtype"]),
+  );
+  addString(
+    details,
+    "complaint_feedback_type",
+    firstString(searchSources, [
+      "complaintFeedbackType",
+      "complaint_feedback_type",
+    ]),
+  );
+  addString(
+    details,
+    "diagnostic_code",
+    firstString(searchSources, ["diagnosticCode", "diagnostic_code"]),
+  );
+  addString(
+    details,
+    "smtp_response",
+    firstString(searchSources, ["smtpResponse", "smtp_response"]),
+  );
+  addString(
+    details,
+    "remote_mta_ip",
+    firstString(searchSources, ["remoteMtaIp", "remote_mta_ip"]),
+  );
+  addString(details, "status", firstString(searchSources, ["status"]));
+  addString(details, "action", firstString(searchSources, ["action"]));
+  addString(details, "timestamp", firstString(searchSources, ["timestamp"]));
+  addNumber(
+    details,
+    "processing_time_ms",
+    firstNumber(searchSources, ["processingTimeMillis", "processing_time_ms"]),
+  );
+  addNumber(
+    details,
+    "attempt_count",
+    firstNumber(searchSources, ["attempt_count", "attemptCount"]),
+  );
+  addBoolean(
+    details,
+    "tls_used",
+    firstBoolean(searchSources, ["tlsUsed", "tls_used"]),
+  );
+  addRecipients(details, extractedRecipients);
+
+  return {
+    object: "email_event",
+    id: event.id,
+    type: event.type,
+    created_at: event.receivedAt,
+    summary: buildSummary(event.type, details),
+    details,
+  };
+}

--- a/packages/core/src/services/emailLifecycle.ts
+++ b/packages/core/src/services/emailLifecycle.ts
@@ -1,6 +1,11 @@
 import { and, asc, eq } from "drizzle-orm";
 import { db } from "../db/client";
 import { emailEvents, emails } from "../db/schema";
+import {
+  type EmailEventTraceDetails,
+  type EmailEventTraceItem,
+  toEmailEventTraceItem,
+} from "./emailEventTrace";
 import { storageService } from "./storage";
 
 type EmailRow = typeof emails.$inferSelect;
@@ -45,11 +50,9 @@ export type EmailLifecycleCancelResponse = {
   status: "canceled";
 };
 
-export type EmailLifecycleEventListItem = {
-  object: "email_event";
-  id: string;
-  type: string;
+export type EmailLifecycleEventListItem = EmailEventTraceItem & {
   payload: unknown;
+  details: EmailEventTraceDetails;
   created_at: EmailEventRow["receivedAt"];
 };
 
@@ -149,11 +152,8 @@ function toEmailEventListItem(
   event: EmailEventRow,
 ): EmailLifecycleEventListItem {
   return {
-    object: "email_event",
-    id: event.id,
-    type: event.type,
+    ...toEmailEventTraceItem(event),
     payload: event.payload,
-    created_at: event.receivedAt,
   };
 }
 

--- a/src/app/(dashboard)/emails/[id]/page.tsx
+++ b/src/app/(dashboard)/emails/[id]/page.tsx
@@ -2,7 +2,8 @@ import { EmailDetail } from "@/components/email-detail";
 import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { emailEvents, emailSuppressions, emails, logs } from "@/lib/db/schema";
-import { and, desc, eq, sql } from "drizzle-orm";
+import { toEmailEventTraceItem } from "@opensend/core";
+import { and, asc, desc, eq, sql } from "drizzle-orm";
 import { notFound, redirect } from "next/navigation";
 
 export default async function EmailDetailPage({
@@ -30,7 +31,7 @@ export default async function EmailDetailPage({
     .select()
     .from(emailEvents)
     .where(and(eq(emailEvents.emailId, id), eq(emailEvents.userId, userId)))
-    .orderBy(desc(emailEvents.receivedAt));
+    .orderBy(asc(emailEvents.receivedAt));
 
   const associatedLogs = await db
     .select({
@@ -78,10 +79,16 @@ export default async function EmailDetailPage({
           suppressedAt: suppression.suppressedAt.toISOString(),
         }
       : null,
-    events: events.map((e) => ({
-      type: e.type,
-      timestamp: e.receivedAt.toISOString(),
-    })),
+    events: events.map((event) => {
+      const trace = toEmailEventTraceItem(event);
+      return {
+        id: trace.id,
+        type: trace.type,
+        timestamp: trace.created_at.toISOString(),
+        summary: trace.summary,
+        details: trace.details,
+      };
+    }),
     logs: associatedLogs.map((log) => ({
       id: log.id,
       method: log.method ?? "GET",

--- a/src/components/email-detail.tsx
+++ b/src/components/email-detail.tsx
@@ -109,7 +109,13 @@ export interface EmailDetailData {
     reason: "bounced" | "complained";
     suppressedAt: string;
   } | null;
-  events: Array<{ type: string; timestamp: string }>;
+  events: Array<{
+    id: string;
+    type: string;
+    timestamp: string;
+    summary: string;
+    details: Record<string, string | number | boolean | string[]>;
+  }>;
   logs?: Array<{
     id: string;
     method: string;
@@ -176,6 +182,21 @@ function formatEventTimestamp(dateStr: string): string {
   const ampm = hours >= 12 ? "PM" : "AM";
   const h = hours % 12 || 12;
   return `${month} ${day}, ${h}:${minutes} ${ampm}`;
+}
+
+function formatDetailLabel(key: string): string {
+  return key
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function formatDetailValue(
+  value: string | number | boolean | string[],
+): string {
+  if (Array.isArray(value)) return value.join(", ");
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  return String(value);
 }
 
 /**
@@ -419,36 +440,70 @@ export function EmailDetail({ email }: EmailDetailProps) {
       {/* Email Events */}
       <div className="mb-8">
         <p className="text-[11px] font-medium text-[#A1A4A5] tracking-wider mb-4">
-          EMAIL EVENTS
+          EMAIL EVENT TRACE
         </p>
         <div className="space-y-3" data-testid="event-timeline">
           {email.events.length > 0 ? (
-            email.events.map((event) => (
-              <div
-                key={`${event.timestamp}-${event.type}`}
-                className="flex items-center gap-3 text-[13px] group"
-              >
+            email.events.map((event) => {
+              const details = Object.entries(event.details);
+              return (
                 <div
-                  className={clsx(
-                    "w-2 h-2 rounded-full",
-                    event.type === "delivered" || event.type === "sent"
-                      ? "bg-emerald-500"
-                      : event.type === "bounced" || event.type === "failed"
-                        ? "bg-red-500"
-                        : "bg-blue-500",
-                  )}
-                />
-                <span
-                  className="text-[#F0F0F0] min-w-[100px]"
-                  data-testid="event-badge"
+                  key={event.id}
+                  className="rounded-lg border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.5)] px-4 py-3 text-[13px] group"
+                  data-testid="event-trace-row"
                 >
-                  {formatStatusLabel(event.type)}
-                </span>
-                <span className="text-[#666]">
-                  {formatEventTimestamp(event.timestamp)}
-                </span>
-              </div>
-            ))
+                  <div className="flex items-start gap-3">
+                    <div
+                      className={clsx(
+                        "w-2 h-2 rounded-full mt-1.5 shrink-0",
+                        event.type === "delivered" || event.type === "sent"
+                          ? "bg-emerald-500"
+                          : event.type === "bounced" || event.type === "failed"
+                            ? "bg-red-500"
+                            : "bg-blue-500",
+                      )}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                        <span
+                          className="text-[#F0F0F0] font-medium"
+                          data-testid="event-badge"
+                        >
+                          {formatStatusLabel(event.type)}
+                        </span>
+                        <span className="text-[#666]">
+                          {formatEventTimestamp(event.timestamp)}
+                        </span>
+                        <span
+                          className="font-mono text-[11px] text-[#A1A4A5]"
+                          data-testid="event-id"
+                        >
+                          event_id: {event.id}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-[#D6D6D6]">{event.summary}</p>
+                      {details.length > 0 && (
+                        <dl className="mt-2 grid gap-x-4 gap-y-1 sm:grid-cols-2">
+                          {details.map(([key, value]) => (
+                            <div
+                              key={key}
+                              className="min-w-0 font-mono text-[11px]"
+                            >
+                              <dt className="inline text-[#666]">
+                                {formatDetailLabel(key)}:
+                              </dt>{" "}
+                              <dd className="inline break-words text-[#A1A4A5]">
+                                {formatDetailValue(value)}
+                              </dd>
+                            </div>
+                          ))}
+                        </dl>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            })
           ) : (
             <div className="py-4 px-4 rounded-lg bg-[rgba(24,25,28,0.5)] border border-dashed border-[rgba(176,199,217,0.145)] text-center text-[13px] text-[#666]">
               No events recorded yet
@@ -470,6 +525,9 @@ export function EmailDetail({ email }: EmailDetailProps) {
             View all logs
           </Link>
         </div>
+        <p className="mb-3 text-[12px] text-[#666]">
+          Showing request logs linked to this message by the same email_id.
+        </p>
         <div className="space-y-3" data-testid="associated-logs">
           {email.logs && email.logs.length > 0 ? (
             email.logs.map((log) => (
@@ -481,6 +539,12 @@ export function EmailDetail({ email }: EmailDetailProps) {
                 <StatusBadge status={log.method.toUpperCase()} variant="info" />
                 <span className="font-mono text-[#F0F0F0] truncate flex-1">
                   {log.endpoint || "-"}
+                </span>
+                <span className="font-mono text-[11px] text-[#A1A4A5]">
+                  same email_id
+                </span>
+                <span className="font-mono text-[11px] text-[#666]">
+                  log_id: {log.id}
                 </span>
                 <StatusBadge
                   status={String(log.statusCode)}

--- a/tests/e2e/email-detail-trace.spec.ts
+++ b/tests/e2e/email-detail-trace.spec.ts
@@ -1,0 +1,173 @@
+import { createE2ETenant, expect, test } from "./fixtures/auth";
+
+test("dashboard email detail trace shows sanitized event details and linked logs for one tenant", async ({
+  authenticatedPage: page,
+  e2eDb,
+  e2eRunId,
+  e2eTenant,
+}) => {
+  const otherTenant = await createE2ETenant(e2eDb, e2eRunId, "other");
+  const recipient = `trace@${e2eRunId}.e2e.opensend.test`;
+  const otherRecipient = `other-trace@${e2eRunId}.e2e.opensend.test`;
+  const rawSecret = `Bearer e2e-secret-${e2eRunId}`;
+  const rawBody = `raw-html-secret-${e2eRunId}`;
+  const otherTenantMarker = `other-tenant-marker-${e2eRunId}`;
+
+  const insertedEmail = await e2eDb.query<{ id: string }>(
+    `insert into emails ("from", "to", subject, html, text, status, user_id, created_at)
+     values ($1, $2::jsonb, $3, $4, $5, 'bounced', $6, $7)
+     returning id`,
+    [
+      "sender@example.com",
+      JSON.stringify([recipient]),
+      "Trace detail e2e",
+      "<p>Hello trace</p>",
+      "Hello trace",
+      e2eTenant.user.id,
+      "2026-05-11T00:00:00.000Z",
+    ],
+  );
+  const emailId = insertedEmail.rows[0]?.id ?? "";
+  expect(emailId).toBeTruthy();
+
+  const insertedOtherEmail = await e2eDb.query<{ id: string }>(
+    `insert into emails ("from", "to", subject, status, user_id, created_at)
+     values ($1, $2::jsonb, $3, 'bounced', $4, $5)
+     returning id`,
+    [
+      "sender@example.com",
+      JSON.stringify([otherRecipient]),
+      otherTenantMarker,
+      otherTenant.user.id,
+      "2026-05-11T00:00:00.000Z",
+    ],
+  );
+  const otherEmailId = insertedOtherEmail.rows[0]?.id ?? "";
+  expect(otherEmailId).toBeTruthy();
+
+  const sentEvent = await e2eDb.query<{ id: string }>(
+    `insert into email_events (email_id, source_id, type, payload, user_id, received_at)
+     values ($1, $2, 'sent', $3::jsonb, $4, $5)
+     returning id`,
+    [
+      emailId,
+      `e2e-trace-sent-${e2eRunId}`,
+      JSON.stringify({ messageId: `ses-message-${e2eRunId}` }),
+      e2eTenant.user.id,
+      "2026-05-11T00:01:00.000Z",
+    ],
+  );
+  const sentEventId = sentEvent.rows[0]?.id ?? "";
+
+  const bounceEvent = await e2eDb.query<{ id: string }>(
+    `insert into email_events (email_id, source_id, type, payload, user_id, received_at)
+     values ($1, $2, 'bounced', $3::jsonb, $4, $5)
+     returning id`,
+    [
+      emailId,
+      `e2e-trace-bounced-${e2eRunId}`,
+      JSON.stringify({
+        bounceType: "Permanent",
+        bounceSubType: "General",
+        bouncedRecipients: [
+          {
+            emailAddress: recipient,
+            action: "failed",
+            status: "5.1.1",
+            diagnosticCode: "smtp; 550 5.1.1 user unknown",
+          },
+        ],
+        authorization: rawSecret,
+        html: rawBody,
+      }),
+      e2eTenant.user.id,
+      "2026-05-11T00:02:00.000Z",
+    ],
+  );
+  const bounceEventId = bounceEvent.rows[0]?.id ?? "";
+  expect(sentEventId).toBeTruthy();
+  expect(bounceEventId).toBeTruthy();
+
+  await e2eDb.query(
+    `insert into email_events (email_id, source_id, type, payload, user_id, received_at)
+     values ($1, $2, 'bounced', $3::jsonb, $4, $5)`,
+    [
+      otherEmailId,
+      `e2e-trace-other-${e2eRunId}`,
+      JSON.stringify({ bounceType: "Transient", reason: otherTenantMarker }),
+      otherTenant.user.id,
+      "2026-05-11T00:02:00.000Z",
+    ],
+  );
+
+  const logResult = await e2eDb.query<{ id: string }>(
+    `insert into logs (
+       endpoint, status, method, user_agent, request_body, response_body,
+       document, user_id, api_key_id, created_at
+     )
+     values ($1, 202, 'POST', $2, $3::jsonb, $4::jsonb, $5::jsonb, $6, $7, $8)
+     returning id`,
+    [
+      "/api/emails",
+      "opensend-e2e",
+      JSON.stringify({ to: [recipient], subject: "Trace detail e2e" }),
+      JSON.stringify({ id: emailId }),
+      JSON.stringify({ emailId, test_run_id: e2eRunId }),
+      e2eTenant.user.id,
+      e2eTenant.apiKey.id,
+      "2026-05-11T00:03:00.000Z",
+    ],
+  );
+  const logId = logResult.rows[0]?.id ?? "";
+  expect(logId).toBeTruthy();
+
+  await e2eDb.query(
+    `insert into logs (endpoint, status, method, document, user_id, api_key_id, created_at)
+     values ($1, 202, 'POST', $2::jsonb, $3, $4, $5)`,
+    [
+      `/api/${otherTenantMarker}`,
+      JSON.stringify({ emailId: otherEmailId, test_run_id: e2eRunId }),
+      otherTenant.user.id,
+      otherTenant.apiKey.id,
+      "2026-05-11T00:03:00.000Z",
+    ],
+  );
+
+  await page.goto(`/emails/${emailId}`);
+
+  await expect(page.getByText("EMAIL EVENT TRACE")).toBeVisible();
+  const eventRows = page.getByTestId("event-trace-row");
+  await expect(eventRows).toHaveCount(2);
+  await expect(eventRows.nth(0).getByTestId("event-badge")).toHaveText("Sent");
+  await expect(eventRows.nth(1).getByTestId("event-badge")).toHaveText(
+    "Bounced",
+  );
+  await expect(page.getByText(`event_id: ${bounceEventId}`)).toBeVisible();
+  await expect(
+    page.getByText("Permanent bounce", { exact: false }),
+  ).toBeVisible();
+  await expect(page.getByText("Diagnostic Code:")).toBeVisible();
+  await expect(
+    page.locator("dd").filter({ hasText: "smtp; 550 5.1.1 user unknown" }),
+  ).toBeVisible();
+  await expect(page.getByText(rawSecret)).toHaveCount(0);
+  await expect(page.getByText(rawBody)).toHaveCount(0);
+  await expect(page.getByText(otherTenantMarker)).toHaveCount(0);
+
+  await expect(page.getByText("ASSOCIATED LOGS")).toBeVisible();
+  await expect(
+    page.locator("span").filter({ hasText: "same email_id" }),
+  ).toBeVisible();
+  await expect(page.getByText(`log_id: ${logId}`)).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: /View all logs/i }),
+  ).toHaveAttribute("href", `/logs?q=${encodeURIComponent(emailId)}`);
+  await expect(page.locator(`a[href="/logs/${logId}"]`)).toBeVisible();
+  await page.locator(`a[href="/logs/${logId}"]`).click();
+  await expect(
+    page.getByRole("heading", { name: "POST /api/emails" }),
+  ).toBeVisible();
+
+  const notFoundResponse = await page.goto(`/emails/${otherEmailId}`);
+  expect(notFoundResponse?.status()).toBe(404);
+});

--- a/tests/e2e/email-detail.spec.ts
+++ b/tests/e2e/email-detail.spec.ts
@@ -30,7 +30,7 @@ test.describe("Email Detail Page", () => {
       await expect(page.getByText("ID")).toBeVisible();
 
       // Verify Email Events section
-      await expect(page.getByText("EMAIL EVENTS")).toBeVisible();
+      await expect(page.getByText("EMAIL EVENT TRACE")).toBeVisible();
 
       // Verify content tabs
       await expect(page.getByText("Preview")).toBeVisible();

--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -116,6 +116,10 @@ export async function cleanupE2ERun(
     `${userPrefix}%`,
   ]);
   await client.query(
+    "delete from logs where user_id like $1 or document->>'test_run_id' = $2",
+    [`${userPrefix}%`, runId],
+  );
+  await client.query(
     "delete from webhooks where user_id like $1 or document->>'test_run_id' = $2",
     [`${userPrefix}%`, runId],
   );

--- a/tests/email-detail-insights.test.tsx
+++ b/tests/email-detail-insights.test.tsx
@@ -1,4 +1,4 @@
-import { EmailDetail } from "@/components/email-detail";
+import { EmailDetail, type EmailDetailData } from "@/components/email-detail";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -6,7 +6,7 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
 }));
 
-const mockEmail = {
+const mockEmail: EmailDetailData = {
   id: "88269538-8271-43a8-9ee3-1300abcd1234",
   from: "test@updates.foreverbrowsing.com",
   to: ["jaeyunha0317@gmail.com"],
@@ -18,8 +18,20 @@ const mockEmail = {
   tags: [],
   headers: {},
   events: [
-    { type: "sent", timestamp: "2026-03-28T16:14:00.000Z" },
-    { type: "delivered", timestamp: "2026-03-28T16:14:02.000Z" },
+    {
+      id: "event-sent",
+      type: "sent",
+      timestamp: "2026-03-28T16:14:00.000Z",
+      summary: "Accepted by provider",
+      details: {},
+    },
+    {
+      id: "event-delivered",
+      type: "delivered",
+      timestamp: "2026-03-28T16:14:02.000Z",
+      summary: "Delivered",
+      details: {},
+    },
   ],
 };
 

--- a/tests/email-detail.test.tsx
+++ b/tests/email-detail.test.tsx
@@ -1,4 +1,4 @@
-import { EmailDetail } from "@/components/email-detail";
+import { EmailDetail, type EmailDetailData } from "@/components/email-detail";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -6,7 +6,7 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
 }));
 
-const mockEmail = {
+const mockEmail: EmailDetailData = {
   id: "88269538-8271-43a8-9ee3-1300abcd1234",
   from: "test@updates.foreverbrowsing.com",
   to: ["jaeyunha0317@gmail.com"],
@@ -18,8 +18,23 @@ const mockEmail = {
   tags: [],
   headers: {},
   events: [
-    { type: "sent", timestamp: "2026-03-28T16:14:00.000Z" },
-    { type: "delivered", timestamp: "2026-03-28T16:14:02.000Z" },
+    {
+      id: "event-sent",
+      type: "sent",
+      timestamp: "2026-03-28T16:14:00.000Z",
+      summary: "Accepted by provider as ses-message-123",
+      details: { message_id: "ses-message-123" },
+    },
+    {
+      id: "event-delivered",
+      type: "delivered",
+      timestamp: "2026-03-28T16:14:02.000Z",
+      summary: "Delivered to jaeyunha0317@gmail.com — 250 Ok",
+      details: {
+        recipients: ["jaeyunha0317@gmail.com"],
+        smtp_response: "250 Ok",
+      },
+    },
   ],
 };
 
@@ -46,7 +61,7 @@ describe("EmailDetail", () => {
   it("renders event timeline in chronological order", () => {
     render(<EmailDetail email={mockEmail} />);
 
-    expect(screen.getByText("EMAIL EVENTS")).toBeTruthy();
+    expect(screen.getByText("EMAIL EVENT TRACE")).toBeTruthy();
 
     const sentBadge = screen.getByText("Sent");
     const deliveredBadge = screen.getByText("Delivered");
@@ -59,6 +74,17 @@ describe("EmailDetail", () => {
     expect(badges.length).toBe(2);
     expect(badges[0].textContent).toBe("Sent");
     expect(badges[1].textContent).toBe("Delivered");
+  });
+
+  it("renders event ids and sanitized payload-backed details", () => {
+    render(<EmailDetail email={mockEmail} />);
+
+    expect(screen.getByText("event_id: event-delivered")).toBeTruthy();
+    expect(
+      screen.getByText("Delivered to jaeyunha0317@gmail.com — 250 Ok"),
+    ).toBeTruthy();
+    expect(screen.getByText("Smtp Response:")).toBeTruthy();
+    expect(screen.getByText("250 Ok")).toBeTruthy();
   });
 
   it("renders email ID with copy button", () => {
@@ -122,6 +148,8 @@ describe("EmailDetail", () => {
 
     expect(screen.getByText("ASSOCIATED LOGS")).toBeTruthy();
     expect(screen.getByText("/api/emails")).toBeTruthy();
+    expect(screen.getByText("same email_id")).toBeTruthy();
+    expect(screen.getByText("log_id: log-123")).toBeTruthy();
     expect(
       screen.getByRole("link", { name: /View all logs/i }).getAttribute("href"),
     ).toBe(`/logs?q=${mockEmail.id}`);

--- a/tests/email-lifecycle-service.test.ts
+++ b/tests/email-lifecycle-service.test.ts
@@ -275,6 +275,8 @@ describe("email lifecycle service boundary", () => {
           type: "queued",
           payload: { delivery: true },
           created_at: new Date("2026-05-01T00:00:00.000Z"),
+          summary: "Provider event recorded",
+          details: {},
         },
         {
           object: "email_event",
@@ -282,10 +284,78 @@ describe("email lifecycle service boundary", () => {
           type: "delivered",
           payload: { delivery: true },
           created_at: new Date("2026-05-01T00:01:00.000Z"),
+          summary: "Delivered",
+          details: {},
         },
       ],
     });
     expect(capturedScope).toEqual({ id: "email-1", userId: "user-1" });
     expect(capturedEmailId).toBe("email-1");
+  });
+
+  it("adds bounded sanitized event trace details without removing legacy payload", async () => {
+    const service = createEmailLifecycleService({
+      repository: makeRepository({
+        async listEventsByEmailIdAsc() {
+          return [
+            makeEvent({
+              id: "event-bounce",
+              type: "bounced",
+              payload: {
+                bounceType: "Permanent",
+                bounceSubType: "General",
+                bouncedRecipients: [
+                  {
+                    emailAddress: "recipient@example.com",
+                    action: "failed",
+                    status: "5.1.1",
+                    diagnosticCode: "smtp; 550 5.1.1 user unknown",
+                  },
+                ],
+                authorization: "Bearer should-not-render",
+                html: "<p>body should not render</p>",
+              },
+              receivedAt: new Date("2026-05-01T00:01:00.000Z"),
+            }),
+          ];
+        },
+      }),
+    });
+
+    await expect(service.listEvents("user-1", "email-1")).resolves.toEqual({
+      object: "list",
+      data: [
+        {
+          object: "email_event",
+          id: "event-bounce",
+          type: "bounced",
+          payload: {
+            bounceType: "Permanent",
+            bounceSubType: "General",
+            bouncedRecipients: [
+              {
+                emailAddress: "recipient@example.com",
+                action: "failed",
+                status: "5.1.1",
+                diagnosticCode: "smtp; 550 5.1.1 user unknown",
+              },
+            ],
+            authorization: "Bearer should-not-render",
+            html: "<p>body should not render</p>",
+          },
+          created_at: new Date("2026-05-01T00:01:00.000Z"),
+          summary:
+            "Permanent bounce — for recipient@example.com — smtp; 550 5.1.1 user unknown",
+          details: {
+            bounce_type: "Permanent",
+            bounce_subtype: "General",
+            diagnostic_code: "smtp; 550 5.1.1 user unknown",
+            status: "5.1.1",
+            action: "failed",
+            recipients: ["recipient@example.com"],
+          },
+        },
+      ],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds a shared bounded email event trace mapper so the lifecycle API and dashboard detail agree on chronological event ids, timestamps, summaries, and safe details.
- Upgrades the dashboard email detail trace to show provider-backed event context and makes same-`email_id` request-log links explicit.
- Adds payload-backed Vitest coverage plus a real-dependency Playwright tenant scenario for seeded email events and linked logs.

Closes #391

## Changes
- **core**: Added `emailEventTrace` mapper with allowlisted, bounded provider payload fields; `EmailLifecycleService` now reuses it while preserving legacy `payload` in the API response.
- **dashboard**: Email detail loads events ascending, renders event id/summary/details, and labels associated request logs as same-`email_id` evidence.
- **tests**: Added mapper/UI assertions and a Better Auth/Postgres Playwright scenario covering tenant isolation, sanitized trace details, and associated log navigation.
- **docs/learnings**: Recorded the sanitizer decision to avoid future raw payload rendering.

## Validation
- [x] `make check` passed.
- [x] `make test` passed: 140 test files / 1114 tests.
- [x] Focused Playwright passed against local Docker Postgres on port 56543:
  - `PORT=3015 DATABASE_URL=postgresql://opensend:opensend@localhost:56543/opensend bunx playwright test tests/e2e/email-detail-trace.spec.ts`

## Notes / Residual Risk
- The trace mapper intentionally exposes only allowlisted provider fields; future provider payload details need explicit additions.
- Full Playwright suite was not run; focused real-dependency scenario passed for this slice.
