### PR TITLE
Harden send API contract boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-12-issue-442-send-contract-boundary.md
+++ b/agent_docs/learnings/active/2026-05-12-issue-442-send-contract-boundary.md
@@ -1,0 +1,20 @@
+---
+date: 2026-05-12
+issue: "#442"
+type: decision
+promoted_to: null
+---
+
+## Send/batch public contract boundary lives in core contracts
+
+For issue #442, the adopted public send route family moved request validation,
+recipient normalization, success response schemas, and public error-envelope
+helpers into `packages/core/src/contracts/`. Keep `src/lib/api-errors.ts` and
+`src/lib/validation/emails.ts` as compatibility re-export shims only; new route,
+service, SDK, and docs checks should import the core contract boundary instead
+of app-local validation internals.
+
+The TypeScript SDK still builds DTO declarations from `packages/core/src/dto` to
+avoid pulling Zod/runtime contract files into the published package output.
+Mirror public error-code/detail shape changes there when contract response types
+change, and prove compatibility with type assertions in `tests/send-contract.test.ts`.

--- a/docs/public-send-contract.md
+++ b/docs/public-send-contract.md
@@ -1,0 +1,47 @@
+# Public send email contract boundary
+
+The contract-stable boundary for the adopted send route family lives in
+`packages/core/src/contracts/`:
+
+- `send.ts` owns public `POST /emails`, `POST /api/emails`,
+  `POST /emails/batch`, and `POST /api/emails/batch` request validation,
+  recipient normalization helpers, and success response schemas.
+- `public-api-errors.ts` owns the public JSON error envelope used by the send
+  route family: `name`, `code`, `message`, `statusCode`, and optional sanitized
+  `details`.
+
+These modules may be imported by Next route handlers, `services/api`, tests,
+SDK compatibility checks, and documentation code. They must not import Next.js
+app internals, route handlers, database clients, SES/SQS clients, or dashboard
+components.
+
+## Contract-stable
+
+- Request field names and casing for send payloads: `from`, `to`, `cc`, `bcc`,
+  `reply_to`, `subject`, `html`, `text`, `headers`, `attachments`, `tags`,
+  `scheduled_at`, `topic_id`, and `template`.
+- Recipient input accepts either a string email address or an array of email
+  addresses. Runtime handlers normalize accepted recipients to arrays before
+  persistence or suppression checks.
+- Batch send accepts an array of send payloads with a maximum of 100 items.
+- Single-send success response is `{ id: string }`.
+- Batch-send success response is `{ data: Array<{ id: string } | { error:
+  PublicApiErrorEnvelope }> }`.
+- Public error envelopes include `name`, `code`, `message`, `statusCode`, and
+  optional sanitized `details`.
+- Validation details expose only `formErrors` and `fieldErrors`.
+
+## App-internal
+
+- Next.js route files and middleware rewrites.
+- Hono service adapter plumbing in `services/api`.
+- API-key lookup, permission checks, quota reservation, suppression checks,
+  template rendering, unsubscribe header injection, database rows, telemetry,
+  queue publishing, and audit logging.
+- Storage-specific normalization for attachments after request validation.
+- Public docs/OpenAPI rendering code; it should reference the same contract
+  shapes but is not the source of truth.
+
+When changing send or batch send behavior, update the contract module and its
+focused contract tests first, then adapt app/service handlers and SDK/docs tests
+to that boundary.

--- a/packages/core/src/contracts/index.ts
+++ b/packages/core/src/contracts/index.ts
@@ -1,0 +1,2 @@
+export * from "./public-api-errors";
+export * from "./send";

--- a/packages/core/src/contracts/public-api-errors.ts
+++ b/packages/core/src/contracts/public-api-errors.ts
@@ -1,0 +1,105 @@
+import { type ZodError, flattenError, z } from "zod";
+
+export const PUBLIC_API_ERROR_CODES = [
+  "invalid_json",
+  "validation_error",
+  "missing_api_key",
+  "malformed_api_key",
+  "invalid_api_key",
+  "invalid_idempotency_key",
+  "insufficient_api_key_permission",
+  "api_key_domain_restricted",
+  "idempotency_conflict",
+  "not_found",
+  "quota_exceeded",
+  "recipient_suppressed",
+  "rate_limit_exceeded",
+  "rate_limit_unavailable",
+  "internal_server_error",
+] as const;
+
+export const publicApiValidationDetailsSchema = z
+  .object({
+    formErrors: z.array(z.string()),
+    fieldErrors: z.record(z.string(), z.array(z.string())),
+  })
+  .strict();
+
+export const publicApiFlatDetailsSchema = z.record(
+  z.string(),
+  z.union([z.string(), z.number(), z.boolean(), z.null()]),
+);
+
+export const publicApiErrorEnvelopeSchema = z
+  .object({
+    name: z.enum(PUBLIC_API_ERROR_CODES),
+    code: z.enum(PUBLIC_API_ERROR_CODES),
+    message: z.string(),
+    statusCode: z.number().int(),
+    details: z
+      .union([publicApiValidationDetailsSchema, publicApiFlatDetailsSchema])
+      .optional(),
+  })
+  .strict();
+
+export type PublicApiErrorCode = (typeof PUBLIC_API_ERROR_CODES)[number];
+
+export type PublicApiErrorDetails =
+  | { formErrors: string[]; fieldErrors: Record<string, string[]> }
+  | Record<string, string | number | boolean | null>;
+
+export interface PublicApiErrorEnvelope {
+  name: PublicApiErrorCode;
+  code: PublicApiErrorCode;
+  message: string;
+  statusCode: number;
+  details?: PublicApiErrorDetails;
+}
+
+export function publicApiError(
+  code: PublicApiErrorCode,
+  message: string,
+  statusCode: number,
+  details?: PublicApiErrorDetails,
+): PublicApiErrorEnvelope {
+  return details === undefined
+    ? { name: code, code, message, statusCode }
+    : { name: code, code, message, statusCode, details };
+}
+
+export function publicApiErrorResponse(
+  code: PublicApiErrorCode,
+  message: string,
+  statusCode: number,
+  init?: ResponseInit & { details?: PublicApiErrorDetails },
+): Response {
+  const headers = new Headers(init?.headers);
+  return Response.json(
+    publicApiError(code, message, statusCode, init?.details),
+    {
+      ...init,
+      status: statusCode,
+      headers,
+    },
+  );
+}
+
+export function zodValidationDetails(error: ZodError): {
+  formErrors: string[];
+  fieldErrors: Record<string, string[]>;
+} {
+  const flattened = flattenError(error);
+  const fieldErrors: Record<string, string[]> = { ...flattened.fieldErrors };
+
+  for (const issue of error.issues) {
+    if (issue.path.length < 2) continue;
+
+    const fieldPath = issue.path.join(".");
+    fieldErrors[fieldPath] = [...(fieldErrors[fieldPath] ?? []), issue.message];
+  }
+
+  return {
+    formErrors: flattened.formErrors,
+    fieldErrors,
+  };
+}

