### PR TITLE
Expose Resend-compatible segments root API

### DIFF
--- a/agent_docs/learnings/active/2026-05-12-issue-455-segments-root-auth-boundary.md
+++ b/agent_docs/learnings/active/2026-05-12-issue-455-segments-root-auth-boundary.md
@@ -1,0 +1,18 @@
+---
+date: 2026-05-12
+issue: 455
+type: decision
+promoted_to: null
+---
+
+# Root segments aliases stay API-key-only
+
+Issue #455 adds Resend-compatible root `/segments` routes while preserving the older
+`/api/segments` dashboard-compatible collection route for internal/dashboard callers.
+
+Decision: root `/segments` collection routes call `validateApiKey` and
+`requireFullAccessApiKey` directly instead of re-exporting `src/app/api/segments/route.ts`.
+This prevents dashboard session cookies from becoming valid public API auth at the root
+Resend-compatible surface. Detail aliases (`/segments/:id` and
+`/segments/:id/contacts`) can re-export the existing `/api/segments/:id` handlers because
+those handlers were already API-key-only and tenant-scoped through `auth.userId`.

--- a/packages/core/src/dto/index.ts
+++ b/packages/core/src/dto/index.ts
@@ -293,6 +293,49 @@ export interface ContactListResponse {
   has_more: boolean;
 }
 
