### PR TITLE
Integrate shared renderer into template send flows

### DIFF
--- a/agent_docs/learnings/active/2026-05-12-issue-449-stored-renderer-metadata.md
+++ b/agent_docs/learnings/active/2026-05-12-issue-449-stored-renderer-metadata.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-12
+issue: "#449"
+type: decision
+promoted_to: null
+---
+
+## Stored template render mode metadata stays in `templates.document.rendering`
+
+Issue #449 wires send flows to the shared core template renderer without adding template schema columns. React Email-backed stored templates are selected by repo-owned registry metadata in `templates.document.rendering`, using the safe renderer input shape `{ kind: "react_email", templateKey: "..." }`.
+
+Legacy templates remain the default when render metadata is absent. Unknown React Email keys and missing keys are converted to automation run failures or public API validation errors before queue/provider delivery, rather than evaluating tenant-provided JSX/TS/JS strings or crashing the send path.

--- a/src/lib/api/emails/send.ts
+++ b/src/lib/api/emails/send.ts
@@ -19,9 +19,11 @@ import {
   suppressedRecipientError,
 } from "@/lib/suppressions";
 import {
-  interpolateTemplateVariables,
-  normalizeStoredTemplateVariables,
-} from "@/lib/templates/variables";
+  StoredTemplateRendererConfigError,
+  getStoredTemplateRendererConfig,
+  renderStoredTemplateContent,
+} from "@/lib/templates/stored-renderer";
+import { normalizeStoredTemplateVariables } from "@/lib/templates/variables";
 import {
   buildOneClickUnsubscribeHeaders,
   createUnsubscribeUrl,
@@ -30,6 +32,7 @@ import {
   replaceUnsubscribePlaceholder,
 } from "@/lib/unsubscribe";
 import {
+  TemplateRendererError,
   createBackgroundJob,
   createTelemetryContext,
   detectSandboxTestRecipient,
@@ -82,6 +85,16 @@ function recordAcceptMetric(
       Outcome: input.outcome,
     },
   });
+}
+
+function templateRenderApiFailureMessage(error: unknown): string | null {
+  if (error instanceof TemplateRendererError) {
+    return error.message;
+  }
+  if (error instanceof StoredTemplateRendererConfigError) {
+    return error.message;
+  }
+  return null;
 }
 
 function summarizeQueuePublishError(error: unknown): {
@@ -526,13 +539,43 @@ export async function handlePostEmailRequest(
         }
       }
 
-      finalHtml = template.html || "";
-      if (template.subject) finalSubject = template.subject;
-      if (template.text !== null) finalText = template.text ?? "";
+      try {
+        const rendererConfig = getStoredTemplateRendererConfig(
+          template.document,
+        );
+        const storedSubject =
+          typeof template.subject === "string" && template.subject.length > 0
+            ? template.subject
+            : null;
+        const renderedTemplate = await renderStoredTemplateContent({
+          template,
+          subject:
+            storedSubject ??
+            (rendererConfig.kind === "legacy" ? finalSubject : undefined),
+          variables: renderVars,
+        });
+        finalHtml = renderedTemplate.html;
+        finalText = renderedTemplate.text;
+        finalSubject = renderedTemplate.subject;
+      } catch (error) {
+        const message = templateRenderApiFailureMessage(error);
+        if (!message) throw error;
 
-      finalHtml = interpolateTemplateVariables(finalHtml, renderVars);
-      finalText = interpolateTemplateVariables(finalText, renderVars);
-      finalSubject = interpolateTemplateVariables(finalSubject, renderVars);
+        recordAcceptMetric(telemetry, {
+          durationMs: performance.now() - startedAt,
+          outcome: "invalid",
+        });
+        return await logResponse(
+          jsonWithTelemetry(
+            publicApiError("validation_error", message, 422, {
+              formErrors: [],
+              fieldErrors: { template: [message] },
+            }),
+            telemetry,
+            { status: 422 },
+          ),
+        );
+      }
     }
 
     const shouldQueueNow = !scheduledAt || scheduledAt <= new Date();

