### PR TITLE
Add control-plane suppression routes

### DIFF
--- a/agent_docs/learnings/active/2026-05-12-issue-441-control-plane-suppression-mocks.md
+++ b/agent_docs/learnings/active/2026-05-12-issue-441-control-plane-suppression-mocks.md
@@ -1,0 +1,10 @@
+---
+date: 2026-05-12
+issue: 441
+type: pattern
+promoted_to: null
+---
+
+# services/api route additions must satisfy all createApp mocks
+
+Adding a new statically registered `services/api` route imports its shared handler whenever `createApp()` is imported, even if a focused test only exercises `/emails` or `/webhooks`. Tests that mock `@opensend/core` for existing Hono route families must include the new service exports used by the added handler, or unrelated Hono parity suites fail at module import time before their route under test runs.

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -15,11 +15,15 @@ Current endpoints:
 
 - `POST /emails` — transactional send API. Uses the shared send implementation that also backs the compatibility Next.js adapter at `POST /api/emails`; preserves OpenSend/Resend-compatible auth, validation, idempotency, queueing, response, and error shapes.
 - `POST /emails/batch` — transactional batch send API with the same shared behavior as `POST /api/emails/batch`.
+- `GET /suppressions` — list user-scoped suppression records for a full-access API key or dashboard session. Matches the compatibility Next.js adapter at `GET /api/suppressions`, including `limit`/`after` pagination and response fields.
+- `DELETE /suppressions/:email` — remove a user-scoped suppression for a full-access API key or dashboard session. Matches the compatibility Next.js adapter at `DELETE /api/suppressions/:email`, including `404 { error, code }` not-found behavior.
 - `GET /healthz` — service/version health metadata
 - `GET /readyz` — static readiness response that does not require AWS, database, queue, or other external credentials
 - `POST /mcp` — Streamable HTTP-compatible JSON-RPC MCP endpoint for agent clients. Requires `Authorization: Bearer <opensend_api_key>` and forwards tool calls to the existing public OpenSend API (`OPENSEND_API_BASE_URL`, default `http://localhost:3015`).
 
-The transactional send route family is now owned by shared send handlers consumed by this Hono service. The existing Next.js handlers remain compatibility adapters for the current public `/api/emails` URLs; no production routing cutover is implied by local service ownership.
+The transactional send and suppression route families are now owned by shared handlers consumed by this Hono service. The existing Next.js handlers remain compatibility adapters for the current public `/api/emails` and `/api/suppressions` URLs; no production routing cutover is implied by local service ownership.
+
+Next.js still owns dashboard-only and not-yet-migrated public route families, including API keys, contacts/audience, broadcasts, email read/detail, billing, Better Auth, internal cron, and dashboard UI routes. Webhooks remain available in this service through the current shared adapter.
 
 ### Transactional send local testing
 
@@ -36,10 +40,16 @@ Exercise the service route with an OpenSend API key:
 bun -e 'const r = await fetch("http://localhost:3026/emails", { method: "POST", headers: { "authorization": "Bearer os_...", "content-type": "application/json" }, body: JSON.stringify({ from: "sender@example.com", to: "recipient@example.com", subject: "Hello", html: "<p>Hello</p>" }) }); console.log(r.status, await r.text())'
 ```
 
-Focused tests for this route family live in `tests/api-emails.test.ts` and cover both the Hono service routes and the Next.js compatibility adapters:
+Focused tests for the transactional send route family live in `tests/api-emails.test.ts` and cover both the Hono service routes and the Next.js compatibility adapters:
 
 ```bash
 bun run test -- tests/api-emails.test.ts
