### PR TITLE
architecture: extract tracking route lookup boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-399-tracking-route-boundary.md
+++ b/agent_docs/learnings/active/2026-05-11-399-tracking-route-boundary.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-11
+issue: "#399"
+type: pattern
+promoted_to: null
+---
+
+## Tracking route lookup belongs behind the core service seam
+
+**What:** Public open/click route adapters should mock and call the tracking route service, while tenant-scoped email/domain lookup and domain tracking toggles live in `@opensend/core` behind an injectable repository.
+**Why:** Keeping Drizzle queries out of `src/app/api/track/tracking-route.ts` preserves thin HTTP adapters and makes tenant/toggle behavior testable without coupling route tests to database internals.
+**Fix:** Add focused service tests for repository scope and toggle gating, then keep route tests on response/event-payload compatibility.

--- a/packages/core/src/db/repositories/domainRepo.ts
+++ b/packages/core/src/db/repositories/domainRepo.ts
@@ -23,6 +23,12 @@ export const domainRepo = {
     });
   },
 
+  async findByIdForUser(id: string, userId: string) {
+    return await db.query.domains.findFirst({
+      where: and(eq(domains.id, id), eq(domains.userId, userId)),
+    });
+  },
+
   async create(data: typeof domains.$inferInsert) {
     return await db.insert(domains).values(data).returning();
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,7 @@ export * from "./services/auditEvents";
 export * from "./services/suppressions";
 export * from "./services/emailProvider";
 export * from "./services/tracking";
+export * from "./services/trackingRoute";
 export * from "./services/sandboxTestRecipients";
 export * from "./services/storage";
 export * from "./services/template";

--- a/packages/core/src/services/trackingRoute.ts
+++ b/packages/core/src/services/trackingRoute.ts
@@ -1,0 +1,59 @@
+import { domainRepo } from "../db/repositories/domainRepo";
+import { emailRepo } from "../db/repositories/emailRepo";
+import type { domains, emails } from "../db/schema";
+import type { VerifiedEmailTrackingToken } from "./tracking";
+
+type EmailRow = typeof emails.$inferSelect;
+type DomainRow = typeof domains.$inferSelect;
+
+export type TrackingRouteContext = {
+  email: EmailRow;
+  domain: DomainRow;
+};
+
+export type TrackingRouteLookupRepository = {
+  findEmailByIdForUser(
+    id: string,
+    userId: string,
+  ): Promise<EmailRow | undefined>;
+  findDomainByIdForUser(
+    id: string,
+    userId: string,
+  ): Promise<DomainRow | undefined>;
+};
+
+const defaultTrackingRouteLookupRepository: TrackingRouteLookupRepository = {
+  async findEmailByIdForUser(id, userId) {
+    return await emailRepo.findByIdForUser(id, userId);
+  },
+  async findDomainByIdForUser(id, userId) {
+    return await domainRepo.findByIdForUser(id, userId);
+  },
+};
+
+export type TrackingRouteServiceDependencies = {
+  repository?: TrackingRouteLookupRepository;
+};
+
+export function createTrackingRouteService({
+  repository = defaultTrackingRouteLookupRepository,
+}: TrackingRouteServiceDependencies = {}) {
+  return {
+    async findTrackingContext(
+      payload: VerifiedEmailTrackingToken,
+    ): Promise<TrackingRouteContext | null> {
+      const [email, domain] = await Promise.all([
+        repository.findEmailByIdForUser(payload.emailId, payload.userId),
+        repository.findDomainByIdForUser(payload.domainId, payload.userId),
+      ]);
+
+      if (!email || !domain) return null;
+      if (payload.kind === "click" && !domain.trackClicks) return null;
+      if (payload.kind === "open" && !domain.trackOpens) return null;
+
+      return { email, domain };
+    },
+  };
+}
+
+export const trackingRouteService = createTrackingRouteService();

--- a/src/app/api/track/tracking-route.ts
+++ b/src/app/api/track/tracking-route.ts
@@ -1,28 +1,10 @@
-import { db } from "@/lib/db";
-import { domains, emails } from "@/lib/db/schema";
-import type { VerifiedEmailTrackingToken } from "@opensend/core";
-import { and, eq } from "drizzle-orm";
+import {
+  type VerifiedEmailTrackingToken,
+  trackingRouteService,
+} from "@opensend/core";
 
 export async function findTrackingContext(payload: VerifiedEmailTrackingToken) {
-  const [email, domain] = await Promise.all([
-    db.query.emails.findFirst({
-      where: and(
-        eq(emails.id, payload.emailId),
-        eq(emails.userId, payload.userId),
-      ),
-    }),
-    db.query.domains.findFirst({
-      where: and(
-        eq(domains.id, payload.domainId),
-        eq(domains.userId, payload.userId),
-      ),
-    }),
-  ]);
-
-  if (!email || !domain) return null;
-  if (payload.kind === "click" && !domain.trackClicks) return null;
-  if (payload.kind === "open" && !domain.trackOpens) return null;
-  return { email, domain };
+  return await trackingRouteService.findTrackingContext(payload);
 }
 
 export function getRequestMetadata(

--- a/tests/tracking-route-service.test.ts
+++ b/tests/tracking-route-service.test.ts
@@ -1,0 +1,197 @@
+import {
+  type TrackingRouteLookupRepository,
+  createTrackingRouteService,
+} from "@opensend/core";
+import { describe, expect, it } from "vitest";
+
+type EmailRow = NonNullable<
+  Awaited<ReturnType<TrackingRouteLookupRepository["findEmailByIdForUser"]>>
+>;
+type DomainRow = NonNullable<
+  Awaited<ReturnType<TrackingRouteLookupRepository["findDomainByIdForUser"]>>
+>;
+
+function makeEmail(overrides: Partial<EmailRow> = {}): EmailRow {
+  return {
+    id: "email-1",
+    from: "sender@example.com",
+    to: ["person@example.com"],
+    cc: null,
+    bcc: null,
+    replyTo: null,
+    subject: "Hello",
+    html: "<p>Hello</p>",
+    text: null,
+    status: "delivered",
+    providerRetryCount: 0,
+    providerLastAttemptedAt: null,
+    providerNextRetryAt: null,
+    providerLastErrorCode: null,
+    providerLastErrorMessage: null,
+    providerDeadLetteredAt: null,
+    tags: null,
+    headers: null,
+    attachments: null,
+    scheduledAt: null,
+    sentAt: new Date("2026-01-01T00:00:05Z"),
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    document: null,
+    userId: "user-1",
+    topicId: null,
+    idempotencyKey: null,
+    ...overrides,
+  };
+}
+
+function makeDomain(overrides: Partial<DomainRow> = {}): DomainRow {
+  return {
+    id: "domain-1",
+    name: "example.com",
+    status: "verified",
+    region: "us-east-1",
+    dkimTokens: null,
+    records: null,
+    trackClicks: true,
+    trackOpens: true,
+    tls: "opportunistic",
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    document: null,
+    userId: "user-1",
+    customReturnPath: null,
+    trackingSubdomain: null,
+    capabilities: null,
+    dkimOrigin: "AWS_SES",
+    dkimSelector: null,
+    dkimPublicKey: null,
+    dkimPrivateKeyCt: null,
+    dkimPrivateKeyIv: null,
+    ...overrides,
+  };
+}
+
+function makeRepository(
+  overrides: Partial<TrackingRouteLookupRepository> = {},
+): TrackingRouteLookupRepository {
+  return {
+    async findEmailByIdForUser() {
+      return makeEmail();
+    },
+    async findDomainByIdForUser() {
+      return makeDomain();
+    },
+    ...overrides,
+  };
+}
+
+describe("tracking route service boundary", () => {
+  it("looks up email and domain using token tenant scope", async () => {
+    const captured: Array<{
+      type: "email" | "domain";
+      id: string;
+      userId: string;
+    }> = [];
+    const service = createTrackingRouteService({
+      repository: makeRepository({
+        async findEmailByIdForUser(id, userId) {
+          captured.push({ type: "email", id, userId });
+          return makeEmail({ id, userId });
+        },
+        async findDomainByIdForUser(id, userId) {
+          captured.push({ type: "domain", id, userId });
+          return makeDomain({ id, userId });
+        },
+      }),
+    });
+
+    const result = await service.findTrackingContext({
+      v: 1,
+      kind: "click",
+      userId: "user-2",
+      emailId: "email-2",
+      domainId: "domain-2",
+      targetUrl: "https://destination.example.com",
+    });
+
+    expect(result).toMatchObject({
+      email: { id: "email-2", userId: "user-2" },
+      domain: { id: "domain-2", userId: "user-2" },
+    });
+    expect(captured).toEqual([
+      { type: "email", id: "email-2", userId: "user-2" },
+      { type: "domain", id: "domain-2", userId: "user-2" },
+    ]);
+  });
+
+  it("returns null when the tenant-scoped email or domain is missing", async () => {
+    const missingEmailService = createTrackingRouteService({
+      repository: makeRepository({
+        async findEmailByIdForUser() {
+          return undefined;
+        },
+      }),
+    });
+    const missingDomainService = createTrackingRouteService({
+      repository: makeRepository({
+        async findDomainByIdForUser() {
+          return undefined;
+        },
+      }),
+    });
+
+    await expect(
+      missingEmailService.findTrackingContext({
+        v: 1,
+        kind: "open",
+        userId: "user-1",
+        emailId: "email-1",
+        domainId: "domain-1",
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      missingDomainService.findTrackingContext({
+        v: 1,
+        kind: "open",
+        userId: "user-1",
+        emailId: "email-1",
+        domainId: "domain-1",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("gates click and open contexts with the matching domain tracking toggle", async () => {
+    const clickDisabledService = createTrackingRouteService({
+      repository: makeRepository({
+        async findDomainByIdForUser() {
+          return makeDomain({ trackClicks: false, trackOpens: true });
+        },
+      }),
+    });
+    const openDisabledService = createTrackingRouteService({
+      repository: makeRepository({
+        async findDomainByIdForUser() {
+          return makeDomain({ trackClicks: true, trackOpens: false });
+        },
+      }),
+    });
+
+    await expect(
+      clickDisabledService.findTrackingContext({
+        v: 1,
+        kind: "click",
+        userId: "user-1",
+        emailId: "email-1",
+        domainId: "domain-1",
+        targetUrl: "https://destination.example.com",
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      openDisabledService.findTrackingContext({
+        v: 1,
+        kind: "open",
+        userId: "user-1",
+        emailId: "email-1",
+        domainId: "domain-1",
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/tests/tracking-routes.test.ts
+++ b/tests/tracking-routes.test.ts
@@ -1,18 +1,20 @@
 import { createEmailTrackingToken } from "@opensend/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockFindEmail = vi.hoisted(() => vi.fn());
-const mockFindDomain = vi.hoisted(() => vi.fn());
+const mockFindTrackingContext = vi.hoisted(() => vi.fn());
 const mockQueueEvent = vi.hoisted(() => vi.fn());
 
-vi.mock("@/lib/db", () => ({
-  db: {
-    query: {
-      emails: { findFirst: mockFindEmail },
-      domains: { findFirst: mockFindDomain },
+vi.mock("@opensend/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@opensend/core")>();
+
+  return {
+    ...actual,
+    trackingRouteService: {
+      ...actual.trackingRouteService,
+      findTrackingContext: mockFindTrackingContext,
     },
-  },
-}));
+  };
+});
 
 vi.mock("@/lib/events", () => ({
   queueEvent: mockQueueEvent,
@@ -32,15 +34,14 @@ function trackingToken(kind: "open" | "click", targetUrl?: string) {
 describe("tracking routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFindEmail.mockResolvedValue({
-      id: "email-1",
-      userId: "user-1",
-    });
-    mockFindDomain.mockResolvedValue({
-      id: "domain-1",
-      userId: "user-1",
-      trackClicks: true,
-      trackOpens: true,
+    mockFindTrackingContext.mockResolvedValue({
+      email: { id: "email-1", userId: "user-1" },
+      domain: {
+        id: "domain-1",
+        userId: "user-1",
+        trackClicks: true,
+        trackOpens: true,
+      },
     });
     mockQueueEvent.mockResolvedValue({ eventId: "event-1", deliveryIds: [] });
   });
@@ -127,12 +128,7 @@ describe("tracking routes", () => {
   });
 
   it("does not create events when the domain toggle is disabled", async () => {
-    mockFindDomain.mockResolvedValue({
-      id: "domain-1",
-      userId: "user-1",
-      trackClicks: false,
-      trackOpens: true,
-    });
+    mockFindTrackingContext.mockResolvedValue(null);
     const { GET } = await import("../src/app/api/track/click/[token]/route");
 
     const response = await GET(
@@ -150,7 +146,7 @@ describe("tracking routes", () => {
   });
 
   it("does not create events when token tenant context is missing", async () => {
-    mockFindDomain.mockResolvedValue(null);
+    mockFindTrackingContext.mockResolvedValue(null);
     const { GET } = await import("../src/app/api/track/open/[token]/route");
 
     const response = await GET(


### PR DESCRIPTION
## Summary\n- move public tracking route email/domain lookup and domain toggle decisions behind a core tracking route service\n- add tenant-scoped domain repository lookup and export the new service seam\n- keep open/click route adapters focused on token validation, HTTP response behavior, and event payloads\n\n## Validation\n- make check\n- make test\n- bun run vitest run tests/tracking-route-service.test.ts tests/tracking-routes.test.ts\n\nCloses #399