### PR TITLE
Fix webhooks dashboard create endpoint flow

### DIFF
--- a/agent_docs/learnings/active/2026-05-12-issue-405-webhook-dashboard-create-auth.md
+++ b/agent_docs/learnings/active/2026-05-12-issue-405-webhook-dashboard-create-auth.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-12
+issue: "#405"
+type: decision
+promoted_to: null
+---
+
+## Dashboard webhook create uses the shared API route
+
+The `/webhooks` dashboard create flow should POST to the existing `/api/webhooks` handler rather than adding a dashboard-only insert path. That route must accept authenticated dashboard sessions in addition to full-access API keys, resolve the caller's tenant id through the shared audit context, and keep sending-access API keys forbidden.
+
+Why: the dashboard can then exercise the same validation, signing-secret generation, audit event, service, and tenant-scoped repository path as public API callers. Regression proof should include a real Playwright flow that signs in through the Better Auth fixture, creates the endpoint through the route, and verifies the persisted `webhooks.user_id` row.

--- a/src/app/(dashboard)/webhooks/page.tsx
+++ b/src/app/(dashboard)/webhooks/page.tsx
@@ -26,7 +26,6 @@ export default async function WebhooksPage() {
 
   return (
     <div>
-      <h1 className="text-2xl font-semibold text-[#F0F0F0]">Webhooks</h1>
       <WebhooksList
         supportedEventTypes={[...SUPPORTED_WEBHOOK_EVENT_TYPES]}
         webhooks={data}

--- a/src/components/webhooks-list.tsx
+++ b/src/components/webhooks-list.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { Modal } from "@/components/modal";
 import { StatusBadge } from "@/components/status-badge";
 import type { SupportedWebhookEventType } from "@opensend/core/src/webhook-events";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
 
 interface Webhook {
   id: string;
@@ -12,6 +15,12 @@ interface Webhook {
   createdAt: string;
 }
 
+type CreatedWebhook = {
+  id: string;
+  endpoint: string;
+  signingSecret: string | null;
+};
+
 function formatEventType(eventType: string): string {
   return eventType
     .replace(/^email\./, "")
@@ -20,15 +29,244 @@ function formatEventType(eventType: string): string {
     .join(" ");
 }
 
+function isValidEndpoint(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
 export function WebhooksList({
   supportedEventTypes,
   webhooks,
 }: {
-  supportedEventTypes: SupportedWebhookEventType[];
+  supportedEventTypes: readonly SupportedWebhookEventType[];
   webhooks: Webhook[];
 }) {
+  const router = useRouter();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [endpoint, setEndpoint] = useState("");
+  const [selectedEvents, setSelectedEvents] = useState<
+    SupportedWebhookEventType[]
+  >([]);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [createdWebhook, setCreatedWebhook] = useState<CreatedWebhook | null>(
+    null,
+  );
+
+  const canCreate = useMemo(
+    () =>
+      endpoint.trim().length > 0 &&
+      isValidEndpoint(endpoint.trim()) &&
+      selectedEvents.length > 0 &&
+      !creating,
+    [creating, endpoint, selectedEvents.length],
+  );
+
+  function openCreateModal() {
+    setCreateOpen(true);
+    setError(null);
+  }
+
+  function resetCreateForm() {
+    setEndpoint("");
+    setSelectedEvents([]);
+    setError(null);
+    setCreatedWebhook(null);
+  }
+
+  function closeCreateModal() {
+    setCreateOpen(false);
+    resetCreateForm();
+    router.refresh();
+  }
+
+  function viewCreatedEndpoint() {
+    const createdId = createdWebhook?.id;
+    if (!createdId) return;
+
+    setCreateOpen(false);
+    resetCreateForm();
+    router.push(`/webhooks/${createdId}`);
+  }
+
+  function toggleEvent(eventType: SupportedWebhookEventType) {
+    setSelectedEvents((current) =>
+      current.includes(eventType)
+        ? current.filter((event) => event !== eventType)
+        : [...current, eventType],
+    );
+  }
+
+  async function handleCreateWebhook() {
+    if (!canCreate) return;
+
+    setCreating(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/webhooks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          endpoint: endpoint.trim(),
+          events: selectedEvents,
+        }),
+      });
+
+      const body = (await response.json().catch(() => ({}))) as {
+        id?: unknown;
+        endpoint?: unknown;
+        signing_secret?: unknown;
+        error?: unknown;
+      };
+
+      if (!response.ok) {
+        setError(
+          typeof body.error === "string"
+            ? body.error
+            : "Failed to create webhook endpoint.",
+        );
+        return;
+      }
+
+      if (typeof body.id !== "string" || typeof body.endpoint !== "string") {
+        setError("Webhook endpoint was created, but the response was invalid.");
+        return;
+      }
+
+      setCreatedWebhook({
+        id: body.id,
+        endpoint: body.endpoint,
+        signingSecret:
+          typeof body.signing_secret === "string" ? body.signing_secret : null,
+      });
+      router.refresh();
+    } catch {
+      setError("Failed to create webhook endpoint.");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  function renderCreateModal() {
+    if (createdWebhook) {
+      return (
+        <Modal
+          open={createOpen}
+          onClose={closeCreateModal}
+          title="Webhook endpoint created"
+          actionLabel="View endpoint"
+          onAction={viewCreatedEndpoint}
+        >
+          <div className="space-y-4">
+            <p className="text-[13px] text-[#A1A4A5]">
+              Your endpoint is active and ready to receive subscribed events.
+              Copy the signing secret now; it is only shown once.
+            </p>
+            <div>
+              <p className="mb-1 text-[12px] uppercase tracking-wider text-white/40">
+                Endpoint
+              </p>
+              <code className="block rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] px-3 py-2 text-[13px] text-[#F0F0F0] break-all">
+                {createdWebhook.endpoint}
+              </code>
+            </div>
+            <div>
+              <p className="mb-1 text-[12px] uppercase tracking-wider text-white/40">
+                Signing secret
+              </p>
+              <code className="block rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] px-3 py-2 text-[13px] text-[#F0F0F0] break-all">
+                {createdWebhook.signingSecret ?? "Unavailable"}
+              </code>
+            </div>
+          </div>
+        </Modal>
+      );
+    }
+
+    return (
+      <Modal
+        open={createOpen}
+        onClose={closeCreateModal}
+        title="Add webhook endpoint"
+        actionLabel={creating ? "Creating..." : "Create endpoint"}
+        onAction={handleCreateWebhook}
+        actionDisabled={!canCreate}
+      >
+        <div className="space-y-5">
+          <div>
+            <label
+              htmlFor="webhook-endpoint"
+              className="mb-1.5 block text-[13px] text-[#F0F0F0]"
+            >
+              Endpoint URL
+            </label>
+            <input
+              id="webhook-endpoint"
+              type="url"
+              value={endpoint}
+              onChange={(event) => setEndpoint(event.target.value)}
+              placeholder="https://example.com/webhooks/opensend"
+              className="w-full rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] px-3 py-2 text-[14px] text-[#F0F0F0] outline-none placeholder:text-[#52525b] focus:border-[rgba(176,199,217,0.3)]"
+            />
+          </div>
+
+          <fieldset>
+            <legend className="mb-2 text-[13px] text-[#F0F0F0]">Events</legend>
+            <div className="grid max-h-60 gap-2 overflow-y-auto rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.5)] p-3 sm:grid-cols-2">
+              {supportedEventTypes.map((eventType) => (
+                <label
+                  key={eventType}
+                  className="flex items-center gap-2 text-[13px] text-[#A1A4A5]"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedEvents.includes(eventType)}
+                    onChange={() => toggleEvent(eventType)}
+                    className="h-4 w-4 rounded border-white/20 bg-transparent"
+                  />
+                  <span>{eventType}</span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          {error && (
+            <p role="alert" className="text-[13px] text-red-400">
+              {error}
+            </p>
+          )}
+        </div>
+      </Modal>
+    );
+  }
+
   return (
-    <div className="mt-8 space-y-6">
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="text-2xl font-semibold text-[#F0F0F0]">Webhooks</h1>
+        <button
+          type="button"
+          onClick={openCreateModal}
+          className="flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 text-[13px] font-medium text-black transition-colors hover:bg-gray-200"
+        >
+          <svg
+            aria-hidden="true"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+          >
+            <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+          </svg>
+          Add endpoint
+        </button>
+      </div>
+
       <section className="rounded-lg border border-white/5 bg-black p-6">
         <h2 className="text-sm font-medium uppercase tracking-wider text-white/40">
           Supported events
@@ -103,13 +341,23 @@ export function WebhooksList({
                   colSpan={4}
                   className="px-6 py-12 text-center text-sm text-white/40"
                 >
-                  No webhooks configured.
+                  <div className="flex flex-col items-center gap-3">
+                    <span>No webhooks configured.</span>
+                    <button
+                      type="button"
+                      onClick={openCreateModal}
+                      className="rounded-md border border-white/10 px-3 py-1.5 text-[13px] font-medium text-[#F0F0F0] transition-colors hover:bg-white/[0.06]"
+                    >
+                      Add your first endpoint
+                    </button>
+                  </div>
                 </td>
               </tr>
             )}
           </tbody>
         </table>
       </div>
+      {renderCreateModal()}
     </div>
   );
 }

--- a/src/lib/api/webhooks/handlers.ts
+++ b/src/lib/api/webhooks/handlers.ts
@@ -3,13 +3,14 @@ import {
   authorizeDashboardOrApiKey,
   getServerSession,
   unauthorizedResponse,
-  validateApiKey,
 } from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
 import {
-  requireFullAccessApiKey,
-  requireFullAccessForApiKeyCaller,
-} from "@/lib/api-key-permissions";
-import { auditContextForApiKey, recordAuditEvent } from "@/lib/audit-events";
+  type AuditContext,
+  auditContextForApiKey,
+  auditContextForDashboardSession,
+  recordAuditEvent,
+} from "@/lib/audit-events";
 import {
   createWebhookSchema,
   updateWebhookSchema,
@@ -71,7 +72,10 @@ function mapWebhookDetail(webhook: WebhookServiceDetail) {
   };
 }
 
-type WebhookAuth = AuthResult & { userId: string };
+type WebhookAuth = {
+  userId: string;
+  auditContext: AuditContext;
+};
 
 type WebhookAuthResult =
   | { ok: true; auth: WebhookAuth }
@@ -84,13 +88,40 @@ type DashboardOrApiKeyAuth = NonNullable<
 async function requireWebhookAuth(
   request: Request,
 ): Promise<WebhookAuthResult> {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth?.userId) return { ok: false, response: unauthorizedResponse() };
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
+  if (!auth) return { ok: false, response: unauthorizedResponse() };
 
-  const permissionError = requireFullAccessApiKey(auth);
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
   if (permissionError) return { ok: false, response: permissionError };
 
-  return { ok: true, auth: { ...auth, userId: auth.userId } };
+  if ("userId" in auth) {
+    if (!auth.userId) return { ok: false, response: unauthorizedResponse() };
+
+    return {
+      ok: true,
+      auth: {
+        userId: auth.userId,
+        auditContext: auditContextForApiKey({
+          userId: auth.userId,
+          apiKeyId: auth.apiKeyId,
+        }),
+      },
+    };
+  }
+
+  const session = await getServerSession();
+  const auditContext = auditContextForDashboardSession(session);
+  if (!auditContext) return { ok: false, response: unauthorizedResponse() };
+
+  return {
+    ok: true,
+    auth: {
+      userId: auditContext.userId,
+      auditContext,
+    },
+  };
 }
 
 async function resolveDashboardOrApiKeyUserId(
@@ -203,10 +234,7 @@ export async function handleCreateWebhookRequest(
     });
 
     await recordAuditEvent({
-      context: auditContextForApiKey({
-        userId: authResult.auth.userId,
-        apiKeyId: authResult.auth.apiKeyId,
-      }),
+      context: authResult.auth.auditContext,
       action: "webhook.created",
       targetType: "webhook",
       targetId: webhook.id,
@@ -286,10 +314,7 @@ export async function handleUpdateWebhookRequest(
     }
 
     await recordAuditEvent({
-      context: auditContextForApiKey({
-        userId: authResult.auth.userId,
-        apiKeyId: authResult.auth.apiKeyId,
-      }),
+      context: authResult.auth.auditContext,
       action: "webhook.updated",
       targetType: "webhook",
       targetId: updated.id,
@@ -328,10 +353,7 @@ export async function handleDeleteWebhookRequest(
     }
 
     await recordAuditEvent({
-      context: auditContextForApiKey({
-        userId: authResult.auth.userId,
-        apiKeyId: authResult.auth.apiKeyId,
-      }),
+      context: authResult.auth.auditContext,
       action: "webhook.deleted",
       targetType: "webhook",
       targetId: deleted.id,

--- a/tests/e2e/webhooks-create.spec.ts
+++ b/tests/e2e/webhooks-create.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "./fixtures/auth";
+
+test("dashboard empty webhooks page creates an endpoint through the real API route", async ({
+  authenticatedPage,
+  e2eDb,
+  e2eRunId,
+  e2eUser,
+}) => {
+  const endpoint = `https://example.com/opensend/${e2eRunId}`;
+
+  await authenticatedPage.goto("/webhooks");
+
+  await expect(
+    authenticatedPage.getByRole("heading", { name: "Webhooks" }),
+  ).toBeVisible();
+  await expect(
+    authenticatedPage.getByRole("button", { name: "Add endpoint" }),
+  ).toBeVisible();
+  await expect(
+    authenticatedPage.getByRole("button", { name: "Add your first endpoint" }),
+  ).toBeVisible();
+
+  await authenticatedPage.getByRole("button", { name: "Add endpoint" }).click();
+  await authenticatedPage.getByLabel("Endpoint URL").fill(endpoint);
+  await authenticatedPage.getByLabel("email.sent").check();
+  await authenticatedPage
+    .getByRole("button", { name: "Create endpoint" })
+    .click();
+
+  await expect(
+    authenticatedPage.getByText("Webhook endpoint created"),
+  ).toBeVisible();
+  await expect(authenticatedPage.getByText(/^whsec_/)).toBeVisible();
+
+  const created = await e2eDb.query<{
+    id: string;
+    user_id: string;
+    event_types: string[];
+    signing_secret: string | null;
+  }>(
+    `select id, user_id, event_types, signing_secret
+     from webhooks
+     where url = $1`,
+    [endpoint],
+  );
+
+  expect(created.rowCount).toBe(1);
+  expect(created.rows[0]?.user_id).toBe(e2eUser.id);
+  expect(created.rows[0]?.event_types).toEqual(["email.sent"]);
+  expect(created.rows[0]?.signing_secret).toMatch(/^whsec_/);
+
+  await authenticatedPage
+    .getByRole("button", { name: "View endpoint" })
+    .click();
+  await expect(authenticatedPage).toHaveURL(
+    new RegExp(`/webhooks/${created.rows[0]?.id}$`),
+  );
+});

--- a/tests/webhook-event-types.test.tsx
+++ b/tests/webhook-event-types.test.tsx
@@ -1,11 +1,16 @@
-import { WebhooksList } from "@/components/webhooks-list";
 import {
   createWebhookSchema,
   updateWebhookSchema,
 } from "@/lib/validation/webhooks";
 import { SUPPORTED_WEBHOOK_EVENT_TYPES } from "@opensend/core/src/webhook-events";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+import { WebhooksList } from "@/components/webhooks-list";
 
 describe("webhook event type support", () => {
   it("accepts every shared supported webhook event type for create and update", () => {

--- a/tests/webhooks-api-keys-tenant-isolation.test.ts
+++ b/tests/webhooks-api-keys-tenant-isolation.test.ts
@@ -203,6 +203,45 @@ describe("webhook API tenant isolation", () => {
     });
   });
 
+  it("lets a signed-in dashboard user create an owned webhook", async () => {
+    mockValidateApiKey.mockResolvedValueOnce({ dashboard: true });
+    mockGetServerSession.mockResolvedValueOnce({
+      user: { id: "dashboard-user-b", email: "dashboard@example.com" },
+    });
+    mockCreateWebhook.mockResolvedValue({
+      id: "wh-dashboard",
+      endpoint: "https://example.com/dashboard",
+      events: ["email.sent"],
+      status: "enabled",
+      signingSecret: "whsec_dashboard",
+      createdAt: "2026-05-12T00:00:00.000Z",
+    });
+
+    const route = await import("@/app/api/webhooks/route");
+    const response = await route.POST(
+      new Request("http://localhost/api/webhooks", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          endpoint: "https://example.com/dashboard",
+          events: ["email.sent"],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      object: "webhook",
+      id: "wh-dashboard",
+      signing_secret: "whsec_dashboard",
+    });
+    expect(mockCreateWebhook).toHaveBeenCalledWith({
+      userId: "dashboard-user-b",
+      endpoint: "https://example.com/dashboard",
+      events: ["email.sent"],
+    });
+  });
+
   it("returns 404 and cannot mutate user A's webhook as user B", async () => {
     mockGetWebhook.mockResolvedValue(undefined);
     mockUpdateWebhook.mockResolvedValue(undefined);

--- a/tests/webhooks-list.test.tsx
+++ b/tests/webhooks-list.test.tsx
@@ -1,0 +1,122 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPush = vi.fn();
+const mockRefresh = vi.fn();
+const mockFetch = vi.fn();
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+}));
+
+vi.stubGlobal("fetch", mockFetch);
+
+import { WebhooksList } from "@/components/webhooks-list";
+
+const supportedEventTypes = [
+  "email.sent",
+  "email.delivered",
+  "contact.created",
+] as const;
+
+const existingWebhooks = [
+  {
+    id: "wh-1",
+    url: "https://example.com/webhook",
+    status: "active" as const,
+    eventTypes: ["email.sent"],
+    createdAt: "2026-05-11T00:00:00.000Z",
+  },
+];
+
+describe("WebhooksList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: "wh-created",
+        endpoint: "https://example.com/opensend",
+        signing_secret: "whsec_created",
+      }),
+    });
+  });
+
+  afterEach(cleanup);
+
+  it("exposes a visible create action in the empty state", () => {
+    render(
+      <WebhooksList supportedEventTypes={supportedEventTypes} webhooks={[]} />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Webhooks" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Add endpoint" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Add your first endpoint" }),
+    ).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add your first endpoint" }),
+    );
+
+    expect(screen.getByText("Add webhook endpoint")).toBeTruthy();
+    expect(screen.getByLabelText("Endpoint URL")).toBeTruthy();
+    expect(screen.getByLabelText("email.sent")).toBeTruthy();
+  });
+
+  it("exposes a create action when webhooks already exist", () => {
+    render(
+      <WebhooksList
+        supportedEventTypes={supportedEventTypes}
+        webhooks={existingWebhooks}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Add endpoint" })).toBeTruthy();
+    expect(screen.getByText("https://example.com/webhook")).toBeTruthy();
+  });
+
+  it("posts a selected endpoint and events, then reveals the signing secret", async () => {
+    render(
+      <WebhooksList supportedEventTypes={supportedEventTypes} webhooks={[]} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add endpoint" }));
+    fireEvent.change(screen.getByLabelText("Endpoint URL"), {
+      target: { value: "https://example.com/opensend" },
+    });
+    fireEvent.click(screen.getByLabelText("email.sent"));
+    fireEvent.click(screen.getByRole("button", { name: "Create endpoint" }));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/webhooks",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          endpoint: "https://example.com/opensend",
+          events: ["email.sent"],
+        }),
+      }),
+    );
+    expect(await screen.findByText("Webhook endpoint created")).toBeTruthy();
+    expect(screen.getByText("whsec_created")).toBeTruthy();
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds visible `/webhooks` create endpoint CTAs in both header/non-empty and empty-state paths.
- Adds a dashboard create modal for endpoint URL + event selection, with signing-secret reveal after creation.
- Lets signed-in dashboard sessions use the existing `/api/webhooks` create/list/update/delete handler path while preserving full-access API-key requirements and tenant scoping.

Closes #405

## Changed files
- `src/app/(dashboard)/webhooks/page.tsx`
- `src/components/webhooks-list.tsx`
- `src/lib/api/webhooks/handlers.ts`
- `tests/webhooks-list.test.tsx`
- `tests/webhooks-api-keys-tenant-isolation.test.ts`
- `tests/webhook-event-types.test.tsx`
- `tests/e2e/webhooks-create.spec.ts`
- `agent_docs/learnings/active/2026-05-12-issue-405-webhook-dashboard-create-auth.md`

## Validation
- `bun run db:push` with `.env` pointing at local compose Postgres `localhost:55433` — no schema changes detected.
- `make check` — passed.
- Focused webhooks tests: `bun run test -- tests/webhooks-list.test.tsx tests/webhook-event-types.test.tsx tests/webhooks-api-keys-tenant-isolation.test.ts tests/webhook-service.test.ts` — 30 tests passed.
- Playwright webhooks create E2E: `.scratch/webhooks-create-e2e.sh` — passed after loading the minimal gitignored `.env` and clearing a stale dev server on port `3015`; real Better Auth fixture + dashboard UI + `/api/webhooks` route + Postgres row proof.
- Broad `make test` initially failed in `tests/webhook-event-types.test.tsx` because the updated client component now calls `useRouter()` and that test lacked a navigation mock. Patched the test navigation mock, reran focused tests, then reran broad `make test`.
- Final broad `make test` — passed; 144 files / 1136 tests.
- `git push` pre-push guardrail (`node scripts/check-changed-files.mjs`) — passed.

## E2E status
The first E2E attempt skipped because `.env` was not loaded, so it was not counted as proof. After creating a gitignored minimal `.env`, running `db:push`, clearing stale port `3015`, and rerunning the webhooks create scenario, the E2E passed against local compose Postgres on port `55433`.

## Residual risk
- Production OAuth/login was not manually exercised; E2E used the existing Better Auth session fixture.
- External delivery to the newly created endpoint was not exercised; this change is scoped to endpoint creation UX/API persistence.
