### PR TITLE
Implement core React Email renderer boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-12-issue-448-react-email-renderer-boundary.md
+++ b/agent_docs/learnings/active/2026-05-12-issue-448-react-email-renderer-boundary.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-12
+issue: "#448"
+type: decision
+promoted_to: null
+---
+
+## React Email renderer boundary is registry-only in core
+
+Issue #448 adds `packages/core/src/services/template-renderer.ts` as the first React Email adoption slice. The boundary preserves legacy stored-template interpolation for `subject`/`html`/`text` and exposes a separate React Email path backed only by repo-owned registry keys such as `demo-welcome`.
+
+Do not evaluate tenant-provided TSX/JS/JSX strings. Future integrations should persist or pass a controlled `templateKey`/safe data representation, reject unknown keys with `TemplateRendererError`, and leave send-flow replacement to the follow-up integration issue.

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "@radix-ui/react-popover": "^1.1.4",
         "@radix-ui/react-switch": "^1.1.2",
         "@radix-ui/react-tabs": "^1.1.2",
+        "@react-email/render": "^2.0.8",
         "@testing-library/dom": "^10.4.1",
         "better-auth": "^1.6.8",
         "clsx": "^2.1.1",
@@ -519,6 +520,8 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@react-email/render": ["@react-email/render@2.0.8", "", { "dependencies": { "html-to-text": "^9.0.5", "prettier": "^3.5.3" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-5udvVr3U/WuGJZfLdLBOhkzrqRWd2Q5ZYmF7ppcy7FzWcwgshdqLMNqJOXcVzAXJXg/2bm7D+WGJzTtZOZMQnQ=="],
+
     "@redis/bloom": ["@redis/bloom@5.12.1", "", { "peerDependencies": { "@redis/client": "^5.12.1" } }, "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA=="],
 
     "@redis/client": ["@redis/client@5.12.1", "", { "dependencies": { "cluster-key-slot": "1.1.2" }, "peerDependencies": { "@node-rs/xxhash": "^1.1.0", "@opentelemetry/api": ">=1 <2" }, "optionalPeers": ["@node-rs/xxhash", "@opentelemetry/api"] }, "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA=="],
@@ -580,6 +583,8 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
+
+    "@selderee/plugin-htmlparser2": ["@selderee/plugin-htmlparser2@0.11.0", "", { "dependencies": { "domhandler": "^5.0.3", "selderee": "^0.11.0" } }, "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ=="],
 
     "@smithy/chunked-blob-reader": ["@smithy/chunked-blob-reader@5.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw=="],
 
@@ -811,6 +816,8 @@
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
 
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
@@ -826,6 +833,14 @@
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
 
@@ -899,6 +914,10 @@
 
     "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
 
+    "html-to-text": ["html-to-text@9.0.5", "", { "dependencies": { "@selderee/plugin-htmlparser2": "^0.11.0", "deepmerge": "^4.3.1", "dom-serializer": "^2.0.0", "htmlparser2": "^8.0.2", "selderee": "^0.11.0" } }, "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg=="],
+
+    "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
+
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
@@ -932,6 +951,8 @@
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "kysely": ["kysely@0.28.17", "", {}, "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q=="],
+
+    "leac": ["leac@0.6.0", "", {}, "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="],
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
@@ -985,6 +1006,8 @@
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
+    "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
+
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
@@ -992,6 +1015,8 @@
     "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "peberminta": ["peberminta@0.9.0", "", {}, "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="],
 
     "pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="],
 