--- a/src/lib/templates/stored-renderer.ts
+++ b/src/lib/templates/stored-renderer.ts
@@ -1,0 +1,131 @@
+import {
+  type RenderedTemplate,
+  type TemplateRenderVariables,
+  renderTemplate,
+} from "@opensend/core";
+
+export type StoredTemplateRendererConfig =
+  | { kind: "legacy" }
+  | { kind: "react_email"; templateKey: string };
+
+export type StoredTemplateRendererConfigErrorCode =
+  | "react_template_key_missing"
+  | "unsupported_template_renderer";
+
+export class StoredTemplateRendererConfigError extends Error {
+  constructor(
+    readonly code: StoredTemplateRendererConfigErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "StoredTemplateRendererConfigError";
+  }
+}
+
+type StoredTemplateContent = {
+  subject?: string | null;
+  html?: string | null;
+  text?: string | null;
+  document?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readConfigCandidate(
+  candidate: Record<string, unknown>,
+): StoredTemplateRendererConfig | null {
+  if (candidate.kind === "legacy") {
+    return { kind: "legacy" };
+  }
+
+  if (candidate.kind === "react_email") {
+    if (typeof candidate.templateKey !== "string") {
+      throw new StoredTemplateRendererConfigError(
+        "react_template_key_missing",
+        "React Email template key is missing.",
+      );
+    }
+
+    const templateKey = candidate.templateKey.trim();
+    if (!templateKey) {
+      throw new StoredTemplateRendererConfigError(
+        "react_template_key_missing",
+        "React Email template key is missing.",
+      );
+    }
+
+    return { kind: "react_email", templateKey };
+  }
+
+  if (candidate.kind !== undefined) {
+    throw new StoredTemplateRendererConfigError(
+      "unsupported_template_renderer",
+      `Unsupported template renderer kind: ${String(candidate.kind)}.`,
+    );
+  }
+
+  return null;
+}
+
+export function getStoredTemplateRendererConfig(
+  document: unknown,
+): StoredTemplateRendererConfig {
+  if (!isRecord(document)) {
+    return { kind: "legacy" };
+  }
+
+  const nestedRendering = document.rendering;
+  if (isRecord(nestedRendering)) {
+    const nestedConfig = readConfigCandidate(nestedRendering);
+    if (nestedConfig) return nestedConfig;
+  }
+
+  const nestedRenderer = document.renderer;
+  if (isRecord(nestedRenderer)) {
+    const nestedConfig = readConfigCandidate(nestedRenderer);
+    if (nestedConfig) return nestedConfig;
+  }
+
+  if (document.kind === "react_email" || document.kind === "legacy") {
+    const topLevelConfig = readConfigCandidate(document);
+    if (topLevelConfig) return topLevelConfig;
+  }
+
+  return { kind: "legacy" };
+}
+
+export async function renderStoredTemplateContent(input: {
+  template: StoredTemplateContent;
+  subject?: string | null;
+  variables?: TemplateRenderVariables;
+}): Promise<RenderedTemplate> {
+  const config = getStoredTemplateRendererConfig(input.template.document);
+  const variables = input.variables ?? {};
+
+  if (config.kind === "react_email") {
+    const rendered = await renderTemplate({
+      kind: "react_email",
+      templateKey: config.templateKey,
+      variables,
+    });
+    if (input.subject !== undefined && input.subject !== null) {
+      const subjectOverride = await renderTemplate({
+        subject: input.subject,
+        html: "",
+        text: "",
+        variables,
+      });
+      return { ...rendered, subject: subjectOverride.subject };
+    }
+    return rendered;
+  }
+
+  return await renderTemplate({
+    subject: input.subject ?? input.template.subject ?? "",
+    html: input.template.html,
+    text: input.template.text,
+    variables,
+  });
+}

--- a/src/lib/workers/automation-runner.ts
+++ b/src/lib/workers/automation-runner.ts
@@ -12,9 +12,15 @@ import {
   templates,
 } from "@/lib/db/schema";
 import {
+  StoredTemplateRendererConfigError,
+  getStoredTemplateRendererConfig,
+  renderStoredTemplateContent,
+} from "@/lib/templates/stored-renderer";
+import {
   type ConditionOperator,
   type ConditionStepConfig,
   type ContactUpdateStepConfig,
+  TemplateRendererError,
   type WaitForEventStepConfig,
   automationRunRepo,
   emailService,
@@ -376,33 +382,46 @@ function resolveReference(
   if (directPath) {
     return getPath(context[directPath[1]], directPath[2].split("."));
   }
-  return value.replace(/{{\s*([^}]+?)\s*}}/g, (_match, token: string) => {
-    const path = token.trim().split(".");
-    const resolved = getPath(context, path);
-    return resolved === undefined || resolved === null ? "" : String(resolved);
-  });
-}
-
-function renderTemplate(
-  content: string | null,
-  variables: Record<string, unknown>,
-) {
-  let rendered = content ?? "";
-  for (const [key, value] of Object.entries(variables)) {
-    if (typeof value === "object") continue;
-    rendered = rendered.replace(
-      new RegExp(
-        `{{\\s*${key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*}}`,
-        "g",
-      ),
-      value === undefined || value === null ? "" : String(value),
-    );
-  }
-  return rendered;
+  return value.replace(
+    /{{{\s*([^}]+?)\s*}}}|{{\s*([^}]+?)\s*}}/g,
+    (
+      match,
+      tripleToken: string | undefined,
+      doubleToken: string | undefined,
+    ) => {
+      if (tripleToken !== undefined) return match;
+      const token = doubleToken ?? "";
+      const path = token.trim().split(".");
+      const resolved = getPath(context, path);
+      return resolved === undefined || resolved === null
+        ? ""
+        : String(resolved);
+    },
+  );
 }
 
 function normalizeReplyTo(value: string | null): string[] | undefined {
   return value ? [value] : undefined;
+}
+
+function legacyAutomationRenderVariables(
+  variables: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(variables)
+      .filter(([, value]) => typeof value !== "object")
+      .map(([key, value]) => [key, value === undefined ? "" : value]),
+  );
+}
+
+function templateRenderFailureReason(error: unknown): string | null {
+  if (error instanceof TemplateRendererError) {
+    return `send_email template render failed: ${error.message}`;
+  }
+  if (error instanceof StoredTemplateRendererConfigError) {
+    return `send_email template render failed: ${error.message}`;
+  }
+  return null;
 }
 
 function getSendEmailConfig(step: AutomationStep): {
@@ -1067,14 +1086,35 @@ async function processSendEmailStep(
   const from = String(
     resolveReference(config.from ?? template.from ?? "", context) ?? "",
   ).trim();
-  const subjectSource = config.subject ?? template.subject ?? "";
-  const subject = renderTemplate(
-    String(resolveReference(subjectSource, context) ?? ""),
-    variables,
-  ).trim();
+  const subjectSource = config.subject ?? template.subject;
+  const subjectOverride =
+    subjectSource === null || subjectSource === undefined
+      ? undefined
+      : String(resolveReference(subjectSource, context) ?? "");
   const replyTo = String(
     resolveReference(config.replyTo ?? template.replyTo ?? "", context) ?? "",
   ).trim();
+
+  let renderedTemplate: { subject: string; html: string; text: string };
+  try {
+    const rendererConfig = getStoredTemplateRendererConfig(template.document);
+    renderedTemplate = await renderStoredTemplateContent({
+      template,
+      subject: subjectOverride,
+      variables:
+        rendererConfig.kind === "legacy"
+          ? legacyAutomationRenderVariables(variables)
+          : variables,
+    });
+  } catch (error) {
+    const reason = templateRenderFailureReason(error);
+    if (reason) {
+      return await failRun(deps, run, step.key, states, now, reason);
+    }
+    throw error;
+  }
+
+  const subject = renderedTemplate.subject.trim();
 
   if (!from) {
     return await failRun(
@@ -1101,8 +1141,8 @@ async function processSendEmailStep(
     from,
     to: [contact.email],
     subject,
-    html: renderTemplate(template.html, variables),
-    text: renderTemplate(template.text, variables),
+    html: renderedTemplate.html,
+    text: renderedTemplate.text,
     replyTo: normalizeReplyTo(replyTo),
     tags: [
       { name: "automation_id", value: automation.id },

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -88,6 +88,9 @@ vi.mock("@opensend/core", async () => {
   const contracts = await vi.importActual<
     typeof import("../packages/core/src/contracts")
   >("../packages/core/src/contracts");
+  const templateRenderer = await vi.importActual<
+    typeof import("../packages/core/src/services/template-renderer")
+  >("../packages/core/src/services/template-renderer");
   const testTraceparent =
     "00-11111111111111111111111111111111-2222222222222222-01";
   const getHeader = (
@@ -106,6 +109,7 @@ vi.mock("@opensend/core", async () => {
 
   return {
     ...contracts,
+    ...templateRenderer,
     EmailDetailServiceError: MockEmailDetailServiceError,
     EmailReadServiceError: MockEmailReadServiceError,
     EmailLifecycleServiceError: MockEmailLifecycleServiceError,
@@ -660,6 +664,121 @@ describe("POST /api/emails", () => {
       html: "<p>Widget</p><p>25</p>",
       text: "",
     });
+  });
+
+  it("renders React Email-backed stored templates through the shared renderer", async () => {
+    const valuesMock = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: "react-template-email" }]),
+    });
+    mockDb.insert = vi.fn().mockReturnValue({ values: valuesMock });
+    Object.assign(mockDb.query, {
+      emails: { findFirst: vi.fn().mockResolvedValue(null) },
+      contacts: { findFirst: vi.fn().mockResolvedValue(null) },
+      templates: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: "11111111-1111-4111-8111-111111111111",
+          userId: AUTH_RESULT.userId,
+          subject: null,
+          html: "<p>legacy html should not render</p>",
+          text: "legacy text should not render",
+          variables: [],
+          document: {
+            rendering: {
+              kind: "react_email",
+              templateKey: "demo-welcome",
+            },
+          },
+        }),
+      },
+    });
+
+    const { POST } = await import("@/app/api/emails/route");
+    const res = await POST(
+      makeRequest(
+        "POST",
+        {
+          from: "sender@domain.com",
+          to: ["user@test.com"],
+          subject: "Ignored for React registry templates",
+          template: {
+            id: "11111111-1111-4111-8111-111111111111",
+            variables: {
+              recipientName: "Ada",
+              productName: "Acme",
+              actionUrl: "https://example.com/start",
+            },
+          },
+        },
+        { Authorization: "Bearer os_test123" },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const inserted = valuesMock.mock.calls[0][0];
+    expect(inserted).toMatchObject({
+      subject: "Welcome to Acme",
+      text: expect.stringContaining("Hi Ada"),
+      status: "queued",
+    });
+    expect(inserted.html).toContain("Welcome to Acme");
+    expect(inserted.html).toContain("https://example.com/start");
+  });
+
+  it("returns a public validation error for unknown React Email template keys", async () => {
+    Object.assign(mockDb.query, {
+      emails: { findFirst: vi.fn().mockResolvedValue(null) },
+      contacts: { findFirst: vi.fn().mockResolvedValue(null) },
+      templates: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: "11111111-1111-4111-8111-111111111111",
+          userId: AUTH_RESULT.userId,
+          subject: null,
+          html: null,
+          text: null,
+          variables: [],
+          document: {
+            rendering: {
+              kind: "react_email",
+              templateKey: "tenant-provided-tsx-string",
+            },
+          },
+        }),
+      },
+    });
+
+    const { POST } = await import("@/app/api/emails/route");
+    const res = await POST(
+      makeRequest(
+        "POST",
+        {
+          from: "sender@domain.com",
+          to: ["user@test.com"],
+          subject: "Will not render",
+          template: {
+            id: "11111111-1111-4111-8111-111111111111",
+            variables: {},
+          },
+        },
+        { Authorization: "Bearer os_test123" },
+      ),
+    );
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "validation_error",
+      code: "validation_error",
+      statusCode: 422,
+      message: "Unknown React Email template key: tenant-provided-tsx-string",
+      details: {
+        fieldErrors: {
+          template: [
+            "Unknown React Email template key: tenant-provided-tsx-string",
+          ],
+        },
+      },
+    });
+    expect(mockReserveEmailQuota).not.toHaveBeenCalled();
+    expect(nonLogInsertCalls()).toHaveLength(0);
   });
 
   it("keeps the public validation_error envelope for missing template variables without fallbacks", async () => {

--- a/tests/automation-runner.test.ts
+++ b/tests/automation-runner.test.ts
@@ -282,6 +282,138 @@ describe("automation runner", () => {
     });
   });
 
