### PR TITLE
Support Resend replyTo send alias in TypeScript SDK

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -65,6 +65,21 @@ returns after the API persists the row and queues background delivery work. Poll
 `bounced`, `opened`, or `clicked`. The `created_at` timestamp is queue time;
 `sent_at` is set by the worker after SES accepts the message.
 
+### Multiple Reply-To addresses
+
+Use Resend-compatible `replyTo` for one or more Reply-To addresses. The SDK
+serializes it to the REST `reply_to` field.
+
+```typescript
+await resend.emails.send({
+  from: "hello@updates.example.com",
+  to: "user@example.com",
+  subject: "Need help?",
+  html: "<p>Reply to reach our support team.</p>",
+  replyTo: ["support@example.com", "billing@example.com"],
+});
+```
+
 ### With React components
 
 Install React and ReactDOM alongside the SDK when you use the `react` payload.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -71,6 +71,7 @@ interface ApiResponse<T> {
 }
 
 export type SendEmailPayload = EmailOptions & {
+  replyTo?: string | string[];
   react?: ReactNode;
 };
 export type CreateDomainPayload = DomainOptions;
@@ -331,6 +332,19 @@ function toBroadcastPayload<T extends BroadcastPayloadAliases>(
   return normalized;
 }
 
+type SendEmailRestPayload = Omit<SendEmailPayload, "replyTo">;
+
+function toSendEmailPayload(payload: SendEmailPayload): SendEmailRestPayload {
+  const { replyTo, ...rest } = payload;
+  const normalized: SendEmailRestPayload = { ...rest };
+
+  if (normalized.reply_to === undefined && replyTo !== undefined) {
+    normalized.reply_to = replyTo;
+  }
+
+  return normalized;
+}
+
 interface ReactRenderSuccess {
   html: string;
   error: null;
@@ -436,7 +450,7 @@ class Emails {
     payload: SendEmailPayload,
     options: RequestOptions = {},
   ): Promise<ApiResponse<EmailResponse>> {
-    const { react, ...rest } = payload;
+    const { react, ...rest } = toSendEmailPayload(payload);
 
     if (react != null) {
       const rendered = await renderReactToHtml(react);
@@ -456,7 +470,7 @@ class Emails {
     return this.http.request<BatchEmailResponse>(
       "POST",
       "/emails/batch",
-      payload,
+      payload.map(toSendEmailPayload),
       options,
     );
   }

--- a/tests/sdk-client.test.tsx
+++ b/tests/sdk-client.test.tsx
@@ -154,6 +154,77 @@ describe("Opensend SDK", () => {
     );
   });
 
+  it("serializes Resend replyTo arrays to REST reply_to for single sends", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ id: "email_reply_to" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new Resend("os_test", {
+      baseUrl: "https://api.example.com",
+    });
+
+    await client.emails.send({
+      from: "hello@example.com",
+      to: "user@example.com",
+      subject: "Hello",
+      html: "<p>Hello</p>",
+      replyTo: ["support@example.com", "billing@example.com"],
+    });
+
+    const sendCallOptions = fetchMock.mock.calls[0]?.[1];
+    const outgoingBody = JSON.parse(String(sendCallOptions?.body)) as Record<
+      string,
+      unknown
+    >;
+
+    expect(outgoingBody).toMatchObject({
+      from: "hello@example.com",
+      to: "user@example.com",
+      subject: "Hello",
+      html: "<p>Hello</p>",
+      reply_to: ["support@example.com", "billing@example.com"],
+    });
+    expect(outgoingBody).not.toHaveProperty("replyTo");
+  });
+
+  it("keeps snake_case reply_to precedence over the replyTo send alias", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ id: "email_reply_to_precedence" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new Opensend("os_test", {
+      baseUrl: "https://api.example.com",
+    });
+
+    await client.emails.send({
+      from: "hello@example.com",
+      to: "user@example.com",
+      subject: "Hello",
+      html: "<p>Hello</p>",
+      reply_to: ["snake@example.com"],
+      replyTo: ["camel@example.com"],
+    });
+
+    const sendCallOptions = fetchMock.mock.calls[0]?.[1];
+    const outgoingBody = JSON.parse(String(sendCallOptions?.body)) as Record<
+      string,
+      unknown
+    >;
+
+    expect(outgoingBody.reply_to).toEqual(["snake@example.com"]);
+    expect(outgoingBody).not.toHaveProperty("replyTo");
+  });
+
   it("builds Resend-compatible root segments API requests", async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(JSON.stringify({ object: "segment", id: "seg_123" }), {
@@ -205,7 +276,7 @@ describe("Opensend SDK", () => {
     expectTypeOf<SDKOptions>().toMatchTypeOf<{ baseUrl?: string }>();
     expectTypeOf<RequestOptions>().toMatchTypeOf<{ idempotencyKey?: string }>();
     expectTypeOf<SendEmailPayload>().toMatchTypeOf<
-      EmailOptions & { react?: ReactNode }
+      EmailOptions & { react?: ReactNode; replyTo?: string | string[] }
     >();
     expectTypeOf<ApiResponse<EmailResponse>>().toEqualTypeOf<{
       data: EmailResponse | null;


### PR DESCRIPTION
## Summary
- add TypeScript SDK `replyTo?: string | string[]` support on the send payload
- normalize `replyTo` to REST `reply_to` while preserving existing `reply_to` precedence
- document multi-address `replyTo` usage in the SDK README

## Tests
- `bun .scratch/sdk-replyto-alias.ts`
- `bun run test -- tests/sdk-client.test.tsx`
- `make check`
- `make test`

Closes #467