@@ -1043,6 +1068,8 @@
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
+
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
@@ -1090,6 +1117,8 @@
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "selderee": ["selderee@0.11.0", "", { "dependencies": { "parseley": "^0.12.0" } }, "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -1219,7 +1248,11 @@
 
     "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@radix-ui/react-popover": "^1.1.4",
     "@radix-ui/react-switch": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.2",
+    "@react-email/render": "^2.0.8",
     "@testing-library/dom": "^10.4.1",
     "better-auth": "^1.6.8",
     "clsx": "^2.1.1",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,6 +60,7 @@ export * from "./services/trackingRoute";
 export * from "./services/sandboxTestRecipients";
 export * from "./services/storage";
 export * from "./services/template";
+export * from "./services/template-renderer";
 export * from "./services/broadcast";
 export * from "./services/audience-metadata";
 export * from "./services/automations";

--- a/packages/core/src/services/template-renderer.ts
+++ b/packages/core/src/services/template-renderer.ts
@@ -1,0 +1,186 @@
+import { render as renderReactEmail } from "@react-email/render";
+import React from "react";
+import type { ReactElement } from "react";
+
+export type TemplateRenderVariables = Record<string, unknown>;
+
+export type RenderedTemplate = {
+  subject: string;
+  html: string;
+  text: string;
+};
+
+export type LegacyTemplateRenderInput = {
+  kind?: "legacy";
+  subject?: string | null;
+  html?: string | null;
+  text?: string | null;
+  variables?: TemplateRenderVariables;
+};
+
+export type ReactEmailTemplateRenderInput = {
+  kind: "react_email";
+  templateKey: string;
+  variables?: TemplateRenderVariables;
+};
+
+export type TemplateRenderInput =
+  | LegacyTemplateRenderInput
+  | ReactEmailTemplateRenderInput;
+
+export type TemplateRendererErrorCode =
+  | "react_template_not_found"
+  | "react_render_failed";
+
+export class TemplateRendererError extends Error {
+  constructor(
+    readonly code: TemplateRendererErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "TemplateRendererError";
+  }
+}
+
+type ReactEmailTemplateDefinition = {
+  subject: (variables: TemplateRenderVariables) => string;
+  render: (variables: TemplateRenderVariables) => ReactElement;
+};
+
+function stringVariable(
+  variables: TemplateRenderVariables,
+  key: string,
+  fallback: string,
+): string {
+  const value = variables[key];
+  return value === null || value === undefined ? fallback : String(value);
+}
+
+function demoWelcomeTemplate(variables: TemplateRenderVariables): ReactElement {
+  const recipientName = stringVariable(variables, "recipientName", "there");
+  const productName = stringVariable(variables, "productName", "Opensend");
+  const actionUrl = stringVariable(
+    variables,
+    "actionUrl",
+    "https://opensend.dev",
+  );
+
+  return React.createElement(
+    "html",
+    null,
+    React.createElement(
+      "body",
+      {
+        style: {
+          fontFamily:
+            "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+          color: "#111827",
+        },
+      },
+      React.createElement("h1", null, `Welcome to ${productName}`),
+      React.createElement("p", null, `Hi ${recipientName},`),
+      React.createElement(
+        "p",
+        null,
+        `This is a safe repo-owned React Email template rendered by ${productName}.`,
+      ),
+      React.createElement("a", { href: actionUrl }, "Get started"),
+    ),
+  );
+}
+
+const REACT_EMAIL_TEMPLATES = {
+  "demo-welcome": {
+    subject: (variables: TemplateRenderVariables) =>
+      `Welcome to ${stringVariable(variables, "productName", "Opensend")}`,
+    render: demoWelcomeTemplate,
+  },
+} satisfies Record<string, ReactEmailTemplateDefinition>;
+
+export type ReactEmailTemplateKey = keyof typeof REACT_EMAIL_TEMPLATES;
+
+export const reactEmailTemplateKeys = Object.keys(
+  REACT_EMAIL_TEMPLATES,
+) as ReactEmailTemplateKey[];
+
+export function isReactEmailTemplateKey(
+  key: string,
+): key is ReactEmailTemplateKey {
+  return Object.prototype.hasOwnProperty.call(REACT_EMAIL_TEMPLATES, key);
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function interpolateLegacyTemplateContent(
+  content: string,
+  variables: TemplateRenderVariables = {},
+): string {
+  let rendered = content;
+  for (const [key, value] of Object.entries(variables)) {
+    const escapedKey = escapeRegex(key);
+    const regex = new RegExp(
+      `{{{\\s*${escapedKey}\\s*}}}|{{\\s*${escapedKey}\\s*}}`,
+      "g",
+    );
+    rendered = rendered.replace(regex, String(value));
+  }
+  return rendered;
+}
+
+export function renderLegacyTemplate(
+  input: LegacyTemplateRenderInput,
+): RenderedTemplate {
+  const variables = input.variables ?? {};
+  return {
+    subject: interpolateLegacyTemplateContent(input.subject ?? "", variables),
+    html: interpolateLegacyTemplateContent(input.html ?? "", variables),
+    text: interpolateLegacyTemplateContent(input.text ?? "", variables),
+  };
+}
+
+export async function renderReactEmailTemplate(
+  input: ReactEmailTemplateRenderInput,
+): Promise<RenderedTemplate> {
+  if (!isReactEmailTemplateKey(input.templateKey)) {
+    throw new TemplateRendererError(
+      "react_template_not_found",
+      `Unknown React Email template key: ${input.templateKey}`,
+    );
+  }
+
+  const definition = REACT_EMAIL_TEMPLATES[input.templateKey];
+  const variables = input.variables ?? {};
+  const element = definition.render(variables);
+
+  try {
+    const [html, text] = await Promise.all([
+      renderReactEmail(element),
+      renderReactEmail(element, { plainText: true }),
+    ]);
+
+    return {
+      subject: definition.subject(variables),
+      html,
+      text,
+    };
+  } catch (error) {
+    throw new TemplateRendererError(
+      "react_render_failed",
+      `Failed to render React Email template: ${input.templateKey}`,
+      { cause: error },
+    );
+  }
+}
+
+export async function renderTemplate(
+  input: TemplateRenderInput,
+): Promise<RenderedTemplate> {
+  if (input.kind === "react_email") {
+    return await renderReactEmailTemplate(input);
+  }
+
+  return renderLegacyTemplate(input);
+}

--- a/tests/template-renderer.test.ts
+++ b/tests/template-renderer.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  type TemplateRendererError,
+  interpolateLegacyTemplateContent,
+  renderLegacyTemplate,
+  renderReactEmailTemplate,
+  renderTemplate,
+} from "../packages/core/src/services/template-renderer";
+
+describe("template renderer", () => {
+  it("preserves legacy double and triple brace interpolation without crashing on missing variables", () => {
+    expect(
+      interpolateLegacyTemplateContent("Hello {{ FIRST_NAME }}", {
+        FIRST_NAME: "Ada",
+      }),
+    ).toBe("Hello Ada");
+
+    expect(
+      renderLegacyTemplate({
+        subject: "Receipt for {{ PRODUCT }}",
+        html: "<p>{{{ PRODUCT }}}</p><p>{{ MISSING }}</p>",
+        text: "{{ PRODUCT }} costs {{ PRICE }} and {{ MISSING }} stays",
+        variables: { PRODUCT: "Widget", PRICE: 25 },
+      }),
+    ).toEqual({
+      subject: "Receipt for Widget",
+      html: "<p>Widget</p><p>{{ MISSING }}</p>",
+      text: "Widget costs 25 and {{ MISSING }} stays",
+    });
+  });
+
+  it("renders a controlled React Email template to HTML and plain text", async () => {
+    const rendered = await renderReactEmailTemplate({
+      kind: "react_email",
+      templateKey: "demo-welcome",
+      variables: {
+        recipientName: "Ada",
+        productName: "Opensend",
+        actionUrl: "https://example.com/start",
+      },
+    });
+
+    expect(rendered.subject).toBe("Welcome to Opensend");
+    expect(rendered.html).toContain("Welcome to Opensend");
+    expect(rendered.html).toContain("https://example.com/start");
+    expect(rendered.text).toContain("WELCOME TO OPENSEND");
+    expect(rendered.text).toContain("Hi Ada");
+    expect(rendered.text).toContain("Get started");
+  });
+
+  it("routes through the shared renderer boundary for legacy and React Email inputs", async () => {
+    await expect(
+      renderTemplate({
+        subject: "Hi {{ NAME }}",
+        html: "<p>{{ NAME }}</p>",
+        text: "{{ NAME }}",
+        variables: { NAME: "Grace" },
+      }),
+    ).resolves.toEqual({
+      subject: "Hi Grace",
+      html: "<p>Grace</p>",
+      text: "Grace",
+    });
+
+    await expect(
+      renderTemplate({
+        kind: "react_email",
+        templateKey: "demo-welcome",
+        variables: { productName: "Opensend" },
+      }),
+    ).resolves.toMatchObject({
+      subject: "Welcome to Opensend",
+    });
+  });
+
+  it("fails unknown React Email template keys with a typed domain error", async () => {
+    await expect(
+      renderReactEmailTemplate({
+        kind: "react_email",
+        templateKey: "tenant-provided-tsx-string",
+        variables: {},
+      }),
+    ).rejects.toMatchObject({
+      name: "TemplateRendererError",
+      code: "react_template_not_found",
+      message: "Unknown React Email template key: tenant-provided-tsx-string",
+    } satisfies Partial<TemplateRendererError>);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a shared `@opensend/core` template renderer boundary for legacy stored templates and controlled React Email templates.
- Preserves legacy `{{ KEY }}` / `{{{ KEY }}}` interpolation without evaluating tenant-provided code.
- Adds typed renderer errors for unknown React Email template keys and render failures.

Closes #448

## Changes
- **core**: Added `packages/core/src/services/template-renderer.ts` with legacy rendering, a repo-owned React Email registry, and exported renderer APIs.
- **dependencies**: Added `@react-email/render` as the minimal server rendering dependency.
- **tests**: Added focused coverage for legacy interpolation, React Email HTML/text output, shared boundary routing, and invalid key behavior.
- **learnings**: Captured the registry-only renderer boundary decision.

## How to Test
- [x] `bunx vitest run tests/template-renderer.test.ts`
- [x] `bun .scratch/issue-448-template-renderer.ts` (scenario proof; scratch file removed before commit)
- [x] `make check`
- [x] `make test`
- [x] Push guardrail: `node scripts/check-changed-files.mjs`

## Notes
- Scope intentionally excludes dashboard preview, docs UX, and send-flow integration; follow-up work should reuse this boundary rather than evaluating tenant TSX/JSX strings.