### PR TITLE
Fix Topics unsubscribe editor 404

### DIFF
--- a/agent_docs/learnings/active/2026-05-12-issue-411-unsubscribe-editor-deeplink.md
+++ b/agent_docs/learnings/active/2026-05-12-issue-411-unsubscribe-editor-deeplink.md
@@ -1,0 +1,18 @@
+---
+date: 2026-05-12
+issue: "#411"
+type: pattern
+promoted_to: null
+---
+
+## Missing dashboard editor routes need both CTA removal and direct-route copy
+
+When a dashboard CTA points at a feature that does not exist yet, fix both
+surfaces: disable or remove the visible CTA with honest copy, and add a small
+route-level unavailable page for the old/deep-linked URL. Only removing the CTA
+leaves bookmarked or dogfood-discovered URLs as raw 404s; only adding the page
+keeps advertising a non-working editor.
+
+For the Topics unsubscribe editor, `/audience/topics` now disables the editor
+controls and `/audience/topics/unsubscribe-page/edit` renders explanatory copy
+with a path back to Topics.

--- a/src/app/(dashboard)/audience/topics/unsubscribe-page/edit/page.tsx
+++ b/src/app/(dashboard)/audience/topics/unsubscribe-page/edit/page.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+
+export default function TopicsUnsubscribePageEditorUnavailablePage() {
+  return (
+    <div className="max-w-2xl space-y-4">
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold text-[#F0F0F0]">
+          Unsubscribe page editor unavailable
+        </h2>
+        <p className="text-[14px] text-[#A1A4A5]">
+          Opensend still serves the default unsubscribe page for public topics,
+          but dashboard customization is not available yet.
+        </p>
+      </div>
+
+      <div className="rounded-lg border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.5)] p-4">
+        <p className="text-[13px] text-[#A1A4A5]">
+          Contacts can continue to manage their subscription preferences from
+          unsubscribe links in sent emails. Return to Topics to manage the
+          public topics that appear on that default page.
+        </p>
+      </div>
+
+      <Link
+        href="/audience/topics"
+        className="inline-flex rounded-md border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] px-3 py-1.5 text-[13px] font-medium text-[#F0F0F0] transition-colors hover:bg-[rgba(24,25,28,1)]"
+      >
+        Back to topics
+      </Link>
+    </div>
+  );
+}

--- a/src/components/topics-list.tsx
+++ b/src/components/topics-list.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { formatRelativeTime } from "@/components/emails-sending-data-table";
-import Link from "next/link";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+
+const UNSUBSCRIBE_EDITOR_UNAVAILABLE_COPY =
+  "Editor unavailable; the default unsubscribe page remains active.";
 
 interface Topic {
   id: string;
@@ -116,12 +118,7 @@ export function TopicsList() {
           <option value="opt_out">Opt-out</option>
         </select>
 
-        <Link
-          href="/audience/topics/unsubscribe-page/edit"
-          className="h-9 px-4 text-[13px] font-medium text-[#A1A4A5] border border-[rgba(176,199,217,0.145)] rounded-md hover:text-[#F0F0F0] hover:border-[rgba(176,199,217,0.3)] transition-colors inline-flex items-center"
-        >
-          Edit Unsubscribe Page
-        </Link>
+        <UnsubscribeEditorUnavailableControl label="Edit Unsubscribe Page" />
 
         <button
           type="button"
@@ -155,12 +152,10 @@ export function TopicsList() {
             >
               Create topic
             </button>
-            <Link
-              href="/audience/topics/unsubscribe-page/edit"
-              className="px-4 py-2 rounded-md text-[13px] font-medium text-[#A1A4A5] hover:text-[#F0F0F0] transition-colors"
-            >
-              Customize page
-            </Link>
+            <UnsubscribeEditorUnavailableControl
+              label="Customize page"
+              align="center"
+            />
           </div>
         </div>
       ) : (
@@ -286,12 +281,10 @@ export function TopicsList() {
           <h3 className="text-[14px] font-medium text-[#F0F0F0]">
             Unsubscribe Page Preview
           </h3>
-          <Link
-            href="/audience/topics/unsubscribe-page/edit"
-            className="text-[13px] text-[#A1A4A5] hover:text-[#F0F0F0] transition-colors"
-          >
-            Customize page
-          </Link>
+          <UnsubscribeEditorUnavailableControl
+            label="Customize page"
+            align="right"
+          />
         </div>
         <div className="bg-white rounded-b-lg p-8">
           <div className="max-w-[400px] mx-auto text-center">
@@ -355,6 +348,39 @@ export function TopicsList() {
           }}
         />
       )}
+    </div>
+  );
+}
+
+function UnsubscribeEditorUnavailableControl({
+  label,
+  align = "left",
+}: {
+  label: string;
+  align?: "left" | "center" | "right";
+}) {
+  const copyId = useId();
+  const alignmentClass =
+    align === "right"
+      ? "items-end text-right"
+      : align === "center"
+        ? "items-center text-center"
+        : "items-start text-left";
+
+  return (
+    <div className={`flex max-w-[230px] flex-col gap-1 ${alignmentClass}`}>
+      <button
+        type="button"
+        disabled
+        aria-describedby={copyId}
+        title={UNSUBSCRIBE_EDITOR_UNAVAILABLE_COPY}
+        className="inline-flex cursor-not-allowed items-center rounded-md border border-[rgba(176,199,217,0.145)] px-4 py-2 text-[13px] font-medium text-[#666] opacity-80"
+      >
+        {label}
+      </button>
+      <p id={copyId} className="text-[11px] leading-4 text-[#777]">
+        {UNSUBSCRIBE_EDITOR_UNAVAILABLE_COPY}
+      </p>
     </div>
   );
 }

