### PR TITLE
Add Resend-compatible scheduled email cancellation

### DIFF
--- a/agent_docs/learnings/active/2026-05-12-issue-458-email-cancel-root-alias.md
+++ b/agent_docs/learnings/active/2026-05-12-issue-458-email-cancel-root-alias.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-12
+issue: "#458"
+type: decision
+promoted_to: null
+---
+
+## Root cancel alias delegates errors but normalizes success
+
+Issue #458 adds Resend-compatible `POST /emails/:email_id/cancel` while preserving the existing internal `POST /api/emails/:id/cancel` response. The root route calls the internal cancel route with the remapped param so it keeps the same API-key auth, full-access permission, tenant-scoped lifecycle service call, and invalid-state/not-found behavior. Only a successful response is normalized to Resend's public `{ object: "email", id }` body, leaving the internal `/api` success body with `status: "canceled"` intact for existing callers.
+
+The root cancel path also needs an explicit middleware API-alias bypass. Without `isEmailCancelAlias`, unauthenticated API clients would hit dashboard session redirect logic before the route can return API-key auth errors.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -151,6 +151,14 @@ Resend-compatible natural-language form `in <positive integer>
 within 30 days; unparseable, past, or out-of-policy values return
 `validation_error`.
 
+Cancel a scheduled email before it is sent with the Resend-compatible cancel
+surface:
+
+```typescript
+const { data, error } = await resend.emails.cancel("email-id");
+// data: { object: "email", id: "email-id" }
+```
+
 ## Idempotency Keys
 
 Pass a per-request `idempotencyKey` option to prevent accidental duplicate

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -75,6 +75,11 @@ export type SendEmailPayload = EmailOptions & {
 };
 export type CreateDomainPayload = DomainOptions;
 
+interface CancelEmailResponse {
+  object: "email";
+  id: string;
+}
+
 export interface AutomationStepPayload {
   key: string;
   type:
@@ -482,6 +487,13 @@ class Emails {
 
   async get(id: string): Promise<ApiResponse<EmailDetailResponse>> {
     return this.http.request<EmailDetailResponse>("GET", `/api/emails/${id}`);
+  }
+
+  async cancel(id: string): Promise<ApiResponse<CancelEmailResponse>> {
+    return this.http.request<CancelEmailResponse>(
+      "POST",
+      `/emails/${id}/cancel`,
+    );
   }
 }
 
@@ -891,6 +903,7 @@ export type {
   EmailOptions,
   EmailResponse,
   SendEmailResponse,
+  CancelEmailResponse,
   EmailStatus,
   EmailListOptions,
   BatchEmailItemError,

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -50,6 +50,13 @@ const API_GROUPS: EndpointGroup[] = [
       },
       {
         method: "POST",
+        path: "/emails/:email_id/cancel",
+        description: "Cancel a scheduled email.",
+        curl: `curl -X POST https://api.opensend.com/emails/EMAIL_ID/cancel \\
+  -H "Authorization: Bearer os_YOUR_API_KEY"`,
+      },
+      {
+        method: "POST",
         path: "/api/emails/batch",
         description:
           "Send a batch of emails with one Idempotency-Key for the whole batch. Reusing the same key within 24 hours returns the original accepted { data: [{ id }] } envelope without reserving quota, creating rows, or publishing queue jobs again; after 24 hours the same key is accepted as a new batch.",

--- a/src/app/emails/[email_id]/cancel/route.ts
+++ b/src/app/emails/[email_id]/cancel/route.ts
@@ -1,0 +1,36 @@
+import { POST as cancelEmail } from "@/app/api/emails/[id]/cancel/route";
+import type { NextRequest } from "next/server";
+
+type CancelEmailAliasContext = {
+  params: Promise<{ email_id: string }>;
+};
+
+function getCanceledEmailId(body: unknown): string | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return null;
+  }
+
+  const id = (body as Record<string, unknown>).id;
+  return typeof id === "string" ? id : null;
+}
+
+export async function POST(
+  request: NextRequest,
+  context: CancelEmailAliasContext,
+): Promise<Response> {
+  const { email_id } = await context.params;
+  const response = await cancelEmail(request, {
+    params: Promise.resolve({ id: email_id }),
+  });
+
+  if (!response.ok) {
+    return response;
+  }
+
+  const id = getCanceledEmailId((await response.json()) as unknown);
+  if (!id) {
+    return Response.json({ error: "Failed to cancel email" }, { status: 500 });
+  }
+
+  return Response.json({ object: "email", id });
+}

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -106,6 +106,14 @@ const idPathParameter: ParameterObject = {
   schema: { type: "string", format: "uuid" },
 };
 
+const emailIdPathParameter: ParameterObject = {
+  name: "email_id",
+  in: "path",
+  required: true,
+  description: "Scheduled email ID to cancel.",
+  schema: { type: "string", format: "uuid" },
+};
+
 const paginationParameters: readonly ReferenceObject[] = [
   { $ref: "#/components/parameters/Limit" },
   { $ref: "#/components/parameters/After" },
@@ -178,6 +186,22 @@ export const openApiDocument = {
         responses: {
           "200": { $ref: "#/components/responses/BatchEmailAccepted" },
           "202": { $ref: "#/components/responses/BatchEmailAccepted" },
+          ...errorResponses,
+        },
+      },
+    },
+    "/emails/{email_id}/cancel": {
+      post: {
+        tags: ["Emails"],
+        summary: "Cancel a scheduled email",
+        description:
+          "Resend-compatible endpoint to cancel a scheduled email before it is sent.",
+        operationId: "cancelEmailAlias",
+        security: bearerSecurity,
+        parameters: [emailIdPathParameter],
+        responses: {
+          "200": { $ref: "#/components/responses/EmailCanceled" },
+          "404": { $ref: "#/components/responses/NotFound" },
           ...errorResponses,
         },
       },
@@ -500,6 +524,14 @@ export const openApiDocument = {
           },
         },
       },
+      EmailCanceled: {
+        type: "object",
+        properties: {
+          object: { type: "string", enum: ["email"] },
+          id: { type: "string", format: "uuid" },
+        },
+        required: ["object", "id"],
+      },
       Email: {
         type: "object",
         properties: {
@@ -686,6 +718,12 @@ export const openApiDocument = {
         description: "Batch accepted for delivery or scheduling.",
         content: jsonContent({
           $ref: "#/components/schemas/BatchEmailAccepted",
+        }),
+      },
+      EmailCanceled: {
+        description: "Scheduled email canceled.",
+        content: jsonContent({
+          $ref: "#/components/schemas/EmailCanceled",
         }),
       },
       BadRequest: {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -88,6 +88,13 @@ function isSendPostAlias(pathname: string, method: string): boolean {
   );
 }
 
+function isEmailCancelAlias(pathname: string, method: string): boolean {
+  if (method !== "POST") return false;
+
+  const parts = pathname.split("/").filter(Boolean);
+  return parts[0] === "emails" && parts.length === 3 && parts[2] === "cancel";
+}
+
 function isContactsAlias(pathname: string, method: string): boolean {
   if (pathname === "/contacts") return ["GET", "POST"].includes(method);
   if (pathname.startsWith("/contacts/")) {
@@ -181,6 +188,9 @@ function isSendApiPost(pathname: string, method: string): boolean {
 function getRateLimitPathname(pathname: string, method: string): string {
   if (isSingleSendPostAlias(pathname, method)) return "/api/emails";
   if (isBatchSendPostAlias(pathname, method)) return "/api/emails/batch";
+  if (isEmailCancelAlias(pathname, method)) {
+    return pathname.replace(/^\/emails/, "/api/emails");
+  }
   if (isContactsAlias(pathname, method)) {
     return pathname === "/contacts"
       ? "/api/contacts"
@@ -249,6 +259,7 @@ export async function middleware(request: NextRequest) {
   // Protect non-API page routes with session check. Resend-compatible send
   // aliases must bypass dashboard session redirects and use public API auth.
   const isSendAlias = isSendPostAlias(pathname, request.method);
+  const isEmailCancel = isEmailCancelAlias(pathname, request.method);
   const isContactAlias = isContactsAlias(pathname, request.method);
   const isAudienceAlias = isAudiencesAlias(pathname, request.method);
   const isSegmentAlias = isSegmentsAlias(pathname, request.method);
@@ -256,6 +267,7 @@ export async function middleware(request: NextRequest) {
   if (
     !pathname.startsWith("/api/") &&
     !isSendAlias &&
+    !isEmailCancel &&
     !isContactAlias &&
     !isAudienceAlias &&
     !isSegmentAlias &&

--- a/tests/api-emails.test.ts
+++ b/tests/api-emails.test.ts
@@ -3151,6 +3151,104 @@ describe("POST /api/emails/:id/cancel", () => {
   });
 });
 
+describe("POST /emails/:email_id/cancel", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockEmailLifecycleService.cancelEmail.mockReset();
+    mockValidateApiKey.mockResolvedValue(AUTH_RESULT);
+  });
+
+  it("delegates to the scheduled-email cancel route and returns the Resend-compatible success body", async () => {
+    mockEmailLifecycleService.cancelEmail.mockResolvedValueOnce({
+      object: "email",
+      id: "email-uuid",
+      status: "canceled",
+    });
+
+    const { POST } = await import("@/app/emails/[email_id]/cancel/route");
+    const res = await POST(
+      new Request("http://localhost:3015/emails/email-uuid/cancel", {
+        method: "POST",
+        headers: { Authorization: "Bearer os_test123" },
+      }) as never,
+      { params: Promise.resolve({ email_id: "email-uuid" }) },
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      object: "email",
+      id: "email-uuid",
+    });
+    expect(mockEmailLifecycleService.cancelEmail).toHaveBeenCalledWith(
+      AUTH_RESULT.userId,
+      "email-uuid",
+    );
+  });
+
+  it("uses the same API-key auth boundary as the internal cancel route", async () => {
+    mockValidateApiKey.mockResolvedValueOnce(null);
+
+    const { POST } = await import("@/app/emails/[email_id]/cancel/route");
+    const res = await POST(
+      new Request("http://localhost:3015/emails/email-uuid/cancel", {
+        method: "POST",
+      }) as never,
+      { params: Promise.resolve({ email_id: "email-uuid" }) },
+    );
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({
+      error: "Missing or invalid API key",
+    });
+    expect(mockEmailLifecycleService.cancelEmail).not.toHaveBeenCalled();
+  });
+
+  it("preserves invalid-state behavior for non-scheduled emails", async () => {
+    mockEmailLifecycleService.cancelEmail.mockRejectedValueOnce(
+      new MockEmailLifecycleServiceError(
+        "invalid_state",
+        "Cannot cancel a delivered email",
+      ),
+    );
+
+    const { POST } = await import("@/app/emails/[email_id]/cancel/route");
+    const res = await POST(
+      new Request("http://localhost:3015/emails/email-uuid/cancel", {
+        method: "POST",
+        headers: { Authorization: "Bearer os_test123" },
+      }) as never,
+      { params: Promise.resolve({ email_id: "email-uuid" }) },
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Cannot cancel a delivered email",
+    });
+  });
+
+  it("preserves tenant-scoped not-found behavior from the delegated service", async () => {
+    mockEmailLifecycleService.cancelEmail.mockRejectedValueOnce(
+      new MockEmailLifecycleServiceError("email_not_found", "Email not found"),
+    );
+
+    const { POST } = await import("@/app/emails/[email_id]/cancel/route");
+    const res = await POST(
+      new Request("http://localhost:3015/emails/other-tenant-email/cancel", {
+        method: "POST",
+        headers: { Authorization: "Bearer os_test123" },
+      }) as never,
+      { params: Promise.resolve({ email_id: "other-tenant-email" }) },
+    );
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Email not found" });
+    expect(mockEmailLifecycleService.cancelEmail).toHaveBeenCalledWith(
+      AUTH_RESULT.userId,
+      "other-tenant-email",
+    );
+  });
+});
+
 describe("GET /api/emails/:id/events", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/tests/middleware-rate-limit.test.ts
+++ b/tests/middleware-rate-limit.test.ts
@@ -116,6 +116,23 @@ describe("middleware rate limiting", () => {
     expect(response.headers.get("x-ratelimit-backend")).toBe("disabled");
   });
 
+  it("lets POST /emails/:id/cancel reach the root API route without requiring a dashboard session", async () => {
+    mockGetSessionCookie.mockReturnValue(null);
+    const { middleware } = await import("@/middleware");
+
+    const response = await middleware(
+      makeRequest("https://example.com/emails/email_123/cancel", {
+        method: "POST",
+        headers: { authorization: "Bearer test-api-key" },
+      }),
+    );
+
+    expect(mockGetSessionCookie).not.toHaveBeenCalled();
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+    expect(response.headers.get("x-ratelimit-backend")).toBe("disabled");
+  });
+
   it("preserves dashboard GET /emails/batch session protection", async () => {
     mockGetSessionCookie.mockReturnValue(null);
     const { middleware } = await import("@/middleware");
@@ -305,6 +322,31 @@ describe("middleware rate limiting", () => {
     expect(response.headers.get("x-middleware-rewrite")).toBe(
       "https://example.com/api/emails/batch",
     );
+    expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
+  });
+
+  it("shares rate-limit buckets between root email cancel aliases and /api/emails", async () => {
+    process.env.RATE_LIMIT_BACKEND = "redis";
+    mockGetSessionCookie.mockReturnValue(null);
+    mockIncrCache.mockResolvedValue(1);
+
+    const { middleware } = await import("@/middleware");
+    const response = await middleware(
+      makeRequest("https://example.com/emails/email_123/cancel", {
+        method: "POST",
+        headers: {
+          "x-forwarded-for": "203.0.113.10",
+          authorization: "Bearer test-api-key",
+        },
+      }),
+    );
+
+    expect(mockIncrCache).toHaveBeenCalledWith(
+      "ratelimit:203.0.113.10:Bearer test-api-key:/api/emails/email_123/cancel",
+      60,
+    );
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
     expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
   });
 

--- a/tests/openapi-route.test.ts
+++ b/tests/openapi-route.test.ts
@@ -51,6 +51,7 @@ describe("GET /openapi.json", () => {
     });
     expect(document.paths).toHaveProperty("/emails");
     expect(document.paths).toHaveProperty("/emails/batch");
+    expect(document.paths).toHaveProperty("/emails/{email_id}/cancel");
     expect(document.paths).toHaveProperty("/api/domains");
     expect(serialized).not.toMatch(
       /AWS_ACCESS_KEY|AWS_SECRET_ACCESS_KEY|CLOUDFLARE|DATABASE_URL/i,
@@ -81,5 +82,7 @@ describe("GET /openapi.json", () => {
 
     expect(docsPage).toContain('href="/openapi.json"');
     expect(docsPage).toContain("OpenAPI 3.0 JSON");
+    expect(docsPage).toContain("/emails/:email_id/cancel");
+    expect(docsPage).toContain("Cancel a scheduled email.");
   });
 });

--- a/tests/sdk-client.test.tsx
+++ b/tests/sdk-client.test.tsx
@@ -9,6 +9,7 @@ import type {
   BatchEmailResponse,
   BroadcastListResponse,
   BroadcastResponse,
+  CancelEmailResponse,
   ContactListResponse,
   ContactResponse,
   CreateBroadcastPayload,
@@ -208,6 +209,10 @@ describe("Opensend SDK", () => {
     >();
     expectTypeOf<ApiResponse<EmailResponse>>().toEqualTypeOf<{
       data: EmailResponse | null;
+      error: ApiError | null;
+    }>();
+    expectTypeOf<ApiResponse<CancelEmailResponse>>().toEqualTypeOf<{
+      data: CancelEmailResponse | null;
       error: ApiError | null;
     }>();
     expectTypeOf<BatchEmailResponse>().toMatchTypeOf<{ data: unknown[] }>();
@@ -467,6 +472,32 @@ describe("Opensend SDK", () => {
       object: "email",
       id: "email_123",
       last_event: "delivered",
+    });
+  });
+
+  it("cancels scheduled emails through the Resend-compatible root endpoint", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ object: "email", id: "email_123" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new Resend("os_test", {
+      baseUrl: "https://api.example.com",
+    });
+
+    const response = await client.emails.cancel("email_123");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/emails/email_123/cancel",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(response).toEqual({
+      data: { object: "email", id: "email_123" },
+      error: null,
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `POST /emails/:email_id/cancel` as a root Resend-compatible alias that delegates to the existing tenant-scoped scheduled-email cancel route.
- Preserve `/api/emails/:id/cancel` success shape while normalizing root success to `{ object: "email", id }`.
- Add `resend.emails.cancel(id)` / `opensend.emails.cancel(id)` in the TypeScript SDK and document the endpoint in SDK README, OpenAPI, and `/docs`.
- Cover auth/delegation, success response, invalid-state, tenant-scoped not-found, middleware bypass, SDK path, and OpenAPI/docs discovery.

## Validation
- `make check`
- `make test`
- `bunx vitest run tests/api-emails.test.ts -t "POST /emails/:email_id/cancel|POST /api/emails/:id/cancel"`
- `bunx vitest run tests/sdk-client.test.tsx tests/middleware-rate-limit.test.ts tests/openapi-route.test.ts`

## Scenario / browser proof
No Playwright/browser scenario added: this slice changes API routing, SDK request construction, and docs/OpenAPI copy only. Route tests plus middleware tests prove the public root path reaches the API-key auth boundary rather than dashboard auth, and SDK/OpenAPI tests cover the discoverable public surface.

Closes #458