### PR TITLE
Extract billing checkout and portal service boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-12-issue-419-lazy-provider-boundary.md
+++ b/agent_docs/learnings/active/2026-05-12-issue-419-lazy-provider-boundary.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-12
+issue: "#419"
+type: pattern
+promoted_to: null
+---
+
+## Billing route service boundaries should keep provider creation lazy
+
+When extracting checkout/portal orchestration behind `createBillingSessionService()`, the Stripe client dependency stays lazy in the default factory so invalid checkout requests still short-circuit before touching Stripe. This preserves the old route order: billing flag/session/body validation, public plan lookup, and price/customer checks happen before provider calls where applicable.
+
+For future provider-backed route extractions, inject provider factories rather than eagerly-created clients when existing behavior depends on early 400/404 responses not initializing external SDKs.

--- a/src/app/api/billing/checkout/route.ts
+++ b/src/app/api/billing/checkout/route.ts
@@ -1,14 +1,11 @@
 import { getServerSession } from "@/lib/api-auth";
 import { getBillingBackend } from "@/lib/billing";
-import { getStripe } from "@/lib/billing/stripe";
-import { planRepo, stripeCustomerRepo } from "@opensend/core";
+import { createDefaultBillingSessionService } from "@/lib/billing/session-factory";
+import {
+  type BillingCheckoutBody,
+  normalizeCheckoutPlanId,
+} from "@/lib/billing/sessions";
 import { NextResponse } from "next/server";