--- a/tests/dashboard-deeplinks.test.tsx
+++ b/tests/dashboard-deeplinks.test.tsx
@@ -72,6 +72,30 @@ describe("dashboard production deep links", () => {
     expect(mockRedirect).toHaveBeenCalledWith("/audience");
   });
 
+  it("renders an unavailable state for the topics unsubscribe editor deep link", async () => {
+    const Page = (
+      await import(
+        "@/app/(dashboard)/audience/topics/unsubscribe-page/edit/page"
+      )
+    ).default;
+
+    render(Page() as React.ReactElement);
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Unsubscribe page editor unavailable",
+      }),
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        "Opensend still serves the default unsubscribe page for public topics, but dashboard customization is not available yet.",
+      ),
+    ).toBeDefined();
+    expect(
+      screen.getByRole("link", { name: "Back to topics" }).getAttribute("href"),
+    ).toBe("/audience/topics");
+  });
+
   it("renders a billing unavailable state instead of raw-404 when billing is disabled", async () => {
     const Page = (await import("@/app/(dashboard)/settings/billing/page"))
       .default;

--- a/tests/e2e/topics-unsubscribe-editor.spec.ts
+++ b/tests/e2e/topics-unsubscribe-editor.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "./fixtures/auth";
+
+test.describe("Topics unsubscribe editor unavailable state", () => {
+  test("does not expose broken editor links from the Topics page", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/audience/topics");
+
+    await expect(page.getByText("Unsubscribe Page Preview")).toBeVisible();
+    await expect(
+      page.locator('a[href="/audience/topics/unsubscribe-page/edit"]'),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Edit Unsubscribe Page" }),
+    ).toBeDisabled();
+    await expect(
+      page
+        .getByText(
+          "Editor unavailable; the default unsubscribe page remains active.",
+        )
+        .first(),
+    ).toBeVisible();
+  });
+
+  test("renders explanatory copy for direct editor deep links", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/audience/topics/unsubscribe-page/edit");
+
+    await expect(
+      page.getByRole("heading", {
+        name: "Unsubscribe page editor unavailable",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        "Opensend still serves the default unsubscribe page for public topics, but dashboard customization is not available yet.",
+      ),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Back to topics" }),
+    ).toHaveAttribute("href", "/audience/topics");
+  });
+});

--- a/tests/e2e/topics.spec.ts
+++ b/tests/e2e/topics.spec.ts
@@ -49,9 +49,14 @@ test.describe("Topics page", () => {
     // The unsubscribe preview should always be present
     await expect(page.locator("text=Unsubscribe Page Preview")).toBeVisible();
 
-    // Edit Unsubscribe Page link should be present
+    // Unsubscribe Page editor CTA should be disabled with honest copy.
     await expect(
-      page.getByRole("link", { name: "Customize page" }),
+      page.getByRole("button", { name: "Customize page" }),
+    ).toBeDisabled();
+    await expect(
+      page.getByText(
+        "Editor unavailable; the default unsubscribe page remains active.",
+      ),
     ).toBeVisible();
   });
 

--- a/tests/topics.test.ts
+++ b/tests/topics.test.ts
@@ -58,9 +58,14 @@ describe("TopicsList", () => {
     // Should have create topic buttons (one in filter bar, one in empty state)
     const createButtons = screen.getAllByText("Create topic");
     expect(createButtons.length).toBe(2);
-    // Should have unsubscribe page customize links
-    const customizeLinks = screen.getAllByText("Customize page");
-    expect(customizeLinks.length).toBeGreaterThanOrEqual(1);
+    // The unsubscribe page editor is intentionally disabled until implemented.
+    const customizeControls = screen.getAllByText("Customize page");
+    expect(customizeControls.length).toBeGreaterThanOrEqual(1);
+    expect(
+      screen.getAllByText(
+        "Editor unavailable; the default unsubscribe page remains active.",
+      ).length,
+    ).toBeGreaterThanOrEqual(1);
   });
 
   it("renders topics list with data", async () => {
@@ -259,7 +264,7 @@ describe("TopicsList", () => {
     });
   });
 
-  it("has Edit Unsubscribe Page link", async () => {
+  it("disables the unavailable unsubscribe page editor CTA", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ data: [], total: 0, page: 1, limit: 20 }),
@@ -271,11 +276,16 @@ describe("TopicsList", () => {
       expect(screen.getByText("No topics yet")).toBeTruthy();
     });
 
-    const link = screen.getByText("Edit Unsubscribe Page");
-    expect(link).toBeTruthy();
-    expect(link.closest("a")?.getAttribute("href")).toBe(
-      "/audience/topics/unsubscribe-page/edit",
-    );
+    const control = screen.getByText("Edit Unsubscribe Page");
+    const button = control.closest("button");
+    expect(button).toBeTruthy();
+    expect(button?.hasAttribute("disabled")).toBe(true);
+    expect(control.closest("a")).toBeNull();
+    expect(
+      screen.getAllByText(
+        "Editor unavailable; the default unsubscribe page remains active.",
+      ).length,
+    ).toBeGreaterThanOrEqual(1);
   });
 
   it("shows unsubscribe page preview section", async () => {


### PR DESCRIPTION
## Summary
- Disable the Topics unsubscribe editor CTAs with visible unavailable copy instead of linking to a missing editor.
- Add an explanatory `/audience/topics/unsubscribe-page/edit` dashboard route so direct/deep links no longer render a raw 404.
- Add Vitest and Playwright coverage for the disabled CTA state and direct deep link, alongside the existing #404 dashboard deep-link regression coverage.

## Validation
- `bun run db:push` (no changes detected)
- `bun run test tests/topics.test.ts tests/dashboard-deeplinks.test.tsx`
- `if [ -f .env ]; then set -a; . ./.env; set +a; fi; bunx playwright test tests/e2e/topics-unsubscribe-editor.spec.ts`
- `make check`
- `make test`

Closes #411
