### PR TITLE
Fix broadcasts dashboard refresh loop

### DIFF
--- a/agent_docs/learnings/active/2026-05-12-issue-435-broadcasts-rsc-alias.md
+++ b/agent_docs/learnings/active/2026-05-12-issue-435-broadcasts-rsc-alias.md
@@ -1,0 +1,19 @@
+---
+date: 2026-05-12
+issue: "#435"
+type: decision
+promoted_to: null
+---
+
+## Dashboard/root API alias collisions must recognize Next RSC requests
+
+`GET /broadcasts` is both a dashboard page and a Resend-compatible collection
+alias, so header detection must not treat `Accept: */*` alone as API intent.
+Next browser/RSC navigations can include headers such as `RSC`,
+`Next-Router-State-Tree`, and `Next-Url` while omitting `text/html`; those
+requests should remain dashboard page requests.
+
+For root GET aliases that collide with dashboard pages, require explicit API
+signals such as `Authorization`, `Accept: application/json`, or JSON content
+type before rewriting to `/api/*`. Keep mutation/detail aliases broader because
+they do not occupy the dashboard list page route.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -127,11 +127,24 @@ function isBroadcastsCollectionAlias(
 function isApiLikeRequest(request: NextRequest): boolean {
   const accept = request.headers.get("accept") ?? "";
   const contentType = request.headers.get("content-type") ?? "";
+
+  if (
+    accept.includes("text/html") ||
+    request.headers.has("rsc") ||
+    request.headers.has("next-router-state-tree") ||
+    request.headers.has("next-url") ||
+    request.headers.get("sec-fetch-dest") === "document"
+  ) {
+    return false;
+  }
+
+  // Root GET aliases that collide with dashboard pages are intentionally
+  // narrower than detail/mutation aliases: ambiguous browser/RSC navigations can
+  // send Accept: */*, so require an explicit API signal before rewriting.
   return (
     request.headers.has("authorization") ||
     accept.includes("application/json") ||
-    contentType.includes("application/json") ||
-    !accept.includes("text/html")
+    contentType.includes("application/json")
   );
 }
 

--- a/tests/e2e/broadcasts-refresh-loop.spec.ts
+++ b/tests/e2e/broadcasts-refresh-loop.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "./fixtures/auth";
+
+test.describe("Broadcasts dashboard navigation", () => {
+  test("keeps /broadcasts on the dashboard without repeated hard navigations", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/broadcasts");
+    await expect(
+      page.getByRole("heading", { exact: true, name: "Broadcasts" }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(/\/broadcasts$/);
+
+    const initialTimeOrigin = await page.evaluate(() => performance.timeOrigin);
+
+    await page.waitForTimeout(4_000);
+
+    await expect(page).toHaveURL(/\/broadcasts$/);
+    await expect(
+      page.getByRole("heading", { exact: true, name: "Broadcasts" }),
+    ).toBeVisible();
+    await expect
+      .poll(() => page.evaluate(() => performance.timeOrigin))
+      .toBe(initialTimeOrigin);
+  });
+});

--- a/tests/middleware-rate-limit.test.ts
+++ b/tests/middleware-rate-limit.test.ts
@@ -140,6 +140,68 @@ describe("middleware rate limiting", () => {
     expect(response.headers.get("location")).toBe("https://example.com/auth");
   });
 
+  it("preserves browser/RSC dashboard GET /broadcasts instead of rewriting the API alias", async () => {
+    const { middleware } = await import("@/middleware");
+
+    const response = await middleware(
+      makeRequest("https://example.com/broadcasts", {
+        method: "GET",
+        headers: {
+          accept: "*/*",
+          rsc: "1",
+          "next-router-state-tree": encodeURIComponent("[]"),
+          "next-url": "/broadcasts",
+        },
+      }),
+    );
+
+    expect(mockGetSessionCookie).toHaveBeenCalled();
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("redirects unauthenticated browser/RSC GET /broadcasts to auth instead of the API alias", async () => {
+    mockGetSessionCookie.mockReturnValue(null);
+    const { middleware } = await import("@/middleware");
+
+    const response = await middleware(
+      makeRequest("https://example.com/broadcasts", {
+        method: "GET",
+        headers: {
+          accept: "*/*",
+          rsc: "1",
+          "next-router-state-tree": encodeURIComponent("[]"),
+          "next-url": "/broadcasts",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://example.com/auth");
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+  });
+
+  it("rewrites explicit API GET /broadcasts clients to the Resend-compatible alias", async () => {
+    mockGetSessionCookie.mockReturnValue(null);
+    const { middleware } = await import("@/middleware");
+
+    const response = await middleware(
+      makeRequest("https://example.com/broadcasts", {
+        method: "GET",
+        headers: {
+          accept: "application/json",
+          authorization: "Bearer test-api-key",
+        },
+      }),
+    );
+
+    expect(mockGetSessionCookie).not.toHaveBeenCalled();
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      "https://example.com/api/broadcasts",
+    );
+    expect(response.headers.get("x-ratelimit-backend")).toBe("disabled");
+  });
+
   it("allows root contacts API aliases without requiring a dashboard session", async () => {
     mockGetSessionCookie.mockReturnValue(null);
     const { middleware } = await import("@/middleware");


### PR DESCRIPTION
## Summary
- Fixes #435 by preventing Next browser/RSC `GET /broadcasts` dashboard requests from being classified as the Resend-compatible API alias.
- Narrows the ambiguous root `GET /broadcasts` alias to explicit API signals (`Authorization`, JSON `Accept`, or JSON content type) while preserving rewrite behavior for explicit API clients.
- Adds middleware regression coverage plus a focused Playwright proof that an authenticated `/broadcasts` page remains stable without hard navigation for several seconds.

## Changed files
- `src/middleware.ts`
- `tests/middleware-rate-limit.test.ts`
- `tests/e2e/broadcasts-refresh-loop.spec.ts`
- `agent_docs/learnings/active/2026-05-12-issue-435-broadcasts-rsc-alias.md`

## Validation
- `bun run test -- tests/middleware-rate-limit.test.ts` — 20 tests passed
- `DATABASE_URL=postgresql://opensend:opensend@localhost:55433/opensend bun run db:push` — no schema changes detected for local Docker Postgres
- `set -a; . ./.env; set +a; bunx playwright test tests/e2e/broadcasts-refresh-loop.spec.ts` — 1 passed
- `make check && make test` — typecheck/lint passed; 148 test files / 1183 tests passed
- `make check` after adding the learning note — passed

## Residual risk
- Full Playwright suite was not run; only the focused `/broadcasts` regression proof was run.
- Ambiguous unauthenticated `GET /broadcasts` clients that send only `Accept: */*` now follow dashboard auth behavior instead of the API alias; explicit API clients with auth or JSON headers still rewrite to `/api/broadcasts`.
