### PR TITLE
Fix Settings Team actions and Documents copy

### DIFF
--- a/src/components/settings-documents.tsx
+++ b/src/components/settings-documents.tsx
@@ -1,6 +1,21 @@
-// ABOUTME: Settings Documents tab — static compliance documents list with download links for Penetration test, SOC 2, DPA, Form W-9
+// ABOUTME: Settings Documents tab — compliance document availability without vendor-branded placeholder copy
 
-const DOCUMENTS = [
+type AvailableDocument = {
+  title: string;
+  descriptions: string[];
+  status: "available";
+  file: string;
+};
+
+type UnavailableDocument = {
+  title: string;
+  descriptions: string[];
+  status: "unavailable";
+};
+
+type SettingsDocument = AvailableDocument | UnavailableDocument;
+
+const DOCUMENTS: SettingsDocument[] = [
   {
     title: "Penetration test",
     descriptions: [
@@ -8,22 +23,23 @@ const DOCUMENTS = [
       "You can download the Letter of Attestation below.",
     ],
     file: "/static/documents/penetration-test.pdf",
+    status: "available",
   },
   {
     title: "SOC 2",
     descriptions: [
-      "Resend is SOC 2 Type II compliant, a compliance framework developed by AICPA.",
-      "This audit was completed by Vanta & Advantage Partners and covers the period of February 1, 2024 to February 1, 2025.",
+      "SOC 2 is a compliance framework developed by AICPA for service organizations.",
+      "OpenSend does not currently provide a self-service SOC 2 report in the dashboard. We will publish an OpenSend-specific report here when it is available.",
     ],
-    file: "/static/documents/soc2-report.pdf",
+    status: "unavailable",
   },
   {
     title: "DPA",
     descriptions: [
       "Data Processing Agreement (DPA) is a contract that regulates data processing conducted for business purposes.",
-      "The attached DPA is a version signed by us, and is considered fully executed once you signup to Resend.",
+      "OpenSend does not currently provide a self-service DPA download in the dashboard. Contact support if your organization needs a DPA before it is available here.",
     ],
-    file: "/static/documents/dpa.pdf",
+    status: "unavailable",
   },
   {
     title: "Form W-9",
@@ -32,6 +48,7 @@ const DOCUMENTS = [
       "The attached Form W-9 is a version signed by us.",
     ],
     file: "/static/documents/form-w9.pdf",
+    status: "available",
   },
 ];
 
@@ -54,14 +71,20 @@ export function DocumentsTab() {
               {desc}
             </p>
           ))}
-          <a
-            href={doc.file}
-            className="mt-2 inline-flex items-center px-3 py-1.5 text-[13px] font-medium text-[#F0F0F0] bg-[rgba(176,199,217,0.08)] border border-[rgba(176,199,217,0.145)] rounded-md hover:bg-[rgba(176,199,217,0.15)] transition-colors"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Download
-          </a>
+          {doc.status === "available" ? (
+            <a
+              href={doc.file}
+              className="mt-2 inline-flex items-center px-3 py-1.5 text-[13px] font-medium text-[#F0F0F0] bg-[rgba(176,199,217,0.08)] border border-[rgba(176,199,217,0.145)] rounded-md hover:bg-[rgba(176,199,217,0.15)] transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Download
+            </a>
+          ) : (
+            <span className="mt-2 inline-flex items-center px-3 py-1.5 text-[13px] font-medium text-[#A1A4A5] bg-[rgba(176,199,217,0.04)] border border-dashed border-[rgba(176,199,217,0.145)] rounded-md">
+              Unavailable
+            </span>
+          )}
         </div>
       ))}
     </div>

--- a/src/components/settings-team.tsx
+++ b/src/components/settings-team.tsx
@@ -33,13 +33,25 @@ export function TeamTab() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <p className="text-[14px] text-[#A1A4A5]">
-          Manage your team members and their access levels.
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-2">
+          <p className="text-[14px] text-[#A1A4A5]">
+            View your team members and their access levels.
+          </p>
+          <p
+            id="team-actions-unavailable"
+            className="max-w-2xl text-[13px] text-[#A1A4A5]"
+          >
+            Team invitations and role editing are not available in OpenSend yet.
+            These controls are disabled until member management is ready.
+          </p>
+        </div>
         <button
           type="button"
-          className="h-9 px-4 text-[13px] font-medium bg-white text-black rounded-md hover:bg-gray-200 transition-colors"
+          className="h-9 shrink-0 cursor-not-allowed rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(176,199,217,0.08)] px-4 text-[13px] font-medium text-[#A1A4A5] opacity-70"
+          disabled
+          aria-describedby="team-actions-unavailable"
+          title="Team invitations are not available yet."
         >
           Invite member
         </button>
