### PR TITLE
docs(parity): file #394 for audit log

### DIFF
--- a/agent_docs/resend-parity.md
+++ b/agent_docs/resend-parity.md
@@ -119,7 +119,7 @@ Rows are ordered roughly by priority within each area. The inspector's tie-break
 |---|---|---|---|---|---|---|---|---|---|
 | SOC2 | yes | TBD | ? | ? | ? | ? | needs Jaeyun | | |
 | GDPR / EU data residency | yes | TBD | ? | ? | ? | ? | needs Jaeyun | | |
-| Audit log | yes | TBD | ? | ? | ? | ? | P1 | | |
+| Audit log | yes | TBD | ? | ? | ? | ? | P1 | #394 | 2026-05-11 |
 | Suppression list management | suppresses recipients after hard bounce or spam complaint; suppression details are visible from email detail and can be removed ([docs](https://resend.com/docs/dashboard/emails/email-suppressions)) | missing: no suppression table/API/dashboard route (`https://opensend.namuh.co/api/suppressions` returned 404 on 2026-05-05); contacts only store manual unsubscribe state (`src/lib/db/schema.ts:192`, `src/lib/db/schema.ts:199`); send routes queue recipients without suppression lookup (`src/app/api/emails/route.ts:344`, `src/app/api/emails/route.ts:358`, `src/app/api/emails/batch/route.ts:264`, `src/app/api/emails/batch/route.ts:278`); SES bounce/complaint events update email status but do not create suppressions (`packages/ingester/src/ses-event-normalization.ts:5`, `packages/ingester/src/ses-event-normalization.ts:6`, `packages/core/src/db/repositories/emailEventRepo.ts:5`) | missing | behind | behind | n/a | P0 | #191 | 2026-05-05 |
 
 ## Pricing


### PR DESCRIPTION
## Summary
- Filed parity issue #394 for the unfiled P1 Audit log gap.
- Backfilled the matrix Issue # and Last reviewed date for that row.

## Validation
- Read `agent_docs/resend-parity.md` and skipped rows with non-empty Issue #.
- Resend evidence: Ever observed the Resend Logs docs on 2026-05-11 UTC showing activity/troubleshooting logs and resource endpoints such as `/domains`, `/api-keys`, and `/contacts`.
- OpenSend evidence: Ever observed production `/logs` as request logs and `/settings` without an Audit tab on 2026-05-11 UTC; local file evidence is captured in issue #394.
- `git diff --check`
- `gh issue view 394 --json number,title,labels,state,url,body` confirmed open issue with `spec-ready` and `parity` labels and no closing-reference text.

## Changed files
- `agent_docs/resend-parity.md`

## Residual risk
- The row still has legacy `TBD` comparison cells; this PR intentionally limits the matrix edit to the inspector-required Issue # and Last reviewed fields.