+export interface CreateSegmentPayload {
+  name: string;
+}
+
+export interface SegmentResponse {
+  object: "segment";
+  id: string;
+  name: string;
+  created_at?: string;
+}
+
+export interface SegmentListItem {
+  id: string;
+  name: string;
+  created_at: string;
+}
+
+export interface SegmentListResponse {
+  object: "list";
+  data: SegmentListItem[];
+  has_more: boolean;
+  total?: number;
+}
+
+export interface DeleteSegmentResponse {
+  success: true;
+}
+
+export interface SegmentContactListItem {
+  id: string;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+  status: "subscribed" | "unsubscribed";
+  created_at: string;
+}
+
+export interface SegmentContactListResponse {
+  object: "list";
+  data: SegmentContactListItem[];
+  has_more: boolean;
+}
+
 export interface CreateAudiencePayload {
   name: string;
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -17,8 +17,10 @@ import type {
   CreateAudiencePayload,
   CreateContactPayload,
   CreateContactResponse,
+  CreateSegmentPayload,
   DeleteAudienceResponse,
   DeleteContactResponse,
+  DeleteSegmentResponse,
   DomainCapability,
   DomainListItem,
   DomainListResponse,
@@ -35,6 +37,11 @@ import type {
   EmailStatus,
   EmailTag,
   EmailTemplateReference,
+  SegmentContactListItem,
+  SegmentContactListResponse,
+  SegmentListItem,
+  SegmentListResponse,
+  SegmentResponse,
   SendEmailResponse,
   UpdateContactPayload,
   UpdateDomainPayload,
@@ -120,6 +127,10 @@ export interface ListOptions {
 }
 
 export interface AudienceListOptions extends ListOptions {
+  search?: string;
+}
+
+export interface SegmentListOptions extends ListOptions {
   search?: string;
 }
 
@@ -566,6 +577,57 @@ class Contacts {
   }
 }
 
+class Segments {
+  constructor(private readonly http: HttpClient) {}
+
+  async create(
+    payload: CreateSegmentPayload,
+  ): Promise<ApiResponse<SegmentResponse>> {
+    return this.http.request<SegmentResponse>("POST", "/segments", payload);
+  }
+
+  async list(
+    options: SegmentListOptions = {},
+  ): Promise<ApiResponse<SegmentListResponse>> {
+    const params = new URLSearchParams();
+    if (options.limit !== undefined) params.set("limit", String(options.limit));
+    if (options.after) params.set("after", options.after);
+    if (options.search) params.set("search", options.search);
+
+    const query = params.toString();
+    return this.http.request<SegmentListResponse>(
+      "GET",
+      query ? `/segments?${query}` : "/segments",
+    );
+  }
+
+  async get(id: string): Promise<ApiResponse<SegmentResponse>> {
+    return this.http.request<SegmentResponse>("GET", `/segments/${id}`);
+  }
+
+  async delete(id: string): Promise<ApiResponse<DeleteSegmentResponse>> {
+    return this.http.request<DeleteSegmentResponse>(
+      "DELETE",
+      `/segments/${id}`,
+    );
+  }
+
+  async listContacts(
+    id: string,
+    options: ListOptions = {},
+  ): Promise<ApiResponse<SegmentContactListResponse>> {
+    const params = new URLSearchParams();
+    if (options.limit !== undefined) params.set("limit", String(options.limit));
+    if (options.after) params.set("after", options.after);
+
+    const query = params.toString();
+    return this.http.request<SegmentContactListResponse>(
+      "GET",
+      query ? `/segments/${id}/contacts?${query}` : `/segments/${id}/contacts`,
+    );
+  }
+}
+
 class Audiences {
   constructor(private readonly http: HttpClient) {}
 
@@ -793,6 +855,7 @@ class Opensend {
   public readonly domains: Domains;
   public readonly apiKeys: ApiKeys;
   public readonly contacts: Contacts;
+  public readonly segments: Segments;
   public readonly audiences: Audiences;
   public readonly broadcasts: Broadcasts;
   public readonly automations: Automations;
@@ -809,6 +872,7 @@ class Opensend {
     this.domains = new Domains(http);
     this.apiKeys = new ApiKeys(http);
     this.contacts = new Contacts(http);
+    this.segments = new Segments(http);
     this.audiences = new Audiences(http);
     this.broadcasts = new Broadcasts(http);
     this.automations = new Automations(http);
@@ -853,6 +917,13 @@ export type {
   AudienceListItem,
   AudienceListResponse,
   DeleteAudienceResponse,
+  CreateSegmentPayload,
+  SegmentResponse,
+  SegmentListItem,
+  SegmentListResponse,
+  DeleteSegmentResponse,
+  SegmentContactListItem,
+  SegmentContactListResponse,
   BroadcastStatus,
   CreateBroadcastPayload,
   UpdateBroadcastPayload,

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -263,18 +263,39 @@ await client.broadcasts.send("BROADCAST_ID", {
     endpoints: [
       {
         method: "POST",
-        path: "/api/segments",
+        path: "/segments",
         description: "Create a new segment",
-        curl: `curl -X POST https://api.opensend.com/api/segments \\
+        curl: `curl -X POST https://api.opensend.com/segments \\
   -H "Authorization: Bearer os_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{ "name": "Active Users" }'`,
       },
       {
         method: "GET",
-        path: "/api/segments",
+        path: "/segments",
         description: "List all segments",
-        curl: `curl https://api.opensend.com/api/segments \\
+        curl: `curl https://api.opensend.com/segments \\
+  -H "Authorization: Bearer os_YOUR_API_KEY"`,
+      },
+      {
+        method: "GET",
+        path: "/segments/:id",
+        description: "Retrieve a segment by ID",
+        curl: `curl https://api.opensend.com/segments/SEGMENT_ID \\
+  -H "Authorization: Bearer os_YOUR_API_KEY"`,
+      },
+      {
+        method: "DELETE",
+        path: "/segments/:id",
+        description: "Delete a segment by ID",
+        curl: `curl -X DELETE https://api.opensend.com/segments/SEGMENT_ID \\
+  -H "Authorization: Bearer os_YOUR_API_KEY"`,
+      },
+      {
+        method: "GET",
+        path: "/segments/:id/contacts",
+        description: "List contacts in a segment",
+        curl: `curl https://api.opensend.com/segments/SEGMENT_ID/contacts \\
   -H "Authorization: Bearer os_YOUR_API_KEY"`,
       },
     ],

--- a/src/app/segments/[id]/contacts/route.ts
+++ b/src/app/segments/[id]/contacts/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "@/app/api/segments/[id]/contacts/route";

--- a/src/app/segments/[id]/route.ts
+++ b/src/app/segments/[id]/route.ts
@@ -1,0 +1,1 @@
+export { DELETE, GET } from "@/app/api/segments/[id]/route";

--- a/src/app/segments/route.ts
+++ b/src/app/segments/route.ts
@@ -1,0 +1,75 @@
+import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
+import {
+  AudienceMetadataServiceError,
+  createAudienceMetadataService,
+} from "@opensend/core";
+import { NextResponse } from "next/server";
+
+function audienceMetadataService() {
+  return createAudienceMetadataService();
+}
+
+function mapServiceError(error: unknown, fallback: string) {
+  if (error instanceof AudienceMetadataServiceError) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: error.status },
+    );
+  }
+
+  console.error(`${fallback}:`, error);
+  return NextResponse.json({ error: fallback }, { status: 500 });
+}
+
+async function resolveApiKeyUserId(request: Request): Promise<
+  | {
+      userId: string;
+    }
+  | Response
+> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth) return unauthorizedResponse();
+
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
+  if (!auth.userId) return unauthorizedResponse();
+
+  return { userId: auth.userId };
+}
+
+export async function GET(request: Request) {
+  const auth = await resolveApiKeyUserId(request);
+  if (auth instanceof Response) return auth;
+
+  try {
+    const url = new URL(request.url);
+    const result = await audienceMetadataService().listSegments({
+      userId: auth.userId,
+      limit: Number(url.searchParams.get("limit")) || undefined,
+      search: url.searchParams.get("search") || undefined,
+      after: url.searchParams.get("after") || undefined,
+    });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    return mapServiceError(error, "Failed to fetch segments");
+  }
+}
+
+export async function POST(request: Request) {
+  const auth = await resolveApiKeyUserId(request);
+  if (auth instanceof Response) return auth;
+
+  try {
+    const body = await request.json();
+    const result = await audienceMetadataService().createSegment({
+      userId: auth.userId,
+      body,
+    });
+
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    return mapServiceError(error, "Failed to create segment");
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -104,6 +104,17 @@ function isAudiencesAlias(pathname: string, method: string): boolean {
   return false;
 }
 
+function isSegmentsAlias(pathname: string, method: string): boolean {
+  if (pathname === "/segments") return ["GET", "POST"].includes(method);
+
+  const parts = pathname.split("/").filter(Boolean);
+  if (parts[0] !== "segments") return false;
+  if (parts.length === 2) return ["GET", "DELETE"].includes(method);
+  if (parts.length === 3 && parts[2] === "contacts") return method === "GET";
+
+  return false;
+}
+
 function isBroadcastsAlias(pathname: string, method: string): boolean {
   if (pathname === "/broadcasts") return ["GET", "POST"].includes(method);
   const parts = pathname.split("/").filter(Boolean);
@@ -180,6 +191,11 @@ function getRateLimitPathname(pathname: string, method: string): string {
       ? "/api/segments"
       : pathname.replace(/^\/audiences/, "/api/segments");
   }
+  if (isSegmentsAlias(pathname, method)) {
+    return pathname === "/segments"
+      ? "/api/segments"
+      : pathname.replace(/^\/segments/, "/api/segments");
+  }
   if (isBroadcastsAlias(pathname, method)) {
     return pathname === "/broadcasts"
       ? "/api/broadcasts"
@@ -235,12 +251,14 @@ export async function middleware(request: NextRequest) {
   const isSendAlias = isSendPostAlias(pathname, request.method);
   const isContactAlias = isContactsAlias(pathname, request.method);
   const isAudienceAlias = isAudiencesAlias(pathname, request.method);
+  const isSegmentAlias = isSegmentsAlias(pathname, request.method);
   const isBroadcastAlias = shouldHandleBroadcastsAlias(request);
   if (
     !pathname.startsWith("/api/") &&
     !isSendAlias &&
     !isContactAlias &&
     !isAudienceAlias &&
+    !isSegmentAlias &&
     !isBroadcastAlias
   ) {
     // Allow auth page, public landing page, and static assets

--- a/tests/e2e/segments-api.spec.ts
+++ b/tests/e2e/segments-api.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "./fixtures/auth";
+
+test.describe("Resend-compatible /segments API", () => {
+  test("creates, lists, retrieves, deletes, and lists segment contacts with API-key auth", async ({
+    e2eApiRequest,
+    e2eDb,
+    e2eRunId,
+    e2eTenant,
+  }) => {
+    const name = `Registered Users ${e2eRunId}`;
+
+    const createResponse = await e2eApiRequest.post("/segments", {
+      data: { name },
+    });
+    expect(createResponse.status()).toBe(201);
+    const created = (await createResponse.json()) as {
+      object: string;
+      id: string;
+      name: string;
+    };
+    expect(created).toEqual({
+      object: "segment",
+      id: expect.any(String),
+      name,
+    });
+
+    const segmentRows = await e2eDb.query<{
+      name: string;
+      user_id: string;
+    }>("select name, user_id from segments where id = $1", [created.id]);
+    expect(segmentRows.rows).toEqual([{ name, user_id: e2eTenant.user.id }]);
+
+    const contactEmail = `segment-contact-${e2eRunId}@${e2eRunId}.e2e.opensend.test`;
+    const contactRows = await e2eDb.query<{ id: string }>(
+      `insert into contacts (email, first_name, last_name, user_id, document)
+       values ($1, 'Segment', 'Member', $2, $3::jsonb)
+       returning id`,
+      [
+        contactEmail,
+        e2eTenant.user.id,
+        JSON.stringify({ test_run_id: e2eRunId }),
+      ],
+    );
+    const contactId = contactRows.rows[0]?.id ?? "";
+    await e2eDb.query(
+      `insert into contacts_to_segments (contact_id, segment_id)
+       values ($1, $2)
+       on conflict do nothing`,
+      [contactId, created.id],
+    );
+
+    const listResponse = await e2eApiRequest.get(
+      `/segments?search=${encodeURIComponent(name)}&limit=10`,
+    );
+    expect(listResponse.status()).toBe(200);
+    const listed = (await listResponse.json()) as {
+      object: string;
+      has_more: boolean;
+      data: Array<{ id: string; name: string; created_at: string }>;
+      total: number;
+    };
+    expect(listed).toEqual({
+      object: "list",
+      has_more: false,
+      total: 1,
+      data: [
+        {
+          id: created.id,
+          name,
+          created_at: expect.any(String),
+        },
+      ],
+    });
+
+    const getResponse = await e2eApiRequest.get(`/segments/${created.id}`);
+    expect(getResponse.status()).toBe(200);
+    await expect(getResponse.json()).resolves.toEqual({
+      object: "segment",
+      id: created.id,
+      name,
+      created_at: expect.any(String),
+    });
+
+    const contactsResponse = await e2eApiRequest.get(
+      `/segments/${created.id}/contacts?limit=10`,
+    );
+    expect(contactsResponse.status()).toBe(200);
+    await expect(contactsResponse.json()).resolves.toEqual({
+      object: "list",
+      has_more: false,
+      data: [
+        {
+          id: contactId,
+          email: contactEmail,
+          firstName: "Segment",
+          lastName: "Member",
+          status: "subscribed",
+          created_at: expect.any(String),
+        },
+      ],
+    });
+
+    const deleteResponse = await e2eApiRequest.delete(
+      `/segments/${created.id}`,
+    );
+    expect(deleteResponse.status()).toBe(200);
+    await expect(deleteResponse.json()).resolves.toEqual({ success: true });
+
+    const deletedGetResponse = await e2eApiRequest.get(
+      `/segments/${created.id}`,
+    );
+    expect(deletedGetResponse.status()).toBe(404);
+  });
+});

--- a/tests/middleware-rate-limit.test.ts
+++ b/tests/middleware-rate-limit.test.ts
@@ -354,6 +354,31 @@ describe("middleware rate limiting", () => {
     expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
   });
 
+  it("lets root segments aliases reach API routes without dashboard session redirects", async () => {
+    process.env.RATE_LIMIT_BACKEND = "redis";
+    mockGetSessionCookie.mockReturnValue(null);
+    mockIncrCache.mockResolvedValue(1);
+
+    const { middleware } = await import("@/middleware");
+    const response = await middleware(
+      makeRequest("https://example.com/segments/seg_123/contacts", {
+        method: "GET",
+        headers: {
+          "x-forwarded-for": "203.0.113.10",
+          authorization: "Bearer test-api-key",
+        },
+      }),
+    );
+
+    expect(mockGetSessionCookie).not.toHaveBeenCalled();
+    expect(mockIncrCache).toHaveBeenCalledWith(
+      "ratelimit:203.0.113.10:Bearer test-api-key:/api/segments/seg_123/contacts",
+      60,
+    );
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
+  });
+
   it("returns 429 with Retry-After once the Redis limit is exceeded", async () => {
     process.env.RATE_LIMIT_BACKEND = "redis";
     mockIncrCache.mockResolvedValue(21);

--- a/tests/sdk-client.test.tsx
+++ b/tests/sdk-client.test.tsx
@@ -19,6 +19,9 @@ import type {
   EmailResponse,
   RequestOptions,
   SDKOptions,
+  SegmentContactListResponse,
+  SegmentListResponse,
+  SegmentResponse,
   SendBroadcastPayload,
   SendEmailPayload,
   UpdateBroadcastPayload,
@@ -150,6 +153,53 @@ describe("Opensend SDK", () => {
     );
   });
 
+  it("builds Resend-compatible root segments API requests", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ object: "segment", id: "seg_123" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new Resend("os_test", {
+      baseUrl: "https://api.example.com",
+    });
+
+    await client.segments.create({ name: "Registered Users" });
+    await client.segments.list({ limit: 10, after: "seg_1", search: "vip" });
+    await client.segments.get("seg_123");
+    await client.segments.delete("seg_123");
+    await client.segments.listContacts("seg_123", { limit: 5, after: "c_1" });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example.com/segments",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.example.com/segments?limit=10&after=seg_1&search=vip",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "https://api.example.com/segments/seg_123",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      "https://api.example.com/segments/seg_123",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      5,
+      "https://api.example.com/segments/seg_123/contacts?limit=5&after=c_1",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
   it("keeps SDK public type exports available from the entrypoint", () => {
     expectTypeOf<SDKOptions>().toMatchTypeOf<{ baseUrl?: string }>();
     expectTypeOf<RequestOptions>().toMatchTypeOf<{ idempotencyKey?: string }>();
@@ -178,6 +228,21 @@ describe("Opensend SDK", () => {
     expectTypeOf<DeleteAudienceResponse>().toMatchTypeOf<{
       object: "audience";
       deleted: true;
+    }>();
+    expectTypeOf<SegmentResponse>().toMatchTypeOf<{
+      object: "segment";
+      id: string;
+      name: string;
+    }>();
+    expectTypeOf<SegmentListResponse>().toMatchTypeOf<{
+      object: "list";
+      data: Array<{ id: string; name: string; created_at: string }>;
+      has_more: boolean;
+    }>();
+    expectTypeOf<SegmentContactListResponse>().toMatchTypeOf<{
+      object: "list";
+      data: Array<{ email: string; status: "subscribed" | "unsubscribed" }>;
+      has_more: boolean;
     }>();
     expectTypeOf<CreateBroadcastPayload>().toMatchTypeOf<{
       from: string;

--- a/tests/segment-root-api.test.ts
+++ b/tests/segment-root-api.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockRequireFullAccessApiKey = vi.hoisted(() => vi.fn());
+const mockRequireFullAccessForApiKeyCaller = vi.hoisted(() => vi.fn());
+const mockAudienceMetadataService = vi.hoisted(() => ({
+  createSegment: vi.fn(),
+  listSegments: vi.fn(),
+  getSegment: vi.fn(),
+  deleteSegment: vi.fn(),
+  listSegmentContacts: vi.fn(),
+}));
+
+class TestAudienceMetadataServiceError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "AudienceMetadataServiceError";
+  }
+}
+
+function makeRequest(url: string, init?: RequestInit) {
+  const request = new Request(url, init) as Request & { nextUrl: URL };
+  request.nextUrl = new URL(url);
+  return request;
+}
+
+vi.mock("@/lib/api-auth", () => ({
+  authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
+  getServerSession: mockGetServerSession,
+  validateApiKey: mockValidateApiKey,
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/api-key-permissions", () => ({
+  requireFullAccessApiKey: mockRequireFullAccessApiKey,
+  requireFullAccessForApiKeyCaller: mockRequireFullAccessForApiKeyCaller,
+}));
+
+vi.mock("@opensend/core", () => ({
+  AudienceMetadataServiceError: TestAudienceMetadataServiceError,
+  createAudienceMetadataService: () => mockAudienceMetadataService,
+}));
+
+describe("Resend-compatible root segments API", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    const auth = {
+      apiKeyId: "key-1",
+      permission: "full_access",
+      domain: null,
+      userId: "user-1",
+    };
+    mockValidateApiKey.mockResolvedValue(auth);
+    mockAuthorizeDashboardOrApiKey.mockResolvedValue(auth);
+    mockGetServerSession.mockResolvedValue({ user: { id: "dashboard-user" } });
+    mockRequireFullAccessApiKey.mockReturnValue(null);
+    mockRequireFullAccessForApiKeyCaller.mockReturnValue(null);
+  });
+
+  it("creates, lists, retrieves, deletes, and lists contacts at root /segments paths", async () => {
+    mockAudienceMetadataService.createSegment.mockResolvedValueOnce({
+      object: "segment",
+      id: "seg-1",
+      name: "VIP",
+    });
+    mockAudienceMetadataService.listSegments.mockResolvedValueOnce({
+      object: "list",
+      data: [{ id: "seg-1", name: "VIP", created_at: "2026-05-12" }],
+      has_more: false,
+      total: 1,
+    });
+    mockAudienceMetadataService.getSegment.mockResolvedValueOnce({
+      object: "segment",
+      id: "seg-1",
+      name: "VIP",
+      created_at: "2026-05-12",
+    });
+    mockAudienceMetadataService.deleteSegment.mockResolvedValueOnce(undefined);
+    mockAudienceMetadataService.listSegmentContacts.mockResolvedValueOnce({
+      object: "list",
+      data: [
+        {
+          id: "contact-1",
+          email: "user@example.com",
+          firstName: "User",
+          lastName: "One",
+          status: "subscribed",
+          created_at: "2026-05-12",
+        },
+      ],
+      has_more: false,
+    });
+
+    const collectionRoute = await import("@/app/segments/route");
+    const detailRoute = await import("@/app/segments/[id]/route");
+    const contactsRoute = await import("@/app/segments/[id]/contacts/route");
+
+    const createResponse = await collectionRoute.POST(
+      makeRequest("http://localhost/segments", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer os_test",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ name: "VIP" }),
+      }),
+    );
+    expect(createResponse.status).toBe(201);
+    await expect(createResponse.json()).resolves.toEqual({
+      object: "segment",
+      id: "seg-1",
+      name: "VIP",
+    });
+    expect(mockAudienceMetadataService.createSegment).toHaveBeenCalledWith({
+      userId: "user-1",
+      body: { name: "VIP" },
+    });
+
+    const listResponse = await collectionRoute.GET(
+      makeRequest("http://localhost/segments?limit=10&search=vip&after=seg-0", {
+        headers: { authorization: "Bearer os_test" },
+      }),
+    );
+    expect(listResponse.status).toBe(200);
+    await expect(listResponse.json()).resolves.toMatchObject({
+      object: "list",
+      has_more: false,
+      total: 1,
+    });
+    expect(mockAudienceMetadataService.listSegments).toHaveBeenCalledWith({
+      userId: "user-1",
+      limit: 10,
+      search: "vip",
+      after: "seg-0",
+    });
+
+    const getResponse = await detailRoute.GET(
+      makeRequest("http://localhost/segments/seg-1", {
+        headers: { authorization: "Bearer os_test" },
+      }) as never,
+      { params: Promise.resolve({ id: "seg-1" }) },
+    );
+    expect(getResponse.status).toBe(200);
+    await expect(getResponse.json()).resolves.toMatchObject({
+      object: "segment",
+      id: "seg-1",
+    });
+
+    const deleteResponse = await detailRoute.DELETE(
+      makeRequest("http://localhost/segments/seg-1", {
+        method: "DELETE",
+        headers: { authorization: "Bearer os_test" },
+      }) as never,
+      { params: Promise.resolve({ id: "seg-1" }) },
+    );
+    expect(deleteResponse.status).toBe(200);
+    await expect(deleteResponse.json()).resolves.toEqual({ success: true });
+    expect(mockAudienceMetadataService.deleteSegment).toHaveBeenCalledWith({
+      userId: "user-1",
+      id: "seg-1",
+    });
+
+    const contactsResponse = await contactsRoute.GET(
+      makeRequest("http://localhost/segments/seg-1/contacts?limit=5", {
+        headers: { authorization: "Bearer os_test" },
+      }) as never,
+      { params: Promise.resolve({ id: "seg-1" }) },
+    );
+    expect(contactsResponse.status).toBe(200);
+    await expect(contactsResponse.json()).resolves.toMatchObject({
+      object: "list",
+      has_more: false,
+      data: [{ id: "contact-1", email: "user@example.com" }],
+    });
+    expect(
+      mockAudienceMetadataService.listSegmentContacts,
+    ).toHaveBeenCalledWith({
+      userId: "user-1",
+      segmentId: "seg-1",
+      limit: 5,
+      after: undefined,
+    });
+  });
+
+  it("keeps root /segments API-key-only while preserving dashboard-session access on /api/segments", async () => {
+    mockValidateApiKey.mockResolvedValueOnce(null);
+    mockAuthorizeDashboardOrApiKey.mockResolvedValueOnce({ dashboard: true });
+    mockAudienceMetadataService.listSegments.mockResolvedValueOnce({
+      object: "list",
+      data: [],
+      has_more: false,
+      total: 0,
+    });
+
+    const rootRoute = await import("@/app/segments/route");
+    const apiRoute = await import("@/app/api/segments/route");
+
+    const rootResponse = await rootRoute.GET(
+      makeRequest("http://localhost/segments"),
+    );
+    expect(rootResponse.status).toBe(401);
+    expect(mockAuthorizeDashboardOrApiKey).not.toHaveBeenCalled();
+
+    const apiResponse = await apiRoute.GET(
+      makeRequest("http://localhost/api/segments") as never,
+    );
+    expect(apiResponse.status).toBe(200);
+    expect(mockAudienceMetadataService.listSegments).toHaveBeenCalledWith({
+      userId: "dashboard-user",
+      limit: undefined,
+      search: undefined,
+      after: undefined,
+    });
+  });
+
+  it("requires full-access API keys for root segment collection routes", async () => {
+    mockRequireFullAccessApiKey.mockReturnValueOnce(
+      Response.json(
+        {
+          error:
+            "This API key does not have permission to access this resource.",
+        },
+        { status: 403 },
+      ),
+    );
+
+    const rootRoute = await import("@/app/segments/route");
+    const response = await rootRoute.POST(
+      makeRequest("http://localhost/segments", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer os_test",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ name: "VIP" }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockAudienceMetadataService.createSegment).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add API-key-only root `/segments` collection routes plus root detail/contact aliases
- add SDK `client.segments.create/list/get/delete/listContacts` using root `/segments` URLs and typed response DTOs
- update public docs from `/api/segments` to `/segments` and add route/middleware/SDK/e2e coverage

## Validation
- `make check`
- `make test`
- `bun run test -- tests/segment-root-api.test.ts tests/sdk-client.test.tsx tests/middleware-rate-limit.test.ts`
- `DATABASE_URL=postgresql://opensend:opensend@localhost:55433/opensend bun run test:e2e -- tests/e2e/segments-api.spec.ts`

## Notes
- Root `/segments` collection is intentionally API-key/full-access only; legacy `/api/segments` keeps dashboard-session compatibility for dashboard/internal callers.
- Did not run the full Playwright suite.

Closes #455
