### PR TITLE
Fix templates create CTA

### DIFF
--- a/packages/core/src/db/repositories/templateRepo.ts
+++ b/packages/core/src/db/repositories/templateRepo.ts
@@ -63,15 +63,17 @@ export const templateRepo = {
     options: {
       search?: string;
       status?: string;
+      userId?: string;
     } = {},
   ) {
-    const { search, status } = options;
+    const { search, status, userId } = options;
     const conditions: SQL[] = [];
 
     if (search) conditions.push(ilike(templates.name, `%${search}%`));
     if (status === "published" || status === "draft") {
       conditions.push(eq(templates.status, status));
     }
+    if (userId) conditions.push(eq(templates.userId, userId));
 
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
     const [totalRow] = await db

--- a/packages/core/src/services/template.ts
+++ b/packages/core/src/services/template.ts
@@ -83,6 +83,16 @@ export type TemplatePublishResult = Pick<
   "id" | "status" | "publishedAt" | "hasUnpublishedVersions"
 >;
 
+type TemplateListOptions = {
+  search?: string;
+  status?: string;
+  userId?: string;
+};
+
+type TemplateCreateOptions = {
+  userId?: string;
+};
+
 export type TemplateServiceErrorCode =
   | "invalid_input"
   | "invalid_variables"
@@ -107,6 +117,7 @@ export type TemplateRepository = {
   listForApi(options: {
     search?: string;
     status?: string;
+    userId?: string;
   }): Promise<TemplateListResult>;
 };
 
@@ -384,19 +395,25 @@ export function createTemplateService({
   now = () => new Date(),
 }: TemplateServiceDependencies = {}) {
   return {
-    async listTemplates(options: {
-      search?: string;
-      status?: string;
-    }): Promise<TemplateListResult> {
+    async listTemplates(
+      options: TemplateListOptions,
+    ): Promise<TemplateListResult> {
       const search = options.search?.trim() || "";
       const rawStatus = options.status?.trim() || "";
       const status =
         rawStatus === "published" || rawStatus === "draft" ? rawStatus : "";
 
-      return await repository.listForApi({ search, status });
+      return await repository.listForApi({
+        search,
+        status,
+        userId: options.userId,
+      });
     },
 
-    async createTemplate(input: unknown): Promise<TemplateCreateResult> {
+    async createTemplate(
+      input: unknown,
+      options: TemplateCreateOptions = {},
+    ): Promise<TemplateCreateResult> {
       const body = asRecord(input);
       const name = typeof body.name === "string" ? body.name.trim() : "";
       const html = typeof body.html === "string" ? body.html.trim() : "";
@@ -413,7 +430,7 @@ export function createTemplateService({
           ? body.alias.trim()
           : generateAlias(name);
 
-      const [template] = await repository.create({
+      const createData: TemplateInsert = {
         name,
         alias,
         html,
@@ -424,7 +441,10 @@ export function createTemplateService({
         text: toTruthyStoredString(body.text),
         variables: normalizeVariablesOrThrow(body.variables),
         status: "draft",
-      });
+      };
+      if (options.userId) createData.userId = options.userId;
+
+      const [template] = await repository.create(createData);
 
       return {
         id: template.id,

--- a/src/app/api/templates/auth.ts
+++ b/src/app/api/templates/auth.ts
@@ -1,0 +1,38 @@
+import {
+  authorizeDashboardOrApiKey,
+  getServerSession,
+  unauthorizedResponse,
+} from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
+
+type TemplateRouteAuth = NonNullable<
+  Awaited<ReturnType<typeof authorizeDashboardOrApiKey>>
+>;
+
+type TemplateRouteAuthResult =
+  | { ok: true; userId?: string }
+  | { ok: false; response: Response };
+
+async function getRouteUserId(auth: TemplateRouteAuth): Promise<string | null> {
+  if ("userId" in auth) return auth.userId;
+
+  const session = await getServerSession();
+  return session?.user?.id ?? null;
+}
+
+export async function authorizeTemplateRoute(
+  authHeader: string | null | undefined,
+): Promise<TemplateRouteAuthResult> {
+  const auth = await authorizeDashboardOrApiKey(authHeader);
+  if (!auth) return { ok: false, response: unauthorizedResponse() };
+
+  if ("apiKeyId" in auth) {
+    const permissionError = requireFullAccessApiKey(auth);
+    if (permissionError) return { ok: false, response: permissionError };
+  }
+
+  if ("apiKeyId" in auth) return { ok: true };
+
+  const userId = await getRouteUserId(auth);
+  return userId ? { ok: true, userId } : { ok: true };
+}

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -1,7 +1,6 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { TemplateServiceError, createTemplateService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
+import { authorizeTemplateRoute } from "./auth";
 
 function mapTemplateError(error: unknown, fallback: string) {
   if (error instanceof TemplateServiceError) {
@@ -18,15 +17,16 @@ function templateService() {
 }
 
 export async function GET(request: NextRequest) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
+  const auth = await authorizeTemplateRoute(
+    request.headers.get("authorization"),
+  );
+  if (!auth.ok) return auth.response;
 
   try {
     const result = await templateService().listTemplates({
       search: request.nextUrl.searchParams.get("search") ?? undefined,
       status: request.nextUrl.searchParams.get("status") ?? undefined,
+      userId: auth.userId,
     });
 
     return NextResponse.json({
@@ -49,14 +49,15 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
+  const auth = await authorizeTemplateRoute(
+    request.headers.get("authorization"),
+  );
+  if (!auth.ok) return auth.response;
 
   try {
     const created = await templateService().createTemplate(
       await request.json(),
+      { userId: auth.userId },
     );
 
     return NextResponse.json(

--- a/src/components/templates-list.tsx
+++ b/src/components/templates-list.tsx
@@ -15,10 +15,43 @@ interface Template {
 
 type StatusFilter = "" | "draft" | "published";
 
+async function readCreateTemplateError(res: Response): Promise<string> {
+  const fallback = "Could not create template.";
+  const payload: unknown = await res.json().catch(() => null);
+
+  if (
+    payload &&
+    typeof payload === "object" &&
+    "error" in payload &&
+    typeof payload.error === "string" &&
+    payload.error.trim()
+  ) {
+    return payload.error;
+  }
+
+  return fallback;
+}
+
+function getCreatedTemplateId(payload: unknown): string | null {
+  if (
+    payload &&
+    typeof payload === "object" &&
+    "id" in payload &&
+    typeof payload.id === "string" &&
+    payload.id
+  ) {
+    return payload.id;
+  }
+
+  return null;
+}
+
 export function TemplatesList() {
   const router = useRouter();
   const [templates, setTemplates] = useState<Template[]>([]);
   const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("");
   const [statusDropdownOpen, setStatusDropdownOpen] = useState(false);
@@ -82,6 +115,8 @@ export function TemplatesList() {
   };
 
   const handleCreate = async () => {
+    setCreating(true);
+    setCreateError(null);
     try {
       const apiKey =
         typeof window !== "undefined"
@@ -94,14 +129,29 @@ export function TemplatesList() {
       const res = await fetch("/api/templates", {
         method: "POST",
         headers,
-        body: JSON.stringify({ name: "Untitled Template" }),
+        body: JSON.stringify({
+          name: "Untitled Template",
+          html: "<p>Start writing your email template.</p>",
+        }),
       });
-      if (res.ok) {
-        const template = await res.json();
-        router.push(`/templates/${template.id}/editor`);
+      if (!res.ok) {
+        setCreateError(await readCreateTemplateError(res));
+        return;
       }
+
+      const templateId = getCreatedTemplateId(await res.json());
+      if (!templateId) {
+        setCreateError(
+          "Template was created but no editor route was returned.",
+        );
+        return;
+      }
+
+      router.push(`/templates/${templateId}/editor`);
     } catch {
-      // ignore
+      setCreateError("Could not create template.");
+    } finally {
+      setCreating(false);
     }
   };
 
@@ -278,7 +328,8 @@ export function TemplatesList() {
         <button
           type="button"
           onClick={handleCreate}
-          className="h-9 px-4 text-[13px] font-medium bg-white text-black rounded-md hover:bg-gray-200 transition-colors flex items-center gap-1.5"
+          disabled={creating}
+          className="h-9 px-4 text-[13px] font-medium bg-white text-black rounded-md hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-70 transition-colors flex items-center gap-1.5"
         >
           <svg
             aria-hidden="true"
@@ -292,9 +343,18 @@ export function TemplatesList() {
             <line x1="12" y1="5" x2="12" y2="19" />
             <line x1="5" y1="12" x2="19" y2="12" />
           </svg>
-          Create template
+          {creating ? "Creating..." : "Create template"}
         </button>
       </div>
+
+      {createError ? (
+        <div
+          role="alert"
+          className="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-[13px] text-red-300"
+        >
+          {createError}
+        </div>
+      ) : null}
 
       {/* Content */}
       {loading ? (

--- a/tests/api-template-variables.test.ts
+++ b/tests/api-template-variables.test.ts
@@ -108,6 +108,26 @@ describe("template variable metadata service", () => {
     });
   });
 
+  it("stores the authenticated dashboard user on created templates", async () => {
+    const inserted: TemplateInsert[] = [];
+    const repository = createRepository({
+      async create(data) {
+        inserted.push(data);
+        return [templateRow({ ...data })];
+      },
+    });
+
+    await createTemplateService({ repository }).createTemplate(
+      {
+        name: "Dashboard draft",
+        html: "<p>Hello</p>",
+      },
+      { userId: "user-123" },
+    );
+
+    expect(inserted[0]?.userId).toBe("user-123");
+  });
+
   it("preserves reserved-name and 50-variable validation on create", async () => {
     const create = vi.fn(async () => [templateRow()]);
     const service = createTemplateService({

--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -122,6 +122,9 @@ export async function cleanupE2ERun(
     "delete from logs where user_id like $1 or document->>'test_run_id' = $2",
     [`${userPrefix}%`, runId],
   );
+  await client.query("delete from templates where user_id like $1", [
+    `${userPrefix}%`,
+  ]);
   await client.query(
     "delete from webhooks where user_id like $1 or document->>'test_run_id' = $2",
     [`${userPrefix}%`, runId],

--- a/tests/e2e/templates-list.spec.ts
+++ b/tests/e2e/templates-list.spec.ts
@@ -1,17 +1,17 @@
 import { expect, test } from "./fixtures/auth";
-// E2E category: smoke-only; templates list/create tests need deterministic template fixture follow-up (#229 audit).
-test.skip(
-  true,
-  "E2E category: smoke-only; templates list/create tests need deterministic template fixture follow-up (#229 audit).",
-);
 
 test.describe("Templates List Page", () => {
   test("navigate to template editor from card", async ({
     authenticatedPage: page,
+    e2eDb,
+    e2eUser,
   }) => {
     // Create a template first
     const res = await page.request.post("/api/templates", {
-      data: { name: "E2E Test Template" },
+      data: {
+        name: "E2E Test Template",
+        html: "<p>E2E test template</p>",
+      },
     });
     expect(res.ok()).toBeTruthy();
     const template = await res.json();
@@ -30,10 +30,17 @@ test.describe("Templates List Page", () => {
     );
 
     // Cleanup
-    await page.request.delete(`/api/templates/${template.id}`);
+    await e2eDb.query("delete from templates where id = $1 and user_id = $2", [
+      template.id,
+      e2eUser.id,
+    ]);
   });
 
-  test("create new template", async ({ authenticatedPage: page }) => {
+  test("create new template", async ({
+    authenticatedPage: page,
+    e2eDb,
+    e2eUser,
+  }) => {
     await page.goto("/templates");
     await page.waitForLoadState("networkidle");
 
@@ -42,5 +49,16 @@ test.describe("Templates List Page", () => {
 
     // Verify navigation to editor
     await expect(page).toHaveURL(/\/templates\/[^/]+\/editor/);
+    const templateId = new URL(page.url()).pathname.split("/")[2];
+    const result = await e2eDb.query<{ user_id: string | null }>(
+      "select user_id from templates where id = $1",
+      [templateId],
+    );
+    expect(result.rows[0]?.user_id).toBe(e2eUser.id);
+
+    await e2eDb.query("delete from templates where id = $1 and user_id = $2", [
+      templateId,
+      e2eUser.id,
+    ]);
   });
 });

--- a/tests/templates-list.test.tsx
+++ b/tests/templates-list.test.tsx
@@ -1,12 +1,20 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const routerMock = vi.hoisted(() => ({
+  push: vi.fn(),
+  refresh: vi.fn(),
+}));
 
 // Mock next/navigation
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({
-    push: vi.fn(),
-    refresh: vi.fn(),
-  }),
+  useRouter: () => routerMock,
 }));
 
 // Mock next/link
@@ -113,6 +121,39 @@ describe("TemplatesList", () => {
     await screen.findByText("Welcome Email");
 
     expect(screen.getByText("Create template")).toBeTruthy();
+  });
+
+  it("creates a draft template and navigates to its editor from the CTA", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: mockTemplates, total: 3 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "new-template" }),
+      });
+
+    render(<TemplatesList />);
+
+    await screen.findByText("Welcome Email");
+    fireEvent.click(screen.getByRole("button", { name: "Create template" }));
+
+    await waitFor(() => {
+      expect(routerMock.push).toHaveBeenCalledWith(
+        "/templates/new-template/editor",
+      );
+    });
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      "/api/templates",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          name: "Untitled Template",
+          html: "<p>Start writing your email template.</p>",
+        }),
+      }),
+    );
   });
 
   it("shows card action menu with options", async () => {


### PR DESCRIPTION
## Summary
- Fixes the Templates page Create template CTA by creating a valid starter draft and navigating to `/templates/:id/editor`.
- Allows authenticated dashboard sessions to use the templates collection route while preserving full-access API-key checks.
- Adds regression coverage for CTA navigation and template user attribution.

Closes #403

## Checks
- `bun install --ignore-scripts`
- `bun run test -- tests/templates-list.test.tsx tests/api-template-variables.test.ts`
- `make check`
- `make test`
- `bunx playwright test tests/e2e/templates-list.spec.ts` (skipped locally because this cold worktree has no `DATABASE_URL`)
