### PR TITLE
Standardize API key examples on os_ prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 
 Opensend is a self-hostable email platform with the developer experience of Resend: REST APIs, SDKs, React email templates, domain verification, webhooks, broadcasts, automations, analytics, and an admin dashboard.
 
+Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+
 Use Opensend when you want:
 
 - **Control** — run email infrastructure on your own cloud and AWS SES quota.

--- a/agent_docs/learnings/active/2026-05-12-issue-427-api-key-prefix-docs-runtime.md
+++ b/agent_docs/learnings/active/2026-05-12-issue-427-api-key-prefix-docs-runtime.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-12
+issue: "#427"
+type: decision
+promoted_to: null
+---
+
+## API-key prefix docs can change independently from runtime generation
+
+Issue #427 standardized public examples and synthetic fixtures on `os_...` while explicitly requiring no runtime behavior change. Keep `packages/core/src/services/apiKeys.ts` token generation untouched unless a separate runtime-migration issue changes the persisted/API contract; docs, SDK README examples, in-app snippets, and test fixtures that merely model caller-provided OpenSend keys should use `os_...`.
+
+Legitimate `re_...` references may remain when documenting upstream Resend target-contract behavior in parity docs.

--- a/docs/sdk/go.md
+++ b/docs/sdk/go.md
@@ -4,6 +4,8 @@ OpenSend includes a minimal first-party Go SDK package at
 [`packages/go-sdk`](../../packages/go-sdk) for Resend-shaped transactional email
 sends.
 
+Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+
 ## Install
 
 ```bash

--- a/docs/sdk/python.md
+++ b/docs/sdk/python.md
@@ -4,6 +4,8 @@ OpenSend includes a minimal first-party Python SDK package at
 [`packages/python-sdk`](../../packages/python-sdk) for Resend-shaped
 transactional email sends.
 
+Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+
 ## Install
 
 From this repository:

--- a/packages/go-sdk/README.md
+++ b/packages/go-sdk/README.md
@@ -3,6 +3,8 @@
 Minimal first-party Go SDK for OpenSend transactional email sends with a
 Resend-shaped first send surface.
 
+Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+
 ## Installation
 
 From a Go module, install the package from this repository:

--- a/packages/go-sdk/opensend_test.go
+++ b/packages/go-sdk/opensend_test.go
@@ -33,7 +33,7 @@ func jsonResponse(status int, body string) *http.Response {
 func TestSendConstructsRequestWithAuthAndConfiguredBaseURL(t *testing.T) {
 	var called bool
 	client, err := NewClient(
-		"re_test",
+		"os_test",
 		WithBaseURL("https://api.example.test/base/"),
 		WithHTTPClient(testHTTPClient(t, func(req *http.Request) (*http.Response, error) {
 			called = true
@@ -43,7 +43,7 @@ func TestSendConstructsRequestWithAuthAndConfiguredBaseURL(t *testing.T) {
 			if got := req.URL.String(); got != "https://api.example.test/base/emails" {
 				t.Fatalf("url = %s, want https://api.example.test/base/emails", got)
 			}
-			if got := req.Header.Get("Authorization"); got != "Bearer re_test" {
+			if got := req.Header.Get("Authorization"); got != "Bearer os_test" {
 				t.Fatalf("authorization = %q", got)
 			}
 			if got := req.Header.Get("Content-Type"); got != "application/json" {
@@ -107,7 +107,7 @@ func TestSendConstructsRequestWithAuthAndConfiguredBaseURL(t *testing.T) {
 
 func TestNewClientDefaultsToHostedBaseURL(t *testing.T) {
 	client, err := NewClient(
-		"re_default",
+		"os_default",
 		WithHTTPClient(testHTTPClient(t, func(req *http.Request) (*http.Response, error) {
 			if got := req.URL.String(); got != "https://api.opensend.com/emails" {
 				t.Fatalf("url = %s, want https://api.opensend.com/emails", got)
@@ -135,7 +135,7 @@ func TestNewClientDefaultsToHostedBaseURL(t *testing.T) {
 
 func TestSendParsesAcceptedEmailID(t *testing.T) {
 	client, err := NewClient(
-		"re_parse",
+		"os_parse",
 		WithHTTPClient(testHTTPClient(t, func(req *http.Request) (*http.Response, error) {
 			return jsonResponse(http.StatusAccepted, `{"id":"email_accepted"}`), nil
 		})),
@@ -161,7 +161,7 @@ func TestSendParsesAcceptedEmailID(t *testing.T) {
 func TestSendNon2xxReturnsAPIErrorWithStatusBodyAndEnvelope(t *testing.T) {
 	body := `{"name":"validation_error","code":"validation_error","message":"Validation failed.","details":{"fieldErrors":{"to":["Required"]},"formErrors":[]}}`
 	client, err := NewClient(
-		"re_error",
+		"os_error",
 		WithHTTPClient(testHTTPClient(t, func(req *http.Request) (*http.Response, error) {
 			return jsonResponse(http.StatusUnprocessableEntity, body), nil
 		})),
@@ -198,10 +198,10 @@ func TestClientValidation(t *testing.T) {
 	if _, err := NewClient(""); err == nil || !strings.Contains(err.Error(), "API key") {
 		t.Fatalf("NewClient blank key error = %v", err)
 	}
-	if _, err := NewClient("re_test", WithBaseURL("ftp://example.com")); err == nil || !strings.Contains(err.Error(), "http or https") {
+	if _, err := NewClient("os_test", WithBaseURL("ftp://example.com")); err == nil || !strings.Contains(err.Error(), "http or https") {
 		t.Fatalf("NewClient ftp base url error = %v", err)
 	}
-	if _, err := NewClient("re_test", WithHTTPClient(nil)); err == nil || !strings.Contains(err.Error(), "http client") {
+	if _, err := NewClient("os_test", WithHTTPClient(nil)); err == nil || !strings.Contains(err.Error(), "http client") {
 		t.Fatalf("NewClient nil http client error = %v", err)
 	}
 }

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -3,6 +3,8 @@
 Minimal first-party Python SDK for OpenSend transactional email sends with a
 Resend-shaped API surface.
 
+Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+
 ## Installation
 
 This package is staged for future PyPI publishing. From this repository today:

--- a/packages/python-sdk/tests/test_emails.py
+++ b/packages/python-sdk/tests/test_emails.py
@@ -78,7 +78,7 @@ class OpenSendPythonSdkTests(unittest.TestCase):
         opensend.base_url = opensend.DEFAULT_BASE_URL
 
     def test_module_level_send_serializes_payload_and_auth_header(self) -> None:
-        opensend.api_key = "re_test"
+        opensend.api_key = "os_test"
         opensend.base_url = self.base_url
 
         response = opensend.Emails.send(
@@ -95,7 +95,7 @@ class OpenSendPythonSdkTests(unittest.TestCase):
         self.assertEqual(len(self.state.requests), 1)
         request = self.state.requests[0]
         self.assertEqual(request.path, "/emails")
-        self.assertEqual(request.headers["Authorization"], "Bearer re_test")
+        self.assertEqual(request.headers["Authorization"], "Bearer os_test")
         self.assertEqual(request.headers["Content-Type"], "application/json")
         self.assertEqual(
             request.body,
@@ -109,7 +109,7 @@ class OpenSendPythonSdkTests(unittest.TestCase):
         )
 
     def test_instance_client_normalizes_base_url_and_sends_idempotency_key(self) -> None:
-        client = opensend.OpenSend("re_instance", base_url=self.base_url)
+        client = opensend.OpenSend("os_instance", base_url=self.base_url)
 
         response = client.emails.send(
             {
@@ -124,14 +124,14 @@ class OpenSendPythonSdkTests(unittest.TestCase):
         self.assertEqual(response["id"], "email_123")
         request = self.state.requests[0]
         self.assertEqual(request.path, "/emails")
-        self.assertEqual(request.headers["Authorization"], "Bearer re_instance")
+        self.assertEqual(request.headers["Authorization"], "Bearer os_instance")
         self.assertEqual(request.headers["Idempotency-Key"], "send-key-1")
         self.assertEqual(request.body["from"], "hello@example.com")
         self.assertNotIn("from_", request.body)
 
     def test_send_batch_posts_to_root_batch_endpoint(self) -> None:
         self.state.response_body = {"data": [{"id": "email_a"}, {"id": "email_b"}]}
-        client = opensend.Resend("re_batch", base_url=self.base_url)
+        client = opensend.Resend("os_batch", base_url=self.base_url)
 
         response = client.emails.send_batch(
             [
@@ -154,7 +154,7 @@ class OpenSendPythonSdkTests(unittest.TestCase):
         self.assertEqual(response, {"data": [{"id": "email_a"}, {"id": "email_b"}]})
         request = self.state.requests[0]
         self.assertEqual(request.path, "/emails/batch")
-        self.assertEqual(request.headers["Authorization"], "Bearer re_batch")
+        self.assertEqual(request.headers["Authorization"], "Bearer os_batch")
         self.assertEqual(request.headers["Idempotency-Key"], "batch-key-1")
         self.assertEqual(request.body[1]["from"], "hello@example.com")
         self.assertNotIn("from_email", request.body[1])
@@ -168,7 +168,7 @@ class OpenSendPythonSdkTests(unittest.TestCase):
             "statusCode": 422,
             "details": {"fieldErrors": {"to": ["Required"]}, "formErrors": []},
         }
-        client = opensend.OpenSend("re_error", base_url=self.base_url)
+        client = opensend.OpenSend("os_error", base_url=self.base_url)
 
         with self.assertRaises(opensend.OpenSendError) as context:
             client.emails.send(
@@ -195,7 +195,7 @@ class OpenSendPythonSdkTests(unittest.TestCase):
             opensend.OpenSend("", base_url=self.base_url)
 
         with self.assertRaisesRegex(ValueError, "valid absolute http or https URL"):
-            opensend.OpenSend("re_test", base_url="ftp://example.com")
+            opensend.OpenSend("os_test", base_url="ftp://example.com")
 
         with self.assertRaisesRegex(ValueError, "set opensend.api_key"):
             opensend.Emails.send(

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,6 +2,8 @@
 
 TypeScript SDK for the OpenSend email API with a Resend-compatible client surface.
 
+Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+
 ## Installation
 
 ```bash

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -2,6 +2,8 @@
 
 `services/api` is the Bun + Hono control-plane API runtime for route families that have been moved out of Next.js ownership.
 
+Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+
 Local development convention:
 
 ```bash

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -393,6 +393,10 @@ export default function DocsPage() {
             <code className="px-1.5 py-0.5 bg-[rgba(24,25,28,0.88)] border border-[rgba(176,199,217,0.145)] rounded text-[13px] text-[#F0F0F0] font-mono">
               https://api.opensend.com
             </code>
+            .{" "}
+            {
+              "Use your OpenSend API key (`os_...`) with the Resend-compatible API surface."
+            }
           </p>
           <div className="mt-5 rounded-lg border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.5)] p-4">
             <p className="text-[13px] text-[#A1A4A5]">

--- a/src/components/api-code-drawer.tsx
+++ b/src/components/api-code-drawer.tsx
@@ -45,7 +45,7 @@ const EMAIL_SECTIONS: ApiCodeSection[] = [
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.emails.send({
   from: 'you@example.com',
@@ -54,7 +54,7 @@ const { data, error } = await resend.emails.send({
   html: '<p>Congrats on sending your <strong>first email</strong>!</p>',
 }, { idempotencyKey: 'welcome-user-123' });`,
       curl: `curl -X POST https://api.example.com/emails \\
-  -H "Authorization: Bearer re_123456789" \\
+  -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -H "Idempotency-Key: welcome-user-123" \\
   -d '{
@@ -70,7 +70,7 @@ const { data, error } = await resend.emails.send({
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.batch.send([
   {
@@ -87,7 +87,7 @@ const { data, error } = await resend.batch.send([
   },
 ], { idempotencyKey: 'batch-campaign-123' });`,
       curl: `curl -X POST https://api.example.com/emails/batch \\
-  -H "Authorization: Bearer re_123456789" \\
+  -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -H "Idempotency-Key: batch-campaign-123" \\
   -d '[
@@ -111,13 +111,13 @@ const { data, error } = await resend.batch.send([
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.emails.get(
   '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794'
 );`,
       curl: `curl -X GET https://api.example.com/emails/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794 \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
@@ -125,14 +125,14 @@ const { data, error } = await resend.emails.get(
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.emails.update({
   id: '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794',
   scheduledAt: '2024-08-05T11:52:01.858Z',
 });`,
       curl: `curl -X PATCH https://api.example.com/emails/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794 \\
-  -H "Authorization: Bearer re_123456789" \\
+  -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{
     "scheduledAt": "2024-08-05T11:52:01.858Z"
@@ -147,13 +147,13 @@ const DOMAIN_SECTIONS: ApiCodeSection[] = [
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.domains.create({
   name: 'example.com',
 });`,
       curl: `curl -X POST https://api.example.com/domains \\
-  -H "Authorization: Bearer re_123456789" \\
+  -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{"name": "example.com"}'`,
     },