+  it("renders legacy stored templates through the shared renderer before sending", async () => {
+    const setup = deps({
+      getTemplate: vi.fn().mockResolvedValue({
+        ...template,
+        subject: "Receipt for {{{first_name}}} on {{plan}}",
+        html: "<p>{{{first_name}}} picked {{plan}}</p><p>{{event}}</p>",
+        text: "{{first_name}} picked {{plan}}",
+      }),
+      listSteps: vi.fn().mockResolvedValue([
+        {
+          ...steps[2],
+          config: {
+            template: {
+              id: template.id,
+              variables: { plan: "event.plan" },
+            },
+          },
+        },
+      ]),
+    });
+
+    await processAutomationRunStep(run({ currentStepKey: "send" }), setup.deps);
+
+    expect(setup.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: "Receipt for Ada on pro",
+        html: "<p>Ada picked pro</p><p>{{event}}</p>",
+        text: "Ada picked pro",
+      }),
+    );
+  });
+
+  it("renders React Email-backed stored templates from a safe registry key", async () => {
+    const setup = deps({
+      getDelivery: vi.fn().mockResolvedValue({
+        ...delivery,
+        payload: {
+          productName: "Acme",
+          actionUrl: "https://example.com/start",
+        },
+      }),
+      getTemplate: vi.fn().mockResolvedValue({
+        ...template,
+        subject: null,
+        html: "<p>legacy html should not render</p>",
+        text: "legacy text should not render",
+        document: {
+          rendering: {
+            kind: "react_email",
+            templateKey: "demo-welcome",
+          },
+        },
+      }),
+      listSteps: vi.fn().mockResolvedValue([
+        {
+          ...steps[2],
+          config: {
+            template: {
+              id: template.id,
+              variables: {
+                recipientName: "contact.firstName",
+                productName: "event.productName",
+                actionUrl: "event.actionUrl",
+              },
+            },
+          },
+        },
+      ]),
+    });
+
+    await processAutomationRunStep(run({ currentStepKey: "send" }), setup.deps);
+
+    const sent = setup.sendEmail.mock.calls[0]?.[0];
+    expect(sent).toMatchObject({
+      from: "sender@example.com",
+      to: ["user@example.com"],
+      subject: "Welcome to Acme",
+    });
+    expect(sent?.html).toContain("Welcome to Acme");
+    expect(sent?.html).toContain("Hi Ada");
+    expect(sent?.html).toContain("https://example.com/start");
+    expect(sent?.text).toContain("WELCOME TO ACME");
+    expect(sent?.text).toContain("Hi Ada");
+  });
+
+  it("fails React Email-backed stored templates with unknown registry keys", async () => {
+    const setup = deps({
+      getTemplate: vi.fn().mockResolvedValue({
+        ...template,
+        document: {
+          rendering: {
+            kind: "react_email",
+            templateKey: "tenant-provided-tsx-string",
+          },
+        },
+      }),
+    });
+
+    await processAutomationRunStep(run({ currentStepKey: "send" }), setup.deps);
+
+    expect(setup.sendEmail).not.toHaveBeenCalled();
+    expect(setup.updates[0]).toMatchObject({
+      status: "failed",
+      currentStepKey: "send",
+      failureReason:
+        "send_email template render failed: Unknown React Email template key: tenant-provided-tsx-string",
+    });
+  });
+
+  it("fails React Email-backed stored templates with missing registry keys", async () => {
+    const setup = deps({
+      getTemplate: vi.fn().mockResolvedValue({
+        ...template,
+        document: {
+          rendering: {
+            kind: "react_email",
+          },
+        },
+      }),
+    });
+
+    await processAutomationRunStep(run({ currentStepKey: "send" }), setup.deps);
+
+    expect(setup.sendEmail).not.toHaveBeenCalled();
+    expect(setup.updates[0]).toMatchObject({
+      status: "failed",
+      currentStepKey: "send",
+      failureReason:
+        "send_email template render failed: React Email template key is missing.",
+    });
+  });
+
   it("evaluates condition steps and advances to the met branch in one tick", async () => {
     const conditionAutomation: Automation = {
       ...automation,


### PR DESCRIPTION
## Summary
- Routes stored-template rendering for automation `send_email` and `/api/emails` template sends through the shared core renderer from #448.
- Adds a small stored-template render-mode adapter that defaults to legacy rendering and reads React Email registry metadata from `templates.document.rendering` (`{ kind: "react_email", templateKey }`).
- Converts missing/unknown React Email template metadata into useful automation run failures or public API validation errors before queue/provider delivery.

Closes #449

## Tests
- `bun run test -- tests/automation-runner.test.ts tests/api-emails.test.ts tests/template-renderer.test.ts`
- `make check`
- `make test`
