### PR TITLE
Add dashboard CSV export parity first slice

### DIFF
--- a/agent_docs/learnings/active/2026-05-12-issue-461-dashboard-csv-export-slice.md
+++ b/agent_docs/learnings/active/2026-05-12-issue-461-dashboard-csv-export-slice.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-12
+issue: "#461"
+type: decision
+promoted_to: null
+---
+
+## Dashboard CSV export first slice stays immediate and capped
+
+**What:** Issue #461's first implementation adds a shared dashboard-session CSV export boundary for the main dashboard resources and caps immediate downloads at 1,000 rows instead of adding export-record storage and email delivery in the same PR.
+
+**Why:** The existing dashboard has no durable export storage or team role model yet. A capped immediate route closes the unsafe/no-op/client-only export gap without inventing a larger export platform or widening public API-key auth.
+
+**Fix:** Keep exports session-authenticated and tenant-scoped, return `export_too_large` for over-cap results, and document durable 7-day export records/email delivery as the follow-up when storage/product surface is ready.

--- a/src/app/api/dashboard/exports/[resource]/route.ts
+++ b/src/app/api/dashboard/exports/[resource]/route.ts
@@ -1,0 +1,138 @@
+import { getServerSession, unauthorizedResponse } from "@/lib/api-auth";
+import {
+  type DashboardExportFilters,
+  DashboardExportTooLargeError,
+  createDashboardCsvExport,
+} from "@/lib/dashboard-export-service";
+import {
+  type DashboardExportResource,
+  dashboardExportFilename,
+  isDashboardExportResource,
+} from "@/lib/dashboard-export-types";
+import { type NextRequest, NextResponse } from "next/server";
+
+function parseDate(value: string | null, boundary: "start" | "end") {
+  if (!value) return undefined;
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    const suffix = boundary === "start" ? "T00:00:00.000" : "T23:59:59.999";
+    const parsed = new Date(`${value}${suffix}`);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+function searchParam(
+  params: URLSearchParams,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = params.get(key)?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function filtersFromSearchParams(
+  params: URLSearchParams,
+): DashboardExportFilters {
+  return {
+    search: searchParam(params, "search", "q"),
+    status: searchParam(params, "status", "statuses"),
+    start: parseDate(
+      searchParam(
+        params,
+        "start_date",
+        "startDate",
+        "date_from",
+        "created_after",
+        "after",
+      ) ?? null,
+      "start",
+    ),
+    end: parseDate(
+      searchParam(
+        params,
+        "end_date",
+        "endDate",
+        "date_to",
+        "created_before",
+        "before",
+      ) ?? null,
+      "end",
+    ),
+    apiKeyId: searchParam(params, "api_key_id", "apiKeyId"),
+    segmentId: searchParam(
+      params,
+      "segment_id",
+      "segmentId",
+      "audience_id",
+      "audienceId",
+    ),
+    region: searchParam(params, "region"),
+    permission: searchParam(params, "permission"),
+    method: searchParam(params, "method"),
+    userAgent: searchParam(params, "user_agent", "userAgent"),
+  };
+}
+
+function csvResponse(
+  csv: string,
+  rowCount: number,
+  resource: DashboardExportResource,
+): Response {
+  return new NextResponse(csv, {
+    status: 200,
+    headers: {
+      "content-type": "text/csv;charset=utf-8",
+      "content-disposition": `attachment; filename="${dashboardExportFilename(resource)}"`,
+      "x-opensend-export-rows": String(rowCount),
+    },
+  });
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ resource: string }> },
+): Promise<Response> {
+  const session = await getServerSession();
+  if (!session?.user?.id) return unauthorizedResponse();
+
+  const { resource: resourceParam } = await params;
+  if (!isDashboardExportResource(resourceParam)) {
+    return NextResponse.json(
+      { error: "Unknown export resource" },
+      { status: 404 },
+    );
+  }
+
+  try {
+    const result = await createDashboardCsvExport({
+      resource: resourceParam,
+      userId: session.user.id,
+      filters: filtersFromSearchParams(request.nextUrl.searchParams),
+    });
+
+    return csvResponse(result.csv, result.rowCount, result.resource);
+  } catch (error) {
+    if (error instanceof DashboardExportTooLargeError) {
+      return NextResponse.json(
+        {
+          error: error.message,
+          code: error.code,
+          resource: error.resource,
+          limit: error.limit,
+        },
+        { status: 413 },
+      );
+    }
+
+    console.error("Failed to export dashboard CSV:", error);
+    return NextResponse.json(
+      { error: "Failed to export dashboard CSV" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/api-keys-list.tsx
+++ b/src/components/api-keys-list.tsx
@@ -8,6 +8,10 @@ import { ExportButton } from "@/components/export-button";
 import { Modal } from "@/components/modal";
 import { Pagination } from "@/components/pagination";
 import { SearchInput } from "@/components/search-input";
+import {
+  ExportStatusMessage,
+  useDashboardCsvExport,
+} from "@/components/use-dashboard-csv-export";
 import { useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
 
@@ -81,6 +85,8 @@ export function ApiKeysList({ keys, domains }: ApiKeysListProps) {
   const [newDomainId, setNewDomainId] = useState("");
   const [creating, setCreating] = useState(false);
   const [createdToken, setCreatedToken] = useState<string | null>(null);
+
+  const { exportState, exportCsv } = useDashboardCsvExport("api-keys");
 
   // Filter keys
   const filtered = keys.filter((k) => {
@@ -192,43 +198,40 @@ export function ApiKeysList({ keys, domains }: ApiKeysListProps) {
   }, [newName, newPermission, newDomainId, creating]);
 
   const handleExport = useCallback(() => {
-    const csv = [
-      "Name,Token,Permission,Last Used,Created",
-      ...filtered.map(
-        (k) =>
-          `${k.name},${k.tokenPreview},${formatPermission(k.permission)},${k.lastUsedAt ?? "Never"},${k.createdAt}`,
-      ),
-    ].join("\n");
-    const blob = new Blob([csv], { type: "text/csv" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "api-keys.csv";
-    a.click();
-    URL.revokeObjectURL(url);
-  }, [filtered]);
+    const params = new URLSearchParams();
+    if (search.trim()) params.set("search", search.trim());
+    if (permFilter !== "all") params.set("permission", permFilter);
+    void exportCsv(params);
+  }, [exportCsv, permFilter, search]);
 
   if (keys.length === 0) {
     return (
       <div>
         <div className="flex items-center justify-between mb-6">
           <h1 className="text-2xl font-semibold text-[#F0F0F0]">API Keys</h1>
-          <button
-            type="button"
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[13px] font-medium bg-white text-black hover:bg-gray-200 transition-colors"
-            onClick={() => setCreateOpen(true)}
-          >
-            <svg
-              aria-hidden="true"
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="currentColor"
+          <div className="flex items-center gap-3">
+            <ExportStatusMessage state={exportState} />
+            <ExportButton
+              onClick={handleExport}
+              disabled={exportState.type === "loading"}
+            />
+            <button
+              type="button"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[13px] font-medium bg-white text-black hover:bg-gray-200 transition-colors"
+              onClick={() => setCreateOpen(true)}
             >
-              <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
-            </svg>
-            Create API Key
-          </button>
+              <svg
+                aria-hidden="true"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+              </svg>
+              Create API Key
+            </button>
+          </div>
         </div>
         <EmptyState
           title="No API keys yet"
@@ -382,7 +385,11 @@ export function ApiKeysList({ keys, domains }: ApiKeysListProps) {
           value={permFilter}
           onChange={setPermFilter}
         />
-        <ExportButton onClick={handleExport} />
+        <ExportStatusMessage state={exportState} />
+        <ExportButton
+          onClick={handleExport}
+          disabled={exportState.type === "loading"}
+        />
       </div>
 
       {/* Data table */}

--- a/src/components/broadcasts-list.tsx
+++ b/src/components/broadcasts-list.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { formatRelativeTime } from "@/components/emails-sending-data-table";
+import {
+  ExportStatusMessage,
+  useDashboardCsvExport,
+} from "@/components/use-dashboard-csv-export";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -162,6 +166,7 @@ export function BroadcastsList({
   const statusDropdownRef = useRef<HTMLDivElement>(null);
   const audienceDropdownRef = useRef<HTMLDivElement>(null);
   const actionMenuRef = useRef<HTMLDivElement>(null);
+  const { exportState, exportCsv } = useDashboardCsvExport("broadcasts");
 
   const fetchBroadcasts = useCallback(async () => {
     setLoading(true);
@@ -401,6 +406,14 @@ export function BroadcastsList({
     });
   };
 
+  const handleExport = () => {
+    const params = new URLSearchParams();
+    if (search.trim()) params.set("search", search.trim());
+    if (statusFilter) params.set("status", statusFilter);
+    if (audienceFilter) params.set("segmentId", audienceFilter);
+    void exportCsv(params);
+  };
+
   const totalPages = Math.ceil(total / limit);
   const start = total === 0 ? 0 : (page - 1) * limit + 1;
 
@@ -543,9 +556,12 @@ export function BroadcastsList({
         </div>
 
         {/* Export button */}
+        <ExportStatusMessage state={exportState} />
         <button
           type="button"
-          className="h-9 w-9 flex items-center justify-center border border-[rgba(176,199,217,0.145)] rounded-md text-[#A1A4A5] hover:text-[#F0F0F0] hover:border-[rgba(176,199,217,0.3)] transition-colors"
+          onClick={handleExport}
+          disabled={exportState.type === "loading"}
+          className="h-9 w-9 flex items-center justify-center border border-[rgba(176,199,217,0.145)] rounded-md text-[#A1A4A5] hover:text-[#F0F0F0] hover:border-[rgba(176,199,217,0.3)] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
           aria-label="Export"
         >
           <svg

--- a/src/components/contacts-list.tsx
+++ b/src/components/contacts-list.tsx
@@ -2,6 +2,10 @@
 
 import { formatRelativeTime } from "@/components/emails-sending-data-table";
 import { StatusBadge } from "@/components/status-badge";
+import {
+  ExportStatusMessage,
+  useDashboardCsvExport,
+} from "@/components/use-dashboard-csv-export";
 import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -35,6 +39,7 @@ export function ContactsList() {
   const [loading, setLoading] = useState(true);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const searchTimeout = useRef<ReturnType<typeof setTimeout>>(null);
+  const { exportState, exportCsv } = useDashboardCsvExport("contacts");
 
   const fetchContacts = useCallback(async () => {
     setLoading(true);
@@ -93,6 +98,14 @@ export function ContactsList() {
     });
   };
 
+  const handleExport = () => {
+    const params = new URLSearchParams();
+    if (search.trim()) params.set("search", search.trim());
+    if (statusFilter) params.set("status", statusFilter);
+    if (segmentFilter) params.set("segment_id", segmentFilter);
+    void exportCsv(params);
+  };
+
   const totalPages = Math.ceil(total / limit);
   const start = total === 0 ? 0 : (page - 1) * limit + 1;
   const end = Math.min(page * limit, total);
@@ -142,9 +155,12 @@ export function ContactsList() {
           <option value="unsubscribed">Unsubscribed</option>
         </select>
 
+        <ExportStatusMessage state={exportState} />
         <button
           type="button"
-          className="h-9 px-3 text-[13px] text-[#A1A4A5] border border-[rgba(176,199,217,0.145)] rounded-md hover:text-[#F0F0F0] hover:border-[rgba(176,199,217,0.3)] transition-colors"
+          onClick={handleExport}
+          disabled={exportState.type === "loading"}
+          className="h-9 px-3 text-[13px] text-[#A1A4A5] border border-[rgba(176,199,217,0.145)] rounded-md hover:text-[#F0F0F0] hover:border-[rgba(176,199,217,0.3)] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
         >
           Export
         </button>

--- a/src/components/domains-page.tsx
+++ b/src/components/domains-page.tsx
@@ -6,6 +6,10 @@ import { ExportButton } from "@/components/export-button";
 import { Modal } from "@/components/modal";
 import { SearchInput } from "@/components/search-input";
 import { StatusBadge } from "@/components/status-badge";
+import {
+  ExportStatusMessage,
+  useDashboardCsvExport,
+} from "@/components/use-dashboard-csv-export";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
@@ -84,6 +88,7 @@ export function DomainsPage({ domains }: DomainsPageProps) {
   const [regionFilter, setRegionFilter] = useState("");
   const [page, setPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(40);
+  const { exportState, exportCsv } = useDashboardCsvExport("domains");
 
   const filteredDomains = useMemo(() => {
     let result = domains;
@@ -99,6 +104,14 @@ export function DomainsPage({ domains }: DomainsPageProps) {
     }
     return result;
   }, [domains, search, statusFilter, regionFilter]);
+
+  const handleExport = () => {
+    const params = new URLSearchParams();
+    if (search.trim()) params.set("search", search.trim());
+    if (statusFilter) params.set("status", statusFilter);
+    if (regionFilter) params.set("region", regionFilter);
+    void exportCsv(params);
+  };
 
   const totalPages = Math.max(
     1,
@@ -142,8 +155,12 @@ export function DomainsPage({ domains }: DomainsPageProps) {
             setPage(1);
           }}
         />
-        <div className="ml-auto">
-          <ExportButton onClick={() => {}} />
+        <div className="ml-auto flex items-center gap-3">
+          <ExportStatusMessage state={exportState} />
+          <ExportButton
+            onClick={handleExport}
+            disabled={exportState.type === "loading"}
+          />
         </div>
       </div>
 

--- a/src/components/emails-sending-filter-bar.tsx
+++ b/src/components/emails-sending-filter-bar.tsx
@@ -6,6 +6,10 @@ import { DropdownFilter } from "@/components/dropdown-filter";
 import type { DropdownFilterOption } from "@/components/dropdown-filter";
 import { ExportButton } from "@/components/export-button";
 import { SearchInput } from "@/components/search-input";
+import {
+  ExportStatusMessage,
+  useDashboardCsvExport,
+} from "@/components/use-dashboard-csv-export";
 import { getDateRangeBounds, toIsoDate } from "@/lib/date-range";
 import { useEffect, useRef, useState } from "react";
 
@@ -48,41 +52,21 @@ const STATUS_OPTIONS: DropdownFilterOption[] = [
   { value: "suppressed", label: "Suppressed", color: "#6B7280" },
 ];
 
-const FAILURE_EXPORT_STATUSES = new Set([
-  "bounced",
-  "complained",
-  "suppressed",
-]);
-
-type ExportState =
-  | { type: "idle"; message: string }
-  | { type: "loading"; message: string }
-  | { type: "success"; message: string }
-  | { type: "empty"; message: string }
-  | { type: "error"; message: string };
-
-function downloadCsv(filename: string, blob: Blob) {
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = filename;
-  link.click();
-  URL.revokeObjectURL(url);
-}
-
-function buildFailureExportParams(filters: EmailFilters): URLSearchParams {
+function buildEmailExportParams(filters: EmailFilters): URLSearchParams {
   const params = new URLSearchParams();
-  const statuses = FAILURE_EXPORT_STATUSES.has(filters.status)
-    ? filters.status
-    : Array.from(FAILURE_EXPORT_STATUSES).join(",");
   const { start, end } = getDateRangeBounds(filters.dateRange);
 
-  params.set("statuses", statuses);
   params.set("start_date", toIsoDate(start));
   params.set("end_date", toIsoDate(end));
 
   if (filters.search.trim()) {
     params.set("search", filters.search.trim());
+  }
+  if (filters.status) {
+    params.set("status", filters.status);
+  }
+  if (filters.apiKeyId) {
+    params.set("apiKeyId", filters.apiKeyId);
   }
 
   return params;
@@ -96,10 +80,7 @@ export function EmailsSendingFilterBar({
   const [filters, setFilters] = useState<EmailFilters>(
     getFilters(initialFilters),
   );
-  const [exportState, setExportState] = useState<ExportState>({
-    type: "idle",
-    message: "",
-  });
+  const { exportState, exportCsv } = useDashboardCsvExport("emails");
   const searchTimeout = useRef<ReturnType<typeof setTimeout>>(null);
 
   useEffect(() => {
@@ -158,53 +139,7 @@ export function EmailsSendingFilterBar({
   };
 
   const handleExport = () => {
-    setExportState({
-      type: "loading",
-      message: "Preparing delivery failure export…",
-    });
-
-    const exportFailures = async () => {
-      try {
-        const params = buildFailureExportParams(filters);
-        const response = await fetch(
-          `/api/dashboard/delivery-failures/export?${params.toString()}`,
-        );
-
-        if (!response.ok) {
-          throw new Error("Export request failed");
-        }
-
-        const rowCount = Number(
-          response.headers.get("x-opensend-export-rows") ?? "0",
-        );
-
-        if (rowCount === 0) {
-          setExportState({
-            type: "empty",
-            message:
-              "No bounced, complained, or suppressed failures match these filters.",
-          });
-          return;
-        }
-
-        const blob = await response.blob();
-        const timestamp = new Date().toISOString().slice(0, 10);
-        downloadCsv(`delivery-failures-${timestamp}.csv`, blob);
-        setExportState({
-          type: "success",
-          message: `Exported ${rowCount} failure row${
-            rowCount === 1 ? "" : "s"
-          }.`,
-        });
-      } catch {
-        setExportState({
-          type: "error",
-          message: "Delivery failure export failed. Please try again.",
-        });
-      }
-    };
-
-    void exportFailures();
+    void exportCsv(buildEmailExportParams(filters));
   };
 
   const apiKeyOptions = [
@@ -232,17 +167,11 @@ export function EmailsSendingFilterBar({
         onChange={handleApiKeyChange}
       />
       <div className="ml-auto flex items-center gap-3">
-        {exportState.message ? (
-          <p
-            className={`text-[12px] ${
-              exportState.type === "error" ? "text-[#EF4444]" : "text-[#A1A4A5]"
-            }`}
-            role={exportState.type === "error" ? "alert" : "status"}
-          >
-            {exportState.message}
-          </p>
-        ) : null}
-        <ExportButton onClick={handleExport} />
+        <ExportStatusMessage state={exportState} />
+        <ExportButton
+          onClick={handleExport}
+          disabled={exportState.type === "loading"}
+        />
       </div>
     </div>
   );

--- a/src/components/export-button.tsx
+++ b/src/components/export-button.tsx
@@ -2,15 +2,17 @@
 
 interface ExportButtonProps {
   onClick: () => void;
+  disabled?: boolean;
 }
 
-export function ExportButton({ onClick }: ExportButtonProps) {
+export function ExportButton({ onClick, disabled = false }: ExportButtonProps) {
   return (
     <button
       type="button"
       aria-label="Export"
       onClick={onClick}
-      className="flex items-center justify-center w-8 h-8 rounded-[8px] border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] text-[#A1A4A5] hover:text-[#F0F0F0] hover:border-[rgba(176,199,217,0.3)] transition-colors"
+      disabled={disabled}
+      className="flex items-center justify-center w-8 h-8 rounded-[8px] border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] text-[#A1A4A5] hover:text-[#F0F0F0] hover:border-[rgba(176,199,217,0.3)] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
     >
       <svg
         aria-hidden="true"

--- a/src/components/logs-list-page.tsx
+++ b/src/components/logs-list-page.tsx
@@ -2,6 +2,10 @@
 
 import { DataTable } from "@/components/data-table";
 import { StatusBadge } from "@/components/status-badge";
+import {
+  ExportStatusMessage,
+  useDashboardCsvExport,
+} from "@/components/use-dashboard-csv-export";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -100,29 +104,16 @@ export function LogsListPage({ logs }: { logs: LogRow[] }) {
     [router, pathname, searchParams],
   );
 
-  const handleExport = useCallback(() => {
-    const headers = ["ID", "Method", "Endpoint", "Status", "Created At"];
-    const csvContent = [
-      headers.join(","),
-      ...logs.map((log) =>
-        [log.id, log.method, log.endpoint, log.statusCode, log.createdAt].join(
-          ",",
-        ),
-      ),
-    ].join("\n");
+  const { exportState, exportCsv } = useDashboardCsvExport("logs");
 
-    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.setAttribute("href", url);
-    link.setAttribute(
-      "download",
-      `logs-export-${new Date().toISOString()}.csv`,
-    );
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  }, [logs]);
+  const handleExport = useCallback(() => {
+    const params = new URLSearchParams();
+    if (statusFilter !== "all") params.set("status", statusFilter);
+    if (dateFrom) params.set("after", dateFrom);
+    if (dateTo) params.set("before", dateTo);
+    if (query.trim()) params.set("q", query.trim());
+    void exportCsv(params);
+  }, [dateFrom, dateTo, exportCsv, query, statusFilter]);
 
   const columns = [
     {
@@ -171,24 +162,28 @@ export function LogsListPage({ logs }: { logs: LogRow[] }) {
     <div>
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-semibold text-[#F0F0F0]">Logs</h1>
-        <button
-          type="button"
-          onClick={handleExport}
-          className="h-9 px-4 text-[13px] font-medium bg-[rgba(176,199,217,0.145)] text-[#F0F0F0] border border-[rgba(176,199,217,0.145)] rounded-md hover:bg-[rgba(176,199,217,0.2)] transition-colors flex items-center gap-2"
-        >
-          <svg
-            aria-hidden="true"
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
+        <div className="flex items-center gap-3">
+          <ExportStatusMessage state={exportState} />
+          <button
+            type="button"
+            onClick={handleExport}
+            disabled={exportState.type === "loading"}
+            className="h-9 px-4 text-[13px] font-medium bg-[rgba(176,199,217,0.145)] text-[#F0F0F0] border border-[rgba(176,199,217,0.145)] rounded-md hover:bg-[rgba(176,199,217,0.2)] transition-colors flex items-center gap-2 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3" />
-          </svg>
-          Export CSV
-        </button>
+            <svg
+              aria-hidden="true"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3" />
+            </svg>
+            Export CSV
+          </button>
+        </div>
       </div>
 
       {/* Filters */}

--- a/src/components/segments-list.tsx
+++ b/src/components/segments-list.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { formatRelativeTime } from "@/components/emails-sending-data-table";
+import {
+  ExportStatusMessage,
+  useDashboardCsvExport,
+} from "@/components/use-dashboard-csv-export";
 import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -22,6 +26,7 @@ export function SegmentsList() {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [showModal, setShowModal] = useState(false);
   const searchTimeout = useRef<ReturnType<typeof setTimeout>>(null);
+  const { exportState, exportCsv } = useDashboardCsvExport("segments");
 
   const fetchSegments = useCallback(async () => {
     setLoading(true);
@@ -80,6 +85,12 @@ export function SegmentsList() {
     });
   };
 
+  const handleExport = () => {
+    const params = new URLSearchParams();
+    if (search.trim()) params.set("search", search.trim());
+    void exportCsv(params);
+  };
+
   const totalPages = Math.ceil(total / limit);
   const start = total === 0 ? 0 : (page - 1) * limit + 1;
 
@@ -93,6 +104,16 @@ export function SegmentsList() {
           className="flex-1 h-9 px-3 text-[13px] bg-transparent border border-[rgba(176,199,217,0.145)] rounded-md text-[#F0F0F0] placeholder-[#666] outline-none focus:border-[rgba(176,199,217,0.3)]"
           onChange={(e) => handleSearchChange(e.target.value)}
         />
+
+        <ExportStatusMessage state={exportState} />
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={exportState.type === "loading"}
+          className="h-9 px-3 text-[13px] text-[#A1A4A5] border border-[rgba(176,199,217,0.145)] rounded-md hover:text-[#F0F0F0] hover:border-[rgba(176,199,217,0.3)] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Export
+        </button>
 
         <button
           type="button"

--- a/src/components/use-dashboard-csv-export.tsx
+++ b/src/components/use-dashboard-csv-export.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { downloadDashboardCsvExport } from "@/lib/dashboard-export-client";
+import {
+  type DashboardExportResource,
+  dashboardExportLabel,
+} from "@/lib/dashboard-export-types";
+import { useCallback, useState } from "react";
+
+export type DashboardCsvExportState =
+  | { type: "idle"; message: string }
+  | { type: "loading"; message: string }
+  | { type: "success"; message: string }
+  | { type: "empty"; message: string }
+  | { type: "error"; message: string };
+
+export function useDashboardCsvExport(resource: DashboardExportResource) {
+  const label = dashboardExportLabel(resource);
+  const [exportState, setExportState] = useState<DashboardCsvExportState>({
+    type: "idle",
+    message: "",
+  });
+
+  const exportCsv = useCallback(
+    async (params: URLSearchParams = new URLSearchParams()) => {
+      setExportState({
+        type: "loading",
+        message: `Preparing ${label} export…`,
+      });
+
+      try {
+        const result = await downloadDashboardCsvExport(resource, params);
+        if (result.rowCount === 0) {
+          setExportState({
+            type: "empty",
+            message: `No ${label} match these filters.`,
+          });
+          return;
+        }
+
+        setExportState({
+          type: "success",
+          message: `Exported ${result.rowCount} ${label} row${
+            result.rowCount === 1 ? "" : "s"
+          }.`,
+        });
+      } catch (error) {
+        setExportState({
+          type: "error",
+          message:
+            error instanceof Error
+              ? error.message
+              : "Export request failed. Please try again.",
+        });
+      }
+    },
+    [label, resource],
+  );
+
+  return { exportState, exportCsv };
+}
+
+export function ExportStatusMessage({
+  state,
+}: {
+  state: DashboardCsvExportState;
+}) {
+  if (!state.message) return null;
+
+  return (
+    <p
+      className={`text-[12px] ${
+        state.type === "error" ? "text-[#EF4444]" : "text-[#A1A4A5]"
+      }`}
+      role={state.type === "error" ? "alert" : "status"}
+    >
+      {state.message}
+    </p>
+  );
+}

--- a/src/lib/dashboard-export-client.ts
+++ b/src/lib/dashboard-export-client.ts
@@ -1,0 +1,74 @@
+import {
+  type DashboardExportResource,
+  dashboardExportFilename,
+} from "@/lib/dashboard-export-types";
+
+export type DashboardCsvDownloadResult = {
+  rowCount: number;
+};
+
+function parseFilename(contentDisposition: string | null): string | null {
+  if (!contentDisposition) return null;
+
+  const utf8Match = /filename\*=UTF-8''([^;]+)/i.exec(contentDisposition);
+  if (utf8Match?.[1]) return decodeURIComponent(utf8Match[1]);
+
+  const quotedMatch = /filename="([^"]+)"/i.exec(contentDisposition);
+  if (quotedMatch?.[1]) return quotedMatch[1];
+
+  const bareMatch = /filename=([^;]+)/i.exec(contentDisposition);
+  return bareMatch?.[1]?.trim() ?? null;
+}
+
+function triggerDownload(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export async function downloadDashboardCsvExport(
+  resource: DashboardExportResource,
+  params: URLSearchParams = new URLSearchParams(),
+): Promise<DashboardCsvDownloadResult> {
+  const query = params.toString();
+  const response = await fetch(
+    `/api/dashboard/exports/${resource}${query ? `?${query}` : ""}`,
+  );
+
+  if (!response.ok) {
+    let message = "Export request failed. Please try again.";
+    try {
+      const payload: unknown = await response.json();
+      if (
+        typeof payload === "object" &&
+        payload !== null &&
+        "error" in payload &&
+        typeof payload.error === "string"
+      ) {
+        message = payload.error;
+      }
+    } catch {
+      // Keep fallback message for non-JSON errors.
+    }
+    throw new Error(message);
+  }
+
+  const rowCount = Number(
+    response.headers.get("x-opensend-export-rows") ?? "0",
+  );
+  const blob = await response.blob();
+  if (rowCount > 0) {
+    triggerDownload(
+      blob,
+      parseFilename(response.headers.get("content-disposition")) ??
+        dashboardExportFilename(resource),
+    );
+  }
+
+  return { rowCount };
+}

--- a/src/lib/dashboard-export-service.ts
+++ b/src/lib/dashboard-export-service.ts
@@ -1,0 +1,624 @@
+import {
+  type CsvHeader,
+  type CsvRow,
+  DASHBOARD_EXPORT_LIMIT,
+  type DashboardCsvExport,
+  type DashboardExportResource,
+  serializeDashboardCsv,
+} from "@/lib/dashboard-export-types";
+import { db } from "@/lib/db";
+import {
+  apiKeys,
+  broadcasts,
+  contacts,
+  contactsToSegments,
+  domains,
+  emails,
+  logs,
+  segments,
+} from "@/lib/db/schema";
+import { type SQL, and, desc, eq, gte, lte, or, sql } from "drizzle-orm";
+import type { AnyPgColumn } from "drizzle-orm/pg-core";
+
+export type DashboardExportFilters = {
+  search?: string;
+  status?: string;
+  start?: Date;
+  end?: Date;
+  apiKeyId?: string;
+  segmentId?: string;
+  region?: string;
+  permission?: string;
+  method?: string;
+  userAgent?: string;
+};
+
+export type DashboardCsvExportResult = {
+  csv: string;
+  rowCount: number;
+  resource: DashboardExportResource;
+};
+
+export class DashboardExportTooLargeError extends Error {
+  readonly code = "export_too_large" as const;
+
+  constructor(
+    readonly resource: DashboardExportResource,
+    readonly limit: number = DASHBOARD_EXPORT_LIMIT,
+  ) {
+    super(
+      `More than ${limit.toLocaleString("en-US")} ${resource} match these filters. Refine your filters and try again; durable export delivery is tracked as a follow-up.`,
+    );
+    this.name = "DashboardExportTooLargeError";
+  }
+}
+
+type EmailKey =
+  | "id"
+  | "to"
+  | "from"
+  | "subject"
+  | "status"
+  | "created_at"
+  | "sent_at"
+  | "scheduled_at";
+
+type BroadcastKey =
+  | "id"
+  | "name"
+  | "status"
+  | "audience_id"
+  | "subject"
+  | "created_at"
+  | "scheduled_at";
+
+type ContactKey =
+  | "id"
+  | "email"
+  | "first_name"
+  | "last_name"
+  | "status"
+  | "segments"
+  | "created_at";
+
+type SegmentKey =
+  | "id"
+  | "name"
+  | "contacts_count"
+  | "unsubscribed_count"
+  | "created_at";
+
+type DomainKey = "id" | "name" | "status" | "region" | "created_at";
+
+type LogKey =
+  | "id"
+  | "method"
+  | "endpoint"
+  | "status"
+  | "api_key_id"
+  | "user_agent"
+  | "created_at";
+
+type ApiKeyKey =
+  | "id"
+  | "name"
+  | "token_preview"
+  | "permission"
+  | "domain"
+  | "last_used_at"
+  | "created_at";
+
+const EMAIL_HEADERS: readonly CsvHeader<EmailKey>[] = [
+  { key: "id", label: "id" },
+  { key: "to", label: "to" },
+  { key: "from", label: "from" },
+  { key: "subject", label: "subject" },
+  { key: "status", label: "status" },
+  { key: "created_at", label: "created_at" },
+  { key: "sent_at", label: "sent_at" },
+  { key: "scheduled_at", label: "scheduled_at" },
+];
+
+const BROADCAST_HEADERS: readonly CsvHeader<BroadcastKey>[] = [
+  { key: "id", label: "id" },
+  { key: "name", label: "name" },
+  { key: "status", label: "status" },
+  { key: "audience_id", label: "audience_id" },
+  { key: "subject", label: "subject" },
+  { key: "created_at", label: "created_at" },
+  { key: "scheduled_at", label: "scheduled_at" },
+];
+
+const CONTACT_HEADERS: readonly CsvHeader<ContactKey>[] = [
+  { key: "id", label: "id" },
+  { key: "email", label: "email" },
+  { key: "first_name", label: "first_name" },
+  { key: "last_name", label: "last_name" },
+  { key: "status", label: "status" },
+  { key: "segments", label: "segments" },
+  { key: "created_at", label: "created_at" },
+];
+
+const SEGMENT_HEADERS: readonly CsvHeader<SegmentKey>[] = [
+  { key: "id", label: "id" },
+  { key: "name", label: "name" },
+  { key: "contacts_count", label: "contacts_count" },
+  { key: "unsubscribed_count", label: "unsubscribed_count" },
+  { key: "created_at", label: "created_at" },
+];
+
+const DOMAIN_HEADERS: readonly CsvHeader<DomainKey>[] = [
+  { key: "id", label: "id" },
+  { key: "name", label: "name" },
+  { key: "status", label: "status" },
+  { key: "region", label: "region" },
+  { key: "created_at", label: "created_at" },
+];
+
+const LOG_HEADERS: readonly CsvHeader<LogKey>[] = [
+  { key: "id", label: "id" },
+  { key: "method", label: "method" },
+  { key: "endpoint", label: "endpoint" },
+  { key: "status", label: "status" },
+  { key: "api_key_id", label: "api_key_id" },
+  { key: "user_agent", label: "user_agent" },
+  { key: "created_at", label: "created_at" },
+];
+
+const API_KEY_HEADERS: readonly CsvHeader<ApiKeyKey>[] = [
+  { key: "id", label: "id" },
+  { key: "name", label: "name" },
+  { key: "token_preview", label: "token_preview" },
+  { key: "permission", label: "permission" },
+  { key: "domain", label: "domain" },
+  { key: "last_used_at", label: "last_used_at" },
+  { key: "created_at", label: "created_at" },
+];
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function likePattern(value: string | undefined): string | undefined {
+  const trimmed = nonEmpty(value);
+  return trimmed ? `%${trimmed}%` : undefined;
+}
+
+function iso(value: Date | null | undefined): string {
+  return value?.toISOString() ?? "";
+}
+
+function pushCreatedAtFilters(
+  conditions: SQL[],
+  column: AnyPgColumn,
+  filters: DashboardExportFilters,
+) {
+  if (filters.start) conditions.push(gte(column, filters.start));
+  if (filters.end) conditions.push(lte(column, filters.end));
+}
+
+function assertWithinLimit<T extends string>(
+  resource: DashboardExportResource,
+  headers: readonly CsvHeader<T>[],
+  rows: CsvRow<T>[],
+): DashboardCsvExport<T> {
+  if (rows.length > DASHBOARD_EXPORT_LIMIT) {
+    throw new DashboardExportTooLargeError(resource);
+  }
+  return { resource, headers, rows };
+}
+
+async function emailsExport(
+  userId: string,
+  filters: DashboardExportFilters,
+): Promise<DashboardCsvExport<EmailKey>> {
+  const conditions: SQL[] = [eq(emails.userId, userId)];
+  const status = nonEmpty(filters.status);
+  if (status && status !== "all") conditions.push(eq(emails.status, status));
+  pushCreatedAtFilters(conditions, emails.createdAt, filters);
+
+  const pattern = likePattern(filters.search);
+  if (pattern) {
+    const searchCondition = or(
+      sql`${emails.id}::text ILIKE ${pattern}`,
+      sql`${emails.to}::text ILIKE ${pattern}`,
+      sql`${emails.from} ILIKE ${pattern}`,
+      sql`${emails.subject} ILIKE ${pattern}`,
+    );
+    if (searchCondition) conditions.push(searchCondition);
+  }
+
+  const rows = await db
+    .select({
+      id: emails.id,
+      to: emails.to,
+      from: emails.from,
+      subject: emails.subject,
+      status: emails.status,
+      createdAt: emails.createdAt,
+      sentAt: emails.sentAt,
+      scheduledAt: emails.scheduledAt,
+    })
+    .from(emails)
+    .where(and(...conditions))
+    .orderBy(desc(emails.createdAt))
+    .limit(DASHBOARD_EXPORT_LIMIT + 1);
+
+  return assertWithinLimit(
+    "emails",
+    EMAIL_HEADERS,
+    rows.map((row) => ({
+      id: row.id,
+      to: row.to.join("; "),
+      from: row.from,
+      subject: row.subject,
+      status: row.status,
+      created_at: row.createdAt.toISOString(),
+      sent_at: iso(row.sentAt),
+      scheduled_at: iso(row.scheduledAt),
+    })),
+  );
+}
+
+async function broadcastsExport(
+  userId: string,
+  filters: DashboardExportFilters,
+): Promise<DashboardCsvExport<BroadcastKey>> {
+  const conditions: SQL[] = [eq(broadcasts.userId, userId)];
+  const status = nonEmpty(filters.status);
+  if (status && status !== "all")
+    conditions.push(eq(broadcasts.status, status));
+  const segmentId = nonEmpty(filters.segmentId);
+  if (segmentId) conditions.push(eq(broadcasts.audienceId, segmentId));
+  pushCreatedAtFilters(conditions, broadcasts.createdAt, filters);
+
+  const pattern = likePattern(filters.search);
+  if (pattern) {
+    const searchCondition = or(
+      sql`${broadcasts.id}::text ILIKE ${pattern}`,
+      sql`${broadcasts.name} ILIKE ${pattern}`,
+      sql`${broadcasts.subject} ILIKE ${pattern}`,
+    );
+    if (searchCondition) conditions.push(searchCondition);
+  }
+
+  const rows = await db
+    .select({
+      id: broadcasts.id,
+      name: broadcasts.name,
+      status: broadcasts.status,
+      audienceId: broadcasts.audienceId,
+      subject: broadcasts.subject,
+      createdAt: broadcasts.createdAt,
+      scheduledAt: broadcasts.scheduledAt,
+    })
+    .from(broadcasts)
+    .where(and(...conditions))
+    .orderBy(desc(broadcasts.createdAt))
+    .limit(DASHBOARD_EXPORT_LIMIT + 1);
+
+  return assertWithinLimit(
+    "broadcasts",
+    BROADCAST_HEADERS,
+    rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      status: row.status,
+      audience_id: row.audienceId,
+      subject: row.subject,
+      created_at: row.createdAt.toISOString(),
+      scheduled_at: iso(row.scheduledAt),
+    })),
+  );
+}
+
+async function contactsExport(
+  userId: string,
+  filters: DashboardExportFilters,
+): Promise<DashboardCsvExport<ContactKey>> {
+  const conditions: SQL[] = [eq(contacts.userId, userId)];
+  const status = nonEmpty(filters.status);
+  if (status === "subscribed")
+    conditions.push(eq(contacts.unsubscribed, false));
+  if (status === "unsubscribed")
+    conditions.push(eq(contacts.unsubscribed, true));
+  pushCreatedAtFilters(conditions, contacts.createdAt, filters);
+
+  const pattern = likePattern(filters.search);
+  if (pattern) {
+    const searchCondition = or(
+      sql`${contacts.id}::text ILIKE ${pattern}`,
+      sql`${contacts.email} ILIKE ${pattern}`,
+      sql`${contacts.firstName} ILIKE ${pattern}`,
+      sql`${contacts.lastName} ILIKE ${pattern}`,
+    );
+    if (searchCondition) conditions.push(searchCondition);
+  }
+
+  const segmentId = nonEmpty(filters.segmentId);
+  if (segmentId) {
+    conditions.push(
+      sql`exists (select 1 from ${contactsToSegments} where ${contactsToSegments.contactId} = ${contacts.id} and ${contactsToSegments.segmentId} = ${segmentId})`,
+    );
+  }
+
+  const rows = await db
+    .select({
+      id: contacts.id,
+      email: contacts.email,
+      firstName: contacts.firstName,
+      lastName: contacts.lastName,
+      unsubscribed: contacts.unsubscribed,
+      segments: contacts.segments,
+      createdAt: contacts.createdAt,
+    })
+    .from(contacts)
+    .where(and(...conditions))
+    .orderBy(desc(contacts.createdAt))
+    .limit(DASHBOARD_EXPORT_LIMIT + 1);
+
+  return assertWithinLimit(
+    "contacts",
+    CONTACT_HEADERS,
+    rows.map((row) => ({
+      id: row.id,
+      email: row.email,
+      first_name: row.firstName,
+      last_name: row.lastName,
+      status: row.unsubscribed ? "unsubscribed" : "subscribed",
+      segments: Array.isArray(row.segments) ? row.segments.join("; ") : "",
+      created_at: row.createdAt.toISOString(),
+    })),
+  );
+}
+
+async function segmentsExport(
+  userId: string,
+  filters: DashboardExportFilters,
+): Promise<DashboardCsvExport<SegmentKey>> {
+  const conditions: SQL[] = [eq(segments.userId, userId)];
+  pushCreatedAtFilters(conditions, segments.createdAt, filters);
+
+  const pattern = likePattern(filters.search);
+  if (pattern) {
+    const searchCondition = or(
+      sql`${segments.id}::text ILIKE ${pattern}`,
+      sql`${segments.name} ILIKE ${pattern}`,
+    );
+    if (searchCondition) conditions.push(searchCondition);
+  }
+
+  const rows = await db
+    .select({
+      id: segments.id,
+      name: segments.name,
+      contactsCount: segments.contactsCount,
+      unsubscribedCount: segments.unsubscribedCount,
+      createdAt: segments.createdAt,
+    })
+    .from(segments)
+    .where(and(...conditions))
+    .orderBy(desc(segments.createdAt))
+    .limit(DASHBOARD_EXPORT_LIMIT + 1);
+
+  return assertWithinLimit(
+    "segments",
+    SEGMENT_HEADERS,
+    rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      contacts_count: row.contactsCount,
+      unsubscribed_count: row.unsubscribedCount,
+      created_at: row.createdAt.toISOString(),
+    })),
+  );
+}
+
+async function domainsExport(
+  userId: string,
+  filters: DashboardExportFilters,
+): Promise<DashboardCsvExport<DomainKey>> {
+  const conditions: SQL[] = [eq(domains.userId, userId)];
+  const status = nonEmpty(filters.status);
+  if (status && status !== "all") conditions.push(eq(domains.status, status));
+  const region = nonEmpty(filters.region);
+  if (region) conditions.push(eq(domains.region, region));
+  pushCreatedAtFilters(conditions, domains.createdAt, filters);
+
+  const pattern = likePattern(filters.search);
+  if (pattern) {
+    const searchCondition = or(
+      sql`${domains.id}::text ILIKE ${pattern}`,
+      sql`${domains.name} ILIKE ${pattern}`,
+    );
+    if (searchCondition) conditions.push(searchCondition);
+  }
+
+  const rows = await db
+    .select({
+      id: domains.id,
+      name: domains.name,
+      status: domains.status,
+      region: domains.region,
+      createdAt: domains.createdAt,
+    })
+    .from(domains)
+    .where(and(...conditions))
+    .orderBy(desc(domains.createdAt))
+    .limit(DASHBOARD_EXPORT_LIMIT + 1);
+
+  return assertWithinLimit(
+    "domains",
+    DOMAIN_HEADERS,
+    rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      status: row.status,
+      region: row.region,
+      created_at: row.createdAt.toISOString(),
+    })),
+  );
+}
+
+async function logsExport(
+  userId: string,
+  filters: DashboardExportFilters,
+): Promise<DashboardCsvExport<LogKey>> {
+  const conditions: SQL[] = [eq(logs.userId, userId)];
+  const status = nonEmpty(filters.status);
+  if (status === "2xx") {
+    conditions.push(and(gte(logs.status, 200), lte(logs.status, 299)) as SQL);
+  } else if (status === "4xx") {
+    conditions.push(and(gte(logs.status, 400), lte(logs.status, 499)) as SQL);
+  } else if (status === "5xx") {
+    conditions.push(gte(logs.status, 500));
+  } else if (status && !Number.isNaN(Number(status))) {
+    conditions.push(eq(logs.status, Number(status)));
+  }
+
+  const method = nonEmpty(filters.method);
+  if (method) conditions.push(eq(logs.method, method.toUpperCase()));
+  const apiKeyId = nonEmpty(filters.apiKeyId);
+  if (apiKeyId) conditions.push(eq(logs.apiKeyId, apiKeyId));
+  pushCreatedAtFilters(conditions, logs.createdAt, filters);
+
+  const userAgentPattern = likePattern(filters.userAgent);
+  if (userAgentPattern)
+    conditions.push(sql`${logs.userAgent} ILIKE ${userAgentPattern}`);
+
+  const pattern = likePattern(filters.search);
+  if (pattern) {
+    const searchCondition = or(
+      sql`${logs.id}::text ILIKE ${pattern}`,
+      sql`${logs.endpoint} ILIKE ${pattern}`,
+      sql`${logs.userAgent} ILIKE ${pattern}`,
+      sql`${logs.status}::text ILIKE ${pattern}`,
+      sql`${logs.requestBody}::text ILIKE ${pattern}`,
+      sql`${logs.responseBody}::text ILIKE ${pattern}`,
+      sql`${logs.document}::text ILIKE ${pattern}`,
+    );
+    if (searchCondition) conditions.push(searchCondition);
+  }
+
+  const rows = await db
+    .select({
+      id: logs.id,
+      method: logs.method,
+      endpoint: logs.endpoint,
+      status: logs.status,
+      apiKeyId: logs.apiKeyId,
+      userAgent: logs.userAgent,
+      createdAt: logs.createdAt,
+    })
+    .from(logs)
+    .where(and(...conditions))
+    .orderBy(desc(logs.createdAt))
+    .limit(DASHBOARD_EXPORT_LIMIT + 1);
+
+  return assertWithinLimit(
+    "logs",
+    LOG_HEADERS,
+    rows.map((row) => ({
+      id: row.id,
+      method: row.method,
+      endpoint: row.endpoint,
+      status: row.status,
+      api_key_id: row.apiKeyId,
+      user_agent: row.userAgent,
+      created_at: row.createdAt.toISOString(),
+    })),
+  );
+}
+
+export async function apiKeysExport(
+  userId: string,
+  filters: DashboardExportFilters,
+): Promise<DashboardCsvExport<ApiKeyKey>> {
+  const conditions: SQL[] = [eq(apiKeys.userId, userId)];
+  const permission = nonEmpty(filters.permission ?? filters.status);
+  if (permission && permission !== "all") {
+    conditions.push(eq(apiKeys.permission, permission));
+  }
+  pushCreatedAtFilters(conditions, apiKeys.createdAt, filters);
+
+  const pattern = likePattern(filters.search);
+  if (pattern) {
+    const searchCondition = or(
+      sql`${apiKeys.id}::text ILIKE ${pattern}`,
+      sql`${apiKeys.name} ILIKE ${pattern}`,
+      sql`${apiKeys.tokenPreview} ILIKE ${pattern}`,
+    );
+    if (searchCondition) conditions.push(searchCondition);
+  }
+
+  const rows = await db
+    .select({
+      id: apiKeys.id,
+      name: apiKeys.name,
+      tokenPreview: apiKeys.tokenPreview,
+      permission: apiKeys.permission,
+      domain: apiKeys.domain,
+      lastUsedAt: apiKeys.lastUsedAt,
+      createdAt: apiKeys.createdAt,
+    })
+    .from(apiKeys)
+    .where(and(...conditions))
+    .orderBy(desc(apiKeys.createdAt))
+    .limit(DASHBOARD_EXPORT_LIMIT + 1);
+
+  return assertWithinLimit(
+    "api-keys",
+    API_KEY_HEADERS,
+    rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      token_preview: row.tokenPreview,
+      permission: row.permission,
+      domain: row.domain,
+      last_used_at: iso(row.lastUsedAt),
+      created_at: row.createdAt.toISOString(),
+    })),
+  );
+}
+
+export async function loadDashboardCsvExport(
+  resource: DashboardExportResource,
+  userId: string,
+  filters: DashboardExportFilters,
+): Promise<DashboardCsvExport> {
+  switch (resource) {
+    case "emails":
+      return emailsExport(userId, filters);
+    case "broadcasts":
+      return broadcastsExport(userId, filters);
+    case "contacts":
+      return contactsExport(userId, filters);
+    case "segments":
+      return segmentsExport(userId, filters);
+    case "domains":
+      return domainsExport(userId, filters);
+    case "logs":
+      return logsExport(userId, filters);
+    case "api-keys":
+      return apiKeysExport(userId, filters);
+  }
+}
+
+export async function createDashboardCsvExport(input: {
+  resource: DashboardExportResource;
+  userId: string;
+  filters: DashboardExportFilters;
+}): Promise<DashboardCsvExportResult> {
+  const exportData = await loadDashboardCsvExport(
+    input.resource,
+    input.userId,
+    input.filters,
+  );
+
+  return {
+    resource: input.resource,
+    rowCount: exportData.rows.length,
+    csv: serializeDashboardCsv(exportData.headers, exportData.rows),
+  };
+}

--- a/src/lib/dashboard-export-types.ts
+++ b/src/lib/dashboard-export-types.ts
@@ -1,0 +1,83 @@
+export const DASHBOARD_EXPORT_LIMIT = 1000;
+
+export const DASHBOARD_EXPORT_RESOURCES = [
+  "emails",
+  "broadcasts",
+  "contacts",
+  "segments",
+  "domains",
+  "logs",
+  "api-keys",
+] as const;
+
+export type DashboardExportResource =
+  (typeof DASHBOARD_EXPORT_RESOURCES)[number];
+
+export type CsvValue = string | number | boolean | Date | null | undefined;
+
+export type CsvHeader<T extends string = string> = {
+  key: T;
+  label: string;
+};
+
+export type CsvRow<T extends string = string> = Record<T, CsvValue>;
+
+export type DashboardCsvExport<T extends string = string> = {
+  resource: DashboardExportResource;
+  headers: readonly CsvHeader<T>[];
+  rows: readonly CsvRow<T>[];
+};
+
+export function isDashboardExportResource(
+  value: string,
+): value is DashboardExportResource {
+  return DASHBOARD_EXPORT_RESOURCES.includes(value as DashboardExportResource);
+}
+
+export function escapeCsvValue(value: CsvValue): string {
+  const raw = value instanceof Date ? value.toISOString() : String(value ?? "");
+  if (/[",\n\r]/.test(raw)) {
+    return `"${raw.replace(/"/g, '""')}"`;
+  }
+  return raw;
+}
+
+export function serializeDashboardCsv<T extends string>(
+  headers: readonly CsvHeader<T>[],
+  rows: readonly CsvRow<T>[],
+): string {
+  return [
+    headers.map((header) => escapeCsvValue(header.label)).join(","),
+    ...rows.map((row) =>
+      headers.map((header) => escapeCsvValue(row[header.key])).join(","),
+    ),
+  ].join("\n");
+}
+
+export function dashboardExportFilename(
+  resource: DashboardExportResource,
+  now: Date = new Date(),
+): string {
+  return `${resource}-${now.toISOString().slice(0, 10)}.csv`;
+}
+
+export function dashboardExportLabel(
+  resource: DashboardExportResource,
+): string {
+  switch (resource) {
+    case "api-keys":
+      return "API keys";
+    case "emails":
+      return "emails";
+    case "broadcasts":
+      return "broadcasts";
+    case "contacts":
+      return "contacts";
+    case "segments":
+      return "segments";
+    case "domains":
+      return "domains";
+    case "logs":
+      return "logs";
+  }
+}

--- a/tests/dashboard-csv-export.test.ts
+++ b/tests/dashboard-csv-export.test.ts
@@ -1,0 +1,178 @@
+import {
+  type CsvHeader,
+  type CsvRow,
+  serializeDashboardCsv,
+} from "@/lib/dashboard-export-types";
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSelect = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockCreateDashboardCsvExport = vi.hoisted(() => vi.fn());
+
+class MockDashboardExportTooLargeError extends Error {
+  readonly code = "export_too_large" as const;
+
+  constructor(
+    readonly resource: string,
+    readonly limit: number,
+  ) {
+    super("too large");
+  }
+}
+
+vi.mock("@/lib/db", () => ({
+  db: { select: mockSelect },
+}));
+
+vi.mock("@/lib/api-auth", () => ({
+  getServerSession: mockGetServerSession,
+  unauthorizedResponse: () =>
+    Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/dashboard-export-service", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/dashboard-export-service")>();
+  return {
+    ...actual,
+    DashboardExportTooLargeError: MockDashboardExportTooLargeError,
+    createDashboardCsvExport: mockCreateDashboardCsvExport,
+  };
+});
+
+describe("dashboard CSV export helpers", () => {
+  it("escapes CSV values consistently", () => {
+    const headers: readonly CsvHeader<"email" | "note">[] = [
+      { key: "email", label: "email" },
+      { key: "note", label: "note" },
+    ];
+    const rows: readonly CsvRow<"email" | "note">[] = [
+      { email: 'quoted,"person"@example.com', note: "line\nbreak" },
+      { email: "plain@example.com", note: null },
+    ];
+
+    expect(serializeDashboardCsv(headers, rows)).toBe(
+      'email,note\n"quoted,""person""@example.com","line\nbreak"\nplain@example.com,',
+    );
+  });
+
+  it("redacts API key secrets by exporting token previews only", async () => {
+    const limit = vi.fn(async () => [
+      {
+        id: "key-1",
+        name: "Production",
+        tokenPreview: "os_abc...1234",
+        tokenHash: "full-secret-hash-should-not-export",
+        permission: "full_access",
+        domain: null,
+        lastUsedAt: new Date("2026-05-01T00:00:00.000Z"),
+        createdAt: new Date("2026-04-30T00:00:00.000Z"),
+      },
+    ]);
+    mockSelect.mockReturnValue({
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({ limit }),
+        }),
+      }),
+    });
+
+    const { apiKeysExport } = await import("@/lib/dashboard-export-service");
+    const { serializeDashboardCsv } = await import(
+      "@/lib/dashboard-export-types"
+    );
+    const result = await apiKeysExport("user-1", { search: "Production" });
+    const csv = serializeDashboardCsv(result.headers, result.rows);
+
+    expect(csv).toContain("token_preview");
+    expect(csv).toContain("os_abc...1234");
+    expect(csv).not.toContain("token_hash");
+    expect(csv).not.toContain("full-secret-hash-should-not-export");
+    expect(limit).toHaveBeenCalledWith(1001);
+  });
+});
+
+describe("dashboard CSV export route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requires dashboard session auth", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const { GET } = await import(
+      "@/app/api/dashboard/exports/[resource]/route"
+    );
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/dashboard/exports/emails"),
+      { params: Promise.resolve({ resource: "emails" }) },
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockCreateDashboardCsvExport).not.toHaveBeenCalled();
+  });
+
+  it("passes session user and normalized visible filters to the shared service", async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: "user-session" } });
+    mockCreateDashboardCsvExport.mockResolvedValue({
+      resource: "emails",
+      rowCount: 1,
+      csv: "id,to\nemail-1,a@example.com",
+    });
+    const { GET } = await import(
+      "@/app/api/dashboard/exports/[resource]/route"
+    );
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost/api/dashboard/exports/emails?search=a%40example.com&status=bounced&start_date=2026-05-01&end_date=2026-05-03&apiKeyId=key-1&segmentId=seg-1&region=us-east-1&permission=full_access&method=post&userAgent=Chrome",
+      ),
+      { params: Promise.resolve({ resource: "emails" }) },
+    );
+
+    await expect(response.text()).resolves.toBe("id,to\nemail-1,a@example.com");
+    expect(response.headers.get("content-type")).toContain("text/csv");
+    expect(response.headers.get("content-disposition")).toContain("emails-");
+    expect(response.headers.get("x-opensend-export-rows")).toBe("1");
+    expect(mockCreateDashboardCsvExport).toHaveBeenCalledWith({
+      resource: "emails",
+      userId: "user-session",
+      filters: {
+        search: "a@example.com",
+        status: "bounced",
+        start: new Date("2026-05-01T00:00:00.000"),
+        end: new Date("2026-05-03T23:59:59.999"),
+        apiKeyId: "key-1",
+        segmentId: "seg-1",
+        region: "us-east-1",
+        permission: "full_access",
+        method: "post",
+        userAgent: "Chrome",
+      },
+    });
+  });
+
+  it("returns a bounded staged response when the immediate export cap is exceeded", async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: "user-session" } });
+    mockCreateDashboardCsvExport.mockRejectedValue(
+      new MockDashboardExportTooLargeError("contacts", 1000),
+    );
+    const { GET } = await import(
+      "@/app/api/dashboard/exports/[resource]/route"
+    );
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/dashboard/exports/contacts"),
+      { params: Promise.resolve({ resource: "contacts" }) },
+    );
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({
+      error: "too large",
+      code: "export_too_large",
+      resource: "contacts",
+      limit: 1000,
+    });
+  });
+});

--- a/tests/e2e/delivery-failure-export.spec.ts
+++ b/tests/e2e/delivery-failure-export.spec.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { createE2ETenant, expect, test } from "./fixtures/auth";
 
-test("dashboard delivery failure export uses session auth and tenant scope", async ({
+test("dashboard email CSV export uses session auth and tenant scope", async ({
   authenticatedPage: page,
   e2eDb,
   e2eRunId,
@@ -80,13 +80,23 @@ test("dashboard delivery failure export uses session auth and tenant scope", asy
   expect(path).toBeTruthy();
 
   const csv = await readFile(path ?? "", "utf8");
-  expect(csv).toContain("id,recipient,status,reason,source_email_id");
+  expect(csv).toContain("id,to,from,subject,status,created_at");
   expect(csv).toContain(recipientA);
-  expect(csv).toContain(suppressedA);
   expect(csv).not.toContain(recipientB);
+  expect(csv).not.toContain(suppressedA);
+
+  const legacyFailureExport = await page.evaluate(async () => {
+    const response = await fetch(
+      "/api/dashboard/delivery-failures/export?statuses=suppressed",
+    );
+    return { status: response.status, body: await response.text() };
+  });
+  expect(legacyFailureExport.status).toBe(200);
+  expect(legacyFailureExport.body).toContain(suppressedA);
+  expect(legacyFailureExport.body).not.toContain(recipientB);
 });
 
-test("empty dashboard delivery failure export shows a visible empty state", async ({
+test("empty dashboard email export shows a visible empty state", async ({
   authenticatedPage: page,
 }) => {
   await page.goto("/emails");
@@ -94,8 +104,7 @@ test("empty dashboard delivery failure export shows a visible empty state", asyn
 
   await expect(
     page.getByRole("status").filter({
-      hasText:
-        "No bounced, complained, or suppressed failures match these filters.",
+      hasText: "No emails match these filters.",
     }),
   ).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- Adds a dashboard-session-only CSV export API for Emails, Broadcasts, Contacts, Segments, Domains, Logs, and API keys.
- Wires existing export buttons/no-op/client-only controls into the shared export flow with stable filenames, CSV escaping, tenant predicates, and API-key secret redaction.
- Keeps the first slice immediate and capped at 1,000 matching rows; over-cap exports return `export_too_large` and durable 7-day export records/email delivery remain the explicit follow-up.

Addresses #461

## Validation
- [x] `make check` — passed
- [x] `make test` — passed: 156 files / 1227 tests
- [x] Targeted Vitest: `bun run test tests/dashboard-csv-export.test.ts tests/delivery-failure-export-route.test.ts tests/delivery-failure-export-service.test.ts` — passed
- [x] Focused Playwright attempted with local Postgres/session fixture: `set -a; . ./.env; set +a; bunx playwright test tests/e2e/delivery-failure-export.spec.ts`
  - Blocked before page load because Next dev fails with the existing dynamic-route conflict: `You cannot use different slug names for the same dynamic path ('id' !== 'email_id')`.

## Notes / Follow-up
- This PR intentionally does not add Settings → Team → Exports because the implemented path is immediate-download only.
- Durable export records (`pending|ready|expired|failed`), 7-day retained downloads, and email delivery should be added before lifting the 1,000-row immediate cap.
- Existing delivery-failure export behavior remains in place and is still covered by route/service tests; the focused E2E now also checks the legacy endpoint when the app can boot.