@@ -91,7 +103,11 @@ export function TeamTab() {
                 <td className="px-4 py-4 text-right">
                   <button
                     type="button"
-                    className="text-[12px] text-[#A1A4A5] hover:text-[#F0F0F0] transition-colors"
+                    className="cursor-not-allowed text-[12px] text-[#6F7377] opacity-70"
+                    disabled
+                    aria-describedby="team-actions-unavailable"
+                    aria-label={`Edit ${member.name} unavailable`}
+                    title="Team role editing is not available yet."
                   >
                     Edit
                   </button>

--- a/tests/e2e/settings-documents.spec.ts
+++ b/tests/e2e/settings-documents.spec.ts
@@ -1,49 +1,61 @@
-// ABOUTME: E2E test for Settings Documents tab — verifies all 4 compliance document sections with download links
-// E2E category: smoke-only; settings documents assertions are UI-copy smoke and need refresh follow-up (#229 audit).
-test.skip(
-  true,
-  "E2E category: smoke-only; settings documents assertions are UI-copy smoke and need refresh follow-up (#229 audit).",
-);
+// ABOUTME: E2E tests for Settings Team/Documents tabs — verifies honest disabled actions and OpenSend document copy
 
 import { expect, test } from "./fixtures/auth";
 
-test.describe("Settings Documents Page", () => {
-  test("documents page displays all sections with download links", async ({
+test.describe("Settings Team and Documents Page", () => {
+  test("team tab disables unavailable member management actions", async ({
     authenticatedPage: page,
   }) => {
     await page.goto("/settings");
 
-    // Click Documents tab
-    const documentsTab = page.locator('button:has-text("Documents")');
-    await expect(documentsTab).toBeVisible();
-    await documentsTab.click();
+    await page.getByRole("button", { name: "Team" }).click();
 
-    // Verify Penetration test section
-    await expect(page.locator("text=Penetration test")).toBeVisible();
+    await expect(
+      page.getByText(/Team invitations and role editing are not available/),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole("button", { name: "Invite member" }),
+    ).toBeDisabled();
+
+    const editButtons = page.getByRole("button", {
+      name: /Edit .* unavailable/,
+    });
+    await expect(editButtons.first()).toBeDisabled();
+    await expect(editButtons).toHaveCount(2);
+  });
+
+  test("documents tab avoids Resend branding and marks unavailable docs", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/settings");
+
+    await page.getByRole("button", { name: "Documents" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Penetration test" }),
+    ).toBeVisible();
     await expect(
       page.locator("text=/Penetration testing is performed/"),
     ).toBeVisible();
 
-    // Verify SOC 2 section
-    await expect(page.locator("text=SOC 2").first()).toBeVisible();
-    await expect(page.locator("text=/SOC 2 Type II compliant/")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "SOC 2" })).toBeVisible();
+    await expect(page.locator("text=/OpenSend-specific report/")).toBeVisible();
 
-    // Verify DPA section
-    await expect(page.locator("text=DPA").first()).toBeVisible();
+    await expect(page.getByRole("heading", { name: "DPA" })).toBeVisible();
     await expect(
-      page.locator("text=/Data Processing Agreement/"),
+      page.locator("text=/self-service DPA download/"),
     ).toBeVisible();
 
-    // Verify Form W-9 section
-    await expect(page.locator("text=Form W-9")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Form W-9" })).toBeVisible();
     await expect(page.locator("text=/tax document/")).toBeVisible();
 
-    // Verify 4 download links exist
-    const downloadLinks = page.locator('a:has-text("Download")');
-    await expect(downloadLinks).toHaveCount(4);
+    await expect(page.locator("body")).not.toContainText("Resend");
+    await expect(page.getByText("Unavailable")).toHaveCount(2);
 
-    // Verify download links point to PDF files
-    for (let i = 0; i < 4; i++) {
+    const downloadLinks = page.locator('a:has-text("Download")');
+    await expect(downloadLinks).toHaveCount(2);
+    for (let i = 0; i < 2; i++) {
       const href = await downloadLinks.nth(i).getAttribute("href");
       expect(href).toContain("/static/documents/");
       expect(href).toMatch(/\.pdf$/);

--- a/tests/settings-documents.test.tsx
+++ b/tests/settings-documents.test.tsx
@@ -20,21 +20,22 @@ describe("DocumentsTab", () => {
     expect(
       screen.getByText(/Penetration testing is performed at least annually/),
     ).toBeDefined();
-    expect(screen.getByText(/SOC 2 Type II compliant/)).toBeDefined();
+    expect(screen.getByText(/SOC 2 is a compliance framework/)).toBeDefined();
     expect(screen.getByText(/Data Processing Agreement/)).toBeDefined();
     expect(screen.getByText(/Form W-9 is a tax document/)).toBeDefined();
   });
 
-  it("renders a Download link for each document", () => {
+  it("renders Download links only for available documents", () => {
     render(<DocumentsTab />);
     const downloadLinks = screen.getAllByText("Download");
-    expect(downloadLinks.length).toBe(4);
+    expect(downloadLinks.length).toBe(2);
+    expect(screen.getAllByText("Unavailable").length).toBe(2);
   });
 
-  it("download links point to /static/documents/ PDF paths", () => {
+  it("available download links point to /static/documents/ PDF paths", () => {
     const { container } = render(<DocumentsTab />);
     const links = container.querySelectorAll('a[href*="/static/documents/"]');
-    expect(links.length).toBe(4);
+    expect(links.length).toBe(2);
     for (const link of links) {
       expect(link.getAttribute("href")).toMatch(/\.pdf$/);
     }
@@ -43,6 +44,13 @@ describe("DocumentsTab", () => {
   it("renders secondary description text for documents", () => {
     render(<DocumentsTab />);
     expect(screen.getByText(/Letter of Attestation/)).toBeDefined();
-    expect(screen.getByText(/Vanta & Advantage Partners/)).toBeDefined();
+    expect(screen.getByText(/OpenSend-specific report/)).toBeDefined();
+  });
+
+  it("does not render Resend-branded placeholder copy", () => {
+    const { container } = render(<DocumentsTab />);
+
+    expect(container.textContent).not.toContain("Resend");
+    expect(container.textContent).not.toContain("signup to");
   });
 });

--- a/tests/settings-team.test.tsx
+++ b/tests/settings-team.test.tsx
@@ -1,0 +1,42 @@
+// ABOUTME: Unit tests for the Settings Team tab — member action availability and explanatory copy
+
+import { TeamTab } from "@/components/settings-team";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+afterEach(cleanup);
+
+describe("TeamTab", () => {
+  it("disables Invite member with explanatory copy while team management is unavailable", () => {
+    render(<TeamTab />);
+
+    expect(
+      screen.getByText(/Team invitations and role editing are not available/),
+    ).toBeDefined();
+
+    const inviteButton = screen.getByRole("button", {
+      name: "Invite member",
+    }) as HTMLButtonElement;
+
+    expect(inviteButton.disabled).toBe(true);
+    expect(inviteButton.getAttribute("aria-describedby")).toBe(
+      "team-actions-unavailable",
+    );
+  });
+
+  it("disables member Edit controls instead of leaving inert enabled buttons", () => {
+    render(<TeamTab />);
+
+    const editButtons = screen.getAllByRole("button", {
+      name: /Edit .* unavailable/,
+    }) as HTMLButtonElement[];
+
+    expect(editButtons.length).toBeGreaterThan(0);
+    for (const editButton of editButtons) {
+      expect(editButton.disabled).toBe(true);
+      expect(editButton.getAttribute("aria-describedby")).toBe(
+        "team-actions-unavailable",
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Disables Settings → Team invite/edit controls with explanatory copy because the current backend is list-only and no usable invite/edit flow exists yet.
- Removes Resend-branded Settings → Documents copy and marks unavailable OpenSend SOC 2/DPA documents as unavailable instead of linking placeholder downloads.
- Adds unit and Playwright regression coverage for the Team controls and Documents branding/availability behavior.

Closes #407
Closes #408

## Changed Files
- `src/components/settings-team.tsx`
- `src/components/settings-documents.tsx`
- `tests/settings-team.test.tsx`
- `tests/settings-documents.test.tsx`
- `tests/e2e/settings-documents.spec.ts`

## Validation
- `make check` — passed
- `make test` — passed (`144` files, `1135` tests)
- `bun run test tests/settings-team.test.tsx tests/settings-documents.test.tsx` — passed (`8` tests)
- `PORT=4015 bunx playwright test tests/e2e/settings-documents.spec.ts` with local Postgres `DATABASE_URL` — passed (`2` tests)

## E2E Notes
- The first focused Playwright attempt reused an existing server on port `3015` that was serving stale Settings UI and exposed the Documents locator strictness issue. I inspected the Playwright error context, updated the heading locators, and reran on fresh `PORT=4015`; the focused Settings Team/Documents spec now passes.
- The Next dev server emitted existing warnings about `experimental.nodeMiddleware`, workspace-root inference, and the deprecated `middleware` convention; these warnings did not fail the focused spec.

## Residual Risk
- Team invite/edit remain unavailable by design until a real product/backend member-management flow exists.
- SOC 2 and DPA downloads are intentionally unavailable until OpenSend-specific documents are ready to publish.
- Full `make test-e2e` across all specs was not run; focused Settings E2E plus full unit/static validation passed.
