### PR TITLE
Add React Email template previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Never commit `.env`, API keys, bearer tokens, database URLs with real passwords,
 - **REST API** — send single or batch emails with API-key auth and idempotency keys.
 - **Resend-compatible surface** — transactional sends, audiences/contacts, suppressions, and webhook semantics shaped for easy migration.
 - **SDKs** — first-party TypeScript, Python, and Go packages.
-- **React email templates** — pass React components via the TypeScript SDK.
+- **React email templates** — pass React components via the TypeScript SDK, or use registry-controlled dashboard starters with shared-renderer previews (see [docs/react-email-templates.md](docs/react-email-templates.md)).
 - **Domain verification** — DKIM, SPF, DMARC, click tracking, and custom return paths, with Cloudflare automation.
 - **Broadcasts** — block editor, slash commands, audience targeting, and review flow.
 - **Automations** — multi-step workflows triggered by contact updates and custom events, executed by the ingester worker.

--- a/agent_docs/learnings/active/2026-05-12-issue-450-preview-renderer-contract.md
+++ b/agent_docs/learnings/active/2026-05-12-issue-450-preview-renderer-contract.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-12
+issue: "#450"
+type: decision
+promoted_to: null
+---
+
+## Template previews must reuse send variable resolution semantics
+
+Issue #450 added `/api/templates/:id/preview` for dashboard preview rendering. The preview route intentionally calls `renderStoredTemplateContent` and the shared `resolveStoredTemplateRenderVariables` helper rather than implementing a dashboard-only renderer.
+
+Production sends use `mode: "send"`, which fails missing required variables before queue/provider delivery. Dashboard previews use `mode: "preview"`, which labels fallback values and inserts sample values only for required variables so users can inspect the HTML/text output before send. Those preview samples are returned as diagnostics and must not be treated as production send defaults.
+
+React Email templates remain registry-controlled through `templates.document.rendering.templateKey`; dashboard starter creation stores a safe registry key and variable metadata, not tenant-provided TSX/JS.

--- a/docs/react-email-templates.md
+++ b/docs/react-email-templates.md
@@ -1,0 +1,57 @@
+# React Email template previews
+
+Opensend supports a first path for React Email-backed stored templates without
+adding a dependency on Resend-hosted rendering services.
+
+## What is supported now
+
+- Dashboard template previews render through the same stored-template renderer
+  used by `/api/emails` sends and automation send steps.
+- Previews show rendered HTML and generated `text/plain` output when the
+  renderer can produce them.
+- Variable diagnostics show whether a preview value came from an explicit
+  value, stored fallback metadata, or a preview-only sample for a required
+  send-time variable.
+- React Email stored templates are selected by repo-owned registry metadata in
+  `templates.document.rendering`, for example:
+
+```json
+{
+  "rendering": {
+    "kind": "react_email",
+    "templateKey": "onboarding-welcome"
+  }
+}
+```
+
+- The dashboard can create the `onboarding-welcome` starter template. It stores
+  the registry key plus variable metadata/fallbacks; it does not store or
+  execute tenant-provided TSX.
+
+## Self-hosting model
+
+Rendering runs inside the Opensend app process using the bundled renderer and
+registry. A self-hosted deployment only needs the normal app dependencies and
+its database. No preview or send path calls Resend-hosted rendering services.
+
+## Limitations
+
+- Arbitrary tenant TSX/JS execution is not supported. Template keys must be
+  present in the Opensend-owned registry before they can render.
+- Runtime sandboxing for tenant-authored React components is intentionally out
+  of scope until a later issue designs a safe execution boundary.
+- Preview-only sample values are for dashboard debugging. Production sends must
+  still provide required variables unless stored fallback metadata exists.
+- Legacy HTML/text templates continue to render with the existing `{{var}}` and
+  `{{{var}}}` interpolation semantics.
+
+## Adding another registry-controlled starter
+
+1. Add the React Email template definition and metadata in
+   `packages/core/src/services/template-renderer.ts`.
+2. Include variable metadata with explicit `required` and `fallbackValue`
+   settings so preview diagnostics match send behavior.
+3. Create stored templates with `document.rendering.kind = "react_email"` and a
+   registry `templateKey` only. Do not accept raw tenant code as metadata.
+4. Cover the renderer, preview API, dashboard component, and Playwright preview
+   path before shipping.

