### PR TITLE
Fix Audience Add manually crash

### DIFF
--- a/agent_docs/learnings/active/2026-05-12-issue-406-manual-contact-add.md
+++ b/agent_docs/learnings/active/2026-05-12-issue-406-manual-contact-add.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-12
+issue: "#406"
+type: pattern
+promoted_to: null
+---
+
+## Manual audience add must follow current list/create API contracts
+
+The Audience manual-add modal is a dashboard client of the real `/api/segments` and `/api/contacts` routes. `/api/segments` returns the public list envelope (`{ object, data, has_more, total }`), not a raw segment array, and `/api/contacts` creates one contact per request with `{ email, segments }`, not the legacy UI shape `{ emails, segment_ids }`.
+
+Future dashboard contact-add changes should normalize list envelopes at the UI boundary and submit the same single-contact payload the route validates, then prove the path with an auth-backed Playwright test against a real database row instead of route-only mocks.

--- a/src/components/add-contact-modal.tsx
+++ b/src/components/add-contact-modal.tsx
@@ -7,6 +7,28 @@ interface Segment {
   name: string;
 }
 
+function isSegment(value: unknown): value is Segment {
+  if (typeof value !== "object" || value === null) return false;
+
+  const maybeSegment = value as Record<string, unknown>;
+  return (
+    typeof maybeSegment.id === "string" && typeof maybeSegment.name === "string"
+  );
+}
+
+function extractSegments(payload: unknown): Segment[] {
+  if (Array.isArray(payload)) {
+    return payload.filter(isSegment);
+  }
+
+  if (typeof payload !== "object" || payload === null) {
+    return [];
+  }
+
+  const maybeList = payload as Record<string, unknown>;
+  return Array.isArray(maybeList.data) ? maybeList.data.filter(isSegment) : [];
+}
+
 interface AddContactModalProps {
   open: boolean;
   onClose: () => void;
@@ -24,6 +46,7 @@ export function AddContactModal({
   const [segmentSearch, setSegmentSearch] = useState("");
   const [segmentDropdownOpen, setSegmentDropdownOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const segmentRef = useRef<HTMLDivElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
 
@@ -38,7 +61,7 @@ export function AddContactModal({
       const res = await fetch("/api/segments", { headers: authHeaders });
       if (res.ok) {
         const data = await res.json();
-        setSegments(data);
+        setSegments(extractSegments(data));
       }
     } catch {
       // ignore
@@ -51,6 +74,7 @@ export function AddContactModal({
       setEmailText("");
       setSelectedSegments([]);
       setSegmentSearch("");
+      setSubmitError(null);
     }
   }, [open, fetchSegments]);
 
@@ -109,6 +133,7 @@ export function AddContactModal({
     if (emails.length === 0) return;
 
     setSubmitting(true);
+    setSubmitError(null);
     try {
       const apiKey =
         typeof window !== "undefined"
@@ -118,21 +143,28 @@ export function AddContactModal({
         "Content-Type": "application/json",
       };
       if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
-      const res = await fetch("/api/contacts", {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          emails,
-          segment_ids: selectedSegments.map((s) => s.id),
-        }),
-      });
 
-      if (res.ok) {
-        onSuccess();
-        onClose();
+      for (const email of emails) {
+        const res = await fetch("/api/contacts", {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            email,
+            segments: selectedSegments.map((s) => s.id),
+          }),
+        });
+
+        if (!res.ok) {
+          throw new Error("Failed to add contact");
+        }
       }
+
+      onSuccess();
+      onClose();
     } catch {
-      // ignore
+      setSubmitError(
+        "Could not add contacts. Check the email address and try again.",
+      );
     } finally {
       setSubmitting(false);
     }
@@ -199,6 +231,11 @@ export function AddContactModal({
             <p className="mt-1 text-[12px] text-[#A1A4A5]">
               Use commas or line breaks to separate multiple email addresses.
             </p>
+            {submitError && (
+              <p className="mt-2 text-[12px] text-red-400" role="alert">
+                {submitError}
+              </p>
+            )}
           </div>
 
           {/* Segments autocomplete */}

--- a/tests/add-contact-modal.test.tsx
+++ b/tests/add-contact-modal.test.tsx
@@ -108,11 +108,11 @@ describe("AddContactModal", () => {
       );
       expect(postCall).toBeDefined();
       const body = JSON.parse((postCall?.[1] as RequestInit).body as string);
-      expect(body.emails).toEqual(["new@example.com"]);
+      expect(body.email).toBe("new@example.com");
     });
   });
 
-  it("parses comma-separated emails", async () => {
+  it("parses comma-separated emails and submits one API-compatible request per contact", async () => {
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
@@ -120,7 +120,11 @@ describe("AddContactModal", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve({ created: 2 }),
+        json: () => Promise.resolve({ id: "contact-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: "contact-2" }),
       });
 
     render(<AddContactModal {...defaultProps} />);
@@ -133,14 +137,20 @@ describe("AddContactModal", () => {
     fireEvent.click(screen.getByRole("button", { name: "Add" }));
 
     await waitFor(() => {
-      const postCall = mockFetch.mock.calls.find(
+      const postCalls = mockFetch.mock.calls.filter(
         (call: unknown[]) =>
           call[0] === "/api/contacts" &&
           (call[1] as RequestInit)?.method === "POST",
       );
-      expect(postCall).toBeDefined();
-      const body = JSON.parse((postCall?.[1] as RequestInit).body as string);
-      expect(body.emails).toEqual(["a@b.com", "c@d.com"]);
+      expect(postCalls).toHaveLength(2);
+      expect(
+        postCalls.map((call) =>
+          JSON.parse((call[1] as RequestInit).body as string),
+        ),
+      ).toEqual([
+        { email: "a@b.com", segments: [] },
+        { email: "c@d.com", segments: [] },
+      ]);
     });
   });
 
@@ -152,7 +162,11 @@ describe("AddContactModal", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve({ created: 2 }),
+        json: () => Promise.resolve({ id: "contact-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: "contact-2" }),
       });
 
     render(<AddContactModal {...defaultProps} />);
@@ -165,13 +179,16 @@ describe("AddContactModal", () => {
     fireEvent.click(screen.getByRole("button", { name: "Add" }));
 
     await waitFor(() => {
-      const postCall = mockFetch.mock.calls.find(
+      const postCalls = mockFetch.mock.calls.filter(
         (call: unknown[]) =>
           call[0] === "/api/contacts" &&
           (call[1] as RequestInit)?.method === "POST",
       );
-      const body = JSON.parse((postCall?.[1] as RequestInit).body as string);
-      expect(body.emails).toEqual(["a@b.com", "c@d.com"]);
+      expect(
+        postCalls.map(
+          (call) => JSON.parse((call[1] as RequestInit).body as string).email,
+        ),
+      ).toEqual(["a@b.com", "c@d.com"]);
     });
   });
 
@@ -235,7 +252,29 @@ describe("AddContactModal", () => {
     });
   });
 
-  it("sends segment_ids in request body when segments selected", async () => {
+  it("normalizes list-envelope segment responses on open", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          object: "list",
+          data: [{ id: "s1", name: "VIP" }],
+          has_more: false,
+        }),
+    });
+
+    render(<AddContactModal {...defaultProps} />);
+
+    const segmentInput = screen.getByPlaceholderText("Search segments...");
+    fireEvent.focus(segmentInput);
+    fireEvent.change(segmentInput, { target: { value: "VIP" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("VIP")).toBeDefined();
+    });
+  });
+
+  it("sends segments in request body when segments selected", async () => {
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
@@ -278,7 +317,7 @@ describe("AddContactModal", () => {
       );
       expect(postCall).toBeDefined();
       const body = JSON.parse((postCall?.[1] as RequestInit).body as string);
-      expect(body.segment_ids).toEqual(["s1"]);
+      expect(body.segments).toEqual(["s1"]);
     });
   });
 });

--- a/tests/e2e/add-contact-modal.spec.ts
+++ b/tests/e2e/add-contact-modal.spec.ts
@@ -4,6 +4,9 @@ test.describe("Add contact modal", () => {
   test("opens modal from Add contacts dropdown", async ({
     authenticatedPage: page,
   }) => {
+    const pageErrors: string[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
     await page.goto("/audience");
 
     // Click "Add contacts" button
@@ -24,16 +27,26 @@ test.describe("Add contact modal", () => {
         "Use commas or line breaks to separate multiple email addresses.",
       ),
     ).toBeVisible();
+    await expect(page.getByText("This page couldn’t load")).not.toBeVisible();
+    expect(pageErrors).toEqual([]);
   });
 
-  test("add single contact manually", async ({ authenticatedPage: page }) => {
+  test("add single contact manually", async ({
+    authenticatedPage: page,
+    e2eDb,
+    e2eRunId,
+    e2eTenant,
+  }) => {
     await page.goto("/audience");
 
     await page.getByRole("button", { name: /add contacts/i }).click();
     await page.getByText("Add manually").click();
+    await expect(
+      page.getByRole("heading", { name: "Add contacts" }),
+    ).toBeVisible();
 
     // Type email
-    const uniqueEmail = `test-${Date.now()}@example.com`;
+    const uniqueEmail = `manual-${Date.now()}@${e2eRunId}.e2e.opensend.test`;
     await page
       .getByPlaceholder("foo@gmail.com, bar@gmail.com")
       .fill(uniqueEmail);
@@ -45,6 +58,23 @@ test.describe("Add contact modal", () => {
     await expect(
       page.getByRole("heading", { name: "Add contacts" }),
     ).not.toBeVisible();
+
+    const { rows } = await e2eDb.query<{
+      email: string;
+      user_id: string | null;
+    }>(
+      `select email, user_id
+       from contacts
+       where email = $1`,
+      [uniqueEmail],
+    );
+
+    expect(rows).toEqual([
+      {
+        email: uniqueEmail,
+        user_id: e2eTenant.user.id,
+      },
+    ]);
   });
 
   test("closes modal with Cancel button", async ({


### PR DESCRIPTION
## Summary
- Fixes the Audience → Add contacts → Add manually crash by normalizing the real `/api/segments` list-envelope response before rendering segment options.
- Updates manual contact submission to call `/api/contacts` with its validated single-contact payload (`email`, `segments`) instead of the stale batch-only UI payload.
- Adds regression coverage for both the envelope normalization and an auth-backed, database-backed manual add flow.

Closes #406

## Changed files
- `src/components/add-contact-modal.tsx`
- `tests/add-contact-modal.test.tsx`
- `tests/e2e/add-contact-modal.spec.ts`
- `agent_docs/learnings/active/2026-05-12-issue-406-manual-contact-add.md`

## Validation evidence
- `make check` — passed
- `make test` — 143 files / 1133 tests passed
- `bun run test tests/add-contact-modal.test.tsx tests/audience-layout.test.tsx tests/dashboard-deeplinks.test.tsx` — 26 focused tests passed
- `PORT=3315 E2E_BASE_URL=http://localhost:3315 NEXT_PUBLIC_APP_URL=http://localhost:3315 BETTER_AUTH_URL=http://localhost:3315 bun run test:e2e tests/e2e/add-contact-modal.spec.ts` — 5 Playwright tests passed against real Better Auth + Postgres fixtures

## Notes / residual risk
- Full Playwright suite was not run; targeted Add contact modal E2E passed with a fresh worktree dev server on port 3315 to avoid reusing an unrelated stale server on port 3015.
- Manual multi-email add now sends one create request per parsed email; no new bulk API route was added to keep scope limited to #406.