--- a/packages/core/src/contracts/send.ts
+++ b/packages/core/src/contracts/send.ts
@@ -1,0 +1,252 @@
+import { z } from "zod";
+import { publicApiErrorEnvelopeSchema } from "./public-api-errors";
+
+// ── Common Fragments ──────────────────────────────────────────────
+
+export const MAX_EMAIL_ATTACHMENT_BASE64_BYTES = 40 * 1024 * 1024;
+
+export const emailAddressSchema = z.string().email().min(3).max(512);
+
+export const emailRecipientSchema = z.union([
+  emailAddressSchema,
+  z.array(emailAddressSchema),
+]);
+
+const EMAIL_TAG_PATTERN = /^[A-Za-z0-9_-]*$/;
+const EMAIL_TAG_PATTERN_MESSAGE =
+  "Tag names and values may only contain ASCII letters, numbers, underscores, or dashes.";
+const EMAIL_TAG_LENGTH_MESSAGE =
+  "Tag names and values must be no more than 256 characters.";
+
+export const tagSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(256, EMAIL_TAG_LENGTH_MESSAGE)
+    .regex(EMAIL_TAG_PATTERN, EMAIL_TAG_PATTERN_MESSAGE),
+  value: z
+    .string()
+    .max(256, EMAIL_TAG_LENGTH_MESSAGE)
+    .regex(EMAIL_TAG_PATTERN, EMAIL_TAG_PATTERN_MESSAGE),
+});
+
+function hasAllowedAttachmentUrlScheme(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function getBase64EncodedSize(byteLength: number): number {
+  return Math.ceil(byteLength / 3) * 4;
+}
+
+function getInlineAttachmentEncodedSize(content: string): number {
+  const normalized = content.replace(/\s/g, "");
+  return normalized.length;
+}
+
+function getTotalInlineAttachmentEncodedSize(
+  attachments: Array<{ content?: string }> | undefined,
+): number {
+  return (
+    attachments?.reduce(
+      (total, attachment) =>
+        total +
+        (typeof attachment.content === "string"
+          ? getInlineAttachmentEncodedSize(attachment.content)
+          : 0),
+      0,
+    ) ?? 0
+  );
+}
+
+export function getAttachmentBase64EncodedSize(byteLength: number): number {
+  return getBase64EncodedSize(byteLength);
+}
+
+export const attachmentSchema = z
+  .object({
+    filename: z.string().min(1).max(255),
+    content: z.string().optional(),
+    path: z.string().url().optional(),
+    content_type: z.string().min(1).optional(),
+    content_id: z.string().min(1).optional(),
+  })
+  .superRefine((attachment, ctx) => {
+    if (!attachment.content && !attachment.path) {
+      ctx.addIssue({
+        code: "custom",
+        message: "attachment requires content or path",
+        path: ["content"],
+      });
+    }
+
+    if (attachment.path && !hasAllowedAttachmentUrlScheme(attachment.path)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "attachment path must use http or https",
+        path: ["path"],
+      });
+    }
+  });
+
+// ── Scheduled send parsing ────────────────────────────────────────
+
+const MAX_SCHEDULE_DELAY_MS = 30 * 24 * 60 * 60 * 1000;
+const NATURAL_LANGUAGE_SCHEDULE_RE =
+  /^in\s+([1-9]\d*)\s+(min|minute|minutes|hour|hours|day|days)$/i;
+const ISO_8601_WITH_TIMEZONE_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+export const scheduledAtValidationMessage =
+  "scheduled_at must be a future ISO 8601 date-time or 'in <positive integer> <minute|min|minutes|hour|hours|day|days>' within 30 days.";
+
+export type ScheduledAtParseResult =
+  | { ok: true; date: Date }
+  | { ok: false; message: string };
+
+function isAllowedScheduledDate(date: Date, now: Date): boolean {
+  const time = date.getTime();
+  const nowTime = now.getTime();
+  return (
+    Number.isFinite(time) &&
+    time > nowTime &&
+    time <= nowTime + MAX_SCHEDULE_DELAY_MS
+  );
+}
+
+function parseNaturalLanguageScheduledAt(
+  value: string,
+  now: Date,
+): Date | null {
+  const match = NATURAL_LANGUAGE_SCHEDULE_RE.exec(value.trim());
+  if (!match) return null;
+
+  const amount = Number(match[1]);
+  const unit = match[2]?.toLowerCase();
+  if (!Number.isSafeInteger(amount)) return null;
+
+  const multiplier = unit?.startsWith("day")
+    ? 24 * 60 * 60 * 1000
+    : unit?.startsWith("hour")
+      ? 60 * 60 * 1000
+      : 60 * 1000;
+
+  return new Date(now.getTime() + amount * multiplier);
+}
+
+export function parseScheduledAt(
+  value: string,
+  now: Date = new Date(),
+): ScheduledAtParseResult {
+  const trimmed = value.trim();
+  const naturalDate = parseNaturalLanguageScheduledAt(trimmed, now);
+  const parsedDate = naturalDate
+    ? naturalDate
+    : ISO_8601_WITH_TIMEZONE_RE.test(trimmed)
+      ? new Date(trimmed)
+      : null;
+
+  if (!parsedDate || !isAllowedScheduledDate(parsedDate, now)) {
+    return { ok: false, message: scheduledAtValidationMessage };
+  }
+
+  return { ok: true, date: parsedDate };
+}
+
+export function normalizeScheduledAt(
+  value: string,
+  now: Date = new Date(),
+): Date {
+  const parsed = parseScheduledAt(value, now);
+  if (!parsed.ok) {
+    throw new Error(parsed.message);
+  }
+  return parsed.date;
+}
+
+const scheduledAtSchema = z.string().superRefine((value, ctx) => {
+  const parsed = parseScheduledAt(value);
+  if (!parsed.ok) {
+    ctx.addIssue({
+      code: "custom",
+      message: parsed.message,
+    });
+  }
+});
+
+// ── Email Request Schemas ──────────────────────────────────────────
+
+export const sendEmailSchema = z
+  .object({
+    from: emailAddressSchema,
+    to: emailRecipientSchema,
+    subject: z.string().min(1).max(1024),
+    html: z.string().optional(),
+    text: z.string().optional(),
+    cc: emailRecipientSchema.optional(),
+    bcc: emailRecipientSchema.optional(),
+    reply_to: emailRecipientSchema.optional(),
+    headers: z.record(z.string(), z.string()).optional(),
+    attachments: z.array(attachmentSchema).optional(),
+    tags: z.array(tagSchema).max(75).optional(),
+    scheduled_at: scheduledAtSchema.optional(),
+    topic_id: z.string().uuid().optional(),
+    template: z
+      .object({
+        id: z.string().uuid(),
+        variables: z.record(z.string(), z.unknown()).optional(),
+      })
+      .optional(),
+  })
+  .refine((data) => data.html || data.text || data.template, {
+    message: "html, text, or template is required",
+    path: ["html"],
+  })
+  .refine(
+    (data) =>
+      getTotalInlineAttachmentEncodedSize(data.attachments) <=
+      MAX_EMAIL_ATTACHMENT_BASE64_BYTES,
+    {
+      message:
+        "attachments must be no more than 40MB per email after Base64 encoding",
+      path: ["attachments"],
+    },
+  );
+
+export const batchSendEmailSchema = z.array(sendEmailSchema).max(100);
+
+export const sendEmailResponseSchema = z.object({ id: z.string() }).strict();
+
+export const batchSendEmailItemErrorSchema = z
+  .object({ error: publicApiErrorEnvelopeSchema })
+  .strict();
+
+export const batchSendEmailItemResponseSchema = z.union([
+  sendEmailResponseSchema,
+  batchSendEmailItemErrorSchema,
+]);
+
+export const batchSendEmailResponseSchema = z
+  .object({ data: z.array(batchSendEmailItemResponseSchema) })
+  .strict();
+
+export type SendEmailRequest = z.infer<typeof sendEmailSchema>;
+export type BatchSendEmailRequest = z.infer<typeof batchSendEmailSchema>;
+export type SendEmailSuccessResponse = z.infer<typeof sendEmailResponseSchema>;
+export type BatchSendEmailItemResponse = z.infer<
+  typeof batchSendEmailItemResponseSchema
+>;
+export type BatchSendEmailResponseBody = z.infer<
+  typeof batchSendEmailResponseSchema
+>;
+
+export function normalizeEmailRecipient(
+  value: SendEmailRequest["to"] | undefined,
+): string[] | undefined {
+  if (!value) return undefined;
+  return Array.isArray(value) ? value : [value];
+}