+```
+
+Focused suppression parity tests live in `tests/suppressions-route.test.ts`:
+
+```bash
+bun run test -- tests/suppressions-route.test.ts
 ```
 
 

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -2,6 +2,7 @@ import { handleMcpHttpRequest } from "@opensend/mcp";
 import { Hono } from "hono";
 import { handlePostEmailBatchRequest } from "../../../src/lib/api/emails/batch-send";
 import { handlePostEmailRequest } from "../../../src/lib/api/emails/send";
+import { registerSuppressionRoutes } from "./routes/suppressions";
 import { registerWebhookRoutes } from "./routes/webhooks";
 
 export const CONTROL_PLANE_API_SERVICE = "control-plane-api";
@@ -44,6 +45,7 @@ export function createApp(options: ControlPlaneAppOptions = {}) {
   );
 
   registerWebhookRoutes(app);
+  registerSuppressionRoutes(app);
 
   app.all(
     "/mcp",

--- a/services/api/src/routes/suppressions.ts
+++ b/services/api/src/routes/suppressions.ts
@@ -1,0 +1,18 @@
+import type { Hono } from "hono";
+import {
+  handleDeleteSuppressionRequest,
+  handleListSuppressionsRequest,
+} from "../../../../src/lib/api/suppressions";
+
+export function registerSuppressionRoutes(app: Hono) {
+  app.get(
+    "/suppressions",
+    async (c) => await handleListSuppressionsRequest(c.req.raw),
+  );
+
+  app.delete(
+    "/suppressions/:email",
+    async (c) =>
+      await handleDeleteSuppressionRequest(c.req.raw, c.req.param("email")),
+  );
+}

--- a/src/app/api/suppressions/[email]/route.ts
+++ b/src/app/api/suppressions/[email]/route.ts
@@ -1,47 +1,9 @@
-import {
-  authorizeDashboardOrApiKey,
-  getServerSession,
-  unauthorizedResponse,
-} from "@/lib/api-auth";
-import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
-import {
-  SuppressionServiceError,
-  createSuppressionService,
-} from "@opensend/core";
-import { NextResponse } from "next/server";
-
-const suppressionService = createSuppressionService();
+import { handleDeleteSuppressionRequest } from "@/lib/api/suppressions";
 
 export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ email: string }> },
-) {
-  const auth = await authorizeDashboardOrApiKey(
-    request.headers.get("authorization"),
-  );
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessForApiKeyCaller(auth);
-  if (permissionError) return permissionError;
-  const session = "dashboard" in auth ? await getServerSession() : null;
-  const userId = "userId" in auth ? auth.userId : session?.user?.id;
-  if (!userId) return unauthorizedResponse();
-
+): Promise<Response> {
   const { email } = await params;
-  const decodedEmail = decodeURIComponent(email);
-
-  try {
-    const deleted = await suppressionService.deleteSuppression(
-      userId,
-      decodedEmail,
-    );
-    return NextResponse.json(deleted);
-  } catch (err) {
-    if (err instanceof SuppressionServiceError && err.code === "not_found") {
-      return NextResponse.json(
-        { error: "Suppression not found", code: "not_found" },
-        { status: 404 },
-      );
-    }
-    throw err;
-  }
+  return await handleDeleteSuppressionRequest(request, email);
 }

--- a/src/app/api/suppressions/route.ts
+++ b/src/app/api/suppressions/route.ts
@@ -1,34 +1,5 @@
-import {
-  authorizeDashboardOrApiKey,
-  getServerSession,
-  unauthorizedResponse,
-} from "@/lib/api-auth";
-import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
-import { createSuppressionService } from "@opensend/core";
-import { NextResponse } from "next/server";
+import { handleListSuppressionsRequest } from "@/lib/api/suppressions";
 
-const suppressionService = createSuppressionService();
-
-export async function GET(request: Request) {
-  const auth = await authorizeDashboardOrApiKey(
-    request.headers.get("authorization"),
-  );
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessForApiKeyCaller(auth);
-  if (permissionError) return permissionError;
-  const session = "dashboard" in auth ? await getServerSession() : null;
-  const userId = "userId" in auth ? auth.userId : session?.user?.id;
-  if (!userId) return unauthorizedResponse();
-
-  const url = new URL(request.url);
-  const limit = Number(url.searchParams.get("limit"));
-  const after = url.searchParams.get("after") || undefined;
-
-  const result = await suppressionService.listSuppressions({
-    userId,
-    limit,
-    after,
-  });
-
-  return NextResponse.json(result);
+export async function GET(request: Request): Promise<Response> {
+  return await handleListSuppressionsRequest(request);
 }

--- a/src/lib/api/suppressions/handlers.ts
+++ b/src/lib/api/suppressions/handlers.ts
@@ -1,0 +1,84 @@
+import {
+  authorizeDashboardOrApiKey,
+  getServerSession,
+  unauthorizedResponse,
+} from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
+import {
+  SuppressionServiceError,
+  createSuppressionService,
+} from "@opensend/core";
+
+const suppressionService = createSuppressionService();
+
+type SuppressionAuthResult =
+  | { ok: true; userId: string }
+  | { ok: false; response: Response };
+
+async function requireSuppressionAuth(
+  request: Request,
+): Promise<SuppressionAuthResult> {
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
+  if (!auth) return { ok: false, response: unauthorizedResponse() };
+
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return { ok: false, response: permissionError };
+
+  if ("userId" in auth) {
+    if (!auth.userId) return { ok: false, response: unauthorizedResponse() };
+    return { ok: true, userId: auth.userId };
+  }
+
+  const session = await getServerSession();
+  const userId = session?.user?.id;
+  if (!userId) return { ok: false, response: unauthorizedResponse() };
+
+  return { ok: true, userId };
+}
+
+export async function handleListSuppressionsRequest(
+  request: Request,
+): Promise<Response> {
+  const authResult = await requireSuppressionAuth(request);
+  if (!authResult.ok) return authResult.response;
+
+  const url = new URL(request.url);
+  const limit = Number(url.searchParams.get("limit"));
+  const after = url.searchParams.get("after") || undefined;
+
+  const result = await suppressionService.listSuppressions({
+    userId: authResult.userId,
+    limit,
+    after,
+  });
+
+  return Response.json(result);
+}
+
+export async function handleDeleteSuppressionRequest(
+  request: Request,
+  email: string,
+): Promise<Response> {
+  const authResult = await requireSuppressionAuth(request);
+  if (!authResult.ok) return authResult.response;
+
+  const decodedEmail = decodeURIComponent(email);
+
+  try {
+    const deleted = await suppressionService.deleteSuppression(
+      authResult.userId,
+      decodedEmail,
+    );
+    return Response.json(deleted);
+  } catch (err) {
+    if (err instanceof SuppressionServiceError && err.code === "not_found") {
+      return Response.json(
+        { error: "Suppression not found", code: "not_found" },
+        { status: 404 },
+      );
+    }
+    throw err;
+  }
+}

--- a/src/lib/api/suppressions/index.ts
+++ b/src/lib/api/suppressions/index.ts
@@ -1,0 +1,4 @@
+export {
+  handleDeleteSuppressionRequest,
+  handleListSuppressionsRequest,
+} from "./handlers";

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -9,6 +9,8 @@ const mockGetApiKeyAuthHeaderError = vi.hoisted(() => vi.fn());
 const mockEmitCloudWatchMetric = vi.hoisted(() => vi.fn());
 const mockLogTelemetry = vi.hoisted(() => vi.fn());
 const mockRecordTelemetryError = vi.hoisted(() => vi.fn());
+const mockListSuppressions = vi.hoisted(() => vi.fn());
+const mockDeleteSuppression = vi.hoisted(() => vi.fn());
 const mockReserveEmailQuota = vi.hoisted(() => vi.fn());
 const mockReleaseEmailQuota = vi.hoisted(() => vi.fn());
 const mockEmailReadService = vi.hoisted(() => ({
@@ -105,6 +107,19 @@ vi.mock("@opensend/core", () => {
     createEmailDetailService: () => mockEmailDetailService,
     createEmailLifecycleService: () => mockEmailLifecycleService,
     createEmailReadService: () => mockEmailReadService,
+    SuppressionServiceError: class SuppressionServiceError extends Error {
+      constructor(
+        readonly code: string,
+        message: string,
+      ) {
+        super(message);
+        this.name = "SuppressionServiceError";
+      }
+    },
+    createSuppressionService: () => ({
+      listSuppressions: mockListSuppressions,
+      deleteSuppression: mockDeleteSuppression,
+    }),
     detectSandboxTestRecipient: (recipient: string) => {
       const normalized = recipient.trim().toLowerCase();
       const [local, domain] = normalized.split("@");

--- a/tests/suppressions-route.test.ts
+++ b/tests/suppressions-route.test.ts
@@ -316,4 +316,114 @@ describe("suppression management routes", () => {
       code: "not_found",
     });
   });
+
+  it("exposes suppression list and delete through the Hono control-plane routes", async () => {
+    mockListSuppressions.mockResolvedValue({
+      object: "list",
+      scope: "user",
+      data: [
+        {
+          id: "supp-1",
+          object: "suppression",
+          email: "blocked@test.com",
+          reason: "bounced",
+          scope: "user",
+        },
+      ],
+      has_more: true,
+    });
+    mockDeleteSuppression.mockResolvedValue({
+      object: "suppression",
+      deleted: true,
+    });
+
+    const { Hono } = await import("hono");
+    const { registerSuppressionRoutes } = await import(
+      "../services/api/src/routes/suppressions"
+    );
+    const app = new Hono();
+    registerSuppressionRoutes(app);
+
+    const listResponse = await app.request(
+      "/suppressions?limit=10&after=supp-0",
+      {
+        headers: { Authorization: "Bearer os_test" },
+      },
+    );
+
+    expect(listResponse.status).toBe(200);
+    await expect(listResponse.json()).resolves.toEqual({
+      object: "list",
+      scope: "user",
+      data: [
+        {
+          id: "supp-1",
+          object: "suppression",
+          email: "blocked@test.com",
+          reason: "bounced",
+          scope: "user",
+        },
+      ],
+      has_more: true,
+    });
+    expect(mockListSuppressions).toHaveBeenCalledWith({
+      userId: "user-1",
+      limit: 10,
+      after: "supp-0",
+    });
+
+    const deleteResponse = await app.request(
+      "/suppressions/blocked%40test.com",
+      {
+        method: "DELETE",
+        headers: { Authorization: "Bearer os_test" },
+      },
+    );
+
+    expect(deleteResponse.status).toBe(200);
+    await expect(deleteResponse.json()).resolves.toEqual({
+      object: "suppression",
+      deleted: true,
+    });
+    expect(mockDeleteSuppression).toHaveBeenCalledWith(
+      "user-1",
+      "blocked@test.com",
+    );
+  });
+
+  it("preserves Hono suppression auth and permission failures before service calls", async () => {
+    const { Hono } = await import("hono");
+    const { registerSuppressionRoutes } = await import(
+      "../services/api/src/routes/suppressions"
+    );
+    const app = new Hono();
+    registerSuppressionRoutes(app);
+
+    mockAuthorizeDashboardOrApiKey.mockResolvedValueOnce(null);
+    const unauthorized = await app.request("/suppressions");
+
+    expect(unauthorized.status).toBe(401);
+    await expect(unauthorized.json()).resolves.toEqual({
+      error: "Missing or invalid API key",
+    });
+
+    mockAuthorizeDashboardOrApiKey.mockResolvedValueOnce({
+      apiKeyId: "key-1",
+      permission: "sending_access",
+      domain: null,
+      userId: "user-1",
+    });
+    const forbidden = await app.request("/suppressions/blocked%40test.com", {
+      method: "DELETE",
+      headers: { Authorization: "Bearer os_test" },
+    });
+
+    expect(forbidden.status).toBe(403);
+    await expect(forbidden.json()).resolves.toMatchObject({
+      code: "insufficient_api_key_permission",
+      statusCode: 403,
+    });
+    expect(mockListSuppressions).not.toHaveBeenCalled();
+    expect(mockDeleteSuppression).not.toHaveBeenCalled();
+  });
 });

--- a/tests/webhooks-api-keys-tenant-isolation.test.ts
+++ b/tests/webhooks-api-keys-tenant-isolation.test.ts
@@ -7,6 +7,8 @@ const mockGetWebhook = vi.hoisted(() => vi.fn());
 const mockUpdateWebhook = vi.hoisted(() => vi.fn());
 const mockDeleteWebhook = vi.hoisted(() => vi.fn());
 const mockReplayWebhookDelivery = vi.hoisted(() => vi.fn());
+const mockListSuppressions = vi.hoisted(() => vi.fn());
+const mockDeleteSuppression = vi.hoisted(() => vi.fn());
 const mockListApiKeys = vi.hoisted(() => vi.fn());
 const mockCreateApiKey = vi.hoisted(() => vi.fn());
 const mockGetApiKey = vi.hoisted(() => vi.fn());
@@ -21,6 +23,18 @@ const MockApiKeyServiceError = vi.hoisted(
       ) {
         super(message);
         this.name = "ApiKeyServiceError";
+      }
+    },
+);
+const MockSuppressionServiceError = vi.hoisted(
+  () =>
+    class SuppressionServiceError extends Error {
+      constructor(
+        readonly code: string,
+        message: string,
+      ) {
+        super(message);
+        this.name = "SuppressionServiceError";
       }
     },
 );
@@ -54,6 +68,7 @@ vi.mock("@/lib/billing/quota", () => ({
 vi.mock("@opensend/core", () => ({
   ApiKeyServiceError: MockApiKeyServiceError,
   WebhookServiceError: MockWebhookServiceError,
+  SuppressionServiceError: MockSuppressionServiceError,
   createApiKeyService: () => ({
     listApiKeys: mockListApiKeys,
     createApiKey: mockCreateApiKey,
@@ -115,6 +130,10 @@ vi.mock("@opensend/core", () => ({
       domain: key.domain,
     })),
     has_more: result.hasMore,
+  }),
+  createSuppressionService: () => ({
+    listSuppressions: mockListSuppressions,
+    deleteSuppression: mockDeleteSuppression,
   }),
   createWebhookService: () => ({
     listWebhooks: mockListWebhooks,


### PR DESCRIPTION
## Summary\n- Added shared suppression request handlers used by both the existing Next compatibility routes and the Hono control-plane service.\n- Registered services/api Hono parity endpoints for GET /suppressions and DELETE /suppressions/:email.\n- Documented suppression support and remaining Next-owned route families in services/api/README.md.\n- Added Hono suppression parity tests and updated existing createApp-importing route mocks for the new shared handler import.\n\n## Validation\n- bun run test -- tests/suppressions-route.test.ts\n- bun run test -- tests/api-emails.test.ts tests/webhooks-api-keys-tenant-isolation.test.ts tests/suppressions-route.test.ts\n- make check\n- make test\n\nCloses #441