@@ -163,13 +163,13 @@ const { data, error } = await resend.domains.create({
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.domains.get(
   'd91cd9bd-1176-453e-8fc1-35364d380206'
 );`,
       curl: `curl -X GET https://api.example.com/domains/d91cd9bd-1176-453e-8fc1-35364d380206 \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
@@ -177,13 +177,13 @@ const { data, error } = await resend.domains.get(
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.domains.verify(
   'd91cd9bd-1176-453e-8fc1-35364d380206'
 );`,
       curl: `curl -X POST https://api.example.com/domains/d91cd9bd-1176-453e-8fc1-35364d380206/verify \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
@@ -191,7 +191,7 @@ const { data, error } = await resend.domains.verify(
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.domains.update({
   id: 'd91cd9bd-1176-453e-8fc1-35364d380206',
@@ -199,7 +199,7 @@ const { data, error } = await resend.domains.update({
   clickTracking: true,
 });`,
       curl: `curl -X PATCH https://api.example.com/domains/d91cd9bd-1176-453e-8fc1-35364d380206 \\
-  -H "Authorization: Bearer re_123456789" \\
+  -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{
     "openTracking": true,
@@ -212,11 +212,11 @@ const { data, error } = await resend.domains.update({
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.domains.list();`,
       curl: `curl -X GET https://api.example.com/domains \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
@@ -224,13 +224,13 @@ const { data, error } = await resend.domains.list();`,
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.domains.remove(
   'd91cd9bd-1176-453e-8fc1-35364d380206'
 );`,
       curl: `curl -X DELETE https://api.example.com/domains/d91cd9bd-1176-453e-8fc1-35364d380206 \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
 ];
@@ -241,14 +241,14 @@ const WEBHOOK_SECTIONS: ApiCodeSection[] = [
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.webhooks.create({
   endpoint: 'https://example.com/webhooks',
   events: ['email.sent', 'email.delivered', 'email.bounced'],
 });`,
       curl: `curl -X POST https://api.example.com/webhooks \\
-  -H "Authorization: Bearer re_123456789" \\
+  -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{
     "endpoint": "https://example.com/webhooks",
@@ -261,11 +261,11 @@ const { data, error } = await resend.webhooks.create({
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.webhooks.list();`,
       curl: `curl -X GET https://api.example.com/webhooks \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
@@ -273,13 +273,13 @@ const { data, error } = await resend.webhooks.list();`,
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.webhooks.remove(
   'wh_123456789'
 );`,
       curl: `curl -X DELETE https://api.example.com/webhooks/wh_123456789 \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
 ];
@@ -290,14 +290,14 @@ const API_KEY_SECTIONS: ApiCodeSection[] = [
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.apiKeys.create({
   name: 'Production',
   permission: 'full_access',
 });`,
       curl: `curl -X POST https://api.example.com/api-keys \\
-  -H "Authorization: Bearer re_123456789" \\
+  -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{
     "name": "Production",
@@ -310,11 +310,11 @@ const { data, error } = await resend.apiKeys.create({
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.apiKeys.list();`,
       curl: `curl -X GET https://api.example.com/api-keys \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
@@ -322,13 +322,13 @@ const { data, error } = await resend.apiKeys.list();`,
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.apiKeys.remove(
   'key_123456789'
 );`,
       curl: `curl -X DELETE https://api.example.com/api-keys/key_123456789 \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
 ];
@@ -339,7 +339,7 @@ const CONTACT_SECTIONS: ApiCodeSection[] = [
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.contacts.create({
   email: 'user@example.com',
@@ -349,7 +349,7 @@ const { data, error } = await resend.contacts.create({
   segmentId: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
 });`,
       curl: `curl -X POST https://api.example.com/contacts \\
-  -H "Authorization: Bearer re_123456789" \\
+  -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{
     "email": "user@example.com",
@@ -365,13 +365,13 @@ const { data, error } = await resend.contacts.create({
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.contacts.list({
   segmentId: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
 });`,
       curl: `curl -X GET "https://api.example.com/contacts?segmentId=78261eea-8f8b-4381-83c6-79fa7120f1cf" \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
@@ -379,14 +379,14 @@ const { data, error } = await resend.contacts.list({
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.contacts.remove({
   id: '520784e2-887d-4c25-b53c-4ad46ad38100',
   segmentId: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
 });`,
       curl: `curl -X DELETE "https://api.example.com/contacts/520784e2-887d-4c25-b53c-4ad46ad38100?segmentId=78261eea-8f8b-4381-83c6-79fa7120f1cf" \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
 ];
@@ -397,7 +397,7 @@ const BROADCAST_SECTIONS: ApiCodeSection[] = [
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.broadcasts.create({
   segmentId: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
@@ -406,7 +406,7 @@ const { data, error } = await resend.broadcasts.create({
   html: '<p>Hello subscribers!</p>',
 });`,
       curl: `curl -X POST https://api.example.com/broadcasts \\
-  -H "Authorization: Bearer re_123456789" \\
+  -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{
     "segmentId": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
@@ -421,13 +421,13 @@ const { data, error } = await resend.broadcasts.create({
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.broadcasts.send(
   '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794'
 );`,
       curl: `curl -X POST https://api.example.com/broadcasts/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794/send \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
@@ -435,11 +435,11 @@ const { data, error } = await resend.broadcasts.send(
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.broadcasts.list();`,
       curl: `curl -X GET https://api.example.com/broadcasts \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
 ];
@@ -450,14 +450,14 @@ const TEMPLATE_SECTIONS: ApiCodeSection[] = [
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.templates.create({
   name: 'Welcome Email',
   html: '<p>Welcome {{name}}!</p>',
 });`,
       curl: `curl -X POST https://api.example.com/templates \\
-  -H "Authorization: Bearer re_123456789" \\
+  -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{
     "name": "Welcome Email",
@@ -470,11 +470,11 @@ const { data, error } = await resend.templates.create({
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.templates.list();`,
       curl: `curl -X GET https://api.example.com/templates \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
@@ -482,13 +482,13 @@ const { data, error } = await resend.templates.list();`,
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.templates.remove(
   'tmpl_123456789'
 );`,
       curl: `curl -X DELETE https://api.example.com/templates/tmpl_123456789 \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
 ];
@@ -499,13 +499,13 @@ const SEGMENT_SECTIONS: ApiCodeSection[] = [
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.segments.create({
   name: 'Newsletter Subscribers',
 });`,
       curl: `curl -X POST https://api.example.com/segments \\
-  -H "Authorization: Bearer re_123456789" \\
+  -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{"name": "Newsletter Subscribers"}'`,
     },
@@ -515,11 +515,11 @@ const { data, error } = await resend.segments.create({
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.segments.list();`,
       curl: `curl -X GET https://api.example.com/segments \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
@@ -527,13 +527,13 @@ const { data, error } = await resend.segments.list();`,
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.segments.remove(
   '78261eea-8f8b-4381-83c6-79fa7120f1cf'
 );`,
       curl: `curl -X DELETE https://api.example.com/segments/78261eea-8f8b-4381-83c6-79fa7120f1cf \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
 ];
@@ -544,13 +544,13 @@ const TOPIC_SECTIONS: ApiCodeSection[] = [
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.topics.create({
   name: 'Product Updates',
 });`,
       curl: `curl -X POST https://api.example.com/topics \\
-  -H "Authorization: Bearer re_123456789" \\
+  -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{"name": "Product Updates"}'`,
     },
@@ -560,11 +560,11 @@ const { data, error } = await resend.topics.create({
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.topics.list();`,
       curl: `curl -X GET https://api.example.com/topics \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
@@ -572,13 +572,13 @@ const { data, error } = await resend.topics.list();`,
     code: {
       nodejs: `import { Resend } from 'resend';
 
-const resend = new Resend('re_123456789');
+const resend = new Resend('os_123456789');
 
 const { data, error } = await resend.topics.remove(
   'topic_123456789'
 );`,
       curl: `curl -X DELETE https://api.example.com/topics/topic_123456789 \\
-  -H "Authorization: Bearer re_123456789"`,
+  -H "Authorization: Bearer os_123456789"`,
     },
   },
 ];

--- a/src/components/settings-page.tsx
+++ b/src/components/settings-page.tsx
@@ -169,7 +169,7 @@ export function SettingsPage({
               {`SMTP_HOST=smtp.opensend.com
 SMTP_PORT=465
 SMTP_USER=resend
-SMTP_PASS=re_YOUR_API_KEY`}
+SMTP_PASS=os_YOUR_API_KEY`}
             </pre>
           </div>
         </div>

--- a/tests/api-auth-cache.test.ts
+++ b/tests/api-auth-cache.test.ts
@@ -31,7 +31,7 @@ describe("api key auth cache", () => {
   });
 
   it("returns cached auth results without hitting the database", async () => {
-    const rawKey = "re_cached";
+    const rawKey = "os_cached";
     const tokenHash = createHash("sha256").update(rawKey).digest("hex");
     mockReadCache.mockResolvedValue({
       status: "hit",
@@ -57,7 +57,7 @@ describe("api key auth cache", () => {
   });
 
   it("falls back to the database on cache miss and writes the result back", async () => {
-    const rawKey = "re_miss";
+    const rawKey = "os_miss";
     const tokenHash = createHash("sha256").update(rawKey).digest("hex");
     mockReadCache.mockResolvedValue({ status: "miss", value: null });
     mockFindFirst.mockResolvedValue({
@@ -97,7 +97,7 @@ describe("api key auth cache", () => {
 
     const { validateApiKey } = await import("@/lib/api-auth");
 
-    await expect(validateApiKey("Bearer re_unknown")).resolves.toBeNull();
+    await expect(validateApiKey("Bearer os_unknown")).resolves.toBeNull();
     expect(mockFindFirst).toHaveBeenCalledOnce();
   });
 

--- a/tests/api-auth-date-range-routes.test.ts
+++ b/tests/api-auth-date-range-routes.test.ts
@@ -81,7 +81,7 @@ describe("lib/api-auth", () => {
   });
 
   it("validates a bearer API key by sha256 token hash", async () => {
-    const rawKey = "re_test_123";
+    const rawKey = "os_test_123";
     const tokenHash = createHash("sha256").update(rawKey).digest("hex");
     mockFindFirst.mockResolvedValue({
       id: "key-1",

--- a/tests/api-automations-events.test.ts
+++ b/tests/api-automations-events.test.ts
@@ -296,7 +296,7 @@ function jsonRequest(url: string, body: unknown, method = "POST") {
   return new Request(url, {
     method,
     headers: {
-      Authorization: "Bearer re_test",
+      Authorization: "Bearer os_test",
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),
@@ -434,7 +434,7 @@ describe("automation API routes", () => {
 
     const response = await GET(
       new Request("http://localhost/api/automations", {
-        headers: { Authorization: "Bearer re_sending" },
+        headers: { Authorization: "Bearer os_sending" },
       }),
     );
 
@@ -1050,7 +1050,7 @@ describe("automation API routes", () => {
     const response = await GET(
       new Request(
         "http://localhost/api/automations/auto_1/runs?status=queued,waiting&limit=10",
-        { headers: { Authorization: "Bearer re_test" } },
+        { headers: { Authorization: "Bearer os_test" } },
       ),
       { params: Promise.resolve({ id: "auto_1" }) },
     );
@@ -1081,7 +1081,7 @@ describe("automation API routes", () => {
 
     const response = await GET(
       new Request("http://localhost/api/automations/auto_1/runs/run_1", {
-        headers: { Authorization: "Bearer re_test" },
+        headers: { Authorization: "Bearer os_test" },
       }),
       { params: Promise.resolve({ id: "auto_1", runId: "run_1" }) },
     );
@@ -1188,7 +1188,7 @@ describe("automation API routes", () => {
     const response = await GET(
       new Request(
         "http://localhost/api/automations/auto_1/runs/metrics?from=2026-05-02T00%3A00%3A00.000Z&to=2026-05-03T00%3A00%3A00.000Z",
-        { headers: { Authorization: "Bearer re_test" } },
+        { headers: { Authorization: "Bearer os_test" } },
       ),
       { params: Promise.resolve({ id: "auto_1" }) },
     );
@@ -1231,7 +1231,7 @@ describe("automation API routes", () => {
 
     const response = await GET(
       new Request("http://localhost/api/automations/auto_1/runs/missing", {
-        headers: { Authorization: "Bearer re_test" },
+        headers: { Authorization: "Bearer os_test" },
       }),
       { params: Promise.resolve({ id: "auto_1", runId: "missing" }) },
     );
@@ -1312,7 +1312,7 @@ describe("events API routes", () => {
     );
     const listed = await GET(
       new Request("http://localhost/api/events?limit=10&after=evt_0", {
-        headers: { Authorization: "Bearer re_test" },
+        headers: { Authorization: "Bearer os_test" },
       }),
     );
 
@@ -1351,7 +1351,7 @@ describe("events API routes", () => {
     const response = await DELETE(
       new Request("http://localhost/api/events?id=evt_1", {
         method: "DELETE",
-        headers: { Authorization: "Bearer re_test" },
+        headers: { Authorization: "Bearer os_test" },
       }),
     );
 
@@ -1376,7 +1376,7 @@ describe("events API routes", () => {
     const response = await DELETE(
       new Request("http://localhost/api/events?id=missing", {
         method: "DELETE",
-        headers: { Authorization: "Bearer re_test" },
+        headers: { Authorization: "Bearer os_test" },
       }),
     );
 

--- a/tests/api-domains.test.ts
+++ b/tests/api-domains.test.ts
@@ -104,7 +104,7 @@ function makeRequest(
   const init: RequestInit = {
     method,
     headers: {
-      Authorization: "Bearer re_test123",
+      Authorization: "Bearer os_test123",
       "Content-Type": "application/json",
     },
   };

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -385,7 +385,7 @@ describe("POST /api/emails", () => {
     const req = makeRequest(
       "POST",
       { from: "test@domain.com" },
-      { Authorization: "Bearer re_test123" },
+      { Authorization: "Bearer os_test123" },
     );
     const res = await POST(req);
     expect(res.status).toBe(422);
@@ -410,7 +410,7 @@ describe("POST /api/emails", () => {
     const req = new Request("http://localhost:3015/api/emails", {
       method: "POST",
       headers: {
-        Authorization: "Bearer re_test123",
+        Authorization: "Bearer os_test123",
         "Content-Type": "application/json",
       },
       body: "{",
@@ -432,7 +432,7 @@ describe("POST /api/emails", () => {
     const req = makeRequest(
       "POST",
       { to: ["user@test.com"], subject: "Test", html: "<p>Hi</p>" },
-      { Authorization: "Bearer re_test123" },
+      { Authorization: "Bearer os_test123" },
     );
     const res = await POST(req);
     expect(res.status).toBe(422);
@@ -459,7 +459,7 @@ describe("POST /api/emails", () => {
         html: "<p>Hello</p>",
       },
       {
-        Authorization: "Bearer re_test123",
+        Authorization: "Bearer os_test123",
         "x-correlation-id": "corr-email-test",
         traceparent,
       },
@@ -558,7 +558,7 @@ describe("POST /api/emails", () => {
             variables: {},
           },
         },
-        { Authorization: "Bearer re_test123" },
+        { Authorization: "Bearer os_test123" },
       ),
     );
 
@@ -619,7 +619,7 @@ describe("POST /api/emails", () => {
             variables: { PRODUCT: "Widget" },
           },
         },
-        { Authorization: "Bearer re_test123" },
+        { Authorization: "Bearer os_test123" },
       ),
     );
 
@@ -668,7 +668,7 @@ describe("POST /api/emails", () => {
             variables: {},
           },
         },
-        { Authorization: "Bearer re_test123" },
+        { Authorization: "Bearer os_test123" },
       ),
     );
 
@@ -712,7 +712,7 @@ describe("POST /api/emails", () => {
           subject: "Test Email",
           html: "<p>Hello</p>",
         },
-        { Authorization: "Bearer re_test123" },
+        { Authorization: "Bearer os_test123" },
       ),
     );
 
@@ -760,7 +760,7 @@ describe("POST /api/emails", () => {
           html: "<p>Hello</p>",
         },
         {
-          Authorization: "Bearer re_test123",
+          Authorization: "Bearer os_test123",
           "Idempotency-Key": "send-key-1",
         },
       ),
@@ -814,7 +814,7 @@ describe("POST /api/emails", () => {
           subject: "Fast queue",
           html: "<p>Hello</p>",
         },
-        { Authorization: "Bearer re_test123" },
+        { Authorization: "Bearer os_test123" },
       );
 
       const startedAt = performance.now();
@@ -855,7 +855,7 @@ describe("POST /api/emails", () => {
         subject: "Test",
         html: "<p>Hi</p>",
       },
-      { Authorization: "Bearer re_test123" },
+      { Authorization: "Bearer os_test123" },
     );
     const res = await POST(req);
     expect(res.status).toBe(200);
@@ -882,7 +882,7 @@ describe("POST /api/emails", () => {
           subject: "Recipient forms",
           html: "<p>Hi</p>",
         },
-        { Authorization: "Bearer re_test123" },
+        { Authorization: "Bearer os_test123" },
       ),
     );
 
@@ -921,7 +921,7 @@ describe("POST /api/emails", () => {
         html: "<p>Hi</p>",
         tags,
       },
-      { Authorization: "Bearer re_test123" },
+      { Authorization: "Bearer os_test123" },
     );
 
     const res = await POST(req);
@@ -945,7 +945,7 @@ describe("POST /api/emails", () => {
         html: "<p>Hi</p>",
         tags: [{ name: "campaign.id", value: "spring 2026" }],
       },
-      { Authorization: "Bearer re_test123" },
+      { Authorization: "Bearer os_test123" },
     );
 
     const res = await POST(req);
@@ -987,7 +987,7 @@ describe("POST /api/emails", () => {
           "POST",
           { ...basePayload, tags },
           {
-            Authorization: "Bearer re_test123",
+            Authorization: "Bearer os_test123",
           },
         ),
       );
@@ -1024,7 +1024,7 @@ describe("POST /api/emails", () => {
           value: "ok",
         })),
       },
-      { Authorization: "Bearer re_test123" },
+      { Authorization: "Bearer os_test123" },
     );
 
     const res = await POST(req);
@@ -1069,7 +1069,7 @@ describe("POST /api/emails", () => {
         html: '<p><a href="{{{RESEND_UNSUBSCRIBE_URL}}}">Unsubscribe</a></p>',
         headers: { "X-Custom": "ok" },
       },
-      { Authorization: "Bearer re_test123" },
+      { Authorization: "Bearer os_test123" },
     );
 
     const res = await POST(req);
@@ -1104,7 +1104,7 @@ describe("POST /api/emails", () => {
         subject: "Sandbox delivered",
         html: "<p>Sandbox</p>",
       },
-      { Authorization: "Bearer re_test123" },
+      { Authorization: "Bearer os_test123" },
     );
 
     const res = await POST(req);
@@ -1141,7 +1141,7 @@ describe("POST /api/emails", () => {
         subject: "Suppressed sandbox",
         html: "<p>No send</p>",
       },
-      { Authorization: "Bearer re_test123" },
+      { Authorization: "Bearer os_test123" },
     );
 
     const res = await POST(req);
@@ -1184,7 +1184,7 @@ describe("POST /api/emails", () => {
         subject: "Suppressed",
         html: "<p>No send</p>",
       },
-      { Authorization: "Bearer re_test123" },
+      { Authorization: "Bearer os_test123" },
     );
 
     const res = await POST(req);
@@ -1230,7 +1230,7 @@ describe("POST /api/emails", () => {
           },
         ],
       },
-      { Authorization: "Bearer re_test123" },
+      { Authorization: "Bearer os_test123" },
     );
 
     const res = await POST(req);
@@ -1270,7 +1270,7 @@ describe("POST /api/emails", () => {
           html: "<p>Hi</p>",
           attachments: [{ filename: "missing.txt" }],
         },
-        { Authorization: "Bearer re_test123" },
+        { Authorization: "Bearer os_test123" },
       ),
     );
 
@@ -1305,7 +1305,7 @@ describe("POST /api/emails", () => {
             },
           ],
         },
-        { Authorization: "Bearer re_test123" },
+        { Authorization: "Bearer os_test123" },
       ),
     );
 
@@ -1346,7 +1346,7 @@ describe("POST /api/emails", () => {
           html: "<p>ISO</p>",
           scheduled_at: "2026-05-08T00:00:00.000Z",
         },
-        { Authorization: "Bearer re_test123" },
+        { Authorization: "Bearer os_test123" },
       ),
     );
     const naturalRes = await POST(
@@ -1359,7 +1359,7 @@ describe("POST /api/emails", () => {
           html: "<p>Natural</p>",
           scheduled_at: "in 1 min",
         },
-        { Authorization: "Bearer re_test123" },
+        { Authorization: "Bearer os_test123" },
       ),
     );
 
@@ -1397,7 +1397,7 @@ describe("POST /api/emails", () => {
         makeRequest(
           "POST",
           { ...payload, scheduled_at },
-          { Authorization: "Bearer re_test123" },
+          { Authorization: "Bearer os_test123" },
         ),
       );
       expect(res.status).toBe(422);
@@ -1467,7 +1467,7 @@ describe("POST /api/emails/batch", () => {
       html: `<p>${i}</p>`,
     }));
     const req = makeRequest("POST", emailsArr, {
-      Authorization: "Bearer re_test123",
+      Authorization: "Bearer os_test123",
     });
     const res = await POST(req);
     expect(res.status).toBe(422);
@@ -1486,7 +1486,7 @@ describe("POST /api/emails/batch", () => {
     const req = new Request("http://localhost:3015/api/emails/batch", {
       method: "POST",
       headers: {
-        Authorization: "Bearer re_test123",
+        Authorization: "Bearer os_test123",
         "Content-Type": "application/json",
       },
       body: "[",
@@ -1521,7 +1521,7 @@ describe("POST /api/emails/batch", () => {
           },
         ],
         {
-          Authorization: "Bearer re_test123",
+          Authorization: "Bearer os_test123",
           "Idempotency-Key": "x".repeat(256),
         },
       ),
@@ -1551,7 +1551,7 @@ describe("POST /api/emails/batch", () => {
         },
       ],
       {
-        Authorization: "Bearer re_test123",
+        Authorization: "Bearer os_test123",
         "Idempotency-Key": "x".repeat(257),
       },
     );
@@ -1610,13 +1610,13 @@ describe("POST /api/emails/batch", () => {
 
     const first = await POST(
       makeRequest("POST", emailsArr, {
-        Authorization: "Bearer re_test123",
+        Authorization: "Bearer os_test123",
         "Idempotency-Key": "batch-key-1",
       }),
     );
     const retry = await POST(
       makeRequest("POST", emailsArr, {
-        Authorization: "Bearer re_test123",
+        Authorization: "Bearer os_test123",
         "Idempotency-Key": "batch-key-1",
       }),
     );
@@ -1700,7 +1700,7 @@ describe("POST /api/emails/batch", () => {
           text: "Leave: {{{RESEND_UNSUBSCRIBE_URL}}}",
         },
       ],
-      { Authorization: "Bearer re_test123" },
+      { Authorization: "Bearer os_test123" },
     );
 
     const res = await POST(req);
@@ -1752,7 +1752,7 @@ describe("POST /api/emails/batch", () => {
           html: "<p>Suppressed</p>",
         },
       ],
-      { Authorization: "Bearer re_test123" },
+      { Authorization: "Bearer os_test123" },
     );
 
     const res = await POST(req);
@@ -1820,7 +1820,7 @@ describe("POST /api/emails/batch", () => {
           html: "<p>Blocked</p>",
         },
       ],
-      { Authorization: "Bearer re_test123" },
+      { Authorization: "Bearer os_test123" },
     );
 
     const res = await POST(req);
@@ -1881,7 +1881,7 @@ describe("POST /api/emails/batch", () => {
       },
     ];
     const req = makeRequest("POST", emailsArr, {
-      Authorization: "Bearer re_test123",
+      Authorization: "Bearer os_test123",
     });
     const res = await POST(req);
     expect(res.status).toBe(200);
@@ -1914,7 +1914,7 @@ describe("POST /api/emails/batch", () => {
             tags: [{ name: "bad.name", value: "bad value" }],
           },
         ],
-        { Authorization: "Bearer re_test123" },
+        { Authorization: "Bearer os_test123" },
       ),
     );
 
@@ -1954,7 +1954,7 @@ describe("POST /api/emails/batch", () => {
             })),
           },
         ],
-        { Authorization: "Bearer re_test123" },
+        { Authorization: "Bearer os_test123" },
       ),
     );
 
@@ -2002,7 +2002,7 @@ describe("POST /api/emails/batch", () => {
             scheduled_at: "in 2 hours",
           },
         ],
-        { Authorization: "Bearer re_test123" },
+        { Authorization: "Bearer os_test123" },
       ),
     );
 
@@ -2037,7 +2037,7 @@ describe("POST /api/emails/batch", () => {
     ]) {
       const res = await POST(
         makeRequest("POST", [{ ...base, scheduled_at }], {
-          Authorization: "Bearer re_test123",
+          Authorization: "Bearer os_test123",
         }),
       );
       expect(res.status).toBe(422);
@@ -2105,7 +2105,7 @@ describe("services/api transactional email routes", () => {
     const res = await createApp().request("/emails", {
       method: "POST",
       headers: {
-        Authorization: "Bearer re_test123",
+        Authorization: "Bearer os_test123",
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
@@ -2157,7 +2157,7 @@ describe("services/api transactional email routes", () => {
     const invalid = await app.request("/emails", {
       method: "POST",
       headers: {
-        Authorization: "Bearer re_test123",
+        Authorization: "Bearer os_test123",
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ from: "sender@domain.com" }),
@@ -2191,7 +2191,7 @@ describe("services/api transactional email routes", () => {
     const res = await createApp().request("/emails", {
       method: "POST",
       headers: {
-        Authorization: "Bearer re_test123",
+        Authorization: "Bearer os_test123",
         "Content-Type": "application/json",
         "Idempotency-Key": "svc-idempotency-1",
       },
@@ -2223,7 +2223,7 @@ describe("services/api transactional email routes", () => {
     const res = await createApp().request("/emails/batch", {
       method: "POST",
       headers: {
-        Authorization: "Bearer re_test123",
+        Authorization: "Bearer os_test123",
         "Content-Type": "application/json",
         "Idempotency-Key": "svc-batch-key-1",
       },
@@ -2309,7 +2309,7 @@ describe("GET /api/emails", () => {
 
     const { GET } = await import("@/app/api/emails/route");
     const req = new Request("http://localhost:3015/api/emails?limit=20", {
-      headers: { Authorization: "Bearer re_test123" },
+      headers: { Authorization: "Bearer os_test123" },
     });
     const res = await GET(req);
     expect(res.status).toBe(200);
@@ -2355,7 +2355,7 @@ describe("GET /api/emails", () => {
 
     const { GET } = await import("@/app/api/emails/route");
     const req = new Request("http://localhost:3015/api/emails?status=queued", {
-      headers: { Authorization: "Bearer re_test123" },
+      headers: { Authorization: "Bearer os_test123" },
     });
 
     const res = await GET(req);
@@ -2409,7 +2409,7 @@ describe("GET /api/emails/:id", () => {
 
     const { GET } = await import("@/app/api/emails/[id]/route");
     const req = new Request("http://localhost:3015/api/emails/email-uuid", {
-      headers: { Authorization: "Bearer re_test123" },
+      headers: { Authorization: "Bearer os_test123" },
     });
     const res = await GET(req, {
       params: Promise.resolve({ id: "email-uuid" }),
@@ -2433,7 +2433,7 @@ describe("GET /api/emails/:id", () => {
 
     const { GET } = await import("@/app/api/emails/[id]/route");
     const req = new Request("http://localhost:3015/api/emails/nonexistent", {
-      headers: { Authorization: "Bearer re_test123" },
+      headers: { Authorization: "Bearer os_test123" },
     });
     const res = await GET(req, {
       params: Promise.resolve({ id: "nonexistent" }),
@@ -2464,7 +2464,7 @@ describe("PATCH /api/emails/:id", () => {
     const res = await PATCH(
       new Request("http://localhost:3015/api/emails/email-uuid", {
         method: "PATCH",
-        headers: { Authorization: "Bearer re_test123" },
+        headers: { Authorization: "Bearer os_test123" },
         body: JSON.stringify({ scheduled_at: "2026-05-08T00:00:00.000Z" }),
       }),
       { params: Promise.resolve({ id: "email-uuid" }) },
@@ -2487,7 +2487,7 @@ describe("PATCH /api/emails/:id", () => {
     const res = await PATCH(
       new Request("http://localhost:3015/api/emails/email-uuid", {
         method: "PATCH",
-        headers: { Authorization: "Bearer re_test123" },
+        headers: { Authorization: "Bearer os_test123" },
         body: "{invalid",
       }),
       { params: Promise.resolve({ id: "email-uuid" }) },
@@ -2525,7 +2525,7 @@ describe("PATCH /api/emails/:id", () => {
       const res = await PATCH(
         new Request("http://localhost:3015/api/emails/email-uuid", {
           method: "PATCH",
-          headers: { Authorization: "Bearer re_test123" },
+          headers: { Authorization: "Bearer os_test123" },
           body: JSON.stringify({ scheduled_at: null }),
         }),
         { params: Promise.resolve({ id: "email-uuid" }) },
@@ -2547,7 +2547,7 @@ describe("PATCH /api/emails/:id", () => {
     const res = await PATCH(
       new Request("http://localhost:3015/api/emails/email-uuid", {
         method: "PATCH",
-        headers: { Authorization: "Bearer re_test123" },
+        headers: { Authorization: "Bearer os_test123" },
         body: JSON.stringify([]),
       }),
       { params: Promise.resolve({ id: "email-uuid" }) },
@@ -2579,7 +2579,7 @@ describe("DELETE /api/emails", () => {
     const res = await DELETE(
       new Request("http://localhost:3015/api/emails?id=email-uuid", {
         method: "DELETE",
-        headers: { Authorization: "Bearer re_test123" },
+        headers: { Authorization: "Bearer os_test123" },
       }),
     );
 
@@ -2615,7 +2615,7 @@ describe("GET /api/emails/:id/attachments", () => {
     const { GET } = await import("@/app/api/emails/[id]/attachments/route");
     const res = await GET(
       new Request("http://localhost:3015/api/emails/email-uuid/attachments", {
-        headers: { Authorization: "Bearer re_test123" },
+        headers: { Authorization: "Bearer os_test123" },
       }) as never,
       { params: Promise.resolve({ id: "email-uuid" }) },
     );
@@ -2645,7 +2645,7 @@ describe("GET /api/emails/:id/attachments", () => {
     const { GET } = await import("@/app/api/emails/[id]/attachments/route");
     const res = await GET(
       new Request("http://localhost:3015/api/emails/email-uuid/attachments", {
-        headers: { Authorization: "Bearer re_test123" },
+        headers: { Authorization: "Bearer os_test123" },
       }) as never,
       { params: Promise.resolve({ id: "email-uuid" }) },
     );
@@ -2669,7 +2669,7 @@ describe("GET /api/emails/:id/attachments", () => {
       new Request(
         "http://localhost:3015/api/emails/email-uuid/attachments/missing",
         {
-          headers: { Authorization: "Bearer re_test123" },
+          headers: { Authorization: "Bearer os_test123" },
         },
       ) as never,
       {
@@ -2710,7 +2710,7 @@ describe("POST /api/emails/:id/cancel", () => {
     const res = await POST(
       new Request("http://localhost:3015/api/emails/email-uuid/cancel", {
         method: "POST",
-        headers: { Authorization: "Bearer re_test123" },
+        headers: { Authorization: "Bearer os_test123" },
       }) as never,
       { params: Promise.resolve({ id: "email-uuid" }) },
     );
@@ -2739,7 +2739,7 @@ describe("POST /api/emails/:id/cancel", () => {
     const res = await POST(
       new Request("http://localhost:3015/api/emails/email-uuid/cancel", {
         method: "POST",
-        headers: { Authorization: "Bearer re_test123" },
+        headers: { Authorization: "Bearer os_test123" },
       }) as never,
       { params: Promise.resolve({ id: "email-uuid" }) },
     );
@@ -2766,7 +2766,7 @@ describe("GET /api/emails/:id/events", () => {
     const { GET } = await import("@/app/api/emails/[id]/events/route");
     const res = await GET(
       new Request("http://localhost:3015/api/emails/email-uuid/events", {
-        headers: { Authorization: "Bearer re_test123" },
+        headers: { Authorization: "Bearer os_test123" },
       }) as never,
       { params: Promise.resolve({ id: "email-uuid" }) },
     );
@@ -2796,7 +2796,7 @@ describe("GET /api/emails/:id/events", () => {
     const { GET } = await import("@/app/api/emails/[id]/events/route");
     const res = await GET(
       new Request("http://localhost:3015/api/emails/email-uuid/events", {
-        headers: { Authorization: "Bearer re_test123" },
+        headers: { Authorization: "Bearer os_test123" },
       }) as never,
       { params: Promise.resolve({ id: "email-uuid" }) },
     );
@@ -2866,7 +2866,7 @@ describe("API key sending permissions", () => {
           subject: "Allowed",
           html: "<p>Hello</p>",
         },
-        { Authorization: "Bearer re_sending" },
+        { Authorization: "Bearer os_sending" },
       ),
     );
 
@@ -2895,7 +2895,7 @@ describe("API key sending permissions", () => {
           subject: "Blocked",
           html: "<p>Hello</p>",
         },
-        { Authorization: "Bearer re_sending" },
+        { Authorization: "Bearer os_sending" },
       ),
     );
 

--- a/tests/api-key-detail.test.tsx
+++ b/tests/api-key-detail.test.tsx
@@ -20,7 +20,7 @@ import {
 const mockKey: ApiKeyDetailData = {
   id: "key-123",
   name: "testing",
-  tokenPreview: "re_jQP...TWu",
+  tokenPreview: "os_jQP...TWu",
   permission: "full_access",
   domain: null,
   domainName: "All domains",
@@ -55,7 +55,7 @@ describe("ApiKeyDetail", () => {
     expect(screen.getByText("All domains")).toBeTruthy();
     expect(screen.getByText("TOTAL USES")).toBeTruthy();
     expect(screen.getByText("TOKEN")).toBeTruthy();
-    expect(screen.getByText("re_jQP...TWu")).toBeTruthy();
+    expect(screen.getByText("os_jQP...TWu")).toBeTruthy();
     expect(screen.getByText("LAST USED")).toBeTruthy();
     expect(screen.getByText("CREATED")).toBeTruthy();
     expect(screen.getByText("CREATOR")).toBeTruthy();
@@ -133,6 +133,6 @@ describe("ApiKeyDetail", () => {
   it("token is always truncated", () => {
     render(<ApiKeyDetail apiKey={mockKey} domains={mockDomains} />);
     // Token should show truncated prefix, never full key
-    expect(screen.getByText("re_jQP...TWu")).toBeTruthy();
+    expect(screen.getByText("os_jQP...TWu")).toBeTruthy();
   });
 });

--- a/tests/api-key-routes.test.ts
+++ b/tests/api-key-routes.test.ts
@@ -67,7 +67,7 @@ const lastUsedAt = new Date("2026-05-10T01:00:00.000Z");
 function request(url: string, init: RequestInit = {}) {
   const headers = new Headers(init.headers);
   if (!headers.has("authorization")) {
-    headers.set("authorization", "Bearer re_test");
+    headers.set("authorization", "Bearer os_test");
   }
 
   return new Request(url, {
@@ -126,7 +126,7 @@ describe("API key route boundary", () => {
           lastUsedAt,
           permission: "full_access",
           domain: null,
-          token: "re_should_not_leak",
+          token: "os_should_not_leak",
           tokenHash: "hash-should-not-leak",
         },
       ],
@@ -163,7 +163,7 @@ describe("API key route boundary", () => {
   it("creates API keys after quota check and returns the token only in the create response", async () => {
     mockCreateApiKey.mockResolvedValue({
       id: "created-key",
-      token: "re_created",
+      token: "os_created",
       tokenHash: "hash-created",
     });
 
@@ -179,7 +179,7 @@ describe("API key route boundary", () => {
     expect(response.status).toBe(201);
     await expect(response.json()).resolves.toEqual({
       id: "created-key",
-      token: "re_created",
+      token: "os_created",
     });
     expect(mockCheckApiKeyQuota).toHaveBeenCalledWith("user-1");
     expect(mockCreateApiKey).toHaveBeenCalledWith({
@@ -208,7 +208,7 @@ describe("API key route boundary", () => {
       },
     });
     expect(JSON.stringify(mockRecordAuditEvent.mock.calls)).not.toContain(
-      "re_created",
+      "os_created",
     );
   });
 

--- a/tests/api-key-service.test.ts
+++ b/tests/api-key-service.test.ts
@@ -18,7 +18,7 @@ function apiKeyRow(overrides: Partial<ApiKeyRow> = {}): ApiKeyRow {
     id: "key-1",
     name: "Primary",
     tokenHash: "hash-1",
-    tokenPreview: "re_123...abcd",
+    tokenPreview: "os_123...abcd",
     permission: "full_access",
     domain: null,
     lastUsedAt: null,
@@ -65,7 +65,7 @@ describe("api key service", () => {
 
     const service = createApiKeyService({
       repository,
-      generateRawKey: () => "re_1234567890abcdef",
+      generateRawKey: () => "os_1234567890abcdef",
       invalidateAuthCache,
     });
 
@@ -77,15 +77,15 @@ describe("api key service", () => {
 
     expect(result).toEqual({
       id: "created-key",
-      token: "re_1234567890abcdef",
+      token: "os_1234567890abcdef",
       tokenHash:
-        "437645b2b0886d92d681fba33b3096bc45cea50aed15a8a812a15fbb7082a49c",
+        "c6211569fdd72118cc04a214c955d05f6d25c8746b012a6cd224359c82841f18",
     });
     expect(inserted).toMatchObject({
       name: "Primary",
       tokenHash:
-        "437645b2b0886d92d681fba33b3096bc45cea50aed15a8a812a15fbb7082a49c",
-      tokenPreview: "re_123...cdef",
+        "c6211569fdd72118cc04a214c955d05f6d25c8746b012a6cd224359c82841f18",
+      tokenPreview: "os_123...cdef",
       permission: "sending_access",
       domain: "domain-1",
     });
@@ -183,7 +183,7 @@ describe("api key service", () => {
   it("formats public API-key payloads with token visible only on create", () => {
     const created = {
       id: "created-key",
-      token: "re_created",
+      token: "os_created",
       tokenHash: "hash-created",
     };
     const list = toApiKeyListResponse({
@@ -196,7 +196,7 @@ describe("api key service", () => {
 
     expect(toApiKeyCreateResponse(created)).toEqual({
       id: "created-key",
-      token: "re_created",
+      token: "os_created",
     });
     expect(JSON.stringify(list)).not.toContain("token");
     expect(JSON.stringify(detail)).not.toContain("token");

--- a/tests/api-keys-modal.test.tsx
+++ b/tests/api-keys-modal.test.tsx
@@ -28,7 +28,7 @@ const mockKeys: ApiKeyRow[] = [
   {
     id: "key-1",
     name: "Production Key",
-    tokenPreview: "re_abc...123",
+    tokenPreview: "os_abc...123",
     permission: "full_access",
     lastUsedAt: null,
     createdAt: "2026-03-01T10:00:00Z",
@@ -108,8 +108,8 @@ describe("Create API Key Modal — feature-031", () => {
       json: async () => ({
         id: "new-key",
         name: "My Key",
-        token: "re_abc123def456ghi789",
-        key_prefix: "re_abc123de...",
+        token: "os_abc123def456ghi789",
+        key_prefix: "os_abc123de...",
         permission: "full_access",
       }),
     });
@@ -118,7 +118,7 @@ describe("Create API Key Modal — feature-031", () => {
     const addBtn = screen.getByRole("button", { name: "Add" });
     fireEvent.click(addBtn);
     // Wait for the token to appear
-    const tokenEl = await screen.findByText("re_abc123def456ghi789");
+    const tokenEl = await screen.findByText("os_abc123def456ghi789");
     expect(tokenEl).toBeTruthy();
   });
 
@@ -129,8 +129,8 @@ describe("Create API Key Modal — feature-031", () => {
       json: async () => ({
         id: "new-key",
         name: "My Key",
-        token: "re_abc123def456ghi789",
-        key_prefix: "re_abc123de...",
+        token: "os_abc123def456ghi789",
+        key_prefix: "os_abc123de...",
         permission: "full_access",
       }),
     });

--- a/tests/api-keys-page.test.tsx
+++ b/tests/api-keys-page.test.tsx
@@ -24,7 +24,7 @@ const mockKeys: ApiKeyRow[] = [
   {
     id: "key-1",
     name: "Production Key",
-    tokenPreview: "re_abc...123",
+    tokenPreview: "os_abc...123",
     permission: "full_access",
     lastUsedAt: "2026-03-28T10:00:00Z",
     createdAt: "2026-03-01T10:00:00Z",
@@ -32,7 +32,7 @@ const mockKeys: ApiKeyRow[] = [
   {
     id: "key-2",
     name: "Staging Key",
-    tokenPreview: "re_def...456",
+    tokenPreview: "os_def...456",
     permission: "sending_access",
     lastUsedAt: null,
     createdAt: "2026-03-15T10:00:00Z",
@@ -40,7 +40,7 @@ const mockKeys: ApiKeyRow[] = [
   {
     id: "key-3",
     name: "Dev Key",
-    tokenPreview: "re_ghi...789",
+    tokenPreview: "os_ghi...789",
     permission: "full_access",
     lastUsedAt: "2026-03-27T10:00:00Z",
     createdAt: "2026-03-20T10:00:00Z",
@@ -69,8 +69,8 @@ describe("API Keys List Page", () => {
     expect(screen.getByText("Staging Key")).toBeTruthy();
     expect(screen.getByText("Dev Key")).toBeTruthy();
     // Token prefix displayed
-    expect(screen.getByText("re_abc...123")).toBeTruthy();
-    expect(screen.getByText("re_def...456")).toBeTruthy();
+    expect(screen.getByText("os_abc...123")).toBeTruthy();
+    expect(screen.getByText("os_def...456")).toBeTruthy();
   });
 
   it("renders permission labels correctly", () => {

--- a/tests/api-logs.test.ts
+++ b/tests/api-logs.test.ts
@@ -41,7 +41,7 @@ const detailCreatedAt = new Date("2026-05-06T01:00:00.000Z");
 
 function request(url: string) {
   return new Request(url, {
-    headers: { Authorization: "Bearer re_test" },
+    headers: { Authorization: "Bearer os_test" },
   });
 }
 

--- a/tests/api-received-emails.test.ts
+++ b/tests/api-received-emails.test.ts
@@ -71,7 +71,7 @@ describe("received email API route boundary", () => {
     const response = await GET(
       new Request(
         "http://localhost:3015/api/emails/receiving?limit=2&after=received-0&to=User@Example.com",
-        { headers: { Authorization: "Bearer re_test123" } },
+        { headers: { Authorization: "Bearer os_test123" } },
       ),
     );
 
@@ -111,7 +111,7 @@ describe("received email API route boundary", () => {
     const { GET } = await import("@/app/api/emails/receiving/[id]/route");
     const response = await GET(
       new Request("http://localhost:3015/api/emails/receiving/received-1", {
-        headers: { Authorization: "Bearer re_test123" },
+        headers: { Authorization: "Bearer os_test123" },
       }),
       { params: Promise.resolve({ id: "received-1" }) },
     );
@@ -138,7 +138,7 @@ describe("received email API route boundary", () => {
     const { GET } = await import("@/app/api/emails/receiving/[id]/route");
     const response = await GET(
       new Request("http://localhost:3015/api/emails/receiving/missing", {
-        headers: { Authorization: "Bearer re_test123" },
+        headers: { Authorization: "Bearer os_test123" },
       }),
       { params: Promise.resolve({ id: "missing" }) },
     );
@@ -168,7 +168,7 @@ describe("received email API route boundary", () => {
     const response = await GET(
       new Request(
         "http://localhost:3015/api/emails/receiving/received-1/attachments",
-        { headers: { Authorization: "Bearer re_test123" } },
+        { headers: { Authorization: "Bearer os_test123" } },
       ),
       { params: Promise.resolve({ id: "received-1" }) },
     );
@@ -204,7 +204,7 @@ describe("received email API route boundary", () => {
     const response = await GET(
       new Request(
         "http://localhost:3015/api/emails/receiving/missing/attachments",
-        { headers: { Authorization: "Bearer re_test123" } },
+        { headers: { Authorization: "Bearer os_test123" } },
       ),
       { params: Promise.resolve({ id: "missing" }) },
     );
@@ -232,7 +232,7 @@ describe("received email API route boundary", () => {
     const response = await GET(
       new Request(
         "http://localhost:3015/api/emails/receiving/received-1/attachments/att-1",
-        { headers: { Authorization: "Bearer re_test123" } },
+        { headers: { Authorization: "Bearer os_test123" } },
       ),
       {
         params: Promise.resolve({ id: "received-1", attachmentId: "att-1" }),
@@ -269,7 +269,7 @@ describe("received email API route boundary", () => {
     const response = await GET(
       new Request(
         "http://localhost:3015/api/emails/receiving/received-1/attachments/missing",
-        { headers: { Authorization: "Bearer re_test123" } },
+        { headers: { Authorization: "Bearer os_test123" } },
       ),
       {
         params: Promise.resolve({

--- a/tests/audience-metadata-routes.test.ts
+++ b/tests/audience-metadata-routes.test.ts
@@ -134,7 +134,7 @@ describe("audience metadata route adapters", () => {
 
     const response = await GET(
       makeNextRequest("http://localhost/api/properties/prop-1", {
-        headers: { authorization: "Bearer re_test" },
+        headers: { authorization: "Bearer os_test" },
       }) as never,
       { params: Promise.resolve({ id: "prop-1" }) },
     );
@@ -168,7 +168,7 @@ describe("audience metadata route adapters", () => {
       makeNextRequest(
         "http://localhost/api/segments/seg-1/contacts?limit=10&after=contact-9",
         {
-          headers: { authorization: "Bearer re_test" },
+          headers: { authorization: "Bearer os_test" },
         },
       ) as never,
       { params: Promise.resolve({ id: "seg-1" }) },
@@ -198,7 +198,7 @@ describe("audience metadata route adapters", () => {
       makeNextRequest("http://localhost/api/topics/topic-1", {
         method: "PATCH",
         headers: {
-          authorization: "Bearer re_test",
+          authorization: "Bearer os_test",
           "content-type": "application/json",
         },
         body: JSON.stringify({}),
@@ -223,7 +223,7 @@ describe("audience metadata route adapters", () => {
 
     const response = await GET(
       makeNextRequest("http://localhost/api/properties/prop-1", {
-        headers: { authorization: "Bearer re_test" },
+        headers: { authorization: "Bearer os_test" },
       }) as never,
       { params: Promise.resolve({ id: "prop-1" }) },
     );

--- a/tests/audit-events.test.ts
+++ b/tests/audit-events.test.ts
@@ -30,9 +30,9 @@ describe("audit event service", () => {
   it("redacts API keys, tokens, secrets, cookies, auth headers, and body fields", () => {
     const sanitized = sanitizeAuditMetadata({
       name: "Primary",
-      apiKey: "re_plaintext",
+      apiKey: "os_plaintext",
       token: "tok_plaintext",
-      authorization: "Bearer re_plaintext",
+      authorization: "Bearer os_plaintext",
       cookie: "better-auth.session_token=value",
       signingSecret: "whsec_plaintext",
       nested: {
@@ -81,7 +81,7 @@ describe("audit event service", () => {
       sourceApiKeyId: "caller-key",
       metadata: {
         name: "Created key",
-        token: "re_plaintext",
+        token: "os_plaintext",
         tokenHash: "hash_plaintext",
       },
     });
@@ -111,7 +111,7 @@ describe("audit event service", () => {
         tokenHash: "[REDACTED]",
       },
     });
-    expect(JSON.stringify(inserted)).not.toContain("re_plaintext");
+    expect(JSON.stringify(inserted)).not.toContain("os_plaintext");
     expect(JSON.stringify(inserted)).not.toContain("hash_plaintext");
   });
 

--- a/tests/broadcast-tenant-routes.test.ts
+++ b/tests/broadcast-tenant-routes.test.ts
@@ -66,7 +66,7 @@ function jsonRequest(url: string, body: Record<string, unknown>): NextRequest {
   return makeNextRequest(url, {
     method: "POST",
     headers: {
-      Authorization: "Bearer re_test",
+      Authorization: "Bearer os_test",
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),
@@ -249,7 +249,7 @@ describe("broadcast tenant isolation", () => {
     );
     const getRewrite = await middleware(
       makeNextRequest("http://localhost:3015/broadcasts?limit=5", {
-        headers: { Authorization: "Bearer re_test" },
+        headers: { Authorization: "Bearer os_test" },
       }),
     );
     expect(postRewrite.headers.get("x-middleware-rewrite")).toBe(
@@ -265,7 +265,7 @@ describe("broadcast tenant isolation", () => {
     );
     const listResponse = await apiRoute.GET(
       makeNextRequest("http://localhost:3015/api/broadcasts?limit=5", {
-        headers: { Authorization: "Bearer re_test" },
+        headers: { Authorization: "Bearer os_test" },
       }),
     );
 
@@ -288,7 +288,7 @@ describe("broadcast tenant isolation", () => {
     const { GET } = await import("@/app/api/broadcasts/[id]/route");
     const response = await GET(
       makeNextRequest("http://localhost:3015/api/broadcasts/broadcast-a", {
-        headers: { Authorization: "Bearer re_test" },
+        headers: { Authorization: "Bearer os_test" },
       }),
       { params: Promise.resolve({ id: "broadcast-a" }) },
     );
@@ -343,7 +343,7 @@ describe("broadcast tenant isolation", () => {
     const deleteResponse = await DELETE(
       makeNextRequest("http://localhost:3015/api/broadcasts/broadcast-1", {
         method: "DELETE",
-        headers: { Authorization: "Bearer re_test" },
+        headers: { Authorization: "Bearer os_test" },
       }),
       { params: Promise.resolve({ id: "broadcast-1" }) },
     );
@@ -383,7 +383,7 @@ describe("broadcast tenant isolation", () => {
     const sendRoute = await import("@/app/broadcasts/[id]/send/route");
     const detailResponse = await detailRoute.GET(
       makeNextRequest("http://localhost:3015/broadcasts/broadcast-1", {
-        headers: { Authorization: "Bearer re_test" },
+        headers: { Authorization: "Bearer os_test" },
       }),
       { params: Promise.resolve({ id: "broadcast-1" }) },
     );
@@ -498,7 +498,7 @@ describe("broadcast tenant isolation", () => {
     const response = await GET(
       makeNextRequest(
         "http://localhost:3015/api/broadcasts/broadcast-1/metrics",
-        { headers: { Authorization: "Bearer re_test" } },
+        { headers: { Authorization: "Bearer os_test" } },
       ),
       { params: Promise.resolve({ id: "broadcast-1" }) },
     );

--- a/tests/cache-invalidation-routes.test.ts
+++ b/tests/cache-invalidation-routes.test.ts
@@ -191,7 +191,7 @@ describe("cache invalidation routes", () => {
   it("delegates api-key create through the thin adapter", async () => {
     mockCreateApiKey.mockResolvedValue({
       id: "created-key",
-      token: "re_created",
+      token: "os_created",
       tokenHash: "hash-123",
     });
 
@@ -210,7 +210,7 @@ describe("cache invalidation routes", () => {
     expect(response.status).toBe(201);
     await expect(response.json()).resolves.toEqual({
       id: "created-key",
-      token: "re_created",
+      token: "os_created",
     });
     expect(mockCreateApiKey).toHaveBeenCalledWith({
       name: "Primary",

--- a/tests/e2e/audit-log.spec.ts
+++ b/tests/e2e/audit-log.spec.ts
@@ -40,7 +40,8 @@ test("audit log shows same-tenant dashboard mutations and hides other tenants", 
   }, primaryKeyName);
 
   expect(createResponse.status).toBe(201);
-  expect(JSON.stringify(createResponse.body)).toContain("token");
+  const createdBody = createResponse.body as { token?: unknown };
+  expect(typeof createdBody.token).toBe("string");
 
   const auditRows = await e2eDb.query<{
     action: string;
@@ -61,10 +62,11 @@ test("audit log shows same-tenant dashboard mutations and hides other tenants", 
     actor_type: "user",
   });
   expect(auditRows.rows[0]?.metadata?.name).toBe(primaryKeyName);
-  expect(JSON.stringify(auditRows.rows[0]?.metadata)).not.toContain("re_");
-  expect(JSON.stringify(auditRows.rows[0]?.metadata)).not.toContain(
-    "tokenHash",
-  );
+  const serializedMetadata = JSON.stringify(auditRows.rows[0]?.metadata);
+  if (typeof createdBody.token === "string") {
+    expect(serializedMetadata).not.toContain(createdBody.token);
+  }
+  expect(serializedMetadata).not.toContain("tokenHash");
 
   await page.goto(`/audit-log?q=${encodeURIComponent(primaryKeyName)}`);
   await expect(page.getByRole("heading", { name: "Audit Log" })).toBeVisible();

--- a/tests/e2e/automations-dashboard.spec.ts
+++ b/tests/e2e/automations-dashboard.spec.ts
@@ -240,7 +240,7 @@ test("empty automations dashboard uses session auth without a client API key", a
   await signIn(context);
   const mocks = await mockEmptyAutomationApis(page);
   await page.addInitScript(() => {
-    window.localStorage.setItem("api_key", "re_should_not_be_sent");
+    window.localStorage.setItem("api_key", "os_should_not_be_sent");
   });
 
   await page.goto("/automations");

--- a/tests/issue-200-missed-tenant-scope.test.tsx
+++ b/tests/issue-200-missed-tenant-scope.test.tsx
@@ -130,7 +130,7 @@ const AUTH_RESULT = {
 function makeRequest(url: string, method = "GET"): NextRequest {
   return new Request(url, {
     method,
-    headers: { Authorization: "Bearer re_user_b" },
+    headers: { Authorization: "Bearer os_user_b" },
   }) as unknown as NextRequest;
 }
 

--- a/tests/observability.test.ts
+++ b/tests/observability.test.ts
@@ -47,7 +47,7 @@ describe("observability telemetry helpers", () => {
   it("redacts PII-bearing fields and hashes email addresses in freeform logs", () => {
     const sanitized = sanitizeTelemetryFields({
       Authorization: "Bearer secret-token",
-      apiKey: "re_secret",
+      apiKey: "os_secret",
       from: "sender@example.com",
       metadata: "recipient@example.com clicked",
       email_id: "email-1",
@@ -59,7 +59,7 @@ describe("observability telemetry helpers", () => {
 
     const serialized = JSON.stringify(sanitized);
     expect(serialized).not.toContain("secret-token");
-    expect(serialized).not.toContain("re_secret");
+    expect(serialized).not.toContain("os_secret");
     expect(serialized).not.toContain("sender@example.com");
     expect(serialized).not.toContain("recipient@example.com");
     expect(serialized).not.toContain("Account reset");

--- a/tests/quota-routes.test.ts
+++ b/tests/quota-routes.test.ts
@@ -84,7 +84,7 @@ function jsonRequest(url: string, body: unknown): Request {
   return new Request(url, {
     method: "POST",
     headers: {
-      Authorization: "Bearer re_test",
+      Authorization: "Bearer os_test",
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),

--- a/tests/sdk-client.test.tsx
+++ b/tests/sdk-client.test.tsx
@@ -41,8 +41,8 @@ describe("Opensend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const resend = new Resend("re_test");
-    const opensend = new Opensend("re_test");
+    const resend = new Resend("os_test");
+    const opensend = new Opensend("os_test");
 
     expect(resend).toBeInstanceOf(Resend);
     expect(opensend).toBeInstanceOf(Opensend);
@@ -61,11 +61,11 @@ describe("Opensend SDK", () => {
   });
 
   it("validates invalid baseUrl overrides", () => {
-    expect(() => new Resend("re_test", { baseUrl: "" })).toThrow(
+    expect(() => new Resend("os_test", { baseUrl: "" })).toThrow(
       "baseUrl must be a non-empty string when provided",
     );
     expect(
-      () => new Resend("re_test", { baseUrl: "ftp://example.com" }),
+      () => new Resend("os_test", { baseUrl: "ftp://example.com" }),
     ).toThrow("baseUrl must use http or https");
   });
 
@@ -79,7 +79,7 @@ describe("Opensend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new Opensend("re_test", {
+    const client = new Opensend("os_test", {
       baseUrl: "https://api.example.com/",
     });
 
@@ -95,7 +95,7 @@ describe("Opensend SDK", () => {
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
-          Authorization: "Bearer re_test",
+          Authorization: "Bearer os_test",
         }),
       }),
     );
@@ -115,7 +115,7 @@ describe("Opensend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new Opensend("re_test", {
+    const client = new Opensend("os_test", {
       baseUrl: "https://api.example.com",
     });
     const payload = {
@@ -232,7 +232,7 @@ describe("Opensend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new Opensend("re_test", {
+    const client = new Opensend("os_test", {
       baseUrl: "https://api.example.com",
     });
 
@@ -268,7 +268,7 @@ describe("Opensend SDK", () => {
     const fetchMock = vi.fn<typeof fetch>();
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new MockedOpensend("re_test", {
+    const client = new MockedOpensend("os_test", {
       baseUrl: "https://api.example.com",
     });
 
@@ -307,7 +307,7 @@ describe("Opensend SDK", () => {
     const fetchMock = vi.fn<typeof fetch>();
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new Opensend("re_test", {
+    const client = new Opensend("os_test", {
       baseUrl: "https://api.example.com",
     });
 
@@ -342,7 +342,7 @@ describe("Opensend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new Opensend("re_test", {
+    const client = new Opensend("os_test", {
       baseUrl: "https://api.example.com",
     });
 
@@ -388,7 +388,7 @@ describe("Opensend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new Opensend("re_test", {
+    const client = new Opensend("os_test", {
       baseUrl: "https://api.example.com",
     });
 
@@ -415,7 +415,7 @@ describe("Opensend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new Opensend("re_test", {
+    const client = new Opensend("os_test", {
       baseUrl: "https://api.example.com",
     });
 
@@ -465,10 +465,10 @@ describe("Opensend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new Opensend("re_test", {
+    const client = new Opensend("os_test", {
       baseUrl: "https://api.example.com",
     });
-    const resend = new Resend("re_test", {
+    const resend = new Resend("os_test", {
       baseUrl: "https://api.example.com",
     });
 
@@ -512,10 +512,10 @@ describe("Opensend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new Opensend("re_test", {
+    const client = new Opensend("os_test", {
       baseUrl: "https://api.example.com",
     });
-    const resend = new Resend("re_test", {
+    const resend = new Resend("os_test", {
       baseUrl: "https://api.example.com",
     });
 
@@ -634,7 +634,7 @@ describe("Opensend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new Opensend("re_test", {
+    const client = new Opensend("os_test", {
       baseUrl: "https://api.example.com",
     });
 
@@ -667,7 +667,7 @@ describe("Opensend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new Opensend("re_test", {
+    const client = new Opensend("os_test", {
       baseUrl: "https://api.example.com",
     });
 
@@ -689,7 +689,7 @@ describe("Opensend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new Opensend("re_test", {
+    const client = new Opensend("os_test", {
       baseUrl: "https://api.example.com",
     });
 
@@ -711,7 +711,7 @@ describe("Opensend SDK", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new Opensend("re_test", {
+    const client = new Opensend("os_test", {
       baseUrl: "https://api.example.com",
     });
 

--- a/tests/suppressions-route.test.ts
+++ b/tests/suppressions-route.test.ts
@@ -185,7 +185,7 @@ describe("suppression management routes", () => {
       new Request(
         "http://localhost:3015/api/suppressions?limit=10&after=supp-0",
         {
-          headers: { Authorization: "Bearer re_test" },
+          headers: { Authorization: "Bearer os_test" },
         },
       ),
     );
@@ -258,7 +258,7 @@ describe("suppression management routes", () => {
 
     const forbidden = await GET(
       new Request("http://localhost:3015/api/suppressions", {
-        headers: { Authorization: "Bearer re_test" },
+        headers: { Authorization: "Bearer os_test" },
       }),
     );
 
@@ -280,7 +280,7 @@ describe("suppression management routes", () => {
     const res = await DELETE(
       new Request("http://localhost:3015/api/suppressions/blocked%40test.com", {
         method: "DELETE",
-        headers: { Authorization: "Bearer re_test" },
+        headers: { Authorization: "Bearer os_test" },
       }),
       { params: Promise.resolve({ email: "blocked%40test.com" }) },
     );
@@ -305,7 +305,7 @@ describe("suppression management routes", () => {
     const res = await DELETE(
       new Request("http://localhost:3015/api/suppressions/absent%40test.com", {
         method: "DELETE",
-        headers: { Authorization: "Bearer re_test" },
+        headers: { Authorization: "Bearer os_test" },
       }),
       { params: Promise.resolve({ email: "absent%40test.com" }) },
     );

--- a/tests/ui-primitives.test.tsx
+++ b/tests/ui-primitives.test.tsx
@@ -245,22 +245,22 @@ describe("CopyToClipboard", () => {
   });
 
   it("renders the value text", () => {
-    render(<CopyToClipboard value="re_abc123" />);
-    expect(screen.getByText("re_abc123")).toBeTruthy();
+    render(<CopyToClipboard value="os_abc123" />);
+    expect(screen.getByText("os_abc123")).toBeTruthy();
   });
 
   it("copies value to clipboard on click", async () => {
-    render(<CopyToClipboard value="re_abc123" />);
+    render(<CopyToClipboard value="os_abc123" />);
     const button = screen.getByRole("button");
     await act(async () => {
       fireEvent.click(button);
     });
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("re_abc123");
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("os_abc123");
   });
 
   it("shows confirmation state after copy", async () => {
     vi.useFakeTimers();
-    render(<CopyToClipboard value="re_abc123" />);
+    render(<CopyToClipboard value="os_abc123" />);
     const button = screen.getByRole("button");
     await act(async () => {
       fireEvent.click(button);


### PR DESCRIPTION
## Summary

Closes #427.

Standardizes OpenSend API-key examples and synthetic fixtures on the `os_...` namespace without changing runtime token generation behavior.

## Files changed

- `README.md` — adds the OpenSend `os_...` Resend-compatible API sentence.
- `docs/sdk/go.md` — adds the OpenSend `os_...` Resend-compatible API sentence.
- `docs/sdk/python.md` — adds the OpenSend `os_...` Resend-compatible API sentence.
- `packages/sdk/README.md` — adds the OpenSend `os_...` Resend-compatible API sentence.
- `packages/go-sdk/README.md` — adds the OpenSend `os_...` Resend-compatible API sentence.
- `packages/python-sdk/README.md` — adds the OpenSend `os_...` Resend-compatible API sentence.
- `services/api/README.md` — adds the OpenSend `os_...` Resend-compatible API sentence.
- `src/app/docs/page.tsx` — adds the sentence to in-app API docs.
- `src/components/api-code-drawer.tsx` — changes in-app Node/cURL API snippets from `re_123456789` to `os_123456789`.
- `src/components/settings-page.tsx` — changes SMTP example password placeholder from `re_YOUR_API_KEY` to `os_YOUR_API_KEY`.
- `packages/go-sdk/opensend_test.go` — changes synthetic OpenSend SDK auth fixtures to `os_...`.
- `packages/python-sdk/tests/test_emails.py` — changes synthetic OpenSend SDK auth fixtures to `os_...`.
- `tests/sdk-client.test.tsx` — changes synthetic TypeScript SDK auth fixtures to `os_...`.
- `tests/api-auth-cache.test.ts` — changes synthetic API-key auth fixtures to `os_...`.
- `tests/api-auth-date-range-routes.test.ts` — changes synthetic API-key auth fixtures to `os_...`.
- `tests/api-automations-events.test.ts` — changes synthetic API-key auth fixtures to `os_...`.
- `tests/api-domains.test.ts` — changes synthetic API-key auth fixtures to `os_...`.
- `tests/api-emails.test.ts` — changes synthetic API-key auth fixtures to `os_...`.
- `tests/api-key-detail.test.tsx` — changes token preview fixtures to `os_...`.
- `tests/api-key-routes.test.ts` — changes synthetic API-key route fixtures to `os_...`.
- `tests/api-key-service.test.ts` — changes synthetic generated-key fixtures to `os_...` and updates expected SHA-256 hash.
- `tests/api-keys-modal.test.tsx` — changes token and preview fixtures to `os_...`.
- `tests/api-keys-page.test.tsx` — changes token preview fixtures to `os_...`.
- `tests/api-logs.test.ts` — changes synthetic auth fixture to `os_...`.
- `tests/api-received-emails.test.ts` — changes synthetic auth fixtures to `os_...`.
- `tests/audience-metadata-routes.test.ts` — changes synthetic auth fixtures to `os_...`.
- `tests/audit-events.test.ts` — changes synthetic redaction fixtures to `os_...`.
- `tests/broadcast-tenant-routes.test.ts` — changes synthetic auth fixtures to `os_...`.
- `tests/cache-invalidation-routes.test.ts` — changes synthetic token fixtures to `os_...`.
- `tests/e2e/audit-log.spec.ts` — removes hard-coded prefix assertion and checks the actual created token is redacted instead.
- `tests/e2e/automations-dashboard.spec.ts` — changes synthetic localStorage sentinel to `os_...`.
- `tests/issue-200-missed-tenant-scope.test.tsx` — changes synthetic auth fixture to `os_...`.
- `tests/observability.test.ts` — changes synthetic redaction fixture to `os_...`.
- `tests/quota-routes.test.ts` — changes synthetic auth fixture to `os_...`.
- `tests/suppressions-route.test.ts` — changes synthetic auth fixtures to `os_...`.
- `tests/ui-primitives.test.tsx` — changes copy-to-clipboard token fixture to `os_...`.
- `agent_docs/learnings/active/2026-05-12-issue-427-api-key-prefix-docs-runtime.md` — records the no-runtime-change decision and legitimate Resend parity exception.

## Validation

- `git diff --check` — passed.
- `make check` — passed.
- `make test` — passed: 148 files / 1173 tests.
- Push guardrails — passed typecheck and changed-file Biome lint during `git push`.
- Grep proof for misleading OpenSend examples scanned for `Bearer re_`, quoted/backticked `re_` API-key fixtures, and `re_` constructor examples. Remaining matches are intentional:
  - `agent_docs/resend-parity.md:93` and `agent_docs/resend-parity.md:95` are upstream Resend target-contract references.
  - `packages/core/src/services/apiKeys.ts:116` is runtime token generation intentionally left unchanged per issue scope.

## Notes

No runtime behavior changed. I preserved legitimate Resend target-contract mentions in parity docs instead of rewriting them as OpenSend examples.
