### PR TITLE
Extract billing summary service boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-11-issue-422-route-specific-billing-dtos.md
+++ b/agent_docs/learnings/active/2026-05-11-issue-422-route-specific-billing-dtos.md
@@ -1,0 +1,10 @@
+---
+date: 2026-05-11
+issue: "#422"
+type: pattern
+promoted_to: null
+---
+
+## Preserve route-specific billing DTO shapes when extracting shared services
+
+The public plans list and billing summary both expose plan-like objects, but their HTTP shapes are not identical: `/api/billing/plans` list items include `object: "plan"`, while `/api/billing/summary` embeds plan fields without an `object` discriminator. Billing service boundaries should use separate mappers for list-plan DTOs and summary-plan DTOs instead of reusing the public list item mapper everywhere.

--- a/src/app/api/billing/plans/route.ts
+++ b/src/app/api/billing/plans/route.ts
@@ -1,6 +1,8 @@
 import { isBillingEnabled } from "@/lib/billing";
-import { listPublicPlans } from "@/lib/billing/summary";
+import { createDefaultBillingSummaryService } from "@/lib/billing/summary";
 import { NextResponse } from "next/server";
+
+const billingSummaryService = createDefaultBillingSummaryService();
 
 export async function GET() {
   if (!isBillingEnabled()) {
@@ -11,20 +13,7 @@ export async function GET() {
   }
 
   try {
-    const plans = await listPublicPlans();
-    return NextResponse.json({
-      object: "list",
-      data: plans.map((plan) => ({
-        object: "plan",
-        id: plan.id,
-        slug: plan.slug,
-        name: plan.name,
-        monthly_price_cents: plan.monthlyPriceCents,
-        monthly_email_quota: plan.monthlyEmailQuota,
-        max_domains: plan.maxDomains,
-        max_api_keys: plan.maxApiKeys,
-      })),
-    });
+    return NextResponse.json(await billingSummaryService.listPlans());
   } catch (error) {
     console.error("Failed to list public plans:", error);
     return NextResponse.json(

--- a/src/app/api/billing/summary/route.ts
+++ b/src/app/api/billing/summary/route.ts
@@ -1,7 +1,9 @@
 import { getServerSession, unauthorizedResponse } from "@/lib/api-auth";
 import { isBillingEnabled } from "@/lib/billing";
-import { loadBillingSummary } from "@/lib/billing/summary";
+import { createDefaultBillingSummaryService } from "@/lib/billing/summary";
 import { NextResponse } from "next/server";
+
+const billingSummaryService = createDefaultBillingSummaryService();
 
 export async function GET() {
   if (!isBillingEnabled()) {
@@ -15,7 +17,9 @@ export async function GET() {
   if (!session?.user?.id) return unauthorizedResponse();
 
   try {
-    const summary = await loadBillingSummary(session.user.id);
+    const summary = await billingSummaryService.getBillingSummary(
+      session.user.id,
+    );
     if (!summary) {
       return NextResponse.json(
         {
@@ -26,35 +30,7 @@ export async function GET() {
       );
     }
 
-    return NextResponse.json({
-      object: "billing_summary",
-      plan: {
-        id: summary.plan.id,
-        slug: summary.plan.slug,
-        name: summary.plan.name,
-        monthly_price_cents: summary.plan.monthlyPriceCents,
-        monthly_email_quota: summary.plan.monthlyEmailQuota,
-        max_domains: summary.plan.maxDomains,
-        max_api_keys: summary.plan.maxApiKeys,
-      },
-      subscription: summary.subscription
-        ? {
-            id: summary.subscription.id,
-            status: summary.subscription.status,
-            current_period_start: summary.subscription.currentPeriodStart,
-            current_period_end: summary.subscription.currentPeriodEnd,
-            cancel_at_period_end: summary.subscription.cancelAtPeriodEnd,
-          }
-        : null,
-      usage: {
-        emails: summary.usage.emails,
-        domains: summary.usage.domains,
-        api_keys: summary.usage.apiKeys,
-        period_start: summary.usage.periodStart,
-        period_end: summary.usage.periodEnd,
-        has_usage_period: summary.usage.hasUsagePeriod,
-      },
-    });
+    return NextResponse.json(summary);
   } catch (error) {
     console.error("Failed to load billing summary:", error);
     return NextResponse.json(

--- a/src/app/api/usage/route.ts
+++ b/src/app/api/usage/route.ts
@@ -1,10 +1,9 @@
 import { getServerSession, unauthorizedResponse } from "@/lib/api-auth";
 import { isBillingEnabled } from "@/lib/billing";
-import { loadBillingSummary } from "@/lib/billing/summary";
-import { createDashboardAggregateService } from "@opensend/core";
+import { createDefaultBillingSummaryService } from "@/lib/billing/summary";
 import { NextResponse } from "next/server";
 
-const dashboardAggregateService = createDashboardAggregateService();
+const billingSummaryService = createDefaultBillingSummaryService();
 
 // Dashboard-only internal endpoint
 export async function GET() {
@@ -12,31 +11,12 @@ export async function GET() {
   if (!session) return unauthorizedResponse();
 
   try {
-    const payload = await dashboardAggregateService.getUsage();
-
-    if (!isBillingEnabled() || !session.user?.id) {
-      return NextResponse.json(payload);
-    }
-
-    const billingSummary = await loadBillingSummary(session.user.id);
-    if (!billingSummary) return NextResponse.json(payload);
-
-    return NextResponse.json({
-      ...payload,
-      plan: {
-        name: billingSummary.plan.name,
-        slug: billingSummary.plan.slug,
-      },
-      transactional: {
-        ...payload.transactional,
-        monthlyLimit: billingSummary.plan.monthlyEmailQuota,
-      },
-      team: {
-        ...payload.team,
-        domainsUsed: billingSummary.usage.domains.used,
-        domainsLimit: billingSummary.usage.domains.limit,
-      },
-    });
+    return NextResponse.json(
+      await billingSummaryService.getUsage({
+        billingEnabled: isBillingEnabled(),
+        userId: session.user?.id,
+      }),
+    );
   } catch (error) {
     console.error("Failed to fetch usage:", error);
     return NextResponse.json(

--- a/src/lib/billing/summary.ts
+++ b/src/lib/billing/summary.ts
@@ -6,7 +6,12 @@ import {
   subscriptions,
   usagePeriods,
 } from "@/lib/db/schema";
-import { FREE_PLAN_SLUG, type SubscriptionStatus } from "@opensend/core";
+import {
+  type DashboardUsagePayload,
+  FREE_PLAN_SLUG,
+  type SubscriptionStatus,
+  createDashboardAggregateService,
+} from "@opensend/core";
 import { count, desc, eq } from "drizzle-orm";
 
 export interface BillingPlanSummary {
@@ -41,6 +46,67 @@ export interface BillingSummary {
   plan: BillingPlanSummary;
   subscription: BillingSubscriptionSummary | null;
   usage: BillingUsageSummary;
+}
+
+export interface PublicPlanResponse {
+  object: "plan";
+  id: string;
+  slug: string;
+  name: string;
+  monthly_price_cents: number;
+  monthly_email_quota: number;
+  max_domains: number;
+  max_api_keys: number;
+}
+
+export interface BillingPlansResponse {
+  object: "list";
+  data: PublicPlanResponse[];
+}
+
+export interface BillingSummaryPlanResponse {
+  id: string;
+  slug: string;
+  name: string;
+  monthly_price_cents: number;
+  monthly_email_quota: number;
+  max_domains: number;
+  max_api_keys: number;
+}
+
+export interface BillingSummaryResponse {
+  object: "billing_summary";
+  plan: BillingSummaryPlanResponse;
+  subscription: {
+    id: string;
+    status: SubscriptionStatus;
+    current_period_start: string | null;
+    current_period_end: string | null;
+    cancel_at_period_end: boolean;
+  } | null;
+  usage: {
+    emails: BillingUsageSummary["emails"];
+    domains: BillingUsageSummary["domains"];
+    api_keys: BillingUsageSummary["apiKeys"];
+    period_start: string | null;
+    period_end: string | null;
+    has_usage_period: boolean;
+  };
+}
+
+export interface BillingUsageInput {
+  billingEnabled: boolean;
+  userId?: string | null;
+}
+
+export interface DashboardUsageService {
+  getUsage(): Promise<DashboardUsagePayload>;
+}
+
+export interface BillingSummaryServiceDeps {
+  listPlans?: () => Promise<BillingPlanSummary[]>;
+  loadSummary?: (userId: string) => Promise<BillingSummary | null>;
+  dashboardUsage?: DashboardUsageService | (() => DashboardUsageService);
 }
 
 function toIso(value: Date | null | undefined): string | null {
@@ -157,4 +223,119 @@ export async function listPublicPlans(): Promise<BillingPlanSummary[]> {
   return rows
     .map(toPlanSummary)
     .sort((a, b) => a.monthlyPriceCents - b.monthlyPriceCents);
+}
+
+function toPublicPlanResponse(plan: BillingPlanSummary): PublicPlanResponse {
+  return {
+    object: "plan",
+    ...toBillingSummaryPlanResponse(plan),
+  };
+}
+
+function toBillingSummaryPlanResponse(
+  plan: BillingPlanSummary,
+): BillingSummaryPlanResponse {
+  return {
+    id: plan.id,
+    slug: plan.slug,
+    name: plan.name,
+    monthly_price_cents: plan.monthlyPriceCents,
+    monthly_email_quota: plan.monthlyEmailQuota,
+    max_domains: plan.maxDomains,
+    max_api_keys: plan.maxApiKeys,
+  };
+}
+
+function toBillingSummaryResponse(
+  summary: BillingSummary,
+): BillingSummaryResponse {
+  return {
+    object: "billing_summary",
+    plan: toBillingSummaryPlanResponse(summary.plan),
+    subscription: summary.subscription
+      ? {
+          id: summary.subscription.id,
+          status: summary.subscription.status,
+          current_period_start: summary.subscription.currentPeriodStart,
+          current_period_end: summary.subscription.currentPeriodEnd,
+          cancel_at_period_end: summary.subscription.cancelAtPeriodEnd,
+        }
+      : null,
+    usage: {
+      emails: summary.usage.emails,
+      domains: summary.usage.domains,
+      api_keys: summary.usage.apiKeys,
+      period_start: summary.usage.periodStart,
+      period_end: summary.usage.periodEnd,
+      has_usage_period: summary.usage.hasUsagePeriod,
+    },
+  };
+}
+
+let defaultDashboardUsageService: DashboardUsageService | null = null;
+
+function getDefaultDashboardUsageService(): DashboardUsageService {
+  defaultDashboardUsageService ??= createDashboardAggregateService();
+  return defaultDashboardUsageService;
+}
+
+export function createBillingSummaryService({
+  listPlans = listPublicPlans,
+  loadSummary = loadBillingSummary,
+  dashboardUsage = getDefaultDashboardUsageService,
+}: BillingSummaryServiceDeps = {}) {
+  function getDashboardUsageService() {
+    return typeof dashboardUsage === "function"
+      ? dashboardUsage()
+      : dashboardUsage;
+  }
+
+  return {
+    async listPlans(): Promise<BillingPlansResponse> {
+      return {
+        object: "list",
+        data: (await listPlans()).map(toPublicPlanResponse),
+      };
+    },
+
+    async getBillingSummary(
+      userId: string,
+    ): Promise<BillingSummaryResponse | null> {
+      const summary = await loadSummary(userId);
+      return summary ? toBillingSummaryResponse(summary) : null;
+    },
+
+    async getUsage({
+      billingEnabled,
+      userId,
+    }: BillingUsageInput): Promise<DashboardUsagePayload> {
+      const payload = await getDashboardUsageService().getUsage();
+
+      if (!billingEnabled || !userId) return payload;
+
+      const billingSummary = await loadSummary(userId);
+      if (!billingSummary) return payload;
+
+      return {
+        ...payload,
+        plan: {
+          name: billingSummary.plan.name,
+          slug: billingSummary.plan.slug,
+        },
+        transactional: {
+          ...payload.transactional,
+          monthlyLimit: billingSummary.plan.monthlyEmailQuota,
+        },
+        team: {
+          ...payload.team,
+          domainsUsed: billingSummary.usage.domains.used,
+          domainsLimit: billingSummary.usage.domains.limit,
+        },
+      };
+    },
+  };
+}
+
+export function createDefaultBillingSummaryService() {
+  return createBillingSummaryService();
 }

--- a/tests/billing-summary-routes.test.ts
+++ b/tests/billing-summary-routes.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockIsBillingEnabled = vi.hoisted(() => vi.fn());
+const mockListPlans = vi.hoisted(() => vi.fn());
+const mockGetBillingSummary = vi.hoisted(() => vi.fn());
+const mockGetUsage = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api-auth", () => ({
+  getServerSession: mockGetServerSession,
+  unauthorizedResponse: () =>
+    new Response(JSON.stringify({ error: "Missing or invalid API key" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    }),
+}));
+
+vi.mock("@/lib/billing", () => ({
+  isBillingEnabled: mockIsBillingEnabled,
+}));
+
+vi.mock("@/lib/billing/summary", () => ({
+  createDefaultBillingSummaryService: () => ({
+    listPlans: mockListPlans,
+    getBillingSummary: mockGetBillingSummary,
+    getUsage: mockGetUsage,
+  }),
+}));
+
+const plansEnvelope = {
+  object: "list",
+  data: [
+    {
+      object: "plan",
+      id: "plan-free",
+      slug: "free",
+      name: "Free",
+      monthly_price_cents: 0,
+      monthly_email_quota: 3000,
+      max_domains: 1,
+      max_api_keys: 2,
+    },
+  ],
+};
+
+const summaryEnvelope = {
+  object: "billing_summary",
+  plan: {
+    id: "plan-free",
+    slug: "free",
+    name: "Free",
+    monthly_price_cents: 0,
+    monthly_email_quota: 3000,
+    max_domains: 1,
+    max_api_keys: 2,
+  },
+  subscription: null,
+  usage: {
+    emails: { used: null, limit: 3000 },
+    domains: { used: 1, limit: 1 },
+    api_keys: { used: 1, limit: 2 },
+    period_start: null,
+    period_end: null,
+    has_usage_period: false,
+  },
+};
+
+async function importPlansRoute() {
+  return await import("@/app/api/billing/plans/route");
+}
+
+async function importSummaryRoute() {
+  return await import("@/app/api/billing/summary/route");
+}
+
+describe("billing plans and summary route adapters", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockIsBillingEnabled.mockReturnValue(true);
+    mockGetServerSession.mockResolvedValue({ user: { id: "user-1" } });
+    mockListPlans.mockResolvedValue(plansEnvelope);
+    mockGetBillingSummary.mockResolvedValue(summaryEnvelope);
+  });
+
+  it("keeps the billing-disabled plans response and avoids the service", async () => {
+    mockIsBillingEnabled.mockReturnValue(false);
+    const { GET } = await importPlansRoute();
+
+    const response = await GET();
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Billing is not enabled",
+    });
+    expect(mockListPlans).not.toHaveBeenCalled();
+  });
+
+  it("returns the plans service envelope and maps failures", async () => {
+    const { GET } = await importPlansRoute();
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(plansEnvelope);
+
+    mockListPlans.mockRejectedValueOnce(new Error("db down"));
+    const failed = await GET();
+    expect(failed.status).toBe(500);
+    await expect(failed.json()).resolves.toEqual({
+      error: "Failed to list plans",
+    });
+  });
+
+  it("keeps summary billing-disabled and unauthorized responses adapter-side", async () => {
+    mockIsBillingEnabled.mockReturnValue(false);
+    const { GET } = await importSummaryRoute();
+
+    const disabled = await GET();
+    expect(disabled.status).toBe(404);
+    await expect(disabled.json()).resolves.toEqual({
+      error: "Billing is not enabled",
+    });
+    expect(mockGetServerSession).not.toHaveBeenCalled();
+
+    mockIsBillingEnabled.mockReturnValue(true);
+    mockGetServerSession.mockResolvedValueOnce(null);
+    const unauthorized = await GET();
+    expect(unauthorized.status).toBe(401);
+    await expect(unauthorized.json()).resolves.toEqual({
+      error: "Missing or invalid API key",
+    });
+    expect(mockGetBillingSummary).not.toHaveBeenCalled();
+  });
+
+  it("returns the summary service envelope and the missing-plan response", async () => {
+    const { GET } = await importSummaryRoute();
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(summaryEnvelope);
+    expect(mockGetBillingSummary).toHaveBeenCalledWith("user-1");
+
+    mockGetBillingSummary.mockResolvedValueOnce(null);
+    const missing = await GET();
+    expect(missing.status).toBe(503);
+    await expect(missing.json()).resolves.toEqual({
+      error: "No plan available. Run database seed to create the Free plan.",
+    });
+  });
+
+  it("maps unexpected summary failures to the preserved 500 response", async () => {
+    mockGetBillingSummary.mockRejectedValueOnce(new Error("db down"));
+    const { GET } = await importSummaryRoute();
+
+    const response = await GET();
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to load billing summary",
+    });
+  });
+});

--- a/tests/billing-summary-service.test.ts
+++ b/tests/billing-summary-service.test.ts
@@ -1,0 +1,193 @@
+import {
+  type BillingPlanSummary,
+  type BillingSummary,
+  createBillingSummaryService,
+} from "@/lib/billing/summary";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const freePlan: BillingPlanSummary = {
+  id: "plan-free",
+  slug: "free",
+  name: "Free",
+  monthlyPriceCents: 0,
+  monthlyEmailQuota: 3000,
+  maxDomains: 1,
+  maxApiKeys: 2,
+  isPublic: true,
+};
+
+const proSummary: BillingSummary = {
+  plan: {
+    id: "plan-pro",
+    slug: "pro",
+    name: "Pro",
+    monthlyPriceCents: 2900,
+    monthlyEmailQuota: 50000,
+    maxDomains: 10,
+    maxApiKeys: 20,
+    isPublic: true,
+  },
+  subscription: {
+    id: "sub-1",
+    status: "active",
+    currentPeriodStart: "2026-05-01T00:00:00.000Z",
+    currentPeriodEnd: "2026-06-01T00:00:00.000Z",
+    cancelAtPeriodEnd: false,
+  },
+  usage: {
+    emails: { used: 123, limit: 50000 },
+    domains: { used: 4, limit: 10 },
+    apiKeys: { used: 3, limit: 20 },
+    periodStart: "2026-05-01T00:00:00.000Z",
+    periodEnd: "2026-06-01T00:00:00.000Z",
+    hasUsagePeriod: true,
+  },
+};
+
+const baseUsagePayload = {
+  plan: { name: "Free", slug: "free" },
+  transactional: {
+    monthlyUsed: 42,
+    monthlyLimit: 3000,
+    dailyUsed: 3,
+    dailyLimit: 100,
+  },
+  marketing: {
+    contactsUsed: 120,
+    contactsLimit: 1000,
+    segmentsUsed: 4,
+    segmentsLimit: 3,
+    broadcastsLimit: "Unlimited" as const,
+  },
+  team: {
+    domainsUsed: 2,
+    domainsLimit: 1,
+    rateLimit: 2,
+  },
+};
+
+describe("billing summary service", () => {
+  const listPlans = vi.fn<() => Promise<BillingPlanSummary[]>>();
+  const loadSummary =
+    vi.fn<(userId: string) => Promise<BillingSummary | null>>();
+  const getDashboardUsage = vi.fn<() => Promise<typeof baseUsagePayload>>();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listPlans.mockResolvedValue([freePlan, proSummary.plan]);
+    loadSummary.mockResolvedValue(proSummary);
+    getDashboardUsage.mockResolvedValue(baseUsagePayload);
+  });
+
+  it("maps public plans into the stable list envelope", async () => {
+    const service = createBillingSummaryService({ listPlans, loadSummary });
+
+    await expect(service.listPlans()).resolves.toEqual({
+      object: "list",
+      data: [
+        {
+          object: "plan",
+          id: "plan-free",
+          slug: "free",
+          name: "Free",
+          monthly_price_cents: 0,
+          monthly_email_quota: 3000,
+          max_domains: 1,
+          max_api_keys: 2,
+        },
+        {
+          object: "plan",
+          id: "plan-pro",
+          slug: "pro",
+          name: "Pro",
+          monthly_price_cents: 2900,
+          monthly_email_quota: 50000,
+          max_domains: 10,
+          max_api_keys: 20,
+        },
+      ],
+    });
+  });
+
+  it("maps billing summaries into the stable snake_case envelope", async () => {
+    const service = createBillingSummaryService({ listPlans, loadSummary });
+
+    await expect(service.getBillingSummary("user-1")).resolves.toEqual({
+      object: "billing_summary",
+      plan: {
+        id: "plan-pro",
+        slug: "pro",
+        name: "Pro",
+        monthly_price_cents: 2900,
+        monthly_email_quota: 50000,
+        max_domains: 10,
+        max_api_keys: 20,
+      },
+      subscription: {
+        id: "sub-1",
+        status: "active",
+        current_period_start: "2026-05-01T00:00:00.000Z",
+        current_period_end: "2026-06-01T00:00:00.000Z",
+        cancel_at_period_end: false,
+      },
+      usage: {
+        emails: { used: 123, limit: 50000 },
+        domains: { used: 4, limit: 10 },
+        api_keys: { used: 3, limit: 20 },
+        period_start: "2026-05-01T00:00:00.000Z",
+        period_end: "2026-06-01T00:00:00.000Z",
+        has_usage_period: true,
+      },
+    });
+    expect(loadSummary).toHaveBeenCalledWith("user-1");
+  });
+
+  it("enriches dashboard usage from billing summary when billing is enabled", async () => {
+    const service = createBillingSummaryService({
+      loadSummary,
+      dashboardUsage: { getUsage: getDashboardUsage },
+    });
+
+    await expect(
+      service.getUsage({ billingEnabled: true, userId: "user-1" }),
+    ).resolves.toEqual({
+      ...baseUsagePayload,
+      plan: { name: "Pro", slug: "pro" },
+      transactional: {
+        ...baseUsagePayload.transactional,
+        monthlyLimit: 50000,
+      },
+      team: {
+        ...baseUsagePayload.team,
+        domainsUsed: 4,
+        domainsLimit: 10,
+      },
+    });
+    expect(loadSummary).toHaveBeenCalledWith("user-1");
+  });
+
+  it.each([
+    { billingEnabled: false, userId: "user-1" },
+    { billingEnabled: true, userId: null },
+  ])("keeps base dashboard usage for %#", async (input) => {
+    const service = createBillingSummaryService({
+      loadSummary,
+      dashboardUsage: { getUsage: getDashboardUsage },
+    });
+
+    await expect(service.getUsage(input)).resolves.toEqual(baseUsagePayload);
+    expect(loadSummary).not.toHaveBeenCalled();
+  });
+
+  it("keeps base dashboard usage when no billing summary exists", async () => {
+    loadSummary.mockResolvedValueOnce(null);
+    const service = createBillingSummaryService({
+      loadSummary,
+      dashboardUsage: { getUsage: getDashboardUsage },
+    });
+
+    await expect(
+      service.getUsage({ billingEnabled: true, userId: "user-1" }),
+    ).resolves.toEqual(baseUsagePayload);
+  });
+});

--- a/tests/usage-route.test.ts
+++ b/tests/usage-route.test.ts
@@ -1,9 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetServerSession = vi.hoisted(() => vi.fn());
-const mockGetUsage = vi.hoisted(() => vi.fn());
 const mockIsBillingEnabled = vi.hoisted(() => vi.fn());
-const mockLoadBillingSummary = vi.hoisted(() => vi.fn());
+const mockGetUsage = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/api-auth", () => ({
   getServerSession: mockGetServerSession,
@@ -19,11 +18,7 @@ vi.mock("@/lib/billing", () => ({
 }));
 
 vi.mock("@/lib/billing/summary", () => ({
-  loadBillingSummary: mockLoadBillingSummary,
-}));
-
-vi.mock("@opensend/core", () => ({
-  createDashboardAggregateService: () => ({
+  createDefaultBillingSummaryService: () => ({
     getUsage: mockGetUsage,
   }),
 }));
@@ -58,63 +53,38 @@ describe("usage route adapter", () => {
       session: { id: "session-1" },
       user: { id: "user-1" },
     });
-    mockGetUsage.mockResolvedValue(usagePayload);
     mockIsBillingEnabled.mockReturnValue(false);
-    mockLoadBillingSummary.mockResolvedValue(null);
+    mockGetUsage.mockResolvedValue(usagePayload);
   });
 
-  it("keeps dashboard auth adapter-side and returns the core usage envelope", async () => {
+  it("keeps dashboard auth adapter-side and returns the service usage envelope", async () => {
     const usageRoute = await import("@/app/api/usage/route");
     const response = await usageRoute.GET();
 
     expect(response.status).toBe(200);
-    expect(mockGetUsage).toHaveBeenCalledOnce();
-    expect(mockLoadBillingSummary).not.toHaveBeenCalled();
+    expect(mockGetUsage).toHaveBeenCalledWith({
+      billingEnabled: false,
+      userId: "user-1",
+    });
     await expect(response.json()).resolves.toEqual(usagePayload);
   });
 
-  it("uses the billing summary as the source of truth for active plan domain limits", async () => {
+  it("passes billing-enabled state and optional user id to the service", async () => {
     mockIsBillingEnabled.mockReturnValue(true);
-    mockLoadBillingSummary.mockResolvedValueOnce({
-      plan: {
-        id: "plan-pro",
-        slug: "pro",
-        name: "Pro",
-        monthlyPriceCents: 2900,
-        monthlyEmailQuota: 50000,
-        maxDomains: 10,
-        maxApiKeys: 10,
-        isPublic: true,
-      },
-      subscription: null,
-      usage: {
-        emails: { used: 123, limit: 50000 },
-        domains: { used: 4, limit: 10 },
-        apiKeys: { used: 1, limit: 10 },
-        periodStart: null,
-        periodEnd: null,
-        hasUsagePeriod: false,
-      },
+    mockGetServerSession.mockResolvedValueOnce({
+      session: { id: "session-1" },
+      user: null,
     });
-
     const usageRoute = await import("@/app/api/usage/route");
+
     const response = await usageRoute.GET();
 
     expect(response.status).toBe(200);
-    expect(mockLoadBillingSummary).toHaveBeenCalledWith("user-1");
-    await expect(response.json()).resolves.toEqual({
-      ...usagePayload,
-      plan: { name: "Pro", slug: "pro" },
-      transactional: {
-        ...usagePayload.transactional,
-        monthlyLimit: 50000,
-      },
-      team: {
-        ...usagePayload.team,
-        domainsUsed: 4,
-        domainsLimit: 10,
-      },
+    expect(mockGetUsage).toHaveBeenCalledWith({
+      billingEnabled: true,
+      userId: undefined,
     });
+    await expect(response.json()).resolves.toEqual(usagePayload);
   });
 
   it("maps missing sessions and service failures to existing responses", async () => {


### PR DESCRIPTION
## Summary
- Extracted billing plans, billing summary DTO mapping, and `/api/usage` enrichment behind an injectable `createBillingSummaryService()` boundary.
- Kept Next route adapters thin: billing-enabled gates, dashboard auth, request-to-service calls, and preserved HTTP error mapping only.
- Added focused route/service tests for plans, billing summary, usage enrichment, and fallback behavior.

Closes #422

## Validation
- `bun run test tests/billing-summary-service.test.ts tests/billing-summary-routes.test.ts tests/usage-route.test.ts` — 3 files passed, 14 tests passed.
- `make check` — TypeScript passed; Biome lint/format passed.
- `make test` — 148 files passed, 1173 tests passed.
- Push guardrail during `git push` — `scripts/check-changed-files.mjs`, full-project typecheck, and changed-file Biome lint passed.

## Notes
- No live Stripe validation performed; this issue explicitly excludes hosted Stripe deploy/cutover and live Stripe validation.
- No dashboard UI, pricing/tier, trial, overage, paywall, or #132 status changes.
