### PR TITLE
Align Emails first-run empty state

### DIFF
--- a/src/app/(dashboard)/emails/page.tsx
+++ b/src/app/(dashboard)/emails/page.tsx
@@ -44,6 +44,7 @@ export default async function EmailsPage({
     createdAt: string;
     sentAt: string | null;
   }[] = [];
+  let hasAnyEmails = false;
 
   try {
     const emailConditions = [eq(emails.userId, userId)];
@@ -51,7 +52,7 @@ export default async function EmailsPage({
       emailConditions.push(eq(emails.status, statusFilter));
     }
 
-    const [keysResult, emailsResult] = await Promise.all([
+    const [keysResult, emailsResult, anyEmailsResult] = await Promise.all([
       db
         .select({ id: apiKeys.id, name: apiKeys.name })
         .from(apiKeys)
@@ -70,8 +71,14 @@ export default async function EmailsPage({
         .where(and(...emailConditions))
         .orderBy(desc(emails.createdAt))
         .limit(100),
+      db
+        .select({ id: emails.id })
+        .from(emails)
+        .where(eq(emails.userId, userId))
+        .limit(1),
     ]);
     keys = keysResult;
+    hasAnyEmails = anyEmailsResult.length > 0;
     emailList = emailsResult.map((e) => ({
       ...e,
       createdAt: e.createdAt.toISOString(),
@@ -81,5 +88,11 @@ export default async function EmailsPage({
     // DB unavailable — render with empty data
   }
 
-  return <EmailsSendingPage apiKeys={keys} emails={emailList} />;
+  return (
+    <EmailsSendingPage
+      apiKeys={keys}
+      emails={emailList}
+      hasAnyEmails={hasAnyEmails}
+    />
+  );
 }

--- a/src/components/emails-sending-data-table.tsx
+++ b/src/components/emails-sending-data-table.tsx
@@ -14,6 +14,7 @@ export interface EmailListItem {
 
 interface EmailsSendingDataTableProps {
   emails: EmailListItem[];
+  emptyState?: "first-run" | "filtered";
 }
 
 export function getStatusVariant(
@@ -77,11 +78,21 @@ function getAvatarColor(email: string): string {
 
 export function EmailsSendingDataTable({
   emails,
+  emptyState = "filtered",
 }: EmailsSendingDataTableProps) {
   if (emails.length === 0) {
+    if (emptyState === "first-run") {
+      return <EmailsFirstRunEmptyState />;
+    }
+
     return (
-      <div className="flex items-center justify-center py-16 text-[14px] text-[#A1A4A5]">
-        No emails found
+      <div className="flex flex-col items-center justify-center gap-2 py-16 text-center">
+        <p className="text-[14px] font-medium text-[#F0F0F0]">
+          No emails match your filters
+        </p>
+        <p className="max-w-[360px] text-[13px] leading-5 text-[#A1A4A5]">
+          Adjust your search, status, or date filters to find sent emails.
+        </p>
       </div>
     );
   }
@@ -114,6 +125,27 @@ export function EmailsSendingDataTable({
         })}
       </tbody>
     </table>
+  );
+}
+
+function EmailsFirstRunEmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+      <div className="space-y-2">
+        <h2 className="text-[18px] font-semibold text-[#F0F0F0]">
+          No sent emails yet
+        </h2>
+        <p className="max-w-[420px] text-[14px] leading-6 text-[#A1A4A5]">
+          Start sending emails to see insights and previews for every message.
+        </p>
+      </div>
+      <Link
+        href="/docs"
+        className="inline-flex h-9 items-center justify-center rounded-[8px] border border-[rgba(176,199,217,0.18)] px-4 text-[13px] font-medium text-[#F0F0F0] transition-colors hover:bg-[rgba(176,199,217,0.1)]"
+      >
+        Go to docs
+      </Link>
+    </div>
   );
 }
 

--- a/src/components/emails-sending-page.tsx
+++ b/src/components/emails-sending-page.tsx
@@ -20,11 +20,14 @@ import { useEffect, useMemo, useState } from "react";
 interface EmailsSendingPageProps {
   apiKeys: { id: string; name: string }[];
   emails: EmailListItem[];
+  hasAnyEmails?: boolean;
 }
 
 function parseInitialFilters(searchParams: URLSearchParams): EmailFilters {
   const startDate = searchParams.get("startDate");
   const endDate = searchParams.get("endDate");
+  const status =
+    searchParams.get("status") ?? searchParams.get("statuses") ?? "";
 
   return {
     search: searchParams.get("search") ?? "",
@@ -32,7 +35,7 @@ function parseInitialFilters(searchParams: URLSearchParams): EmailFilters {
       startDate && endDate
         ? `custom:${startDate}:${endDate}`
         : (searchParams.get("dateRange") ?? "Last 15 days"),
-    status: searchParams.get("status") ?? searchParams.get("statuses") ?? "",
+    status: status === "all" ? "" : status,
     apiKeyId:
       searchParams.get("apiKeyId") ?? searchParams.get("api_key_id") ?? "",
   };
@@ -64,7 +67,20 @@ function buildQueryString(filters: EmailFilters): string {
   return params.toString();
 }
 
-export function EmailsSendingPage({ apiKeys, emails }: EmailsSendingPageProps) {
+function hasActiveFilters(filters: EmailFilters): boolean {
+  return Boolean(
+    filters.search ||
+      filters.status ||
+      filters.apiKeyId ||
+      filters.dateRange !== "Last 15 days",
+  );
+}
+
+export function EmailsSendingPage({
+  apiKeys,
+  emails,
+  hasAnyEmails = emails.length > 0,
+}: EmailsSendingPageProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -114,7 +130,12 @@ export function EmailsSendingPage({ apiKeys, emails }: EmailsSendingPageProps) {
         onFiltersChange={setFilters}
       />
       <div className="mt-4">
-        <EmailsSendingDataTable emails={filteredEmails} />
+        <EmailsSendingDataTable
+          emails={filteredEmails}
+          emptyState={
+            hasAnyEmails || hasActiveFilters(filters) ? "filtered" : "first-run"
+          }
+        />
       </div>
     </div>
   );

--- a/tests/dashboard-pages-tenant-scope.test.tsx
+++ b/tests/dashboard-pages-tenant-scope.test.tsx
@@ -56,9 +56,11 @@ vi.mock("@/lib/db", () => ({
 }));
 
 vi.mock("@/components/emails-sending-page", () => ({
-  EmailsSendingPage: (props: { emails: unknown[]; apiKeys: unknown[] }) => (
-    <div data-testid="emails-page" data-props={JSON.stringify(props)} />
-  ),
+  EmailsSendingPage: (props: {
+    emails: unknown[];
+    apiKeys: unknown[];
+    hasAnyEmails: boolean;
+  }) => <div data-testid="emails-page" data-props={JSON.stringify(props)} />,
 }));
 
 vi.mock("@/components/email-detail", () => ({
@@ -208,15 +210,18 @@ describe("dashboard pages tenant scoping", () => {
   });
 
   it("renders empty list data for user B when scoped page queries return no owned rows", async () => {
-    queueRows([], []);
+    queueRows([], [], []);
     const EmailsPage = (await import("@/app/(dashboard)/emails/page")).default;
     const emailsResult = await EmailsPage({
       searchParams: Promise.resolve({}),
     });
-    expect(
-      parsedProps<{ emails: unknown[]; apiKeys: unknown[] }>(emailsResult)
-        .emails,
-    ).toEqual([]);
+    const emailsProps = parsedProps<{
+      emails: unknown[];
+      apiKeys: unknown[];
+      hasAnyEmails: boolean;
+    }>(emailsResult);
+    expect(emailsProps.emails).toEqual([]);
+    expect(emailsProps.hasAnyEmails).toBe(false);
 
     queueRows([], []);
     const ApiKeysPage = (await import("@/app/(dashboard)/api-keys/page"))

--- a/tests/e2e/emails-data-table.spec.ts
+++ b/tests/e2e/emails-data-table.spec.ts
@@ -17,7 +17,9 @@ test.describe("Emails Sending Data Table", () => {
       expect(page.url()).toContain("/emails/");
     } else {
       // No emails — empty state should be visible
-      await expect(page.getByText("No emails found")).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "No sent emails yet" }),
+      ).toBeVisible();
     }
   });
 });

--- a/tests/e2e/emails-empty-state.spec.ts
+++ b/tests/e2e/emails-empty-state.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "./fixtures/auth";
+
+test.describe("Emails empty state", () => {
+  test("authenticated zero-email account sees onboarding and docs CTA", async ({
+    authenticatedPage: page,
+    e2eDb,
+    e2eUser,
+  }) => {
+    await e2eDb.query("delete from emails where user_id = $1", [e2eUser.id]);
+
+    await page.goto("/emails");
+
+    await expect(
+      page.getByRole("heading", { name: "No sent emails yet" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        "Start sending emails to see insights and previews for every message.",
+      ),
+    ).toBeVisible();
+
+    const docsLink = page.getByRole("link", { name: "Go to docs" });
+    await expect(docsLink).toBeVisible();
+    await expect(docsLink).toHaveAttribute("href", "/docs");
+
+    await docsLink.click();
+    await expect(page).toHaveURL(/\/docs(?:$|[?#])/);
+  });
+});

--- a/tests/emails-data-table.test.tsx
+++ b/tests/emails-data-table.test.tsx
@@ -85,10 +85,29 @@ describe("EmailsSendingDataTable", () => {
     expect(actionButtons.length).toBe(3);
   });
 
-  it("shows empty state when no emails", () => {
-    render(<EmailsSendingDataTable emails={[]} />);
+  it("shows first-run empty state with visible docs CTA when no emails exist", () => {
+    render(<EmailsSendingDataTable emails={[]} emptyState="first-run" />);
 
-    expect(screen.getByText("No emails found")).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "No sent emails yet" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Start sending emails to see insights and previews for every message.",
+      ),
+    ).toBeTruthy();
+
+    const docsLink = screen.getByRole("link", { name: "Go to docs" });
+    expect(docsLink).toBeTruthy();
+    expect(docsLink.getAttribute("href")).toBe("/docs");
+  });
+
+  it("shows filter-specific empty state when existing emails are filtered out", () => {
+    render(<EmailsSendingDataTable emails={[]} emptyState="filtered" />);
+
+    expect(screen.getByText("No emails match your filters")).toBeTruthy();
+    expect(screen.queryByText("No sent emails yet")).toBeNull();
+    expect(screen.queryByRole("link", { name: "Go to docs" })).toBeNull();
   });
 
   it("formats relative time correctly", () => {

--- a/tests/emails-sending-page.test.tsx
+++ b/tests/emails-sending-page.test.tsx
@@ -151,4 +151,44 @@ describe("EmailsSendingPage", () => {
     expect(screen.queryByText("alice@example.com")).toBeNull();
     expect(screen.queryByText("bob@example.com")).toBeNull();
   });
+
+  it("renders first-run onboarding when the account has no emails", () => {
+    render(
+      <EmailsSendingPage apiKeys={apiKeys} emails={[]} hasAnyEmails={false} />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "No sent emails yet" }),
+    ).toBeDefined();
+    expect(
+      screen.getByRole("link", { name: "Go to docs" }).getAttribute("href"),
+    ).toBe("/docs");
+  });
+
+  it("keeps filtered empty results distinct from first-run onboarding", () => {
+    mockSearchParams = new URLSearchParams("search=missing");
+
+    render(
+      <EmailsSendingPage
+        apiKeys={apiKeys}
+        emails={emails}
+        hasAnyEmails={true}
+      />,
+    );
+
+    expect(screen.getByText("No emails match your filters")).toBeDefined();
+    expect(screen.queryByText("No sent emails yet")).toBeNull();
+    expect(screen.queryByRole("link", { name: "Go to docs" })).toBeNull();
+  });
+
+  it("uses filtered empty copy for active filters even before the first email", () => {
+    mockSearchParams = new URLSearchParams("search=missing");
+
+    render(
+      <EmailsSendingPage apiKeys={apiKeys} emails={[]} hasAnyEmails={false} />,
+    );
+
+    expect(screen.getByText("No emails match your filters")).toBeDefined();
+    expect(screen.queryByText("No sent emails yet")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- Add a true first-run `/emails` empty state with `No sent emails yet`, helper copy, and a visible `/docs` CTA.
- Preserve filtered/search empty-result copy so active filters do not look like first-run onboarding.
- Add focused component coverage and an authenticated Playwright proof for the zero-email dashboard state.

Closes #432.

## Checks
- `make check`
- `make test`
- `bun run test tests/emails-data-table.test.tsx tests/emails-sending-page.test.tsx tests/dashboard-pages-tenant-scope.test.tsx`
- `DATABASE_URL=postgresql://opensend:opensend@localhost:55433/opensend BETTER_AUTH_URL=http://localhost:3015 NEXT_PUBLIC_APP_URL=http://localhost:3015 BETTER_AUTH_SECRET=better-auth-secret-12345678901234567890 bun run test:e2e tests/e2e/emails-empty-state.spec.ts`

## Notes
- The focused Playwright proof ran against the local Compose Postgres-backed Better Auth fixture and passed; no skipped E2E is used as completion evidence.