--- a/packages/core/src/dto/index.ts
+++ b/packages/core/src/dto/index.ts
@@ -44,6 +44,23 @@ export interface EmailResponse {
 
 export type SendEmailResponse = EmailResponse;
 
+export type EmailPublicErrorCode =
+  | "invalid_json"
+  | "validation_error"
+  | "missing_api_key"
+  | "malformed_api_key"
+  | "invalid_api_key"
+  | "invalid_idempotency_key"
+  | "insufficient_api_key_permission"
+  | "api_key_domain_restricted"
+  | "idempotency_conflict"
+  | "not_found"
+  | "quota_exceeded"
+  | "recipient_suppressed"
+  | "rate_limit_exceeded"
+  | "rate_limit_unavailable"
+  | "internal_server_error";
+
 export type EmailStatus =
   | "queued"
   | "processing"
@@ -82,11 +99,13 @@ export interface ProviderRetryVisibility {
 
 export interface BatchEmailItemError {
   error: {
-    name?: string;
-    code: string;
+    name: EmailPublicErrorCode;
+    code: EmailPublicErrorCode;
     message: string;
     statusCode: number;
-    details?: Record<string, string | number | boolean | null>;
+    details?:
+      | { formErrors: string[]; fieldErrors: Record<string, string[]> }
+      | Record<string, string | number | boolean | null>;
   };
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export * from "./billing/stripe-events";
 export * from "./auth/api-auth";
 export * from "./auth/rate-limiter";
 export * from "./dto";
+export * from "./contracts";
 export * from "./webhook-signing";
 export * from "./webhook-events";
 export * from "./services/dns";

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -21,6 +21,8 @@ Current endpoints:
 
 The transactional send route family is now owned by shared send handlers consumed by this Hono service. The existing Next.js handlers remain compatibility adapters for the current public `/api/emails` URLs; no production routing cutover is implied by local service ownership.
 
+The stable send/batch DTO, validation, response, and public error-envelope boundary is documented in [`../../docs/public-send-contract.md`](../../docs/public-send-contract.md) and implemented under `packages/core/src/contracts/`; adapter code should consume that boundary rather than importing Next.js app-local validation internals.
+
 ### Transactional send local testing
 
 Start the Hono service on the default port:

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -1,78 +1,10 @@
-import { type ZodError, flattenError } from "zod";
-
-export type PublicApiErrorCode =
-  | "invalid_json"
-  | "validation_error"
-  | "missing_api_key"
-  | "malformed_api_key"
-  | "invalid_api_key"
-  | "invalid_idempotency_key"
-  | "insufficient_api_key_permission"
-  | "api_key_domain_restricted"
-  | "idempotency_conflict"
-  | "not_found"
-  | "quota_exceeded"
-  | "recipient_suppressed"
-  | "rate_limit_exceeded"
-  | "rate_limit_unavailable"
-  | "internal_server_error";
-
-export type PublicApiErrorDetails =
-  | { formErrors: string[]; fieldErrors: Record<string, string[]> }
-  | Record<string, string | number | boolean | null>;
-
-export interface PublicApiErrorEnvelope {
-  name: PublicApiErrorCode;
-  code: PublicApiErrorCode;
-  message: string;
-  statusCode: number;
-  details?: PublicApiErrorDetails;
-}
-
-export function publicApiError(
-  code: PublicApiErrorCode,
-  message: string,
-  statusCode: number,
-  details?: PublicApiErrorDetails,
-): PublicApiErrorEnvelope {
-  return details === undefined
-    ? { name: code, code, message, statusCode }
-    : { name: code, code, message, statusCode, details };
-}
-
-export function publicApiErrorResponse(
-  code: PublicApiErrorCode,
-  message: string,
-  statusCode: number,
-  init?: ResponseInit & { details?: PublicApiErrorDetails },
-): Response {
-  const headers = new Headers(init?.headers);
-  return Response.json(
-    publicApiError(code, message, statusCode, init?.details),
-    {
-      ...init,
-      status: statusCode,
-      headers,
-    },
-  );
-}
-
-export function zodValidationDetails(error: ZodError): {
-  formErrors: string[];
-  fieldErrors: Record<string, string[]>;
-} {
-  const flattened = flattenError(error);
-  const fieldErrors: Record<string, string[]> = { ...flattened.fieldErrors };
-
-  for (const issue of error.issues) {
-    if (issue.path.length < 2) continue;
-
-    const fieldPath = issue.path.join(".");
-    fieldErrors[fieldPath] = [...(fieldErrors[fieldPath] ?? []), issue.message];
-  }
-
-  return {
-    formErrors: flattened.formErrors,
-    fieldErrors,
-  };
-}
+export {
+  publicApiError,
+  publicApiErrorResponse,
+  zodValidationDetails,
+} from "../../packages/core/src/contracts/public-api-errors";
+export type {
+  PublicApiErrorCode,
+  PublicApiErrorDetails,
+  PublicApiErrorEnvelope,
+} from "../../packages/core/src/contracts/public-api-errors";

--- a/src/lib/api/emails/batch-send.ts
+++ b/src/lib/api/emails/batch-send.ts
@@ -3,11 +3,6 @@ import {
   publicApiKeyUnauthorizedResponse,
   validateApiKey,
 } from "@/lib/api-auth";
-import {
-  type PublicApiErrorEnvelope,
-  publicApiError,
-  zodValidationDetails,
-} from "@/lib/api-errors";
 import { requireAllowedBatchSendingDomains } from "@/lib/api-key-permissions";
 import { captureApiResponseLog } from "@/lib/api-logging";
 import { getIdempotencyWindowStart } from "@/lib/api/emails/idempotency";
@@ -31,10 +26,8 @@ import {
   replaceUnsubscribePlaceholder,
 } from "@/lib/unsubscribe";
 import {
+  type PublicApiErrorEnvelope,
   batchSendEmailSchema,
-  normalizeScheduledAt,
-} from "@/lib/validation/emails";
-import {
   createBackgroundJob,
   createTelemetryContext,
   detectSandboxTestRecipient,
@@ -42,8 +35,12 @@ import {
   getSandboxTestOutcomeForRecipients,
   getTelemetryCarrier,
   logTelemetry,
+  normalizeEmailRecipient,
+  normalizeScheduledAt,
+  publicApiError,
   publishBackgroundJob,
   recordTelemetryError,
+  zodValidationDetails,
 } from "@opensend/core";
 import { and, eq, gte, lt } from "drizzle-orm";
 
@@ -102,13 +99,6 @@ function emailIdsFromBatchResponse(response: BatchSendResponseBody): string[] {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────
-
-function normalizeToArray(
-  value: string | string[] | undefined,
-): string[] | undefined {
-  if (!value) return undefined;
-  return Array.isArray(value) ? value : [value];
-}
 
 function jsonWithTelemetry(
   body: unknown,
@@ -464,13 +454,13 @@ export async function handlePostEmailBatchRequest(
     return await logResponse(domainRestrictionError);
   }
   const itemRecipients = validatedItems.map(
-    (item) => normalizeToArray(item.to) as string[],
+    (item) => normalizeEmailRecipient(item.to) as string[],
   );
   const itemSandboxRecipients = validatedItems.map((item, index) =>
     getSandboxRecipientsForMessage({
       to: itemRecipients[index] ?? [],
-      cc: normalizeToArray(item.cc),
-      bcc: normalizeToArray(item.bcc),
+      cc: normalizeEmailRecipient(item.cc),
+      bcc: normalizeEmailRecipient(item.bcc),
     }),
   );
   const hasMixedSandboxItem = itemSandboxRecipients.some(
@@ -557,10 +547,10 @@ export async function handlePostEmailBatchRequest(
         ) {
           continue;
         }
-        const to = normalizeToArray(item.to) as string[];
-        const cc = normalizeToArray(item.cc);
-        const bcc = normalizeToArray(item.bcc);
-        const replyTo = normalizeToArray(item.reply_to);
+        const to = normalizeEmailRecipient(item.to) as string[];
+        const cc = normalizeEmailRecipient(item.cc);
+        const bcc = normalizeEmailRecipient(item.bcc);
+        const replyTo = normalizeEmailRecipient(item.reply_to);
         const scheduledAt = item.scheduled_at
           ? normalizeScheduledAt(item.scheduled_at)
           : null;

--- a/src/lib/api/emails/send.ts
+++ b/src/lib/api/emails/send.ts
@@ -3,7 +3,6 @@ import {
   publicApiKeyUnauthorizedResponse,
   validateApiKey,
 } from "@/lib/api-auth";
-import { publicApiError, zodValidationDetails } from "@/lib/api-errors";
 import { requireAllowedSendingDomain } from "@/lib/api-key-permissions";
 import { captureApiResponseLog } from "@/lib/api-logging";
 import { getIdempotencyWindowStart } from "@/lib/api/emails/idempotency";
@@ -30,7 +29,6 @@ import {
   hasUnsubscribePlaceholder,
   replaceUnsubscribePlaceholder,
 } from "@/lib/unsubscribe";
-import { normalizeScheduledAt, sendEmailSchema } from "@/lib/validation/emails";
 import {
   createBackgroundJob,
   createTelemetryContext,
@@ -39,19 +37,17 @@ import {
   getSandboxTestOutcomeForRecipients,
   getTelemetryCarrier,
   logTelemetry,
+  normalizeEmailRecipient,
+  normalizeScheduledAt,
+  publicApiError,
   publishBackgroundJob,
   recordTelemetryError,
+  sendEmailSchema,
+  zodValidationDetails,
 } from "@opensend/core";
 import { and, eq, gte, lt } from "drizzle-orm";
 
 // ── Helpers ───────────────────────────────────────────────────────
-
-function normalizeToArray(
-  value: string | string[] | undefined,
-): string[] | undefined {
-  if (!value) return undefined;
-  return Array.isArray(value) ? value : [value];
-}
 
 function jsonWithTelemetry(
   body: unknown,
@@ -400,10 +396,10 @@ export async function handlePostEmailRequest(
     }
   }
 
-  const to = normalizeToArray(validated.to) as string[];
-  const cc = normalizeToArray(validated.cc);
-  const bcc = normalizeToArray(validated.bcc);
-  const replyTo = normalizeToArray(validated.reply_to);
+  const to = normalizeEmailRecipient(validated.to) as string[];
+  const cc = normalizeEmailRecipient(validated.cc);
+  const bcc = normalizeEmailRecipient(validated.bcc);
+  const replyTo = normalizeEmailRecipient(validated.reply_to);
   const scheduledAt = validated.scheduled_at
     ? normalizeScheduledAt(validated.scheduled_at)
     : null;

--- a/src/lib/validation/emails.ts
+++ b/src/lib/validation/emails.ts
@@ -1,222 +1,27 @@
-import { z } from "zod";
-
-// ── Common Fragments ──────────────────────────────────────────────
-
-export const MAX_EMAIL_ATTACHMENT_BASE64_BYTES = 40 * 1024 * 1024;
-
-export const emailAddressSchema = z.string().email().min(3).max(512);
-
-export const emailRecipientSchema = z.union([
+export {
+  MAX_EMAIL_ATTACHMENT_BASE64_BYTES,
+  attachmentSchema,
+  batchSendEmailSchema,
+  batchSendEmailItemErrorSchema,
+  batchSendEmailItemResponseSchema,
+  batchSendEmailResponseSchema,
   emailAddressSchema,
-  z.array(emailAddressSchema),
-]);
-
-const EMAIL_TAG_PATTERN = /^[A-Za-z0-9_-]*$/;
-const EMAIL_TAG_PATTERN_MESSAGE =
-  "Tag names and values may only contain ASCII letters, numbers, underscores, or dashes.";
-const EMAIL_TAG_LENGTH_MESSAGE =
-  "Tag names and values must be no more than 256 characters.";
-
-export const tagSchema = z.object({
-  name: z
-    .string()
-    .min(1)
-    .max(256, EMAIL_TAG_LENGTH_MESSAGE)
-    .regex(EMAIL_TAG_PATTERN, EMAIL_TAG_PATTERN_MESSAGE),
-  value: z
-    .string()
-    .max(256, EMAIL_TAG_LENGTH_MESSAGE)
-    .regex(EMAIL_TAG_PATTERN, EMAIL_TAG_PATTERN_MESSAGE),
-});
-
-function hasAllowedAttachmentUrlScheme(value: string): boolean {
-  try {
-    const url = new URL(value);
-    return url.protocol === "https:" || url.protocol === "http:";
-  } catch {
-    return false;
-  }
-}
-
-function getBase64EncodedSize(byteLength: number): number {
-  return Math.ceil(byteLength / 3) * 4;
-}
-
-function getInlineAttachmentEncodedSize(content: string): number {
-  const normalized = content.replace(/\s/g, "");
-  return normalized.length;
-}
-
-function getTotalInlineAttachmentEncodedSize(
-  attachments: Array<{ content?: string }> | undefined,
-): number {
-  return (
-    attachments?.reduce(
-      (total, attachment) =>
-        total +
-        (typeof attachment.content === "string"
-          ? getInlineAttachmentEncodedSize(attachment.content)
-          : 0),
-      0,
-    ) ?? 0
-  );
-}
-
-export function getAttachmentBase64EncodedSize(byteLength: number): number {
-  return getBase64EncodedSize(byteLength);
-}
-
-export const attachmentSchema = z
-  .object({
-    filename: z.string().min(1).max(255),
-    content: z.string().optional(),
-    path: z.string().url().optional(),
-    content_type: z.string().min(1).optional(),
-    content_id: z.string().min(1).optional(),
-  })
-  .superRefine((attachment, ctx) => {
-    if (!attachment.content && !attachment.path) {
-      ctx.addIssue({
-        code: "custom",
-        message: "attachment requires content or path",
-        path: ["content"],
-      });
-    }
-
-    if (attachment.path && !hasAllowedAttachmentUrlScheme(attachment.path)) {
-      ctx.addIssue({
-        code: "custom",
-        message: "attachment path must use http or https",
-        path: ["path"],
-      });
-    }
-  });
-
-// ── Scheduled send parsing ────────────────────────────────────────
-
-const MAX_SCHEDULE_DELAY_MS = 30 * 24 * 60 * 60 * 1000;
-const NATURAL_LANGUAGE_SCHEDULE_RE =
-  /^in\s+([1-9]\d*)\s+(min|minute|minutes|hour|hours|day|days)$/i;
-const ISO_8601_WITH_TIMEZONE_RE =
-  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
-
-export const scheduledAtValidationMessage =
-  "scheduled_at must be a future ISO 8601 date-time or 'in <positive integer> <minute|min|minutes|hour|hours|day|days>' within 30 days.";
-
-export type ScheduledAtParseResult =
-  | { ok: true; date: Date }
-  | { ok: false; message: string };
-
-function isAllowedScheduledDate(date: Date, now: Date): boolean {
-  const time = date.getTime();
-  const nowTime = now.getTime();
-  return (
-    Number.isFinite(time) &&
-    time > nowTime &&
-    time <= nowTime + MAX_SCHEDULE_DELAY_MS
-  );
-}
-
-function parseNaturalLanguageScheduledAt(
-  value: string,
-  now: Date,
-): Date | null {
-  const match = NATURAL_LANGUAGE_SCHEDULE_RE.exec(value.trim());
-  if (!match) return null;
-
-  const amount = Number(match[1]);
-  const unit = match[2]?.toLowerCase();
-  if (!Number.isSafeInteger(amount)) return null;
-
-  const multiplier = unit?.startsWith("day")
-    ? 24 * 60 * 60 * 1000
-    : unit?.startsWith("hour")
-      ? 60 * 60 * 1000
-      : 60 * 1000;
-
-  return new Date(now.getTime() + amount * multiplier);
-}
-
-export function parseScheduledAt(
-  value: string,
-  now: Date = new Date(),
-): ScheduledAtParseResult {
-  const trimmed = value.trim();
-  const naturalDate = parseNaturalLanguageScheduledAt(trimmed, now);
-  const parsedDate = naturalDate
-    ? naturalDate
-    : ISO_8601_WITH_TIMEZONE_RE.test(trimmed)
-      ? new Date(trimmed)
-      : null;
-
-  if (!parsedDate || !isAllowedScheduledDate(parsedDate, now)) {
-    return { ok: false, message: scheduledAtValidationMessage };
-  }
-
-  return { ok: true, date: parsedDate };
-}
-
-export function normalizeScheduledAt(
-  value: string,
-  now: Date = new Date(),
-): Date {
-  const parsed = parseScheduledAt(value, now);
-  if (!parsed.ok) {
-    throw new Error(parsed.message);
-  }
-  return parsed.date;
-}
-
-const scheduledAtSchema = z.string().superRefine((value, ctx) => {
-  const parsed = parseScheduledAt(value);
-  if (!parsed.ok) {
-    ctx.addIssue({
-      code: "custom",
-      message: parsed.message,
-    });
-  }
-});
-
-// ── Email Request Schemas ──────────────────────────────────────────
-
-export const sendEmailSchema = z
-  .object({
-    from: emailAddressSchema,
-    to: emailRecipientSchema,
-    subject: z.string().min(1).max(1024),
-    html: z.string().optional(),
-    text: z.string().optional(),
-    cc: emailRecipientSchema.optional(),
-    bcc: emailRecipientSchema.optional(),
-    reply_to: emailRecipientSchema.optional(),
-    headers: z.record(z.string(), z.string()).optional(),
-    attachments: z.array(attachmentSchema).optional(),
-    tags: z.array(tagSchema).max(75).optional(),
-    scheduled_at: scheduledAtSchema.optional(),
-    topic_id: z.string().uuid().optional(),
-    template: z
-      .object({
-        id: z.string().uuid(),
-        variables: z.record(z.string(), z.unknown()).optional(),
-      })
-      .optional(),
-  })
-  .refine((data) => data.html || data.text || data.template, {
-    message: "html, text, or template is required",
-    path: ["html"],
-  })
-  .refine(
-    (data) =>
-      getTotalInlineAttachmentEncodedSize(data.attachments) <=
-      MAX_EMAIL_ATTACHMENT_BASE64_BYTES,
-    {
-      message:
-        "attachments must be no more than 40MB per email after Base64 encoding",
-      path: ["attachments"],
-    },
-  );
-
-export const batchSendEmailSchema = z.array(sendEmailSchema).max(100);
-
-export type SendEmailRequest = z.infer<typeof sendEmailSchema>;
-export type BatchSendEmailRequest = z.infer<typeof batchSendEmailSchema>;
+  emailRecipientSchema,
+  getAttachmentBase64EncodedSize,
+  normalizeEmailRecipient,
+  normalizeScheduledAt,
+  parseScheduledAt,
+  scheduledAtValidationMessage,
+  sendEmailResponseSchema,
+  sendEmailSchema,
+  tagSchema,
+} from "../../../packages/core/src/contracts/send";
+export { publicApiErrorEnvelopeSchema } from "../../../packages/core/src/contracts/public-api-errors";
+export type {
+  BatchSendEmailItemResponse,
+  BatchSendEmailRequest,
+  BatchSendEmailResponseBody,
+  ScheduledAtParseResult,
+  SendEmailRequest,
+  SendEmailSuccessResponse,
+} from "../../../packages/core/src/contracts/send";

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  batchSendEmailResponseSchema,
+  publicApiErrorEnvelopeSchema,
+  sendEmailResponseSchema,
+} from "../packages/core/src/contracts";
 
 // ── Mocks ─────────────────────────────────────────────────────────
 
@@ -77,7 +82,10 @@ vi.mock("@/lib/ses", () => ({
   sendEmail: mockSendEmail,
 }));
 
-vi.mock("@opensend/core", () => {
+vi.mock("@opensend/core", async () => {
+  const contracts = await vi.importActual<
+    typeof import("../packages/core/src/contracts")
+  >("../packages/core/src/contracts");
   const testTraceparent =
     "00-11111111111111111111111111111111-2222222222222222-01";
   const getHeader = (
@@ -95,6 +103,7 @@ vi.mock("@opensend/core", () => {
   };
 
   return {
+    ...contracts,
     EmailDetailServiceError: MockEmailDetailServiceError,
     EmailReadServiceError: MockEmailReadServiceError,
     EmailLifecycleServiceError: MockEmailLifecycleServiceError,
@@ -396,7 +405,7 @@ describe("POST /api/emails", () => {
     const res = await POST(req);
     expect(res.status).toBe(422);
     const json = await res.json();
-    expect(json).toEqual({
+    expect(publicApiErrorEnvelopeSchema.parse(json)).toEqual({
       name: "validation_error",
       code: "validation_error",
       message: "Validation failed.",
@@ -474,7 +483,8 @@ describe("POST /api/emails", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("x-correlation-id")).toBe("corr-email-test");
     expect(res.headers.get("traceparent")).toBe(traceparent);
-    await expect(res.json()).resolves.toEqual({ id: emailId });
+    const body = await res.json();
+    expect(sendEmailResponseSchema.parse(body)).toEqual({ id: emailId });
     expect(mockSendEmail).not.toHaveBeenCalled();
     expect(valuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -2365,7 +2375,9 @@ describe("services/api transactional email routes", () => {
     });
 
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({ id: "svc-email-1" });
+    expect(sendEmailResponseSchema.parse(await res.json())).toEqual({
+      id: "svc-email-1",
+    });
     expect(valuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
         to: ["svc@test.com"],
@@ -2396,7 +2408,9 @@ describe("services/api transactional email routes", () => {
       body: JSON.stringify({}),
     });
     expect(unauthenticated.status).toBe(401);
-    await expect(unauthenticated.json()).resolves.toMatchObject({
+    expect(
+      publicApiErrorEnvelopeSchema.parse(await unauthenticated.json()),
+    ).toMatchObject({
       name: "missing_api_key",
       code: "missing_api_key",
       statusCode: 401,
@@ -2411,7 +2425,9 @@ describe("services/api transactional email routes", () => {
       body: JSON.stringify({ from: "sender@domain.com" }),
     });
     expect(invalid.status).toBe(422);
-    await expect(invalid.json()).resolves.toMatchObject({
+    expect(
+      publicApiErrorEnvelopeSchema.parse(await invalid.json()),
+    ).toMatchObject({
       name: "validation_error",
       code: "validation_error",
       statusCode: 422,
@@ -2452,7 +2468,9 @@ describe("services/api transactional email routes", () => {
     });
 
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({ id: "existing-email" });
+    expect(sendEmailResponseSchema.parse(await res.json())).toEqual({
+      id: "existing-email",
+    });
     expect(mockReserveEmailQuota).not.toHaveBeenCalled();
     expect(nonLogInsertCalls()).toHaveLength(0);
   });
@@ -2492,7 +2510,7 @@ describe("services/api transactional email routes", () => {
     });
 
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toMatchObject({
+    expect(batchSendEmailResponseSchema.parse(await res.json())).toMatchObject({
       data: [
         { id: "svc-batch-1" },
         {

--- a/tests/send-contract.test.ts
+++ b/tests/send-contract.test.ts
@@ -1,0 +1,160 @@
+import {
+  batchSendEmailResponseSchema,
+  batchSendEmailSchema,
+  normalizeEmailRecipient,
+  publicApiError,
+  publicApiErrorEnvelopeSchema,
+  sendEmailResponseSchema,
+  sendEmailSchema,
+  zodValidationDetails,
+} from "@opensend/core";
+import type {
+  BatchSendEmailRequest,
+  BatchSendEmailResponseBody,
+  SendEmailRequest,
+  SendEmailSuccessResponse,
+} from "@opensend/core";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type {
+  BatchEmailResponse,
+  EmailResponse,
+  SendEmailPayload,
+} from "../packages/sdk/src";
+
+const validSendPayload = {
+  from: "sender@example.com",
+  to: "user@example.com",
+  cc: ["copy@example.com"],
+  bcc: "audit@example.com",
+  reply_to: "reply@example.com",
+  subject: "Shared contract",
+  html: "<p>Hello</p>",
+  headers: { "X-Campaign": "contract" },
+  tags: [{ name: "issue", value: "442" }],
+  scheduled_at: "in 5 minutes",
+  topic_id: "00000000-0000-4000-8000-000000000442",
+  extra_app_internal: "stripped",
+};
+
+describe("send email public contract boundary", () => {
+  it("validates public send requests and normalizes recipient fields without app internals", () => {
+    const parsed = sendEmailSchema.parse(validSendPayload);
+
+    expect(parsed).toMatchObject({
+      from: "sender@example.com",
+      to: "user@example.com",
+      reply_to: "reply@example.com",
+      scheduled_at: "in 5 minutes",
+      topic_id: "00000000-0000-4000-8000-000000000442",
+    });
+    expect(parsed).not.toHaveProperty("extra_app_internal");
+    expect(normalizeEmailRecipient(parsed.to)).toEqual(["user@example.com"]);
+    expect(normalizeEmailRecipient(parsed.cc)).toEqual(["copy@example.com"]);
+    expect(normalizeEmailRecipient(parsed.bcc)).toEqual(["audit@example.com"]);
+    expect(normalizeEmailRecipient(parsed.reply_to)).toEqual([
+      "reply@example.com",
+    ]);
+  });
+
+  it("validates batch request size and item-level send requirements", () => {
+    const validBatch = batchSendEmailSchema.parse([
+      validSendPayload,
+      { ...validSendPayload, to: ["two@example.com"], text: "Fallback" },
+    ]);
+    expect(validBatch).toHaveLength(2);
+
+    const invalidBatch = batchSendEmailSchema.safeParse([
+      {
+        from: "sender@example.com",
+        to: "user@example.com",
+        subject: "No body",
+      },
+    ]);
+    expect(invalidBatch.success).toBe(false);
+    if (!invalidBatch.success) {
+      const details = zodValidationDetails(invalidBatch.error);
+      expect(details.fieldErrors["0.html"]).toContain(
+        "html, text, or template is required",
+      );
+    }
+
+    const oversized = batchSendEmailSchema.safeParse(
+      Array.from({ length: 101 }, () => validSendPayload),
+    );
+    expect(oversized.success).toBe(false);
+  });
+
+  it("defines public success response fields and casing for send and batch send", () => {
+    expect(sendEmailResponseSchema.parse({ id: "email_123" })).toEqual({
+      id: "email_123",
+    });
+    expect(
+      sendEmailResponseSchema.safeParse({ id: "email_123", object: "email" })
+        .success,
+    ).toBe(false);
+
+    const batchBody = {
+      data: [
+        { id: "email_123" },
+        {
+          error: publicApiError(
+            "recipient_suppressed",
+            "Recipient suppressed.",
+            422,
+            { recipients: "blocked@example.com", reason: "suppressed" },
+          ),
+        },
+      ],
+    };
+
+    expect(batchSendEmailResponseSchema.parse(batchBody)).toEqual(batchBody);
+  });
+
+  it("keeps public error envelopes parseable with validation details and status codes", () => {
+    const result = sendEmailSchema.safeParse({ from: "sender@example.com" });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const envelope = publicApiError(
+      "validation_error",
+      "Validation failed.",
+      422,
+      zodValidationDetails(result.error),
+    );
+
+    expect(publicApiErrorEnvelopeSchema.parse(envelope)).toMatchObject({
+      name: "validation_error",
+      code: "validation_error",
+      message: "Validation failed.",
+      statusCode: 422,
+      details: {
+        fieldErrors: {
+          to: [expect.any(String)],
+          subject: [expect.any(String)],
+        },
+      },
+    });
+  });
+
+  it("keeps SDK send and batch types compatible with the shared contract DTOs", () => {
+    expectTypeOf<SendEmailPayload>().toMatchTypeOf<SendEmailRequest>();
+    expectTypeOf<SendEmailRequest>().toMatchTypeOf<SendEmailPayload>();
+    expectTypeOf<BatchSendEmailRequest>().toMatchTypeOf<SendEmailPayload[]>();
+    expectTypeOf<EmailResponse>().toEqualTypeOf<SendEmailSuccessResponse>();
+    const sdkBatchResponse: BatchEmailResponse = {
+      data: [
+        { id: "email_123" },
+        {
+          error: publicApiError(
+            "recipient_suppressed",
+            "Recipient suppressed.",
+            422,
+          ),
+        },
+      ],
+    };
+    const contractBatchResponse: BatchSendEmailResponseBody = sdkBatchResponse;
+    const sdkRoundTrip: BatchEmailResponse = contractBatchResponse;
+    expect(sdkRoundTrip).toEqual(sdkBatchResponse);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #442.
- Adds `packages/core/src/contracts/` as the shared public contract boundary for send email and batch send validation, normalization, success responses, and JSON error envelopes.
- Leaves app-local validation/error files as compatibility re-export shims while moving Next send handlers to the shared boundary.
- Adds contract-focused tests for request validation/normalization, response casing, error envelopes/status codes, SDK DTO compatibility, and services/api route responses.
- Documents contract-stable versus app-internal send/batch surfaces in `docs/public-send-contract.md`.

## Validation
- `bun run test tests/send-contract.test.ts tests/sdk-client.test.tsx tests/api-emails.test.ts tests/middleware-rate-limit.test.ts tests/openapi-route.test.ts --reporter=dot`
- `make check`
- `bun run --cwd packages/sdk build`
- `bunx tsx .scratch/send-contract-scenario.ts`

## Residual risk
- Playwright E2E against a live database was not rerun; this slice does not change persistence/auth behavior beyond moving the contract boundary and preserving existing route tests.
