### PR TITLE
Fix production dashboard deep links

### DIFF
--- a/src/app/(dashboard)/audience/contacts/page.tsx
+++ b/src/app/(dashboard)/audience/contacts/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AudienceContactsDeepLinkPage() {
+  redirect("/audience");
+}

--- a/src/app/(dashboard)/emails/sending/page.tsx
+++ b/src/app/(dashboard)/emails/sending/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function EmailsSendingDeepLinkPage() {
+  redirect("/emails");
+}

--- a/src/app/(dashboard)/settings/billing/page.tsx
+++ b/src/app/(dashboard)/settings/billing/page.tsx
@@ -5,18 +5,40 @@ import {
 import { getServerSession } from "@/lib/api-auth";
 import { isBillingEnabled } from "@/lib/billing";
 import { loadBillingSummary } from "@/lib/billing/summary";
-import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { redirect } from "next/navigation";
 
 export const dynamic = "force-dynamic";
 
 export default async function BillingSettingsPage() {
-  if (!isBillingEnabled()) {
-    notFound();
-  }
-
   const session = await getServerSession();
   if (!session?.user?.id) {
     redirect("/auth");
+  }
+
+  if (!isBillingEnabled()) {
+    return (
+      <div className="max-w-2xl space-y-4">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold text-[#F0F0F0]">Billing</h1>
+          <p className="text-[14px] text-[#A1A4A5]">
+            Billing is not enabled for this Opensend deployment.
+          </p>
+        </div>
+        <div className="rounded-lg border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.5)] p-4">
+          <p className="text-[13px] text-[#A1A4A5]">
+            Your dashboard is still available, but plan management and checkout
+            are unavailable until the deployment owner configures billing.
+          </p>
+        </div>
+        <Link
+          href="/settings"
+          className="inline-flex rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] px-3 py-1.5 text-[13px] font-medium text-[#F0F0F0] transition-colors hover:bg-[rgba(24,25,28,1)]"
+        >
+          Back to settings
+        </Link>
+      </div>
+    );
   }
 
   const summary = await loadBillingSummary(session.user.id);

--- a/tests/dashboard-deeplinks.test.tsx
+++ b/tests/dashboard-deeplinks.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockIsBillingEnabled = vi.hoisted(() => vi.fn());
+const mockLoadBillingSummary = vi.hoisted(() => vi.fn());
+const mockRedirect = vi.hoisted(() =>
+  vi.fn((path: string): never => {
+    throw new Error(`NEXT_REDIRECT:${path}`);
+  }),
+);
+
+vi.mock("@/lib/api-auth", () => ({
+  getServerSession: mockGetServerSession,
+}));
+
+vi.mock("@/lib/billing", () => ({
+  isBillingEnabled: mockIsBillingEnabled,
+}));
+
+vi.mock("@/lib/billing/summary", () => ({
+  loadBillingSummary: mockLoadBillingSummary,
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: mockRedirect,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/components/billing/billing-view", () => ({
+  BillingView: ({ initial }: { initial: unknown }) => (
+    <div data-testid="billing-view">{JSON.stringify(initial)}</div>
+  ),
+}));
+
+describe("dashboard production deep links", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue({ user: { id: "user-1" } });
+    mockIsBillingEnabled.mockReturnValue(false);
+  });
+
+  it("canonically redirects /emails/sending to the Sending tab page", async () => {
+    const Page = (await import("@/app/(dashboard)/emails/sending/page"))
+      .default;
+
+    expect(() => Page()).toThrow("NEXT_REDIRECT:/emails");
+    expect(mockRedirect).toHaveBeenCalledWith("/emails");
+  });
+
+  it("canonically redirects /audience/contacts to the Contacts tab page", async () => {
+    const Page = (await import("@/app/(dashboard)/audience/contacts/page"))
+      .default;
+
+    expect(() => Page()).toThrow("NEXT_REDIRECT:/audience");
+    expect(mockRedirect).toHaveBeenCalledWith("/audience");
+  });
+
+  it("renders a billing unavailable state instead of raw-404 when billing is disabled", async () => {
+    const Page = (await import("@/app/(dashboard)/settings/billing/page"))
+      .default;
+
+    const result = await Page();
+    render(result as React.ReactElement);
+
+    expect(screen.getByRole("heading", { name: "Billing" })).toBeDefined();
+    expect(
+      screen.getByText("Billing is not enabled for this Opensend deployment."),
+    ).toBeDefined();
+    expect(
+      screen
+        .getByRole("link", { name: "Back to settings" })
+        .getAttribute("href"),
+    ).toBe("/settings");
+    expect(mockLoadBillingSummary).not.toHaveBeenCalled();
+  });
+
+  it("preserves billing dashboard auth before rendering the disabled state", async () => {
+    mockGetServerSession.mockResolvedValueOnce(null);
+    const Page = (await import("@/app/(dashboard)/settings/billing/page"))
+      .default;
+
+    await expect(Page()).rejects.toThrow("NEXT_REDIRECT:/auth");
+    expect(mockRedirect).toHaveBeenCalledWith("/auth");
+    expect(mockIsBillingEnabled).not.toHaveBeenCalled();
+    expect(mockLoadBillingSummary).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add canonical dashboard redirects for `/emails/sending` and `/audience/contacts` so direct navigation no longer falls through to detail/raw 404 routes.
- Render a safe billing-disabled state at `/settings/billing` after dashboard auth instead of returning `notFound()`.
- Add route-level regression coverage for the #401/#404 direct links.

Fixes #401.
Fixes #404.

## Tests
- `bun run test -- tests/dashboard-deeplinks.test.tsx tests/settings-page.test.tsx tests/emails-page.test.tsx tests/audience-layout.test.tsx`
- `make check`
- `make test`
- push guard: `bun run check`

## Notes
- Scope intentionally excludes Broadcasts loading (#402) and Templates create CTA (#403).
- Browser E2E direct navigation was not run; route-level regression coverage proves the direct links redirect/render instead of raw-404/notFound.
