### PR TITLE
Fix Broadcasts loading resolution

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-402-broadcasts-server-initial-load.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-402-broadcasts-server-initial-load.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-11
+issue: "#402"
+type: pattern
+promoted_to: null
+---
+
+## Broadcast dashboard list should not rely solely on first client fetch
+
+Production dogfood showed `/broadcasts` could render the dashboard shell and stay on `Loading broadcasts...` without an observed `/api/*` request. The list now follows the safer dashboard pattern used by other pages: the server page resolves the dashboard session, loads tenant-scoped initial broadcasts via `createBroadcastService`, and passes the result into the client list so empty accounts render `No broadcasts` immediately.
+
+Keep client fetching for filter/search retries, but skip the redundant first list fetch when server initial data or a server load error is present. Client fetch failures should render a visible retryable error state rather than falling through to an indefinite loading message or silently pretending the list is empty.

--- a/src/app/(dashboard)/broadcasts/page.tsx
+++ b/src/app/(dashboard)/broadcasts/page.tsx
@@ -1,10 +1,91 @@
 import { BroadcastsList } from "@/components/broadcasts-list";
+import { getServerSession } from "@/lib/api-auth";
+import { createBroadcastService } from "@opensend/core";
+import { redirect } from "next/navigation";
 
-export default function BroadcastsPage() {
+type BroadcastsPageSearchParams = Record<string, string | string[] | undefined>;
+
+interface BroadcastsPageProps {
+  searchParams?: Promise<BroadcastsPageSearchParams>;
+}
+
+const broadcastService = createBroadcastService();
+
+function getSearchParam(
+  searchParams: BroadcastsPageSearchParams,
+  key: string,
+): string {
+  const value = searchParams[key];
+  if (Array.isArray(value)) return value[0] ?? "";
+  return value ?? "";
+}
+
+function parseLimit(value: string): number {
+  const limit = Number(value) || 40;
+  return limit === 80 || limit === 120 ? limit : 40;
+}
+
+export default async function BroadcastsPage({
+  searchParams,
+}: BroadcastsPageProps = {}) {
+  const session = await getServerSession();
+  if (!session) redirect("/auth");
+
+  const resolvedSearchParams = searchParams ? await searchParams : {};
+  const search = getSearchParam(resolvedSearchParams, "search").trim();
+  const status = getSearchParam(resolvedSearchParams, "status").trim();
+  const segmentId = getSearchParam(resolvedSearchParams, "segmentId").trim();
+  const page = Math.max(
+    1,
+    Number(getSearchParam(resolvedSearchParams, "page")) || 1,
+  );
+  const limit = parseLimit(getSearchParam(resolvedSearchParams, "limit"));
+
+  let initialBroadcasts: {
+    id: string;
+    name: string;
+    status: string;
+    createdAt: string;
+  }[] = [];
+  let initialTotal = 0;
+  let initialError: string | null = null;
+
+  try {
+    const result = await broadcastService.listBroadcasts({
+      userId: session.user.id,
+      limit,
+      search: search || undefined,
+      status: status || undefined,
+      segmentId: segmentId || undefined,
+    });
+
+    initialBroadcasts = result.data.map((broadcast) => ({
+      id: broadcast.id,
+      name: broadcast.name,
+      status: broadcast.status,
+      createdAt: broadcast.createdAt.toISOString(),
+    }));
+    initialTotal = result.hasMore
+      ? initialBroadcasts.length + 1
+      : initialBroadcasts.length;
+  } catch (error) {
+    console.error("Failed to load broadcasts dashboard:", error);
+    initialError = "Failed to load broadcasts.";
+  }
+
   return (
     <div>
       <h1 className="text-2xl font-semibold text-[#F0F0F0] mb-6">Broadcasts</h1>
-      <BroadcastsList />
+      <BroadcastsList
+        initialAudienceFilter={segmentId}
+        initialBroadcasts={initialBroadcasts}
+        initialError={initialError}
+        initialLimit={limit}
+        initialPage={page}
+        initialSearch={search}
+        initialStatusFilter={status}
+        initialTotal={initialTotal}
+      />
     </div>
   );
 }

--- a/src/components/broadcasts-list.tsx
+++ b/src/components/broadcasts-list.tsx
@@ -12,9 +12,35 @@ interface Broadcast {
   createdAt: string;
 }
 
+type ApiBroadcast = {
+  id?: unknown;
+  name?: unknown;
+  status?: unknown;
+  createdAt?: unknown;
+  created_at?: unknown;
+};
+
+type ApiListResponse = {
+  data?: unknown;
+  total?: unknown;
+  has_more?: unknown;
+  error?: unknown;
+};
+
 interface SegmentOption {
   id: string;
   name: string;
+}
+
+export interface BroadcastsListProps {
+  initialBroadcasts?: Broadcast[];
+  initialTotal?: number;
+  initialPage?: number;
+  initialLimit?: number;
+  initialSearch?: string;
+  initialStatusFilter?: string;
+  initialAudienceFilter?: string;
+  initialError?: string | null;
 }
 
 const BROADCAST_STATUSES = [
@@ -29,34 +55,119 @@ function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
-export function BroadcastsList() {
+function getApiKey(): string | null {
+  try {
+    return typeof window !== "undefined"
+      ? (window.localStorage.getItem("api_key") ?? null)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function parseJsonResponse(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+function toApiListResponse(value: unknown): ApiListResponse {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+  return value as ApiListResponse;
+}
+
+function normalizeBroadcast(value: unknown): Broadcast | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as ApiBroadcast;
+  const id = typeof record.id === "string" ? record.id : "";
+  const name = typeof record.name === "string" ? record.name : "";
+  const status = typeof record.status === "string" ? record.status : "";
+  const createdAt =
+    typeof record.createdAt === "string"
+      ? record.createdAt
+      : typeof record.created_at === "string"
+        ? record.created_at
+        : "";
+
+  if (!id || !name || !status || !createdAt) return null;
+
+  return { id, name, status, createdAt };
+}
+
+function normalizeBroadcasts(data: unknown): Broadcast[] {
+  if (!Array.isArray(data)) return [];
+  return data.flatMap((item) => {
+    const broadcast = normalizeBroadcast(item);
+    return broadcast ? [broadcast] : [];
+  });
+}
+
+function responseErrorMessage(response: ApiListResponse): string {
+  return typeof response.error === "string"
+    ? response.error
+    : "Failed to load broadcasts.";
+}
+
+export function BroadcastsList({
+  initialBroadcasts,
+  initialTotal,
+  initialPage,
+  initialLimit,
+  initialSearch,
+  initialStatusFilter,
+  initialAudienceFilter,
+  initialError = null,
+}: BroadcastsListProps = {}) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const [broadcasts, setBroadcasts] = useState<Broadcast[]>([]);
-  const [total, setTotal] = useState(0);
-  const [page, setPage] = useState(1);
-  const [limit, setLimit] = useState(40);
-  const [search, setSearch] = useState(searchParams.get("search") || "");
+  const hasInitialBroadcasts = initialBroadcasts !== undefined;
+  const [broadcasts, setBroadcasts] = useState<Broadcast[]>(
+    initialBroadcasts ?? [],
+  );
+  const [total, setTotal] = useState(
+    initialTotal ?? initialBroadcasts?.length ?? 0,
+  );
+  const [page, setPage] = useState(initialPage ?? 1);
+  const [limit, setLimit] = useState(initialLimit ?? 40);
+  const [search, setSearch] = useState(
+    initialSearch ?? searchParams.get("search") ?? "",
+  );
   const [statusFilter, setStatusFilter] = useState(
-    searchParams.get("status") || "",
+    initialStatusFilter ?? searchParams.get("status") ?? "",
   );
   const [audienceFilter, setAudienceFilter] = useState(
-    searchParams.get("segmentId") || "",
+    initialAudienceFilter ?? searchParams.get("segmentId") ?? "",
   );
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(
+    !hasInitialBroadcasts && !initialError,
+  );
+  const [error, setError] = useState<string | null>(initialError);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [segments, setSegments] = useState<SegmentOption[]>([]);
   const [statusDropdownOpen, setStatusDropdownOpen] = useState(false);
   const [audienceDropdownOpen, setAudienceDropdownOpen] = useState(false);
   const [actionMenuId, setActionMenuId] = useState<string | null>(null);
   const searchTimeout = useRef<ReturnType<typeof setTimeout>>(null);
+  const skipInitialFetch = useRef(
+    hasInitialBroadcasts || Boolean(initialError),
+  );
   const statusDropdownRef = useRef<HTMLDivElement>(null);
   const audienceDropdownRef = useRef<HTMLDivElement>(null);
   const actionMenuRef = useRef<HTMLDivElement>(null);
 
   const fetchBroadcasts = useCallback(async () => {
     setLoading(true);
+    setError(null);
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => controller.abort(), 7000);
     try {
       const params = new URLSearchParams();
       params.set("page", String(page));
@@ -65,32 +176,45 @@ export function BroadcastsList() {
       if (statusFilter) params.set("status", statusFilter);
       if (audienceFilter) params.set("segmentId", audienceFilter);
 
-      const apiKey =
-        typeof window !== "undefined"
-          ? (localStorage?.getItem?.("api_key") ?? null)
-          : null;
+      const apiKey = getApiKey();
       const authHeaders: Record<string, string> = {};
       if (apiKey) authHeaders.Authorization = `Bearer ${apiKey}`;
       const res = await fetch(`/api/broadcasts?${params.toString()}`, {
         headers: authHeaders,
+        signal: controller.signal,
       });
-      const data = await res.json();
-      setBroadcasts(data.data || []);
-      setTotal(data.total || 0);
-    } catch {
+      const data = toApiListResponse(await parseJsonResponse(res));
+      if (!res.ok) {
+        throw new Error(responseErrorMessage(data));
+      }
+      const nextBroadcasts = normalizeBroadcasts(data.data);
+      setBroadcasts(nextBroadcasts);
+      setTotal(
+        typeof data.total === "number"
+          ? data.total
+          : data.has_more === true
+            ? nextBroadcasts.length + 1
+            : nextBroadcasts.length,
+      );
+    } catch (fetchError) {
       setBroadcasts([]);
       setTotal(0);
+      setError(
+        fetchError instanceof Error && fetchError.name === "AbortError"
+          ? "Loading broadcasts timed out. Please retry."
+          : fetchError instanceof Error
+            ? fetchError.message
+            : "Failed to load broadcasts.",
+      );
     } finally {
+      window.clearTimeout(timeoutId);
       setLoading(false);
     }
   }, [page, limit, search, statusFilter, audienceFilter]);
 
   const fetchSegments = useCallback(async () => {
     try {
-      const apiKey =
-        typeof window !== "undefined"
-          ? (localStorage?.getItem?.("api_key") ?? null)
-          : null;
+      const apiKey = getApiKey();
       const authHeaders: Record<string, string> = {};
       if (apiKey) authHeaders.Authorization = `Bearer ${apiKey}`;
       const res = await fetch("/api/segments?limit=100", {
@@ -104,6 +228,10 @@ export function BroadcastsList() {
   }, []);
 
   useEffect(() => {
+    if (skipInitialFetch.current) {
+      skipInitialFetch.current = false;
+      return;
+    }
     fetchBroadcasts();
   }, [fetchBroadcasts]);
 
@@ -460,6 +588,22 @@ export function BroadcastsList() {
       {loading ? (
         <div className="flex items-center justify-center py-16 text-[14px] text-[#A1A4A5]">
           Loading broadcasts...
+        </div>
+      ) : error ? (
+        <div className="flex flex-col items-center justify-center py-16 px-6">
+          <h3 className="text-[16px] font-semibold text-[#F0F0F0] mb-2">
+            Unable to load broadcasts
+          </h3>
+          <p className="text-[14px] text-[#A1A4A5] text-center max-w-[420px] mb-6">
+            {error}
+          </p>
+          <button
+            type="button"
+            onClick={fetchBroadcasts}
+            className="h-9 px-4 text-[13px] font-medium bg-white text-black rounded-md hover:bg-gray-200 transition-colors"
+          >
+            Retry
+          </button>
         </div>
       ) : broadcasts.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 px-6">

--- a/tests/broadcasts-list.test.ts
+++ b/tests/broadcasts-list.test.ts
@@ -30,6 +30,7 @@ vi.mock("next/link", () => ({
   },
 }));
 
+import type { BroadcastsListProps } from "@/components/broadcasts-list";
 import {
   cleanup,
   fireEvent,
@@ -40,7 +41,7 @@ import {
 import React from "react";
 
 type BroadcastsListModule = typeof import("@/components/broadcasts-list");
-let BroadcastsList: BroadcastsListModule["BroadcastsList"];
+let BroadcastsList: React.ComponentType<BroadcastsListProps>;
 
 const mockBroadcasts = [
   {
@@ -96,7 +97,8 @@ describe("BroadcastsList", () => {
     vi.resetModules();
     vi.clearAllMocks();
     const mod = await import("@/components/broadcasts-list");
-    BroadcastsList = mod.BroadcastsList;
+    BroadcastsList =
+      mod.BroadcastsList as BroadcastsListModule["BroadcastsList"];
   });
 
   afterEach(() => {
@@ -162,6 +164,70 @@ describe("BroadcastsList", () => {
     await waitFor(() => {
       expect(screen.getByText("No broadcasts")).toBeDefined();
     });
+  });
+
+  it("renders initial empty broadcasts without staying in loading or requiring a client list fetch", async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("/api/segments")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ data: mockSegments, total: mockSegments.length }),
+        });
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+
+    render(
+      React.createElement(BroadcastsList, {
+        initialBroadcasts: [],
+        initialTotal: 0,
+      }),
+    );
+
+    expect(screen.queryByText("Loading broadcasts...")).toBeNull();
+    expect(screen.getByText("No broadcasts")).toBeDefined();
+
+    await waitFor(() => {
+      const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      expect(
+        calls.some((call) => {
+          const url = call[0];
+          return typeof url === "string" && url.startsWith("/api/segments");
+        }),
+      ).toBe(true);
+    });
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(
+      calls.some((call) => {
+        const url = call[0];
+        return typeof url === "string" && url.startsWith("/api/broadcasts");
+      }),
+    ).toBe(false);
+  });
+
+  it("shows an actionable error state when loading broadcasts fails", async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("/api/segments")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ data: mockSegments, total: mockSegments.length }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({ error: "Session expired" }),
+      });
+    });
+
+    render(React.createElement(BroadcastsList));
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to load broadcasts")).toBeDefined();
+    });
+    expect(screen.getByText("Session expired")).toBeDefined();
+    expect(screen.getByText("Retry")).toBeDefined();
   });
 
   it("has a Create email button", async () => {


### PR DESCRIPTION
## Summary
- Fixes #402
- Server-load tenant-scoped initial Broadcasts data so empty accounts render `No broadcasts` without waiting on a first client fetch.
- Normalize Broadcasts API list responses and show retryable client/server error states instead of silently swallowing failures or staying on loading.
- Add regression coverage for initial empty rendering without a client `/api/broadcasts` fetch plus visible fetch errors.

## Checks
- `bun run test -- tests/broadcasts-list.test.ts tests/broadcast-tenant-routes.test.ts`
- `make check`
- `make test`
- `bun run build`

## Notes
- Scope intentionally limited to `/broadcasts` page/list loading behavior and focused regression coverage.