-import type Stripe from "stripe";
-
-interface CheckoutRequestBody {
-  plan_id?: unknown;
-  planId?: unknown;
-}
 
 function getRequestOrigin(request: Request) {
   return new URL(request.url).origin;
@@ -16,30 +13,10 @@ function getRequestOrigin(request: Request) {
 
 async function readCheckoutBody(request: Request) {
   try {
-    return (await request.json()) as CheckoutRequestBody;
+    return (await request.json()) as BillingCheckoutBody;
   } catch {
     return null;
   }
-}
-
-async function ensureStripeCustomer(params: {
-  stripe: Stripe;
-  userId: string;
-  email?: string | null;
-  name?: string | null;
-}) {
-  const existing = await stripeCustomerRepo.findByUserId(params.userId);
-  if (existing) return existing;
-
-  const customer = await params.stripe.customers.create({
-    email: params.email ?? undefined,
-    name: params.name ?? undefined,
-    metadata: {
-      user_id: params.userId,
-    },
-  });
-
-  return await stripeCustomerRepo.ensureForUser(params.userId, customer.id);
 }
 
 export async function POST(request: Request) {
@@ -56,56 +33,39 @@ export async function POST(request: Request) {
   }
 
   const body = await readCheckoutBody(request);
-  const planId = body?.plan_id ?? body?.planId;
-  if (typeof planId !== "string" || !planId.trim()) {
+  const planId = normalizeCheckoutPlanId(body);
+  if (!planId) {
     return NextResponse.json({ error: "plan_id is required" }, { status: 400 });
   }
 
-  const plan = await planRepo.findById(planId.trim());
-  if (!plan || !plan.isPublic) {
-    return NextResponse.json({ error: "Plan not found" }, { status: 404 });
-  }
-
-  if (!plan.stripePriceId) {
-    return NextResponse.json(
-      { error: "Plan is not available for Stripe checkout" },
-      { status: 400 },
-    );
-  }
-
-  const stripe = getStripe();
-  const customer = await ensureStripeCustomer({
-    stripe,
-    userId: session.user.id,
-    email: session.user.email,
-    name: session.user.name,
-  });
-  const origin = getRequestOrigin(request);
-
-  const checkoutSession = await stripe.checkout.sessions.create({
-    mode: "subscription",
-    customer: customer.stripeCustomerId,
-    line_items: [{ price: plan.stripePriceId, quantity: 1 }],
-    success_url: `${origin}/settings/billing?status=success`,
-    cancel_url: `${origin}/settings/billing?status=cancelled`,
-    metadata: {
-      user_id: session.user.id,
-      plan_id: plan.id,
-    },
-    subscription_data: {
-      metadata: {
-        user_id: session.user.id,
-        plan_id: plan.id,
+  const result =
+    await createDefaultBillingSessionService().createCheckoutSession({
+      planId,
+      user: {
+        id: session.user.id,
+        email: session.user.email,
+        name: session.user.name,
       },
-    },
-  });
+      origin: getRequestOrigin(request),
+    });
 
-  if (!checkoutSession.url) {
+  if (!result.ok) {
+    if (result.error === "plan_not_found") {
+      return NextResponse.json({ error: "Plan not found" }, { status: 404 });
+    }
+
+    if (result.error === "stripe_price_missing") {
+      return NextResponse.json(
+        { error: "Plan is not available for Stripe checkout" },
+        { status: 400 },
+      );
+    }
+
     return NextResponse.json(
       { error: "Stripe did not return a checkout URL" },
       { status: 502 },
     );
   }
 
-  return NextResponse.json({ url: checkoutSession.url });
+  return NextResponse.json({ url: result.url });
 }

--- a/src/app/api/billing/portal/route.ts
+++ b/src/app/api/billing/portal/route.ts
@@ -1,7 +1,6 @@
 import { getServerSession } from "@/lib/api-auth";
 import { getBillingBackend } from "@/lib/billing";
-import { getStripe } from "@/lib/billing/stripe";
-import { stripeCustomerRepo } from "@opensend/core";
+import { createDefaultBillingSessionService } from "@/lib/billing/session-factory";
 import { NextResponse } from "next/server";
 
 function getRequestOrigin(request: Request) {
@@ -21,18 +20,19 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const customer = await stripeCustomerRepo.findByUserId(session.user.id);
-  if (!customer) {
+  const result = await createDefaultBillingSessionService().createPortalSession(
+    {
+      userId: session.user.id,
+      origin: getRequestOrigin(request),
+    },
+  );
+
+  if (!result.ok) {
     return NextResponse.json(
       { error: "Stripe customer not found" },
       { status: 404 },
     );
   }
 
-  const portalSession = await getStripe().billingPortal.sessions.create({
-    customer: customer.stripeCustomerId,
-    return_url: `${getRequestOrigin(request)}/settings/billing`,
-  });
-
-  return NextResponse.json({ url: portalSession.url });
+  return NextResponse.json({ url: result.url });
 }

--- a/src/lib/billing/session-factory.ts
+++ b/src/lib/billing/session-factory.ts
@@ -1,0 +1,11 @@
+import { planRepo, stripeCustomerRepo } from "@opensend/core";
+import { createBillingSessionService } from "./sessions";
+import { getStripe } from "./stripe";
+
+export function createDefaultBillingSessionService() {
+  return createBillingSessionService({
+    plans: planRepo,
+    stripeCustomers: stripeCustomerRepo,
+    stripe: getStripe,
+  });
+}

--- a/src/lib/billing/sessions.ts
+++ b/src/lib/billing/sessions.ts
@@ -1,0 +1,192 @@
+export interface BillingSessionUser {
+  id: string;
+  email?: string | null;
+  name?: string | null;
+}
+
+export interface BillingPlanForCheckout {
+  id: string;
+  isPublic: boolean;
+  stripePriceId?: string | null;
+}
+
+export interface StripeCustomerForBilling {
+  stripeCustomerId: string;
+}
+
+export interface BillingCheckoutBody {
+  plan_id?: unknown;
+  planId?: unknown;
+}
+
+export interface StripeCustomerCreateInput {
+  email?: string;
+  name?: string;
+  metadata: {
+    user_id: string;
+  };
+}
+
+export interface StripeCheckoutCreateInput {
+  mode: "subscription";
+  customer: string;
+  line_items: Array<{ price: string; quantity: 1 }>;
+  success_url: string;
+  cancel_url: string;
+  metadata: {
+    user_id: string;
+    plan_id: string;
+  };
+  subscription_data: {
+    metadata: {
+      user_id: string;
+      plan_id: string;
+    };
+  };
+}
+
+export interface StripePortalCreateInput {
+  customer: string;
+  return_url: string;
+}
+
+export interface BillingStripeClient {
+  customers: {
+    create(input: StripeCustomerCreateInput): Promise<{ id: string }>;
+  };
+  checkout: {
+    sessions: {
+      create(
+        input: StripeCheckoutCreateInput,
+      ): Promise<{ url?: string | null }>;
+    };
+  };
+  billingPortal: {
+    sessions: {
+      create(input: StripePortalCreateInput): Promise<{ url: string }>;
+    };
+  };
+}
+
+export interface BillingSessionServiceDeps {
+  plans: {
+    findById(id: string): Promise<BillingPlanForCheckout | null | undefined>;
+  };
+  stripeCustomers: {
+    findByUserId(
+      userId: string,
+    ): Promise<StripeCustomerForBilling | null | undefined>;
+    ensureForUser(
+      userId: string,
+      stripeCustomerId: string,
+    ): Promise<StripeCustomerForBilling>;
+  };
+  stripe: BillingStripeClient | (() => BillingStripeClient);
+}
+
+export type CheckoutSessionResult =
+  | { ok: true; url: string }
+  | { ok: false; error: "plan_not_found" }
+  | { ok: false; error: "stripe_price_missing" }
+  | { ok: false; error: "checkout_url_missing" };
+
+export type PortalSessionResult =
+  | { ok: true; url: string }
+  | { ok: false; error: "stripe_customer_not_found" };
+
+export function normalizeCheckoutPlanId(body: BillingCheckoutBody | null) {
+  const planId = body?.plan_id ?? body?.planId;
+  if (typeof planId !== "string") return null;
+
+  const trimmed = planId.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function createBillingSessionService(deps: BillingSessionServiceDeps) {
+  function getStripeClient() {
+    if (typeof deps.stripe === "function") {
+      return deps.stripe();
+    }
+
+    return deps.stripe;
+  }
+
+  async function ensureStripeCustomer(
+    user: BillingSessionUser,
+    stripe: BillingStripeClient,
+  ) {
+    const existing = await deps.stripeCustomers.findByUserId(user.id);
+    if (existing) return existing;
+
+    const customer = await stripe.customers.create({
+      email: user.email ?? undefined,
+      name: user.name ?? undefined,
+      metadata: {
+        user_id: user.id,
+      },
+    });
+
+    return await deps.stripeCustomers.ensureForUser(user.id, customer.id);
+  }
+
+  return {
+    async createCheckoutSession(params: {
+      planId: string;
+      user: BillingSessionUser;
+      origin: string;
+    }): Promise<CheckoutSessionResult> {
+      const plan = await deps.plans.findById(params.planId);
+      if (!plan || !plan.isPublic) {
+        return { ok: false, error: "plan_not_found" };
+      }
+
+      if (!plan.stripePriceId) {
+        return { ok: false, error: "stripe_price_missing" };
+      }
+
+      const stripe = getStripeClient();
+      const customer = await ensureStripeCustomer(params.user, stripe);
+      const checkoutSession = await stripe.checkout.sessions.create({
+        mode: "subscription",
+        customer: customer.stripeCustomerId,
+        line_items: [{ price: plan.stripePriceId, quantity: 1 }],
+        success_url: `${params.origin}/settings/billing?status=success`,
+        cancel_url: `${params.origin}/settings/billing?status=cancelled`,
+        metadata: {
+          user_id: params.user.id,
+          plan_id: plan.id,
+        },
+        subscription_data: {
+          metadata: {
+            user_id: params.user.id,
+            plan_id: plan.id,
+          },
+        },
+      });
+
+      if (!checkoutSession.url) {
+        return { ok: false, error: "checkout_url_missing" };
+      }
+
+      return { ok: true, url: checkoutSession.url };
+    },
+
+    async createPortalSession(params: {
+      userId: string;
+      origin: string;
+    }): Promise<PortalSessionResult> {
+      const customer = await deps.stripeCustomers.findByUserId(params.userId);
+      if (!customer) {
+        return { ok: false, error: "stripe_customer_not_found" };
+      }
+
+      const portalSession =
+        await getStripeClient().billingPortal.sessions.create({
+          customer: customer.stripeCustomerId,
+          return_url: `${params.origin}/settings/billing`,
+        });
+
+      return { ok: true, url: portalSession.url };
+    },
+  };
+}

--- a/tests/billing-checkout-portal-service.test.ts
+++ b/tests/billing-checkout-portal-service.test.ts
@@ -1,0 +1,244 @@
+import {
+  type BillingPlanForCheckout,
+  type BillingSessionServiceDeps,
+  type StripeCheckoutCreateInput,
+  type StripeCustomerCreateInput,
+  type StripePortalCreateInput,
+  createBillingSessionService,
+  normalizeCheckoutPlanId,
+} from "@/lib/billing/sessions";
+import { describe, expect, it } from "vitest";
+
+const testUser = {
+  id: "user_123",
+  email: "owner@example.com",
+  name: "Owner Example",
+};
+
+interface FakeState {
+  plan?: BillingPlanForCheckout | null;
+  customer?: { stripeCustomerId: string } | null;
+  createdCustomerId?: string;
+  checkoutUrl?: string | null;
+  portalUrl?: string;
+}
+
+function fakeDeps(state: FakeState = {}) {
+  const calls = {
+    planFindIds: [] as string[],
+    customerFindUserIds: [] as string[],
+    customerCreates: [] as StripeCustomerCreateInput[],
+    customerEnsures: [] as Array<{
+      userId: string;
+      stripeCustomerId: string;
+    }>,
+    checkoutCreates: [] as StripeCheckoutCreateInput[],
+    portalCreates: [] as StripePortalCreateInput[],
+    stripeFactoryCalls: 0,
+  };
+
+  const deps: BillingSessionServiceDeps = {
+    plans: {
+      async findById(id) {
+        calls.planFindIds.push(id);
+        return state.plan;
+      },
+    },
+    stripeCustomers: {
+      async findByUserId(userId) {
+        calls.customerFindUserIds.push(userId);
+        return state.customer;
+      },
+      async ensureForUser(userId, stripeCustomerId) {
+        calls.customerEnsures.push({ userId, stripeCustomerId });
+        return { stripeCustomerId };
+      },
+    },
+    stripe: () => {
+      calls.stripeFactoryCalls += 1;
+      return {
+        customers: {
+          async create(input) {
+            calls.customerCreates.push(input);
+            return { id: state.createdCustomerId ?? "cus_new" };
+          },
+        },
+        checkout: {
+          sessions: {
+            async create(input) {
+              calls.checkoutCreates.push(input);
+              return { url: state.checkoutUrl };
+            },
+          },
+        },
+        billingPortal: {
+          sessions: {
+            async create(input) {
+              calls.portalCreates.push(input);
+              return {
+                url: state.portalUrl ?? "https://billing.example/session",
+              };
+            },
+          },
+        },
+      };
+    },
+  };
+
+  return { calls, service: createBillingSessionService(deps) };
+}
+
+describe("billing checkout and portal session service", () => {
+  it("normalizes the checkout plan ID with the existing plan_id precedence", () => {
+    expect(normalizeCheckoutPlanId({ plan_id: " plan_pro " })).toBe("plan_pro");
+    expect(normalizeCheckoutPlanId({ planId: " plan_legacy " })).toBe(
+      "plan_legacy",
+    );
+    expect(
+      normalizeCheckoutPlanId({ plan_id: " ", planId: "plan_fallback" }),
+    ).toBeNull();
+    expect(normalizeCheckoutPlanId({ plan_id: 123 })).toBeNull();
+    expect(normalizeCheckoutPlanId(null)).toBeNull();
+  });
+
+  it("returns plan_not_found for missing or private checkout plans before touching Stripe", async () => {
+    for (const plan of [
+      null,
+      { id: "plan_private", isPublic: false, stripePriceId: "price_private" },
+    ]) {
+      const { calls, service } = fakeDeps({ plan });
+
+      await expect(
+        service.createCheckoutSession({
+          planId: "plan_private",
+          user: testUser,
+          origin: "https://app.opensend.test",
+        }),
+      ).resolves.toEqual({ ok: false, error: "plan_not_found" });
+
+      expect(calls.planFindIds).toEqual(["plan_private"]);
+      expect(calls.customerFindUserIds).toEqual([]);
+      expect(calls.stripeFactoryCalls).toBe(0);
+    }
+  });
+
+  it("returns stripe_price_missing when a public plan has no Stripe price", async () => {
+    const { calls, service } = fakeDeps({
+      plan: { id: "plan_free", isPublic: true, stripePriceId: null },
+    });
+
+    await expect(
+      service.createCheckoutSession({
+        planId: "plan_free",
+        user: testUser,
+        origin: "https://app.opensend.test",
+      }),
+    ).resolves.toEqual({ ok: false, error: "stripe_price_missing" });
+
+    expect(calls.customerFindUserIds).toEqual([]);
+    expect(calls.stripeFactoryCalls).toBe(0);
+  });
+
+  it("creates a customer and subscription checkout session with current metadata and URLs", async () => {
+    const { calls, service } = fakeDeps({
+      plan: { id: "plan_pro", isPublic: true, stripePriceId: "price_123" },
+      customer: null,
+      createdCustomerId: "cus_new",
+      checkoutUrl: "https://checkout.stripe.com/c/pay/cs_test_123",
+    });
+
+    await expect(
+      service.createCheckoutSession({
+        planId: "plan_pro",
+        user: testUser,
+        origin: "https://app.opensend.test",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      url: "https://checkout.stripe.com/c/pay/cs_test_123",
+    });
+
+    expect(calls.customerCreates).toEqual([
+      {
+        email: "owner@example.com",
+        name: "Owner Example",
+        metadata: { user_id: "user_123" },
+      },
+    ]);
+    expect(calls.customerEnsures).toEqual([
+      { userId: "user_123", stripeCustomerId: "cus_new" },
+    ]);
+    expect(calls.checkoutCreates).toEqual([
+      {
+        mode: "subscription",
+        customer: "cus_new",
+        line_items: [{ price: "price_123", quantity: 1 }],
+        success_url:
+          "https://app.opensend.test/settings/billing?status=success",
+        cancel_url:
+          "https://app.opensend.test/settings/billing?status=cancelled",
+        metadata: { user_id: "user_123", plan_id: "plan_pro" },
+        subscription_data: {
+          metadata: { user_id: "user_123", plan_id: "plan_pro" },
+        },
+      },
+    ]);
+  });
+
+  it("reuses an existing customer and reports a missing checkout URL", async () => {
+    const { calls, service } = fakeDeps({
+      plan: { id: "plan_pro", isPublic: true, stripePriceId: "price_123" },
+      customer: { stripeCustomerId: "cus_existing" },
+      checkoutUrl: null,
+    });
+
+    await expect(
+      service.createCheckoutSession({
+        planId: "plan_pro",
+        user: testUser,
+        origin: "https://app.opensend.test",
+      }),
+    ).resolves.toEqual({ ok: false, error: "checkout_url_missing" });
+
+    expect(calls.customerCreates).toEqual([]);
+    expect(calls.checkoutCreates[0]?.customer).toBe("cus_existing");
+  });
+
+  it("returns stripe_customer_not_found for portal when the user has no customer", async () => {
+    const { calls, service } = fakeDeps({ customer: null });
+
+    await expect(
+      service.createPortalSession({
+        userId: "user_123",
+        origin: "https://app.opensend.test",
+      }),
+    ).resolves.toEqual({ ok: false, error: "stripe_customer_not_found" });
+
+    expect(calls.portalCreates).toEqual([]);
+    expect(calls.stripeFactoryCalls).toBe(0);
+  });
+
+  it("creates a billing portal session with the current return URL", async () => {
+    const { calls, service } = fakeDeps({
+      customer: { stripeCustomerId: "cus_existing" },
+      portalUrl: "https://billing.stripe.com/p/session/test_123",
+    });
+
+    await expect(
+      service.createPortalSession({
+        userId: "user_123",
+        origin: "https://app.opensend.test",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      url: "https://billing.stripe.com/p/session/test_123",
+    });
+
+    expect(calls.portalCreates).toEqual([
+      {
+        customer: "cus_existing",
+        return_url: "https://app.opensend.test/settings/billing",
+      },
+    ]);
+  });
+});

--- a/tests/billing-checkout-portal.test.ts
+++ b/tests/billing-checkout-portal.test.ts
@@ -7,6 +7,7 @@ const mockEnsureCustomerForUser = vi.fn();
 const mockStripeCustomerCreate = vi.fn();
 const mockCheckoutCreate = vi.fn();
 const mockPortalCreate = vi.fn();
+const mockGetStripe = vi.fn();
 
 vi.mock("@/lib/api-auth", () => ({
   getServerSession: mockGetServerSession,
@@ -23,11 +24,7 @@ vi.mock("@opensend/core", () => ({
 }));
 
 vi.mock("@/lib/billing/stripe", () => ({
-  getStripe: () => ({
-    customers: { create: mockStripeCustomerCreate },
-    checkout: { sessions: { create: mockCheckoutCreate } },
-    billingPortal: { sessions: { create: mockPortalCreate } },
-  }),
+  getStripe: mockGetStripe,
 }));
 
 const testSession = {
@@ -62,6 +59,11 @@ describe("billing checkout and portal routes", () => {
     process.env.BILLING_BACKEND = "stripe";
     process.env.STRIPE_SECRET_KEY = "sk_test_unit";
     mockGetServerSession.mockResolvedValue(testSession);
+    mockGetStripe.mockReturnValue({
+      customers: { create: mockStripeCustomerCreate },
+      checkout: { sessions: { create: mockCheckoutCreate } },
+      billingPortal: { sessions: { create: mockPortalCreate } },
+    });
   });
 
   it("returns 404 when Stripe billing is disabled instead of throwing", async () => {
@@ -78,6 +80,92 @@ describe("billing checkout and portal routes", () => {
       error: "Billing is not enabled",
     });
     expect(mockGetServerSession).not.toHaveBeenCalled();
+    expect(mockGetStripe).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 without a dashboard session for checkout and portal", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const checkoutRoute = await importCheckoutRoute();
+    const portalRoute = await importPortalRoute();
+
+    const checkoutResponse = await checkoutRoute.POST(
+      postRequest("/api/billing/checkout", { plan_id: "plan_1" }),
+    );
+    const portalResponse = await portalRoute.POST(
+      postRequest("/api/billing/portal"),
+    );
+
+    expect(checkoutResponse.status).toBe(401);
+    await expect(checkoutResponse.json()).resolves.toEqual({
+      error: "Unauthorized",
+    });
+    expect(portalResponse.status).toBe(401);
+    await expect(portalResponse.json()).resolves.toEqual({
+      error: "Unauthorized",
+    });
+    expect(mockPlanFindById).not.toHaveBeenCalled();
+    expect(mockFindCustomerByUserId).not.toHaveBeenCalled();
+    expect(mockGetStripe).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { plan_id: "" },
+    { plan_id: "   " },
+    { plan_id: 123 },
+    { plan_id: " ", planId: "plan_fallback" },
+    {},
+  ])("returns 400 when checkout plan_id is absent or invalid", async (body) => {
+    const { POST } = await importCheckoutRoute();
+
+    const response = await POST(postRequest("/api/billing/checkout", body));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "plan_id is required",
+    });
+    expect(mockPlanFindById).not.toHaveBeenCalled();
+    expect(mockGetStripe).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when checkout plan is missing or private", async () => {
+    const { POST } = await importCheckoutRoute();
+
+    for (const plan of [null, { id: "plan_private", isPublic: false }]) {
+      mockPlanFindById.mockResolvedValueOnce(plan);
+      const response = await POST(
+        postRequest("/api/billing/checkout", { plan_id: " plan_private " }),
+      );
+
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toEqual({
+        error: "Plan not found",
+      });
+    }
+
+    expect(mockPlanFindById).toHaveBeenCalledWith("plan_private");
+    expect(mockFindCustomerByUserId).not.toHaveBeenCalled();
+    expect(mockGetStripe).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when checkout plan has no Stripe price", async () => {
+    mockPlanFindById.mockResolvedValue({
+      id: "plan_free",
+      isPublic: true,
+      stripePriceId: null,
+    });
+    const { POST } = await importCheckoutRoute();
+
+    const response = await POST(
+      postRequest("/api/billing/checkout", { planId: " plan_free " }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Plan is not available for Stripe checkout",
+    });
+    expect(mockPlanFindById).toHaveBeenCalledWith("plan_free");
+    expect(mockFindCustomerByUserId).not.toHaveBeenCalled();
+    expect(mockGetStripe).not.toHaveBeenCalled();
   });
 
   it("auto-creates a Stripe customer and returns the checkout session URL", async () => {
@@ -114,17 +202,23 @@ describe("billing checkout and portal routes", () => {
       "user_123",
       "cus_new",
     );
-    expect(mockCheckoutCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        customer: "cus_new",
-        line_items: [{ price: "price_123", quantity: 1 }],
-        mode: "subscription",
-        success_url:
-          "https://app.opensend.test/settings/billing?status=success",
-        cancel_url:
-          "https://app.opensend.test/settings/billing?status=cancelled",
-      }),
-    );
+    expect(mockCheckoutCreate).toHaveBeenCalledWith({
+      customer: "cus_new",
+      line_items: [{ price: "price_123", quantity: 1 }],
+      mode: "subscription",
+      success_url: "https://app.opensend.test/settings/billing?status=success",
+      cancel_url: "https://app.opensend.test/settings/billing?status=cancelled",
+      metadata: {
+        user_id: "user_123",
+        plan_id: "plan_pro",
+      },
+      subscription_data: {
+        metadata: {
+          user_id: "user_123",
+          plan_id: "plan_pro",
+        },
+      },
+    });
   });
 
   it("returns a checkout URL for an existing Stripe customer", async () => {
@@ -154,6 +248,42 @@ describe("billing checkout and portal routes", () => {
     expect(mockCheckoutCreate).toHaveBeenCalledWith(
       expect.objectContaining({ customer: "cus_existing" }),
     );
+  });
+
+  it("returns 502 when Stripe omits a checkout URL", async () => {
+    mockPlanFindById.mockResolvedValue({
+      id: "plan_pro",
+      isPublic: true,
+      stripePriceId: "price_123",
+    });
+    mockFindCustomerByUserId.mockResolvedValue({
+      stripeCustomerId: "cus_existing",
+    });
+    mockCheckoutCreate.mockResolvedValue({ url: null });
+    const { POST } = await importCheckoutRoute();
+
+    const response = await POST(
+      postRequest("/api/billing/checkout", { plan_id: "plan_pro" }),
+    );
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: "Stripe did not return a checkout URL",
+    });
+  });
+
+  it("returns 404 when portal has no Stripe customer", async () => {
+    mockFindCustomerByUserId.mockResolvedValue(null);
+    const { POST } = await importPortalRoute();
+
+    const response = await POST(postRequest("/api/billing/portal"));
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Stripe customer not found",
+    });
+    expect(mockPortalCreate).not.toHaveBeenCalled();
+    expect(mockGetStripe).not.toHaveBeenCalled();
   });
 
   it("reuses the current user's Stripe customer for the customer portal", async () => {


### PR DESCRIPTION
## Summary
- Extract checkout and portal Stripe orchestration into an injectable billing session service under `src/lib/billing`
- Keep route adapters responsible for billing enablement, dashboard auth, request parsing, and exact HTTP error mapping
- Add focused route and fake-provider service tests for checkout/portal success and error behavior

## Validation
- ✅ `bunx vitest run tests/billing-checkout-portal.test.ts tests/billing-checkout-portal-service.test.ts` — 2 files, 21 tests passed
- ✅ `make check` — typecheck + Biome passed
- ✅ `make test` — 146 files, 1162 tests passed

Closes #419