--- a/packages/core/src/services/template-renderer.ts
+++ b/packages/core/src/services/template-renderer.ts
@@ -44,8 +44,27 @@ export class TemplateRendererError extends Error {
 }
 
 type ReactEmailTemplateDefinition = {
+  name: string;
+  description: string;
+  variables: ReactEmailTemplateVariableDefinition[];
   subject: (variables: TemplateRenderVariables) => string;
   render: (variables: TemplateRenderVariables) => ReactElement;
+};
+
+export type ReactEmailTemplateVariableDefinition = {
+  key: string;
+  name: string;
+  type: "string" | "number";
+  required: boolean;
+  fallbackValue: string | number | null;
+  description: string;
+};
+
+export type ReactEmailTemplateMetadata = {
+  key: string;
+  name: string;
+  description: string;
+  variables: ReactEmailTemplateVariableDefinition[];
 };
 
 function stringVariable(
@@ -55,6 +74,277 @@ function stringVariable(
 ): string {
   const value = variables[key];
   return value === null || value === undefined ? fallback : String(value);
+}
+
+const emailShellStyle = {
+  margin: 0,
+  padding: 0,
+  backgroundColor: "#f4f7fb",
+  color: "#182230",
+  fontFamily:
+    "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+} satisfies React.CSSProperties;
+
+const cardStyle = {
+  width: "100%",
+  maxWidth: "640px",
+  margin: "0 auto",
+  backgroundColor: "#ffffff",
+  borderRadius: "24px",
+  overflow: "hidden",
+  boxShadow: "0 18px 48px rgba(15, 23, 42, 0.12)",
+} satisfies React.CSSProperties;
+
+const buttonStyle = {
+  display: "inline-block",
+  padding: "14px 22px",
+  borderRadius: "999px",
+  backgroundColor: "#111827",
+  color: "#ffffff",
+  fontSize: "15px",
+  fontWeight: 700,
+  textDecoration: "none",
+} satisfies React.CSSProperties;
+
+function onboardingWelcomeTemplate(
+  variables: TemplateRenderVariables,
+): ReactElement {
+  const recipientName = stringVariable(variables, "recipientName", "there");
+  const productName = stringVariable(variables, "productName", "Opensend");
+  const actionUrl = stringVariable(
+    variables,
+    "actionUrl",
+    "https://opensend.dev/docs",
+  );
+  const supportEmail = stringVariable(
+    variables,
+    "supportEmail",
+    "support@example.com",
+  );
+
+  return React.createElement(
+    "html",
+    null,
+    React.createElement(
+      "body",
+      { style: emailShellStyle },
+      React.createElement(
+        "div",
+        { style: { display: "none", maxHeight: 0, overflow: "hidden" } },
+        `Start sending production email with ${productName}.`,
+      ),
+      React.createElement(
+        "table",
+        {
+          role: "presentation",
+          width: "100%",
+          cellPadding: "0",
+          cellSpacing: "0",
+          style: { backgroundColor: "#f4f7fb", padding: "32px 16px" },
+        },
+        React.createElement(
+          "tbody",
+          null,
+          React.createElement(
+            "tr",
+            null,
+            React.createElement(
+              "td",
+              { align: "center" },
+              React.createElement(
+                "div",
+                { style: cardStyle },
+                React.createElement(
+                  "div",
+                  {
+                    style: {
+                      padding: "28px 32px",
+                      background:
+                        "linear-gradient(135deg, #0f172a 0%, #1d4ed8 100%)",
+                      color: "#ffffff",
+                    },
+                  },
+                  React.createElement(
+                    "div",
+                    {
+                      style: {
+                        display: "inline-block",
+                        padding: "8px 12px",
+                        borderRadius: "999px",
+                        backgroundColor: "rgba(255,255,255,0.14)",
+                        fontSize: "12px",
+                        fontWeight: 700,
+                        letterSpacing: "0.08em",
+                        textTransform: "uppercase",
+                      },
+                    },
+                    productName,
+                  ),
+                  React.createElement(
+                    "h1",
+                    {
+                      style: {
+                        margin: "24px 0 10px",
+                        fontSize: "34px",
+                        lineHeight: "40px",
+                        letterSpacing: "-0.03em",
+                      },
+                    },
+                    "Your email workspace is ready",
+                  ),
+                  React.createElement(
+                    "p",
+                    {
+                      style: {
+                        margin: 0,
+                        maxWidth: "520px",
+                        color: "#dbeafe",
+                        fontSize: "17px",
+                        lineHeight: "27px",
+                      },
+                    },
+                    `Hi ${recipientName}, here is the fastest path to send a trustworthy first production message.`,
+                  ),
+                ),
+                React.createElement(
+                  "div",
+                  { style: { padding: "32px" } },
+                  React.createElement(
+                    "p",
+                    {
+                      style: {
+                        margin: "0 0 22px",
+                        fontSize: "16px",
+                        lineHeight: "26px",
+                        color: "#344054",
+                      },
+                    },
+                    "Verify your sending domain, create an API key, and send a sandbox message before moving real customer traffic. Your dashboard keeps previews, events, and provider status in one place.",
+                  ),
+                  React.createElement(
+                    "a",
+                    { href: actionUrl, style: buttonStyle },
+                    "Open the setup checklist",
+                  ),
+                  React.createElement(
+                    "table",
+                    {
+                      role: "presentation",
+                      width: "100%",
+                      cellPadding: "0",
+                      cellSpacing: "0",
+                      style: { marginTop: "30px" },
+                    },
+                    React.createElement(
+                      "tbody",
+                      null,
+                      [
+                        [
+                          "1",
+                          "Authenticate",
+                          "Add your domain and publish DKIM, SPF, and DMARC records.",
+                        ],
+                        [
+                          "2",
+                          "Integrate",
+                          "Use the Resend-compatible API or SDK with your self-hosted base URL.",
+                        ],
+                        [
+                          "3",
+                          "Observe",
+                          "Watch delivery events, bounces, and complaints in the dashboard.",
+                        ],
+                      ].map(([step, title, copy]) =>
+                        React.createElement(
+                          "tr",
+                          { key: step },
+                          React.createElement(
+                            "td",
+                            {
+                              style: {
+                                padding: "14px 0",
+                                borderTop: "1px solid #eaecf0",
+                              },
+                            },
+                            React.createElement(
+                              "div",
+                              {
+                                style: {
+                                  display: "flex",
+                                  gap: "14px",
+                                  alignItems: "flex-start",
+                                },
+                              },
+                              React.createElement(
+                                "div",
+                                {
+                                  style: {
+                                    width: "30px",
+                                    height: "30px",
+                                    borderRadius: "999px",
+                                    backgroundColor: "#eff6ff",
+                                    color: "#1d4ed8",
+                                    fontWeight: 800,
+                                    lineHeight: "30px",
+                                    textAlign: "center",
+                                    flex: "0 0 auto",
+                                  },
+                                },
+                                step,
+                              ),
+                              React.createElement(
+                                "div",
+                                null,
+                                React.createElement(
+                                  "div",
+                                  {
+                                    style: {
+                                      color: "#101828",
+                                      fontWeight: 700,
+                                      fontSize: "15px",
+                                    },
+                                  },
+                                  title,
+                                ),
+                                React.createElement(
+                                  "div",
+                                  {
+                                    style: {
+                                      marginTop: "4px",
+                                      color: "#667085",
+                                      fontSize: "14px",
+                                      lineHeight: "22px",
+                                    },
+                                  },
+                                  copy,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  React.createElement(
+                    "p",
+                    {
+                      style: {
+                        margin: "28px 0 0",
+                        color: "#667085",
+                        fontSize: "13px",
+                        lineHeight: "21px",
+                      },
+                    },
+                    `Need help? Reply to this email or contact ${supportEmail}.`,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
 }
 
 function demoWelcomeTemplate(variables: TemplateRenderVariables): ReactElement {
@@ -91,7 +381,78 @@ function demoWelcomeTemplate(variables: TemplateRenderVariables): ReactElement {
 }
 
 const REACT_EMAIL_TEMPLATES = {
+  "onboarding-welcome": {
+    name: "Onboarding welcome",
+    description:
+      "A production-ready first-run welcome email with setup checklist, CTA, and support footer.",
+    variables: [
+      {
+        key: "recipientName",
+        name: "Recipient name",
+        type: "string",
+        required: false,
+        fallbackValue: "there",
+        description: "Friendly name used in the opening line.",
+      },
+      {
+        key: "productName",
+        name: "Product name",
+        type: "string",
+        required: false,
+        fallbackValue: "Opensend",
+        description: "Brand or workspace name shown in the hero.",
+      },
+      {
+        key: "actionUrl",
+        name: "Setup checklist URL",
+        type: "string",
+        required: true,
+        fallbackValue: null,
+        description: "Required send-time CTA URL for the setup checklist.",
+      },
+      {
+        key: "supportEmail",
+        name: "Support email",
+        type: "string",
+        required: false,
+        fallbackValue: "support@example.com",
+        description: "Reply-to/support address shown in the footer.",
+      },
+    ],
+    subject: (variables: TemplateRenderVariables) =>
+      `Welcome to ${stringVariable(variables, "productName", "Opensend")}`,
+    render: onboardingWelcomeTemplate,
+  },
   "demo-welcome": {
+    name: "Demo welcome",
+    description:
+      "Minimal registry fixture retained for tests and existing stored templates.",
+    variables: [
+      {
+        key: "recipientName",
+        name: "Recipient name",
+        type: "string",
+        required: false,
+        fallbackValue: "there",
+        description: "Friendly name used in the opening line.",
+      },
+      {
+        key: "productName",
+        name: "Product name",
+        type: "string",
+        required: false,
+        fallbackValue: "Opensend",
+        description: "Product name used in the heading and subject.",
+      },
+      {
+        key: "actionUrl",
+        name: "Action URL",
+        type: "string",
+        required: false,
+        fallbackValue: "https://opensend.dev",
+        description: "CTA URL.",
+      },
+    ],
     subject: (variables: TemplateRenderVariables) =>
       `Welcome to ${stringVariable(variables, "productName", "Opensend")}`,
     render: demoWelcomeTemplate,
@@ -108,6 +469,27 @@ export function isReactEmailTemplateKey(
   key: string,
 ): key is ReactEmailTemplateKey {
   return Object.prototype.hasOwnProperty.call(REACT_EMAIL_TEMPLATES, key);
+}
+
+export const reactEmailTemplateCatalog = Object.entries(
+  REACT_EMAIL_TEMPLATES,
+).map(([key, definition]) => ({
+  key,
+  name: definition.name,
+  description: definition.description,
+  variables: definition.variables.map((variable) => ({ ...variable })),
+})) satisfies ReactEmailTemplateMetadata[];
+
+export function getReactEmailTemplateMetadata(
+  key: ReactEmailTemplateKey,
+): ReactEmailTemplateMetadata {
+  const definition = REACT_EMAIL_TEMPLATES[key];
+  return {
+    key,
+    name: definition.name,
+    description: definition.description,
+    variables: definition.variables.map((variable) => ({ ...variable })),
+  };
 }
 
 function escapeRegex(value: string): string {

--- a/packages/core/src/services/template.ts
+++ b/packages/core/src/services/template.ts
@@ -1,5 +1,9 @@
 import { templateRepo } from "../db/repositories/templateRepo";
 import type { templates } from "../db/schema";
+import {
+  getReactEmailTemplateMetadata,
+  isReactEmailTemplateKey,
+} from "./template-renderer";
 
 type TemplateRow = typeof templates.$inferSelect;
 type TemplateInsert = typeof templates.$inferInsert;
@@ -330,6 +334,32 @@ function toTruthyStoredString(value: unknown): string | null {
   return value ? (value as string) : null;
 }
 
+function toReactEmailStarterVariables(
+  templateKey: string,
+): StoredTemplateVariable[] {
+  if (!isReactEmailTemplateKey(templateKey)) {
+    throw new TemplateServiceError(
+      "invalid_input",
+      `Unknown React Email template key: ${templateKey}`,
+    );
+  }
+
+  return getReactEmailTemplateMetadata(templateKey).variables.map(
+    (variable) => ({
+      name: variable.key,
+      key: variable.key,
+      type: variable.type,
+      required: variable.required,
+      fallbackValue: variable.fallbackValue,
+    }),
+  );
+}
+
+function getReactEmailTemplateKey(input: Record<string, unknown>): string {
+  const rawKey = input.react_email_template_key;
+  return typeof rawKey === "string" ? rawKey.trim() : "";
+}
+
 function generateAlias(name: string): string {
   return (
     name
@@ -417,13 +447,18 @@ export function createTemplateService({
       const body = asRecord(input);
       const name = typeof body.name === "string" ? body.name.trim() : "";
       const html = typeof body.html === "string" ? body.html.trim() : "";
+      const reactEmailTemplateKey = getReactEmailTemplateKey(body);
 
-      if (!name || !html) {
+      if (!name || (!html && !reactEmailTemplateKey)) {
         throw new TemplateServiceError(
           "invalid_input",
           "name and html are required",
         );
       }
+
+      const reactEmailVariables = reactEmailTemplateKey
+        ? toReactEmailStarterVariables(reactEmailTemplateKey)
+        : null;
 
       const alias =
         typeof body.alias === "string" && body.alias.trim()
@@ -433,15 +468,31 @@ export function createTemplateService({
       const createData: TemplateInsert = {
         name,
         alias,
-        html,
+        html:
+          reactEmailVariables === null
+            ? html
+            : `<!-- React Email registry template: ${reactEmailTemplateKey} -->`,
         subject: toTruthyStoredString(body.subject),
         from: toTruthyStoredString(body.from),
         replyTo: toTruthyStoredString(body.reply_to),
         previewText: toTruthyStoredString(body.preview_text),
         text: toTruthyStoredString(body.text),
-        variables: normalizeVariablesOrThrow(body.variables),
+        variables:
+          reactEmailVariables ?? normalizeVariablesOrThrow(body.variables),
         status: "draft",
       };
+      if (reactEmailVariables !== null) {
+        createData.document = {
+          rendering: {
+            kind: "react_email",
+            templateKey: reactEmailTemplateKey,
+          },
+          starter: {
+            key: reactEmailTemplateKey,
+            source: "opensend-registry",
+          },
+        };
+      }
       if (options.userId) createData.userId = options.userId;
 
       const [template] = await repository.create(createData);
@@ -538,6 +589,8 @@ export function createTemplateService({
         html: existing.html,
         text: existing.text,
         variables: existing.variables,
+        document: existing.document,
+        userId: existing.userId,
       });
 
       return {

--- a/src/app/api/templates/[id]/preview/route.ts
+++ b/src/app/api/templates/[id]/preview/route.ts
@@ -1,0 +1,91 @@
+import { db } from "@/lib/db";
+import { templates } from "@/lib/db/schema";
+import {
+  StoredTemplateRendererConfigError,
+  getStoredTemplateRendererConfig,
+  renderStoredTemplateContent,
+  resolveStoredTemplateRenderVariables,
+} from "@/lib/templates/stored-renderer";
+import { TemplateRendererError } from "@opensend/core";
+import { and, eq } from "drizzle-orm";
+import { type NextRequest, NextResponse } from "next/server";
+import { authorizeTemplateRoute } from "../../auth";
+
+function previewErrorResponse(error: unknown) {
+  if (
+    error instanceof TemplateRendererError ||
+    error instanceof StoredTemplateRendererConfigError
+  ) {
+    return NextResponse.json({ error: error.message }, { status: 422 });
+  }
+
+  console.error("Failed to render template preview:", error);
+  return NextResponse.json(
+    { error: "Failed to render template preview" },
+    { status: 500 },
+  );
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await authorizeTemplateRoute(
+    request.headers.get("authorization"),
+  );
+  if (!auth.ok) return auth.response;
+
+  try {
+    const { id } = await params;
+    const template = await db.query.templates.findFirst({
+      where: auth.userId
+        ? and(eq(templates.id, id), eq(templates.userId, auth.userId))
+        : eq(templates.id, id),
+    });
+
+    if (!template) {
+      return NextResponse.json(
+        { error: "Template not found" },
+        { status: 404 },
+      );
+    }
+
+    const rendererConfig = getStoredTemplateRendererConfig(template.document);
+    const variableResult = resolveStoredTemplateRenderVariables({
+      storedVariables: template.variables,
+      mode: "preview",
+    });
+    const storedSubject =
+      typeof template.subject === "string" && template.subject.length > 0
+        ? template.subject
+        : null;
+    const rendered = await renderStoredTemplateContent({
+      template,
+      subject:
+        storedSubject ??
+        (rendererConfig.kind === "legacy"
+          ? (template.subject ?? "")
+          : undefined),
+      variables: variableResult.variables,
+    });
+
+    return NextResponse.json({
+      object: "template_preview",
+      id: template.id,
+      rendering: {
+        kind: rendererConfig.kind,
+        template_key:
+          rendererConfig.kind === "react_email"
+            ? rendererConfig.templateKey
+            : null,
+      },
+      subject: rendered.subject,
+      html: rendered.html,
+      text: rendered.text,
+      variables: variableResult.resolutions,
+      warnings: variableResult.warnings,
+    });
+  } catch (error) {
+    return previewErrorResponse(error);
+  }
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -161,6 +161,14 @@ const API_GROUPS: EndpointGroup[] = [
   -H "Authorization: Bearer os_YOUR_API_KEY"`,
       },
       {
+        method: "GET",
+        path: "/api/templates/:id/preview",
+        description:
+          "Render a dashboard/API preview through the same stored-template renderer used by sends",
+        curl: `curl https://api.opensend.com/api/templates/TEMPLATE_ID/preview \\
+  -H "Authorization: Bearer os_YOUR_API_KEY"`,
+      },
+      {
         method: "PATCH",
         path: "/api/templates/:id",
         description: "Update a template",
@@ -494,6 +502,10 @@ export async function POST() {
               The REST API remains JSON-only: send React components through the
               TypeScript SDK, or send pre-rendered{" "}
               <code className="font-mono text-[#F0F0F0]">html</code> directly.
+              Dashboard React Email starters are registry-controlled and run
+              inside your Opensend app; self-hosted deployments do not call
+              Resend-hosted rendering services, and arbitrary tenant TSX/JS is
+              not executed.
             </p>
           </div>
         </div>

--- a/src/components/template-detail.tsx
+++ b/src/components/template-detail.tsx
@@ -1,5 +1,45 @@
 "use client";
 
+import { useEffect, useState } from "react";
+
+type TemplateVariable = {
+  name: string;
+  key?: string;
+  required: boolean;
+  type?: "string" | "number";
+  fallback_value?: string | number | null;
+};
+
+type PreviewVariableSource =
+  | "provided"
+  | "fallback"
+  | "preview_sample"
+  | "missing_optional"
+  | "missing_required";
+
+type PreviewVariable = {
+  key: string;
+  name: string;
+  type: "string" | "number";
+  required: boolean;
+  fallbackValue: string | number | null;
+  value: string | number | null;
+  source: PreviewVariableSource;
+  sendRequired: boolean;
+};
+
+type TemplatePreview = {
+  subject: string;
+  html: string;
+  text: string;
+  rendering: {
+    kind: "legacy" | "react_email";
+    template_key: string | null;
+  };
+  variables: PreviewVariable[];
+  warnings: string[];
+};
+
 interface TemplateDetailProps {
   template: {
     id: string;
@@ -10,19 +50,103 @@ interface TemplateDetailProps {
     html: string | null;
     text: string | null;
     published: boolean;
-    variables: Array<{ name: string; required: boolean }>;
+    variables: TemplateVariable[];
     createdAt: string;
     updatedAt: string;
   };
 }
 
+function previewSourceLabel(source: PreviewVariableSource): string {
+  switch (source) {
+    case "provided":
+      return "Provided";
+    case "fallback":
+      return "Fallback";
+    case "preview_sample":
+      return "Preview sample";
+    case "missing_optional":
+      return "Not supplied";
+    case "missing_required":
+      return "Missing required";
+  }
+}
+
+function valueLabel(value: string | number | null): string {
+  return value === null ? "—" : String(value);
+}
+
 export function TemplateDetail({ template }: TemplateDetailProps) {
+  const [preview, setPreview] = useState<TemplatePreview | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    async function fetchPreview() {
+      setPreviewLoading(true);
+      setPreviewError(null);
+      try {
+        const apiKey =
+          typeof window !== "undefined"
+            ? (localStorage?.getItem?.("api_key") ?? null)
+            : null;
+        const headers: Record<string, string> = {};
+        if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+        const res = await fetch(`/api/templates/${template.id}/preview`, {
+          headers,
+        });
+        const payload: unknown = await res.json().catch(() => null);
+        if (!active) return;
+
+        if (!res.ok) {
+          const message =
+            payload &&
+            typeof payload === "object" &&
+            "error" in payload &&
+            typeof payload.error === "string"
+              ? payload.error
+              : "Could not render preview.";
+          setPreviewError(message);
+          setPreview(null);
+          return;
+        }
+
+        setPreview(payload as TemplatePreview);
+      } catch {
+        if (active) {
+          setPreviewError("Could not render preview.");
+          setPreview(null);
+        }
+      } finally {
+        if (active) setPreviewLoading(false);
+      }
+    }
+
+    fetchPreview();
+
+    return () => {
+      active = false;
+    };
+  }, [template.id]);
+
+  const htmlPreview = preview?.html || template.html || "";
+  const textPreview = preview?.text || template.text || "";
+  const subjectPreview = preview?.subject || template.subject;
+
   return (
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-[#F0F0F0]">
-          {template.name}
-        </h1>
+        <div>
+          <h1 className="text-2xl font-semibold text-[#F0F0F0]">
+            {template.name}
+          </h1>
+          {preview?.rendering.kind === "react_email" ? (
+            <p className="mt-1 text-sm text-[#A1A4A5]">
+              React Email registry template: {preview.rendering.template_key}
+            </p>
+          ) : null}
+        </div>
         <span
           className={`text-xs px-2 py-1 rounded ${
             template.published
@@ -45,9 +169,9 @@ export function TemplateDetail({ template }: TemplateDetailProps) {
             <span className="text-[#6B7071]">From:</span> {template.from}
           </div>
         )}
-        {template.subject && (
+        {subjectPreview && (
           <div>
-            <span className="text-[#6B7071]">Subject:</span> {template.subject}
+            <span className="text-[#6B7071]">Subject:</span> {subjectPreview}
           </div>
         )}
         <div>
@@ -60,49 +184,126 @@ export function TemplateDetail({ template }: TemplateDetailProps) {
         </div>
       </div>
 
-      {template.variables.length > 0 && (
-        <div>
-          <h3 className="text-sm font-medium text-[#A1A4A5] mb-2">Variables</h3>
-          <div className="flex flex-wrap gap-2">
-            {template.variables.map((v) => (
-              <span
-                key={v.name}
-                className="text-xs px-2 py-1 rounded bg-[#1A1D1E] text-[#A1A4A5] border border-[rgba(176,199,217,0.1)]"
-              >
-                {`{{${v.name}}}`}
-                {v.required && <span className="text-red-400 ml-1">*</span>}
-              </span>
-            ))}
+      <section className="rounded-lg border border-[rgba(176,199,217,0.1)] bg-[#0D0F10] p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-sm font-medium text-[#F0F0F0]">
+              Production renderer preview
+            </h2>
+            <p className="mt-1 text-xs text-[#A1A4A5]">
+              Rendered through the same stored-template renderer used by send
+              and automation flows. Preview sample values are labeled and are
+              not sent automatically.
+            </p>
           </div>
+          <span className="rounded-full bg-[#1A1D1E] px-2 py-1 text-xs text-[#A1A4A5]">
+            {previewLoading ? "Rendering..." : "Rendered"}
+          </span>
         </div>
-      )}
+        {previewError ? (
+          <div
+            role="alert"
+            className="mt-3 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-[13px] text-red-300"
+          >
+            {previewError}
+          </div>
+        ) : null}
+        {preview?.warnings.length ? (
+          <ul className="mt-3 space-y-1 text-xs text-yellow-300">
+            {preview.warnings.map((warning) => (
+              <li key={warning}>{warning}</li>
+            ))}
+          </ul>
+        ) : null}
+      </section>
 
-      {template.html && (
+      {preview?.variables.length || template.variables.length ? (
         <div>
+          <h3 className="text-sm font-medium text-[#A1A4A5] mb-2">
+            Variable resolution
+          </h3>
+          {preview?.variables.length ? (
+            <div className="overflow-hidden rounded-lg border border-[rgba(176,199,217,0.1)]">
+              <table className="w-full text-left text-xs text-[#A1A4A5]">
+                <thead className="bg-[#111415] text-[#F0F0F0]">
+                  <tr>
+                    <th className="px-3 py-2 font-medium">Variable</th>
+                    <th className="px-3 py-2 font-medium">Value</th>
+                    <th className="px-3 py-2 font-medium">Source</th>
+                    <th className="px-3 py-2 font-medium">Send requirement</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {preview.variables.map((variable) => (
+                    <tr
+                      key={variable.key}
+                      className="border-t border-[rgba(176,199,217,0.08)]"
+                    >
+                      <td className="px-3 py-2 font-mono text-[#F0F0F0]">
+                        {`{{${variable.key}}}`}
+                      </td>
+                      <td className="px-3 py-2">
+                        {valueLabel(variable.value)}
+                      </td>
+                      <td className="px-3 py-2">
+                        {previewSourceLabel(variable.source)}
+                      </td>
+                      <td className="px-3 py-2">
+                        {variable.sendRequired
+                          ? "Required before send"
+                          : variable.required
+                            ? "Required with fallback"
+                            : "Optional"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {template.variables.map((variable) => (
+                <span
+                  key={variable.key ?? variable.name}
+                  className="text-xs px-2 py-1 rounded bg-[#1A1D1E] text-[#A1A4A5] border border-[rgba(176,199,217,0.1)]"
+                >
+                  {`{{${variable.key ?? variable.name}}}`}
+                  {variable.required && (
+                    <span className="text-red-400 ml-1">*</span>
+                  )}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      ) : null}
+
+      {htmlPreview ? (
+        <div data-testid="template-html-preview">
           <h3 className="text-sm font-medium text-[#A1A4A5] mb-2">
             HTML Preview
           </h3>
           <div className="border border-[rgba(176,199,217,0.1)] rounded-lg overflow-hidden bg-white">
             <iframe
-              srcDoc={template.html}
-              className="w-full min-h-[400px]"
+              srcDoc={htmlPreview}
+              className="w-full min-h-[520px]"
               title="Template Preview"
               sandbox="allow-same-origin"
             />
           </div>
         </div>
-      )}
+      ) : null}
 
-      {template.text && !template.html && (
-        <div>
+      {textPreview ? (
+        <div data-testid="template-text-preview">
           <h3 className="text-sm font-medium text-[#A1A4A5] mb-2">
-            Text Content
+            Text/plain Preview
           </h3>
           <pre className="text-sm text-[#A1A4A5] bg-[#1A1D1E] p-4 rounded-lg whitespace-pre-wrap">
-            {template.text}
+            {textPreview}
           </pre>
         </div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/src/components/templates-list.tsx
+++ b/src/components/templates-list.tsx
@@ -51,6 +51,7 @@ export function TemplatesList() {
   const [templates, setTemplates] = useState<Template[]>([]);
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
+  const [creatingStarter, setCreatingStarter] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("");
@@ -152,6 +153,47 @@ export function TemplatesList() {
       setCreateError("Could not create template.");
     } finally {
       setCreating(false);
+    }
+  };
+
+  const handleCreateReactEmailStarter = async () => {
+    setCreatingStarter(true);
+    setCreateError(null);
+    try {
+      const apiKey =
+        typeof window !== "undefined"
+          ? (localStorage?.getItem?.("api_key") ?? null)
+          : null;
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+      const res = await fetch("/api/templates", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          name: "Onboarding welcome",
+          react_email_template_key: "onboarding-welcome",
+        }),
+      });
+      if (!res.ok) {
+        setCreateError(await readCreateTemplateError(res));
+        return;
+      }
+
+      const templateId = getCreatedTemplateId(await res.json());
+      if (!templateId) {
+        setCreateError(
+          "Template was created but no preview route was returned.",
+        );
+        return;
+      }
+
+      router.push(`/templates/${templateId}`);
+    } catch {
+      setCreateError("Could not create React Email starter.");
+    } finally {
+      setCreatingStarter(false);
     }
   };
 
@@ -323,6 +365,15 @@ export function TemplatesList() {
             <path d="M16 18l6-6-6-6" />
             <path d="M8 6l-6 6 6 6" />
           </svg>
+        </button>
+
+        <button
+          type="button"
+          onClick={handleCreateReactEmailStarter}
+          disabled={creatingStarter}
+          className="h-9 px-4 text-[13px] font-medium border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] hover:border-[rgba(176,199,217,0.3)] disabled:cursor-not-allowed disabled:opacity-70 transition-colors flex items-center gap-1.5"
+        >
+          {creatingStarter ? "Creating..." : "Use React Email starter"}
         </button>
 
         <button

--- a/src/lib/api/emails/send.ts
+++ b/src/lib/api/emails/send.ts
@@ -22,8 +22,8 @@ import {
   StoredTemplateRendererConfigError,
   getStoredTemplateRendererConfig,
   renderStoredTemplateContent,
+  resolveStoredTemplateRenderVariables,
 } from "@/lib/templates/stored-renderer";
-import { normalizeStoredTemplateVariables } from "@/lib/templates/variables";
 import {
   buildOneClickUnsubscribeHeaders,
   createUnsubscribeUrl,
@@ -498,45 +498,37 @@ export async function handlePostEmailRequest(
         );
       }
 
-      const templateVars = normalizeStoredTemplateVariables(template.variables);
       const providedVars = validated.template.variables ?? {};
-      const renderVars: Record<string, unknown> = { ...providedVars };
+      const renderVariableResult = resolveStoredTemplateRenderVariables({
+        storedVariables: template.variables,
+        providedVariables: providedVars,
+        mode: "send",
+      });
 
-      for (const templateVar of templateVars) {
-        if (
-          Object.prototype.hasOwnProperty.call(providedVars, templateVar.key)
-        ) {
-          continue;
-        }
-
-        if (templateVar.hasFallbackValue) {
-          renderVars[templateVar.key] = templateVar.fallbackValue;
-          continue;
-        }
-
-        if (templateVar.required) {
-          recordAcceptMetric(telemetry, {
-            durationMs: performance.now() - startedAt,
-            outcome: "invalid",
-          });
-          return await logResponse(
-            jsonWithTelemetry(
-              publicApiError(
-                "validation_error",
-                `Missing required template variable: ${templateVar.key}`,
-                422,
-                {
-                  formErrors: [],
-                  fieldErrors: {
-                    template: [`Missing required variable: ${templateVar.key}`],
-                  },
+      if (!renderVariableResult.ok) {
+        recordAcceptMetric(telemetry, {
+          durationMs: performance.now() - startedAt,
+          outcome: "invalid",
+        });
+        return await logResponse(
+          jsonWithTelemetry(
+            publicApiError(
+              "validation_error",
+              `Missing required template variable: ${renderVariableResult.missingRequiredKey}`,
+              422,
+              {
+                formErrors: [],
+                fieldErrors: {
+                  template: [
+                    `Missing required variable: ${renderVariableResult.missingRequiredKey}`,
+                  ],
                 },
-              ),
-              telemetry,
-              { status: 422 },
+              },
             ),
-          );
-        }
+            telemetry,
+            { status: 422 },
+          ),
+        );
       }
 
       try {
@@ -552,7 +544,7 @@ export async function handlePostEmailRequest(
           subject:
             storedSubject ??
             (rendererConfig.kind === "legacy" ? finalSubject : undefined),
-          variables: renderVars,
+          variables: renderVariableResult.variables,
         });
         finalHtml = renderedTemplate.html;
         finalText = renderedTemplate.text;

--- a/src/lib/templates/stored-renderer.ts
+++ b/src/lib/templates/stored-renderer.ts
@@ -3,6 +3,7 @@ import {
   type TemplateRenderVariables,
   renderTemplate,
 } from "@opensend/core";
+import { normalizeStoredTemplateVariables } from "./variables";
 
 export type StoredTemplateRendererConfig =
   | { kind: "legacy" }
@@ -27,7 +28,41 @@ type StoredTemplateContent = {
   html?: string | null;
   text?: string | null;
   document?: unknown;
+  variables?: unknown;
 };
+
+export type StoredTemplateRenderVariableSource =
+  | "provided"
+  | "fallback"
+  | "preview_sample"
+  | "missing_optional"
+  | "missing_required";
+
+export type StoredTemplateRenderVariableResolution = {
+  key: string;
+  name: string;
+  type: "string" | "number";
+  required: boolean;
+  fallbackValue: string | number | null;
+  value: string | number | null;
+  source: StoredTemplateRenderVariableSource;
+  sendRequired: boolean;
+};
+
+export type StoredTemplateRenderVariableResult =
+  | {
+      ok: true;
+      variables: TemplateRenderVariables;
+      resolutions: StoredTemplateRenderVariableResolution[];
+      warnings: string[];
+    }
+  | {
+      ok: false;
+      missingRequiredKey: string;
+      variables: TemplateRenderVariables;
+      resolutions: StoredTemplateRenderVariableResolution[];
+      warnings: string[];
+    };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -94,6 +129,129 @@ export function getStoredTemplateRendererConfig(
   }
 
   return { kind: "legacy" };
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function previewSampleValue(input: {
+  key: string;
+  name: string;
+  type: "string" | "number";
+}): string | number {
+  if (input.type === "number") return 42;
+  const readableName = input.name || input.key;
+  return `Sample ${readableName}`;
+}
+
+export function resolveStoredTemplateRenderVariables(input: {
+  storedVariables: unknown;
+  providedVariables?: TemplateRenderVariables;
+  mode: "send" | "preview";
+}): StoredTemplateRenderVariableResult {
+  const providedVars = input.providedVariables ?? {};
+  const renderVars: TemplateRenderVariables = { ...providedVars };
+  const templateVars = normalizeStoredTemplateVariables(input.storedVariables);
+  const resolutions: StoredTemplateRenderVariableResolution[] = [];
+  const warnings: string[] = [];
+  let missingRequiredKey: string | null = null;
+
+  for (const templateVar of templateVars) {
+    if (hasOwn(providedVars, templateVar.key)) {
+      const value = providedVars[templateVar.key];
+      resolutions.push({
+        key: templateVar.key,
+        name: templateVar.name,
+        type: templateVar.type,
+        required: templateVar.required,
+        fallbackValue: templateVar.fallbackValue,
+        value:
+          typeof value === "string" || typeof value === "number"
+            ? value
+            : value === null || value === undefined
+              ? null
+              : String(value),
+        source: "provided",
+        sendRequired: false,
+      });
+      continue;
+    }
+
+    if (templateVar.hasFallbackValue) {
+      renderVars[templateVar.key] = templateVar.fallbackValue;
+      warnings.push(`Using fallback for ${templateVar.key}.`);
+      resolutions.push({
+        key: templateVar.key,
+        name: templateVar.name,
+        type: templateVar.type,
+        required: templateVar.required,
+        fallbackValue: templateVar.fallbackValue,
+        value: templateVar.fallbackValue,
+        source: "fallback",
+        sendRequired: false,
+      });
+      continue;
+    }
+
+    if (templateVar.required) {
+      if (input.mode === "preview") {
+        const value = previewSampleValue(templateVar);
+        renderVars[templateVar.key] = value;
+        warnings.push(
+          `Preview uses a sample value for required variable ${templateVar.key}; production sends must provide it.`,
+        );
+        resolutions.push({
+          key: templateVar.key,
+          name: templateVar.name,
+          type: templateVar.type,
+          required: true,
+          fallbackValue: null,
+          value,
+          source: "preview_sample",
+          sendRequired: true,
+        });
+        continue;
+      }
+
+      missingRequiredKey ??= templateVar.key;
+      warnings.push(`Missing required variable ${templateVar.key}.`);
+      resolutions.push({
+        key: templateVar.key,
+        name: templateVar.name,
+        type: templateVar.type,
+        required: true,
+        fallbackValue: null,
+        value: null,
+        source: "missing_required",
+        sendRequired: true,
+      });
+      continue;
+    }
+
+    resolutions.push({
+      key: templateVar.key,
+      name: templateVar.name,
+      type: templateVar.type,
+      required: false,
+      fallbackValue: null,
+      value: null,
+      source: "missing_optional",
+      sendRequired: false,
+    });
+  }
+
+  if (missingRequiredKey) {
+    return {
+      ok: false,
+      missingRequiredKey,
+      variables: renderVars,
+      resolutions,
+      warnings,
+    };
+  }
+
+  return { ok: true, variables: renderVars, resolutions, warnings };
 }
 
 export async function renderStoredTemplateContent(input: {

--- a/tests/api-template-preview.test.ts
+++ b/tests/api-template-preview.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockFindFirst = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api-auth", () => ({
+  authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
+  getServerSession: mockGetServerSession,
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/api-key-permissions", () => ({
+  requireFullAccessApiKey: () => null,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      templates: {
+        findFirst: mockFindFirst,
+      },
+    },
+  },
+}));
+
+describe("GET /api/templates/:id/preview", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue({ dashboard: true });
+    mockGetServerSession.mockResolvedValue({ user: { id: "user-1" } });
+  });
+
+  it("renders React Email starters through the stored-template renderer with variable diagnostics", async () => {
+    mockFindFirst.mockResolvedValue({
+      id: "tmpl-1",
+      userId: "user-1",
+      subject: null,
+      html: "<p>legacy placeholder should not render</p>",
+      text: null,
+      variables: [
+        {
+          name: "productName",
+          key: "productName",
+          type: "string",
+          required: false,
+          fallbackValue: "Opensend",
+        },
+        {
+          name: "actionUrl",
+          key: "actionUrl",
+          type: "string",
+          required: true,
+          fallbackValue: null,
+        },
+      ],
+      document: {
+        rendering: {
+          kind: "react_email",
+          templateKey: "onboarding-welcome",
+        },
+      },
+    });
+
+    const { GET } = await import("@/app/api/templates/[id]/preview/route");
+    const response = await GET(
+      new Request("http://localhost/api/templates/tmpl-1/preview") as never,
+      { params: Promise.resolve({ id: "tmpl-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      object: "template_preview",
+      id: "tmpl-1",
+      rendering: {
+        kind: "react_email",
+        template_key: "onboarding-welcome",
+      },
+      subject: "Welcome to Opensend",
+    });
+    expect(body.html).toContain("Your email workspace is ready");
+    expect(body.text).toContain("YOUR EMAIL WORKSPACE IS READY");
+    expect(body.variables).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "productName",
+          source: "fallback",
+          value: "Opensend",
+        }),
+        expect.objectContaining({
+          key: "actionUrl",
+          source: "preview_sample",
+          sendRequired: true,
+        }),
+      ]),
+    );
+  });
+
+  it("returns a validation error for unknown registry keys", async () => {
+    mockFindFirst.mockResolvedValue({
+      id: "tmpl-1",
+      userId: "user-1",
+      subject: null,
+      html: null,
+      text: null,
+      variables: [],
+      document: {
+        rendering: {
+          kind: "react_email",
+          templateKey: "tenant-provided-tsx-string",
+        },
+      },
+    });
+
+    const { GET } = await import("@/app/api/templates/[id]/preview/route");
+    const response = await GET(
+      new Request("http://localhost/api/templates/tmpl-1/preview") as never,
+      { params: Promise.resolve({ id: "tmpl-1" }) },
+    );
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toEqual({
+      error: "Unknown React Email template key: tenant-provided-tsx-string",
+    });
+  });
+});

--- a/tests/api-template-variables.test.ts
+++ b/tests/api-template-variables.test.ts
@@ -128,6 +128,66 @@ describe("template variable metadata service", () => {
     expect(inserted[0]?.userId).toBe("user-123");
   });
 
+  it("creates React Email starter templates from registry metadata only", async () => {
+    const inserted: TemplateInsert[] = [];
+    const repository = createRepository({
+      async create(data) {
+        inserted.push(data);
+        return [templateRow({ ...data })];
+      },
+    });
+
+    await createTemplateService({ repository }).createTemplate({
+      name: "Onboarding welcome",
+      react_email_template_key: "onboarding-welcome",
+    });
+
+    expect(inserted[0]).toMatchObject({
+      name: "Onboarding welcome",
+      html: "<!-- React Email registry template: onboarding-welcome -->",
+      document: {
+        rendering: {
+          kind: "react_email",
+          templateKey: "onboarding-welcome",
+        },
+        starter: {
+          key: "onboarding-welcome",
+          source: "opensend-registry",
+        },
+      },
+      variables: expect.arrayContaining([
+        expect.objectContaining({
+          key: "actionUrl",
+          required: true,
+          fallbackValue: null,
+        }),
+        expect.objectContaining({
+          key: "productName",
+          required: false,
+          fallbackValue: "Opensend",
+        }),
+      ]),
+    });
+  });
+
+  it("rejects unknown React Email starter keys instead of accepting tenant code", async () => {
+    const create = vi.fn(async () => [templateRow()]);
+    const service = createTemplateService({
+      repository: createRepository({ create }),
+    });
+
+    await expect(
+      service.createTemplate({
+        name: "Tenant TSX",
+        react_email_template_key: "tenant-provided-tsx-string",
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_input",
+      message: "Unknown React Email template key: tenant-provided-tsx-string",
+    } satisfies Partial<TemplateServiceError>);
+    expect(create).not.toHaveBeenCalled();
+  });
+
   it("preserves reserved-name and 50-variable validation on create", async () => {
     const create = vi.fn(async () => [templateRow()]);
     const service = createTemplateService({

--- a/tests/e2e/templates-list.spec.ts
+++ b/tests/e2e/templates-list.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { expect, test } from "./fixtures/auth";
 
 test.describe("Templates List Page", () => {
@@ -55,6 +56,79 @@ test.describe("Templates List Page", () => {
       [templateId],
     );
     expect(result.rows[0]?.user_id).toBe(e2eUser.id);
+
+    await e2eDb.query("delete from templates where id = $1 and user_id = $2", [
+      templateId,
+      e2eUser.id,
+    ]);
+  });
+
+  test("renders React Email-backed template preview with text and variable diagnostics", async ({
+    authenticatedPage: page,
+    e2eDb,
+    e2eUser,
+  }) => {
+    const templateId = randomUUID();
+    await e2eDb.query(
+      `insert into templates
+        (id, name, alias, status, html, variables, document, user_id, created_at)
+       values
+        ($1, 'E2E React Email Starter', 'e2e-react-email-starter', 'draft',
+         '<!-- React Email registry template: onboarding-welcome -->',
+         $2::jsonb, $3::jsonb, $4, now())`,
+      [
+        templateId,
+        JSON.stringify([
+          {
+            name: "productName",
+            key: "productName",
+            type: "string",
+            required: false,
+            fallbackValue: "Opensend",
+          },
+          {
+            name: "actionUrl",
+            key: "actionUrl",
+            type: "string",
+            required: true,
+            fallbackValue: null,
+          },
+        ]),
+        JSON.stringify({
+          rendering: {
+            kind: "react_email",
+            templateKey: "onboarding-welcome",
+          },
+        }),
+        e2eUser.id,
+      ],
+    );
+
+    await page.goto(`/templates/${templateId}`);
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.getByRole("heading", { name: "E2E React Email Starter" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("React Email registry template:"),
+    ).toBeVisible();
+    await expect(page.getByText("Variable resolution")).toBeVisible();
+    await expect(page.getByRole("cell", { name: "Fallback" })).toBeVisible();
+    await expect(
+      page.getByRole("cell", { name: "Preview sample" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("cell", { name: "Required before send" }),
+    ).toBeVisible();
+    await expect(page.getByTestId("template-text-preview")).toContainText(
+      "Open the setup checklist",
+    );
+    await expect(
+      page
+        .frameLocator('iframe[title="Template Preview"]')
+        .getByText("Your email workspace is ready"),
+    ).toBeVisible();
 
     await e2eDb.query("delete from templates where id = $1 and user_id = $2", [
       templateId,

--- a/tests/template-detail.test.tsx
+++ b/tests/template-detail.test.tsx
@@ -1,0 +1,90 @@
+import { TemplateDetail } from "@/components/template-detail";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const template = {
+  id: "tmpl-1",
+  name: "Onboarding welcome",
+  alias: "onboarding-welcome",
+  from: null,
+  subject: null,
+  html: "<p>Stored placeholder</p>",
+  text: null,
+  published: false,
+  variables: [
+    { name: "productName", key: "productName", required: false },
+    { name: "actionUrl", key: "actionUrl", required: true },
+  ],
+  createdAt: "2026-05-12T00:00:00.000Z",
+  updatedAt: "2026-05-12T00:00:00.000Z",
+};
+
+describe("TemplateDetail", () => {
+  beforeEach(() => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        subject: "Welcome to Opensend",
+        html: "<h1>Your email workspace is ready</h1>",
+        text: "YOUR EMAIL WORKSPACE IS READY\nOpen the setup checklist",
+        rendering: {
+          kind: "react_email",
+          template_key: "onboarding-welcome",
+        },
+        variables: [
+          {
+            key: "productName",
+            name: "Product name",
+            type: "string",
+            required: false,
+            fallbackValue: "Opensend",
+            value: "Opensend",
+            source: "fallback",
+            sendRequired: false,
+          },
+          {
+            key: "actionUrl",
+            name: "Setup checklist URL",
+            type: "string",
+            required: true,
+            fallbackValue: null,
+            value: "Sample Setup checklist URL",
+            source: "preview_sample",
+            sendRequired: true,
+          },
+        ],
+        warnings: [
+          "Using fallback for productName.",
+          "Preview uses a sample value for required variable actionUrl; production sends must provide it.",
+        ],
+      }),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows shared-renderer HTML, text, and variable/fallback diagnostics", async () => {
+    render(<TemplateDetail template={template} />);
+
+    expect(await screen.findByText("Production renderer preview")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText(/React Email registry template:/)).toBeTruthy();
+    });
+
+    expect(screen.getByText("Welcome to Opensend")).toBeTruthy();
+    expect(screen.getByText("Variable resolution")).toBeTruthy();
+    expect(screen.getByText("Fallback")).toBeTruthy();
+    expect(screen.getByText("Preview sample")).toBeTruthy();
+    expect(screen.getByText("Required before send")).toBeTruthy();
+    expect(screen.getByTestId("template-html-preview")).toBeTruthy();
+    expect(screen.getByTestId("template-text-preview").textContent).toContain(
+      "Open the setup checklist",
+    );
+  });
+});

--- a/tests/templates-list.test.tsx
+++ b/tests/templates-list.test.tsx
@@ -156,6 +156,41 @@ describe("TemplatesList", () => {
     );
   });
 
+  it("creates a React Email starter and navigates to the preview detail", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: mockTemplates, total: 3 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "starter-template" }),
+      });
+
+    render(<TemplatesList />);
+
+    await screen.findByText("Welcome Email");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Use React Email starter" }),
+    );
+
+    await waitFor(() => {
+      expect(routerMock.push).toHaveBeenCalledWith(
+        "/templates/starter-template",
+      );
+    });
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      "/api/templates",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          name: "Onboarding welcome",
+          react_email_template_key: "onboarding-welcome",
+        }),
+      }),
+    );
+  });
+
   it("shows card action menu with options", async () => {
     render(<TemplatesList />);
 


### PR DESCRIPTION
## Summary
- add a shared-renderer `/api/templates/:id/preview` path for dashboard/API previews
- render both HTML and generated text/plain previews while surfacing variable fallback/sample diagnostics
- add a registry-controlled `onboarding-welcome` React Email starter and dashboard CTA
- document first-path React Email preview support, self-hosted constraints, and explicit no arbitrary tenant TSX/JS execution

Closes #450

## Changed files
- `packages/core/src/services/template-renderer.ts` — React Email metadata registry plus polished onboarding starter
- `src/lib/templates/stored-renderer.ts` / `src/lib/api/emails/send.ts` — shared send/preview variable resolution semantics
- `src/app/api/templates/[id]/preview/route.ts` — preview API using stored-template renderer
- `src/components/template-detail.tsx` / `src/components/templates-list.tsx` — preview UI, variable diagnostics, starter CTA
- `docs/react-email-templates.md`, `README.md`, `src/app/docs/page.tsx` — support/limitations docs
- focused Vitest + Playwright coverage under `tests/`

## Validation
- `make check` ✅
- `make test` ✅ (154 files, 1210 tests)
- `bun run test:e2e tests/e2e/templates-list.spec.ts` ✅ (3 passed)
- Manual browser screenshot proof: `test-results/issue-450-template-preview-proof.png` generated locally (ignored artifact)

## Residual risk
- Full `make test-e2e` was not used as PR proof; it hit an unrelated existing strict-locator failure in `tests/e2e/automations-dashboard.spec.ts` (`getByRole('heading', { name: 'Automations' })` also matches `No automations`). The scoped templates spec passes against local Postgres.
