### PR TITLE
Implement tracking subdomain CNAME delegation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,11 @@ DATABASE_URL=postgresql://opensend:opensend@localhost:5432/opensend
 BETTER_AUTH_URL=http://localhost:3015
 # Public URL the frontend uses. Must match BETTER_AUTH_URL for local dev.
 NEXT_PUBLIC_APP_URL=http://localhost:3015
+# Optional public tracking endpoint. CNAME DNS guidance points custom tracking
+# subdomains at this host (or NEXT_PUBLIC_APP_URL when unset).
+# TRACKING_BASE_URL=https://your.app
+# Optional explicit CNAME target if it differs from TRACKING_BASE_URL's host.
+# TRACKING_CNAME_TARGET=your.app
 
 # Google OAuth — create at https://console.cloud.google.com/apis/credentials
 # Authorized redirect URI: ${BETTER_AUTH_URL}/api/auth/callback/google

--- a/agent_docs/learnings/active/2026-05-12-issue-470-tracking-cname-target.md
+++ b/agent_docs/learnings/active/2026-05-12-issue-470-tracking-cname-target.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-12
+issue: "#470"
+type: decision
+promoted_to: null
+---
+
+## Tracking subdomain stores the Resend-compatible label, DNS records store the full host
+
+**What:** `tracking_subdomain` is validated and persisted as a single DNS label such as `links`. Domain DNS guidance expands it to `links.<domain>` and emits a pending CNAME whose target is the configured OpenSend tracking host.
+
+**Why:** Resend-compatible create/update payloads use a label, while self-hosters need a copyable full DNS record. Keeping the row value as the label preserves API parity and avoids storing redundant domain names.
+
+**Pattern:** Build the CNAME target from `TRACKING_CNAME_TARGET`, then `TRACKING_BASE_URL`, then app URL env. Preserve full-host reads for historical rows when deriving tracking URLs, but reject dotted values at the validation boundary for new writes.

--- a/packages/core/src/dto/index.ts
+++ b/packages/core/src/dto/index.ts
@@ -170,7 +170,7 @@ export interface DomainOptions {
 export interface UpdateDomainPayload {
   click_tracking?: boolean;
   open_tracking?: boolean;
-  tracking_subdomain?: string;
+  tracking_subdomain?: string | null;
   capabilities?: DomainCapability[];
   sending_enabled?: boolean;
   receiving_enabled?: boolean;

--- a/packages/core/src/services/domain-detail.ts
+++ b/packages/core/src/services/domain-detail.ts
@@ -2,7 +2,7 @@ import { and, eq } from "drizzle-orm";
 import { db } from "../db/client";
 import { domainRepo } from "../db/repositories/domainRepo";
 import { domains } from "../db/schema";
-import { getEffectiveReturnPathLabel } from "./domain";
+import { getEffectiveReturnPathLabel, syncTrackingCnameRecord } from "./domain";
 import {
   cloudflareDnsCleanupProvider,
   domainIdentityProvider,
@@ -16,7 +16,12 @@ type DomainCapability = NonNullable<DomainRow["capabilities"]>[number];
 type DomainDetailUpdateData = Partial<
   Pick<
     DomainInsert,
-    "trackClicks" | "trackOpens" | "trackingSubdomain" | "capabilities" | "tls"
+    | "trackClicks"
+    | "trackOpens"
+    | "trackingSubdomain"
+    | "capabilities"
+    | "tls"
+    | "records"
   >
 >;
 
@@ -40,7 +45,7 @@ export type DomainDetailResponse = {
 export type UpdateDomainDetailInput = {
   click_tracking?: boolean;
   open_tracking?: boolean;
-  tracking_subdomain?: string;
+  tracking_subdomain?: string | null;
   capabilities?: DomainCapability[];
   sending_enabled?: boolean;
   receiving_enabled?: boolean;
@@ -208,6 +213,12 @@ function toUpdateData(
   }
   if (input.tracking_subdomain !== undefined) {
     updates.trackingSubdomain = input.tracking_subdomain;
+    updates.records = syncTrackingCnameRecord({
+      records: existingDomain.records ?? [],
+      domainName: existingDomain.name,
+      previousTrackingSubdomain: existingDomain.trackingSubdomain,
+      nextTrackingSubdomain: input.tracking_subdomain,
+    });
   }
 
   if (input.capabilities !== undefined) {

--- a/packages/core/src/services/domain.ts
+++ b/packages/core/src/services/domain.ts
@@ -10,6 +10,7 @@ type DomainCapability = NonNullable<DomainRow["capabilities"]>[number];
 
 export const DEFAULT_RETURN_PATH = "send";
 export const DMARC_RECORD_VALUE = "v=DMARC1; p=none;";
+export const DEFAULT_TRACKING_CNAME_TARGET = "localhost";
 
 export function buildDmarcRecordName(domainName: string): string {
   return `_dmarc.${domainName}`;
@@ -26,6 +27,90 @@ export function buildReturnPathRecordName(
   customReturnPath: string | null | undefined,
 ): string {
   return `${getEffectiveReturnPathLabel(customReturnPath)}.${domainName}`;
+}
+
+function normalizeHostnameFromUrlish(value: string | null | undefined): string {
+  const trimmed = value?.trim();
+  if (!trimmed) return "";
+
+  try {
+    return new URL(trimmed).hostname;
+  } catch {
+    try {
+      return new URL(`https://${trimmed}`).hostname;
+    } catch {
+      return "";
+    }
+  }
+}
+
+export function getTrackingCnameTarget(): string {
+  return (
+    normalizeHostnameFromUrlish(process.env.TRACKING_CNAME_TARGET) ||
+    normalizeHostnameFromUrlish(process.env.TRACKING_BASE_URL) ||
+    normalizeHostnameFromUrlish(process.env.NEXT_PUBLIC_APP_URL) ||
+    normalizeHostnameFromUrlish(process.env.APP_URL) ||
+    normalizeHostnameFromUrlish(
+      process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null,
+    ) ||
+    DEFAULT_TRACKING_CNAME_TARGET
+  );
+}
+
+export function buildTrackingSubdomainRecordName(
+  domainName: string,
+  trackingSubdomain: string | null | undefined,
+): string | null {
+  const label = trackingSubdomain?.trim().toLowerCase();
+  if (!label) return null;
+
+  // Historical rows may contain the full host. New Resend-compatible writes are
+  // validated as a single DNS label, but preserving full-host reads avoids
+  // breaking already-configured tracking links.
+  if (label.includes(".")) return label;
+
+  return `${label}.${domainName}`;
+}
+
+export function buildTrackingCnameRecord(
+  domainName: string,
+  trackingSubdomain: string | null | undefined,
+  target = getTrackingCnameTarget(),
+): DomainRecord | null {
+  const name = buildTrackingSubdomainRecordName(domainName, trackingSubdomain);
+  if (!name) return null;
+
+  return {
+    type: "CNAME",
+    name,
+    value: target,
+    status: "pending",
+    ttl: "Auto",
+  };
+}
+
+export function syncTrackingCnameRecord(input: {
+  records: DomainRecord[];
+  domainName: string;
+  previousTrackingSubdomain: string | null | undefined;
+  nextTrackingSubdomain: string | null | undefined;
+}): DomainRecord[] {
+  const previousName = buildTrackingSubdomainRecordName(
+    input.domainName,
+    input.previousTrackingSubdomain,
+  );
+  const nextRecord = buildTrackingCnameRecord(
+    input.domainName,
+    input.nextTrackingSubdomain,
+  );
+  const nextName = nextRecord?.name ?? null;
+
+  const retainedRecords = input.records.filter((record) => {
+    if (record.type !== "CNAME") return true;
+    return record.name !== previousName && record.name !== nextName;
+  });
+
+  return nextRecord ? [...retainedRecords, nextRecord] : retainedRecords;
 }
 
 export type CreateDomainIdentityResult = {
@@ -149,6 +234,7 @@ function buildDomainRecords(
   region: string,
   identity: CreateDomainIdentityResult,
   customReturnPath: string | null | undefined,
+  trackingSubdomain: string | null | undefined,
 ): DomainRecord[] {
   const dkimRecords: DomainRecord[] =
     identity.dkimOrigin === "EXTERNAL" &&
@@ -201,7 +287,18 @@ function buildDomainRecords(
     ttl: "Auto",
   };
 
-  return [...dkimRecords, spfRecord, mxRecord, dmarcRecord];
+  const trackingCnameRecord = buildTrackingCnameRecord(
+    domainName,
+    trackingSubdomain,
+  );
+
+  return [
+    ...dkimRecords,
+    spfRecord,
+    mxRecord,
+    dmarcRecord,
+    ...(trackingCnameRecord ? [trackingCnameRecord] : []),
+  ];
 }
 
 function toDomainDetail(row: DomainRow): DomainDetail {
@@ -271,6 +368,7 @@ export function createDomainService({
         region,
         identity,
         input.customReturnPath,
+        input.trackingSubdomain,
       );
 
       const dkimOrigin = identity.dkimOrigin ?? "AWS_SES";

--- a/packages/ingester/src/queue-worker.ts
+++ b/packages/ingester/src/queue-worker.ts
@@ -10,6 +10,7 @@ import {
   type SandboxTestOutcome,
   type TelemetryContext,
   applyEmailTracking,
+  buildTrackingSubdomainRecordName,
   createBackgroundJob,
   createEmailTrackingToken,
   createTelemetryContext,
@@ -535,7 +536,10 @@ async function renderTrackedHtmlForDelivery(
 
   const recipient = email.to.length === 1 ? email.to[0] : undefined;
   const trackingBaseUrl = getEmailTrackingBaseUrl({
-    trackingSubdomain: domain.trackingSubdomain,
+    trackingSubdomain: buildTrackingSubdomainRecordName(
+      domain.name,
+      domain.trackingSubdomain,
+    ),
   });
 
   return applyEmailTracking({

--- a/src/app/(dashboard)/domains/[id]/page.tsx
+++ b/src/app/(dashboard)/domains/[id]/page.tsx
@@ -77,6 +77,7 @@ export default async function DomainDetailPage({
         createdAt: domain.createdAt.toISOString(),
         clickTracking: domain.trackClicks,
         openTracking: domain.trackOpens,
+        trackingSubdomain: domain.trackingSubdomain,
         tls: domain.tls,
         sendingEnabled: true,
         receivingEnabled: false,

--- a/src/app/api/domains/[id]/auto-configure/route.ts
+++ b/src/app/api/domains/[id]/auto-configure/route.ts
@@ -1,0 +1,87 @@
+import {
+  authorizeDashboardOrApiKey,
+  getServerSession,
+  unauthorizedResponse,
+} from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
+import {
+  auditContextForApiKey,
+  auditContextForDashboardSession,
+  recordAuditEvent,
+} from "@/lib/audit-events";
+import { configureDNSRecords } from "@/lib/cloudflare";
+import { getCachedDomainById } from "@/lib/domain-cache";
+import { domainRouteParamsSchema } from "@/lib/validation/domains";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
+  if (!auth) return unauthorizedResponse();
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
+
+  const session = "dashboard" in auth ? await getServerSession() : null;
+  const auditContext =
+    "userId" in auth
+      ? auth.userId
+        ? auditContextForApiKey({
+            userId: auth.userId,
+            apiKeyId: auth.apiKeyId,
+          })
+        : null
+      : auditContextForDashboardSession(session);
+  if (!auditContext) return unauthorizedResponse();
+  const userId = auditContext.userId;
+
+  const parsedParams = domainRouteParamsSchema.safeParse(await params);
+  if (!parsedParams.success) {
+    return Response.json(
+      { error: "Validation failed", details: parsedParams.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  const { id } = parsedParams.data;
+
+  try {
+    const domain = await getCachedDomainById(id);
+
+    if (!domain || domain.userId !== userId) {
+      return Response.json({ error: "Domain not found" }, { status: 404 });
+    }
+
+    const syncResults = await configureDNSRecords(domain.records ?? []);
+
+    await recordAuditEvent({
+      context: auditContext,
+      action: "domain.updated",
+      targetType: "domain",
+      targetId: domain.id,
+      metadata: {
+        name: domain.name,
+        records: syncResults.map((record) => ({
+          action: record.action,
+          name: record.name,
+          type: record.type,
+          reason: record.reason,
+        })),
+      },
+    });
+
+    return Response.json({
+      object: "domain",
+      id: domain.id,
+      name: domain.name,
+      records: domain.records ?? [],
+      dns_records: syncResults,
+    });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to auto-configure domain";
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/domain-detail.tsx
+++ b/src/components/domain-detail.tsx
@@ -14,6 +14,7 @@ export interface DomainDetailData {
   createdAt: string;
   clickTracking: boolean;
   openTracking: boolean;
+  trackingSubdomain: string | null;
   tls: string;
   sendingEnabled: boolean;
   receivingEnabled: boolean;
@@ -614,6 +615,10 @@ function RecordsTab({ domain }: { domain: DomainDetailData }) {
   const [receivingEnabled, setReceivingEnabled] = useState(
     domain.receivingEnabled,
   );
+  const [autoConfiguring, setAutoConfiguring] = useState(false);
+  const [autoConfigureError, setAutoConfigureError] = useState<string | null>(
+    null,
+  );
 
   const handleToggle = useCallback(
     async (field: "sending_enabled" | "receiving_enabled", value: boolean) => {
@@ -631,6 +636,24 @@ function RecordsTab({ domain }: { domain: DomainDetailData }) {
     },
     [domain.id, router],
   );
+
+  const handleAutoConfigure = useCallback(async () => {
+    if (autoConfiguring) return;
+    setAutoConfiguring(true);
+    setAutoConfigureError(null);
+    try {
+      await apiRequest(`/api/domains/${domain.id}/auto-configure`, {
+        method: "POST",
+      });
+      router.refresh();
+    } catch (err) {
+      setAutoConfigureError(
+        err instanceof Error ? err.message : "Failed to auto-configure DNS",
+      );
+    } finally {
+      setAutoConfiguring(false);
+    }
+  }, [autoConfiguring, domain.id, router]);
 
   const records = domain.records || [];
 
@@ -651,11 +674,32 @@ function RecordsTab({ domain }: { domain: DomainDetailData }) {
     (r) => r.type === "TXT" && r.name.startsWith("_dmarc."),
   );
 
+  const trackingRecords = records.filter(
+    (r) => r.type === "CNAME" && !r.name.includes("_domainkey"),
+  );
+
   return (
     <div className="bg-[rgba(24,25,28,0.88)] border border-[rgba(176,199,217,0.145)] rounded-lg p-6">
-      <h2 className="text-[18px] font-semibold text-[#F0F0F0] mb-6">
-        DNS Records
-      </h2>
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-[18px] font-semibold text-[#F0F0F0]">
+            DNS Records
+          </h2>
+          {autoConfigureError && (
+            <p className="mt-2 text-[12px] text-red-400" role="alert">
+              {autoConfigureError}
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={handleAutoConfigure}
+          disabled={autoConfiguring}
+          className="px-3 py-2 rounded-md border border-[rgba(176,199,217,0.145)] text-[13px] font-medium text-[#F0F0F0] hover:bg-[rgba(24,25,28,0.5)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {autoConfiguring ? "Configuring…" : "Auto configure"}
+        </button>
+      </div>
 
       {/* Section 1: Domain Verification (DKIM) */}
       <div className="mb-8">
@@ -713,7 +757,21 @@ function RecordsTab({ domain }: { domain: DomainDetailData }) {
         />
       </div>
 
-      {/* Section 4: Enable Receiving */}
+      {/* Section 4: Tracking CNAME */}
+      <div className="mb-8 border-t border-[rgba(176,199,217,0.145)] pt-6">
+        <h3 className="text-[14px] font-semibold text-[#F0F0F0] mb-1">
+          Tracking CNAME
+        </h3>
+        <p className="text-[13px] text-[#A1A4A5] mb-4">
+          Point this CNAME at your OpenSend tracking endpoint to use branded
+          click and open tracking URLs.
+        </p>
+        <DNSRecordTable
+          records={trackingRecords.length > 0 ? trackingRecords : null}
+        />
+      </div>
+
+      {/* Section 5: Enable Receiving */}
       <div className="border-t border-[rgba(176,199,217,0.145)] pt-6">
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-[14px] font-semibold text-[#F0F0F0]">
@@ -750,6 +808,13 @@ function ConfigurationTab({ domain }: { domain: DomainDetailData }) {
   const router = useRouter();
   const [clickTracking, setClickTracking] = useState(domain.clickTracking);
   const [openTracking, setOpenTracking] = useState(domain.openTracking);
+  const [trackingSubdomain, setTrackingSubdomain] = useState(
+    domain.trackingSubdomain ?? "",
+  );
+  const [savingTrackingSubdomain, setSavingTrackingSubdomain] = useState(false);
+  const [trackingSubdomainError, setTrackingSubdomainError] = useState<
+    string | null
+  >(null);
   const [tls, setTls] = useState(domain.tls || "opportunistic");
 
   const handleToggle = useCallback(
@@ -787,6 +852,39 @@ function ConfigurationTab({ domain }: { domain: DomainDetailData }) {
     [domain.id, tls, router],
   );
 
+  const handleTrackingSubdomainSave = useCallback(async () => {
+    if (savingTrackingSubdomain) return;
+    const nextValue = trackingSubdomain.trim();
+    const previousValue = domain.trackingSubdomain ?? "";
+    setSavingTrackingSubdomain(true);
+    setTrackingSubdomainError(null);
+    try {
+      await apiRequest(`/api/domains/${domain.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tracking_subdomain: nextValue || null,
+        }),
+      });
+      router.refresh();
+    } catch (err) {
+      setTrackingSubdomain(previousValue);
+      setTrackingSubdomainError(
+        err instanceof Error
+          ? err.message
+          : "Failed to update tracking subdomain",
+      );
+    } finally {
+      setSavingTrackingSubdomain(false);
+    }
+  }, [
+    domain.id,
+    domain.trackingSubdomain,
+    router,
+    savingTrackingSubdomain,
+    trackingSubdomain,
+  ]);
+
   return (
     <div className="bg-[rgba(24,25,28,0.88)] border border-[rgba(176,199,217,0.145)] rounded-lg p-6">
       <h2 className="text-[18px] font-semibold text-[#F0F0F0] mb-6">
@@ -799,9 +897,9 @@ function ConfigurationTab({ domain }: { domain: DomainDetailData }) {
             Click Tracking
           </h3>
           <p className="text-[13px] text-[#A1A4A5] mb-3 max-w-[600px]">
-            To track clicks, Resend modifies each link in the body of the HTML
-            email. When recipients open a link, they are sent to a Resend
-            server, and are immediately redirected to the URL destination.
+            To track clicks, OpenSend rewrites links in your HTML email. When
+            recipients open a link, they visit your OpenSend tracking endpoint
+            and are immediately redirected to the destination URL.
           </p>
           <button
             type="button"
@@ -836,8 +934,8 @@ function ConfigurationTab({ domain }: { domain: DomainDetailData }) {
             </span>
           </div>
           <p className="text-[13px] text-[#A1A4A5] mb-3 max-w-[600px]">
-            To track opens, Resend inserts a 1x1 transparent pixel at the end of
-            your email. This is not recommended as it can negatively impact
+            To track opens, OpenSend inserts a 1x1 transparent pixel at the end
+            of your email. This is not recommended as it can negatively impact
             deliverability.
           </p>
           <button
@@ -861,6 +959,45 @@ function ConfigurationTab({ domain }: { domain: DomainDetailData }) {
               }`}
             />
           </button>
+        </div>
+
+        <div className="border-t border-[rgba(176,199,217,0.145)] pt-8">
+          <h3 className="text-[14px] font-semibold text-[#F0F0F0] mb-2">
+            Custom Tracking Subdomain
+          </h3>
+          <p className="text-[13px] text-[#A1A4A5] mb-3 max-w-[600px]">
+            Optional. Enter a single DNS label such as{" "}
+            <span className="font-mono text-[#F0F0F0]">links</span>. OpenSend
+            will show a CNAME for{" "}
+            <span className="font-mono text-[#F0F0F0]">
+              links.{domain.name}
+            </span>{" "}
+            in DNS Records so your tracking URLs can stay on your branded
+            domain.
+          </p>
+          <div className="flex max-w-[420px] items-center gap-2">
+            <input
+              aria-label="Custom tracking subdomain"
+              type="text"
+              value={trackingSubdomain}
+              onChange={(event) => setTrackingSubdomain(event.target.value)}
+              placeholder="links"
+              className="min-w-0 flex-1 px-3 py-2 bg-[rgba(24,25,28,0.88)] border border-[rgba(176,199,217,0.145)] rounded-lg text-[#F0F0F0] text-[14px] placeholder:text-[#52525b] focus:outline-none focus:border-[rgba(176,199,217,0.3)]"
+            />
+            <button
+              type="button"
+              onClick={handleTrackingSubdomainSave}
+              disabled={savingTrackingSubdomain}
+              className="px-3 py-2 rounded-lg bg-white text-black text-[13px] font-medium hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {savingTrackingSubdomain ? "Saving…" : "Save"}
+            </button>
+          </div>
+          {trackingSubdomainError && (
+            <p className="mt-2 text-[12px] text-red-400" role="alert">
+              {trackingSubdomainError}
+            </p>
+          )}
         </div>
 
         <div className="border-t border-[rgba(176,199,217,0.145)] pt-8">

--- a/src/components/domains-page.tsx
+++ b/src/components/domains-page.tsx
@@ -84,6 +84,8 @@ export function DomainsPage({ domains }: DomainsPageProps) {
   const [statusFilter, setStatusFilter] = useState("");
   const [showAddModal, setShowAddModal] = useState(false);
   const [newDomain, setNewDomain] = useState("");
+  const [trackingSubdomain, setTrackingSubdomain] = useState("");
+  const [showAdvanced, setShowAdvanced] = useState(false);
   const [adding, setAdding] = useState(false);
   const [regionFilter, setRegionFilter] = useState("");
   const [page, setPage] = useState(1);
@@ -245,6 +247,8 @@ export function DomainsPage({ domains }: DomainsPageProps) {
           onClose={() => {
             setShowAddModal(false);
             setNewDomain("");
+            setTrackingSubdomain("");
+            setShowAdvanced(false);
           }}
           title="Add domain"
           actionLabel={adding ? "Adding..." : "Add"}
@@ -255,12 +259,19 @@ export function DomainsPage({ domains }: DomainsPageProps) {
               const res = await fetch("/api/domains", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ name: newDomain.trim() }),
+                body: JSON.stringify({
+                  name: newDomain.trim(),
+                  ...(trackingSubdomain.trim()
+                    ? { tracking_subdomain: trackingSubdomain.trim() }
+                    : {}),
+                }),
               });
               if (res.ok) {
                 const data = await res.json();
                 setShowAddModal(false);
                 setNewDomain("");
+                setTrackingSubdomain("");
+                setShowAdvanced(false);
                 router.push(`/domains/${data.id}`);
                 router.refresh();
               }
@@ -279,6 +290,38 @@ export function DomainsPage({ domains }: DomainsPageProps) {
             placeholder="yourdomain.com"
             className="w-full px-3 py-2 bg-[rgba(24,25,28,0.88)] border border-[rgba(176,199,217,0.145)] rounded-lg text-[#F0F0F0] text-[14px] placeholder:text-[#52525b] focus:outline-none focus:border-[#3b82f6]"
           />
+          <button
+            type="button"
+            className="mt-4 text-[13px] text-blue-400 hover:text-blue-300"
+            onClick={() => setShowAdvanced((value) => !value)}
+          >
+            {showAdvanced ? "Hide advanced options" : "Advanced options"}
+          </button>
+          {showAdvanced && (
+            <div className="mt-3 rounded-lg border border-[rgba(176,199,217,0.145)] bg-[rgba(10,10,10,0.35)] p-3">
+              <label
+                htmlFor="tracking-subdomain"
+                className="block text-[13px] font-medium text-[#F0F0F0] mb-1"
+              >
+                Custom tracking subdomain
+              </label>
+              <p className="text-[12px] text-[#A1A4A5] mb-2">
+                Optional. OpenSend will add a CNAME like{" "}
+                <span className="font-mono text-[#F0F0F0]">
+                  links.yourdomain.com
+                </span>{" "}
+                so tracked clicks and opens can use your branded domain.
+              </p>
+              <input
+                id="tracking-subdomain"
+                type="text"
+                value={trackingSubdomain}
+                onChange={(e) => setTrackingSubdomain(e.target.value)}
+                placeholder="links"
+                className="w-full px-3 py-2 bg-[rgba(24,25,28,0.88)] border border-[rgba(176,199,217,0.145)] rounded-lg text-[#F0F0F0] text-[14px] placeholder:text-[#52525b] focus:outline-none focus:border-[#3b82f6]"
+              />
+            </div>
+          )}
         </Modal>
       )}
     </div>

--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -12,6 +12,28 @@ export interface DNSRecordResult extends DNSRecord {
   id: string;
 }
 
+export interface DomainDnsRecord {
+  type: string;
+  name: string;
+  value: string;
+  ttl?: string | number;
+  priority?: number;
+}
+
+export type DNSRecordSyncAction =
+  | "created"
+  | "updated"
+  | "unchanged"
+  | "skipped";
+
+export interface DNSRecordSyncResult {
+  action: DNSRecordSyncAction;
+  name: string;
+  type: DNSRecord["type"];
+  record?: DNSRecordResult;
+  reason?: string;
+}
+
 interface CloudflareResponse<T> {
   success: boolean;
   result: T;
@@ -38,6 +60,50 @@ function headers(token: string) {
   return {
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
+  };
+}
+
+function isSupportedDnsRecordType(type: string): type is DNSRecord["type"] {
+  return type === "TXT" || type === "MX" || type === "CNAME";
+}
+
+function normalizeTtl(ttl: string | number | undefined): number {
+  if (typeof ttl === "number") return ttl;
+  if (!ttl || ttl.toLowerCase() === "auto") return 1;
+  const parsed = Number(ttl);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+}
+
+function isDmarcRecord(record: DNSRecord): boolean {
+  return (
+    record.type === "TXT" && record.name.toLowerCase().startsWith("_dmarc.")
+  );
+}
+
+function dnsRecordsMatch(
+  expected: DNSRecord,
+  actual: DNSRecordResult,
+): boolean {
+  return (
+    expected.type === actual.type &&
+    expected.name === actual.name &&
+    expected.content === actual.content &&
+    normalizeTtl(actual.ttl) === normalizeTtl(expected.ttl) &&
+    (expected.priority ?? null) === (actual.priority ?? null)
+  );
+}
+
+export function mapDomainRecordToDNSRecord(
+  record: DomainDnsRecord,
+): DNSRecord | null {
+  if (!isSupportedDnsRecordType(record.type)) return null;
+
+  return {
+    type: record.type,
+    name: record.name,
+    content: record.value,
+    ttl: normalizeTtl(record.ttl),
+    ...(record.priority !== undefined ? { priority: record.priority } : {}),
   };
 }
 
@@ -135,4 +201,64 @@ export async function updateDNSRecord(
   });
 
   return handleResponse<DNSRecordResult>(response);
+}
+
+export async function upsertDNSRecord(
+  record: DNSRecord,
+): Promise<DNSRecordSyncResult> {
+  const existing = await listDNSRecords({
+    name: record.name,
+    type: record.type,
+  });
+  const current = existing[0];
+
+  if (!current) {
+    return {
+      action: "created",
+      name: record.name,
+      type: record.type,
+      record: await createDNSRecord(record),
+    };
+  }
+
+  if (dnsRecordsMatch(record, current)) {
+    return {
+      action: "unchanged",
+      name: record.name,
+      type: record.type,
+      record: current,
+    };
+  }
+
+  if (isDmarcRecord(record)) {
+    return {
+      action: "skipped",
+      name: record.name,
+      type: record.type,
+      record: current,
+      reason: "Existing DMARC record is customer-owned and was not overwritten",
+    };
+  }
+
+  return {
+    action: "updated",
+    name: record.name,
+    type: record.type,
+    record: await updateDNSRecord(current.id, record),
+  };
+}
+
+export async function configureDNSRecords(
+  records: DomainDnsRecord[],
+): Promise<DNSRecordSyncResult[]> {
+  const results: DNSRecordSyncResult[] = [];
+
+  for (const record of records) {
+    const dnsRecord = mapDomainRecordToDNSRecord(record);
+    if (!dnsRecord) continue;
+
+    results.push(await upsertDNSRecord(dnsRecord));
+  }
+
+  return results;
 }

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -604,7 +604,12 @@ export const openApiDocument = {
           custom_return_path: { type: "string" },
           open_tracking: { type: "boolean" },
           click_tracking: { type: "boolean" },
-          tracking_subdomain: { type: "string" },
+          tracking_subdomain: {
+            type: "string",
+            description:
+              "Single DNS label for branded tracking URLs, for example links.",
+            maxLength: 63,
+          },
           tls: { type: "string", enum: ["opportunistic", "enforced"] },
           capabilities: {
             type: "array",

--- a/src/lib/validation/domains.ts
+++ b/src/lib/validation/domains.ts
@@ -34,13 +34,25 @@ export const returnPathLabelSchema = z
     "Return path can only contain letters, numbers, and hyphens",
   );
 
+export const trackingSubdomainLabelSchema = z
+  .string()
+  .trim()
+  .min(1, "Tracking subdomain is required")
+  .max(63, "Tracking subdomain must be 63 characters or less")
+  .regex(/^[A-Za-z]/, "Tracking subdomain must start with a letter")
+  .regex(/[A-Za-z0-9]$/, "Tracking subdomain must end with a letter or number")
+  .regex(
+    /^[A-Za-z0-9-]+$/,
+    "Tracking subdomain can only contain letters, numbers, and hyphens",
+  );
+
 export const createDomainSchema = z.object({
   name: z.string().trim().min(1, "Domain name is required").max(255),
   region: domainRegionSchema.optional().default("us-east-1"),
   custom_return_path: returnPathLabelSchema.optional(),
   open_tracking: z.boolean().optional(),
   click_tracking: z.boolean().optional(),
-  tracking_subdomain: z.string().trim().min(1).max(255).optional(),
+  tracking_subdomain: trackingSubdomainLabelSchema.optional(),
   tls: domainTlsSchema.optional().default("opportunistic"),
   capabilities: z.array(domainCapabilitySchema).optional(),
 });
@@ -49,7 +61,7 @@ export const updateDomainSchema = z
   .object({
     click_tracking: z.boolean().optional(),
     open_tracking: z.boolean().optional(),
-    tracking_subdomain: z.string().trim().min(1).max(255).optional(),
+    tracking_subdomain: trackingSubdomainLabelSchema.nullable().optional(),
     capabilities: z.array(domainCapabilitySchema).optional(),
     sending_enabled: z.boolean().optional(),
     receiving_enabled: z.boolean().optional(),

--- a/tests/api-domains.test.ts
+++ b/tests/api-domains.test.ts
@@ -4,6 +4,7 @@ const mockValidateApiKey = vi.hoisted(() => vi.fn());
 const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockDeleteDNSRecord = vi.hoisted(() => vi.fn());
 const mockListDNSRecords = vi.hoisted(() => vi.fn());
+const mockConfigureDNSRecords = vi.hoisted(() => vi.fn());
 const mockQueueEvent = vi.hoisted(() => vi.fn());
 const mockDeleteDomainIdentity = vi.hoisted(() => vi.fn());
 const mockGetDomainIdentity = vi.hoisted(() => vi.fn());
@@ -73,6 +74,7 @@ vi.mock("@opensend/core", () => ({
 }));
 
 vi.mock("@/lib/cloudflare", () => ({
+  configureDNSRecords: mockConfigureDNSRecords,
   deleteDNSRecord: mockDeleteDNSRecord,
   listDNSRecords: mockListDNSRecords,
 }));
@@ -123,6 +125,7 @@ describe("Domain API validation", () => {
     mockGetServerSession.mockReset();
     mockDeleteDNSRecord.mockReset();
     mockListDNSRecords.mockReset();
+    mockConfigureDNSRecords.mockReset();
     mockQueueEvent.mockReset();
     mockDeleteDomainIdentity.mockReset();
     mockGetDomainIdentity.mockReset();
@@ -493,6 +496,69 @@ describe("Domain API validation", () => {
     expect(mockDb.insert).not.toHaveBeenCalled();
   });
 
+  it("forwards a validated tracking subdomain label during create", async () => {
+    mockCreateDomain.mockResolvedValueOnce({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+      status: "not_started",
+      region: "us-east-1",
+      records: [
+        {
+          type: "CNAME",
+          name: "links.example.com",
+          value: "track.opensend.example",
+          status: "pending",
+          ttl: "Auto",
+        },
+      ],
+      customReturnPath: null,
+      trackOpens: false,
+      trackClicks: false,
+      trackingSubdomain: "links",
+      tls: "opportunistic",
+      capabilities: [{ name: "sending", enabled: true }],
+      createdAt: new Date("2026-05-06T00:00:00.000Z"),
+    });
+
+    const { POST } = await import("@/app/api/domains/route");
+    const res = await POST(
+      makeRequest("http://localhost:3015/api/domains", "POST", {
+        name: "example.com",
+        tracking_subdomain: "links",
+      }),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(mockCreateDomain).toHaveBeenCalledWith(
+      expect.objectContaining({ trackingSubdomain: "links" }),
+    );
+    expect(json.tracking_subdomain).toBe("links");
+    expect(json.records).toContainEqual({
+      type: "CNAME",
+      name: "links.example.com",
+      value: "track.opensend.example",
+      status: "pending",
+      ttl: "Auto",
+    });
+  });
+
+  it("returns 422 for invalid tracking subdomain labels", async () => {
+    const { POST } = await import("@/app/api/domains/route");
+    const req = makeRequest("http://localhost:3015/api/domains", "POST", {
+      name: "example.com",
+      tracking_subdomain: "links.example.com",
+    });
+
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(json.error).toBe("Validation failed");
+    expect(json.details.fieldErrors.tracking_subdomain).toBeDefined();
+    expect(mockCreateDomain).not.toHaveBeenCalled();
+  });
+
   it("returns 422 for invalid domain update payload", async () => {
     const { PATCH } = await import("@/app/api/domains/[id]/route");
     const req = makeRequest(
@@ -514,6 +580,51 @@ describe("Domain API validation", () => {
     expect(json.details.fieldErrors.click_tracking).toBeDefined();
     expect(json.details.fieldErrors.tls).toBeDefined();
     expect(mockUpdateDomainDetail).not.toHaveBeenCalled();
+  });
+
+  it("accepts a tracking subdomain label during update", async () => {
+    mockUpdateDomainDetail.mockResolvedValueOnce({
+      response: { object: "domain", id: VALID_DOMAIN_ID },
+      changedFields: ["tracking_subdomain"],
+      eventPayload: {
+        id: VALID_DOMAIN_ID,
+        changed_fields: ["tracking_subdomain"],
+        domain: {
+          id: VALID_DOMAIN_ID,
+          name: "example.com",
+          status: "not_started",
+          region: "us-east-1",
+          records: [
+            {
+              type: "CNAME",
+              name: "links.example.com",
+              value: "track.opensend.example",
+              status: "pending",
+              ttl: "Auto",
+            },
+          ],
+          capabilities: [{ name: "sending", enabled: true }],
+          created_at: "2026-05-06T00:00:00.000Z",
+        },
+      },
+    });
+
+    const { PATCH } = await import("@/app/api/domains/[id]/route");
+    const res = await PATCH(
+      makeRequest(
+        `http://localhost:3015/api/domains/${VALID_DOMAIN_ID}`,
+        "PATCH",
+        { tracking_subdomain: "links" },
+      ),
+      { params: Promise.resolve({ id: VALID_DOMAIN_ID }) },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateDomainDetail).toHaveBeenCalledWith({
+      id: VALID_DOMAIN_ID,
+      userId: "user-1",
+      updates: { tracking_subdomain: "links" },
+    });
   });
 
   it("returns 422 for invalid domain detail params before calling the service", async () => {
@@ -666,6 +777,61 @@ describe("Domain API validation", () => {
 
     expect(res.status).toBe(404);
     expect(mockReconcileVerification).not.toHaveBeenCalled();
+  });
+
+  it("auto-configures persisted DNS records through Cloudflare for the caller tenant", async () => {
+    const records = [
+      {
+        type: "CNAME",
+        name: "links.example.com",
+        value: "track.opensend.example",
+        status: "pending",
+        ttl: "Auto",
+      },
+    ];
+    mockDb.query.domains.findFirst.mockResolvedValue({
+      id: VALID_DOMAIN_ID,
+      name: "example.com",
+      userId: "user-1",
+      status: "pending",
+      records,
+    });
+    mockConfigureDNSRecords.mockResolvedValueOnce([
+      {
+        action: "created",
+        name: "links.example.com",
+        type: "CNAME",
+        record: {
+          id: "dns-track",
+          type: "CNAME",
+          name: "links.example.com",
+          content: "track.opensend.example",
+          ttl: 1,
+        },
+      },
+    ]);
+
+    const { POST } = await import(
+      "@/app/api/domains/[id]/auto-configure/route"
+    );
+    const res = await POST(
+      makeRequest(
+        `http://localhost:3015/api/domains/${VALID_DOMAIN_ID}/auto-configure`,
+        "POST",
+      ),
+      { params: Promise.resolve({ id: VALID_DOMAIN_ID }) },
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockConfigureDNSRecords).toHaveBeenCalledWith(records);
+    expect(json.dns_records).toEqual([
+      expect.objectContaining({
+        action: "created",
+        name: "links.example.com",
+        type: "CNAME",
+      }),
+    ]);
   });
 });
 

--- a/tests/cloudflare.test.ts
+++ b/tests/cloudflare.test.ts
@@ -10,9 +10,12 @@ vi.stubEnv("CLOUDFLARE_ZONE_ID", "test-zone-id-456");
 
 import {
   type DNSRecord,
+  configureDNSRecords,
   createDNSRecord,
   deleteDNSRecord,
   listDNSRecords,
+  mapDomainRecordToDNSRecord,
+  upsertDNSRecord,
 } from "@/lib/cloudflare";
 
 describe("Cloudflare DNS Client", () => {
@@ -315,6 +318,139 @@ describe("Cloudflare DNS Client", () => {
       await expect(deleteDNSRecord("nonexistent")).rejects.toThrow(
         "Cloudflare API error: Record not found",
       );
+    });
+  });
+
+  describe("domain DNS record mapping", () => {
+    it("maps tracking CNAME guidance to Cloudflare's DNS record shape", () => {
+      expect(
+        mapDomainRecordToDNSRecord({
+          type: "CNAME",
+          name: "links.example.com",
+          value: "track.opensend.example",
+          ttl: "Auto",
+        }),
+      ).toEqual({
+        type: "CNAME",
+        name: "links.example.com",
+        content: "track.opensend.example",
+        ttl: 1,
+      });
+    });
+
+    it("maps MX priority and ignores unsupported record types", () => {
+      expect(
+        mapDomainRecordToDNSRecord({
+          type: "MX",
+          name: "send.example.com",
+          value: "feedback-smtp.us-east-1.amazonses.com",
+          ttl: "300",
+          priority: 10,
+        }),
+      ).toEqual({
+        type: "MX",
+        name: "send.example.com",
+        content: "feedback-smtp.us-east-1.amazonses.com",
+        ttl: 300,
+        priority: 10,
+      });
+      expect(
+        mapDomainRecordToDNSRecord({
+          type: "CAA",
+          name: "example.com",
+          value: "0 issue amazon.com",
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("upsertDNSRecord", () => {
+    it("updates an existing tracking CNAME when the target drifts", async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            success: true,
+            result: [
+              {
+                id: "dns-track",
+                type: "CNAME",
+                name: "links.example.com",
+                content: "old.example",
+                ttl: 1,
+              },
+            ],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            success: true,
+            result: {
+              id: "dns-track",
+              type: "CNAME",
+              name: "links.example.com",
+              content: "track.opensend.example",
+              ttl: 1,
+            },
+          }),
+        });
+
+      await expect(
+        upsertDNSRecord({
+          type: "CNAME",
+          name: "links.example.com",
+          content: "track.opensend.example",
+          ttl: 1,
+        }),
+      ).resolves.toMatchObject({
+        action: "updated",
+        name: "links.example.com",
+        type: "CNAME",
+      });
+
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        "https://api.cloudflare.com/client/v4/zones/test-zone-id-456/dns_records/dns-track",
+        expect.objectContaining({ method: "PUT" }),
+      );
+    });
+
+    it("creates the tracking CNAME during batch configure when missing", async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true, result: [] }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            success: true,
+            result: {
+              id: "dns-created",
+              type: "CNAME",
+              name: "links.example.com",
+              content: "track.opensend.example",
+              ttl: 1,
+            },
+          }),
+        });
+
+      await expect(
+        configureDNSRecords([
+          {
+            type: "CNAME",
+            name: "links.example.com",
+            value: "track.opensend.example",
+            ttl: "Auto",
+          },
+        ]),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          action: "created",
+          name: "links.example.com",
+          type: "CNAME",
+        }),
+      ]);
     });
   });
 });

--- a/tests/domain-config.test.tsx
+++ b/tests/domain-config.test.tsx
@@ -37,6 +37,7 @@ function makeDomain(
     createdAt: "2026-01-01T00:00:00.000Z",
     clickTracking: false,
     openTracking: false,
+    trackingSubdomain: null,
     tls: "opportunistic",
     sendingEnabled: true,
     receivingEnabled: false,
@@ -159,5 +160,28 @@ describe("Domain Configuration Tab", () => {
     const openToggle = screen.getByRole("switch", { name: /open tracking/i });
     expect(clickToggle.getAttribute("data-state")).toBe("checked");
     expect(openToggle.getAttribute("data-state")).toBe("checked");
+  });
+
+  it("renders and saves the custom tracking subdomain label", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true })));
+    renderConfigTab({ trackingSubdomain: "links" });
+    const input = screen.getByLabelText(
+      "Custom tracking subdomain",
+    ) as HTMLInputElement;
+
+    expect(input.value).toBe("links");
+    fireEvent.change(input, { target: { value: "clicks" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/domains/d-1",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ tracking_subdomain: "clicks" }),
+      }),
+    );
+    fetchSpy.mockRestore();
   });
 });

--- a/tests/domain-detail-service.test.ts
+++ b/tests/domain-detail-service.test.ts
@@ -63,7 +63,7 @@ describe("domain detail service", () => {
           customReturnPath: "outbound",
           trackOpens: true,
           trackClicks: true,
-          trackingSubdomain: "track.example.com",
+          trackingSubdomain: "links",
           tls: "enforced",
         }),
     });
@@ -92,7 +92,7 @@ describe("domain detail service", () => {
       return_path: "outbound",
       open_tracking: true,
       click_tracking: true,
-      tracking_subdomain: "track.example.com",
+      tracking_subdomain: "links",
       tls: "enforced",
       capabilities: [
         { name: "sending", enabled: true },
@@ -235,6 +235,72 @@ describe("domain detail service", () => {
         },
       },
     });
+  });
+
+  it("updates tracking subdomain and reconciles the pending CNAME record", async () => {
+    const previousTrackingTarget = process.env.TRACKING_CNAME_TARGET;
+    process.env.TRACKING_CNAME_TARGET = "track.opensend.example";
+    const existing = domainRow({
+      trackingSubdomain: null,
+      records: [
+        {
+          type: "TXT",
+          name: "send.example.com",
+          value: "v=spf1 include:amazonses.com ~all",
+          status: "pending",
+          ttl: "Auto",
+        },
+      ],
+    });
+    const updateCalls: DomainUpdateInput[] = [];
+    const service = createDomainDetailService({
+      getDomainById: async () => existing,
+      updateDomainForUser: async (input) => {
+        updateCalls.push(input);
+        return domainRow({ ...existing, ...input.updates });
+      },
+    });
+
+    try {
+      const result = await service.updateDomainDetail({
+        id: existing.id,
+        userId: "user-1",
+        updates: { tracking_subdomain: "links" },
+      });
+
+      expect(result.changedFields).toEqual(["tracking_subdomain"]);
+      expect(updateCalls).toEqual([
+        {
+          id: existing.id,
+          userId: "user-1",
+          updates: {
+            trackingSubdomain: "links",
+            records: [
+              {
+                type: "TXT",
+                name: "send.example.com",
+                value: "v=spf1 include:amazonses.com ~all",
+                status: "pending",
+                ttl: "Auto",
+              },
+              {
+                type: "CNAME",
+                name: "links.example.com",
+                value: "track.opensend.example",
+                status: "pending",
+                ttl: "Auto",
+              },
+            ],
+          },
+        },
+      ]);
+    } finally {
+      if (previousTrackingTarget === undefined) {
+        process.env.TRACKING_CNAME_TARGET = undefined;
+      } else {
+        process.env.TRACKING_CNAME_TARGET = previousTrackingTarget;
+      }
+    }
   });
 
   it("invalidates stale caches when a user-scoped update races with deletion", async () => {

--- a/tests/domain-detail-verify-button.test.tsx
+++ b/tests/domain-detail-verify-button.test.tsx
@@ -18,6 +18,7 @@ const baseDomain: DomainDetailData = {
   createdAt: new Date().toISOString(),
   clickTracking: false,
   openTracking: false,
+  trackingSubdomain: null,
   tls: "opportunistic",
   sendingEnabled: true,
   receivingEnabled: false,

--- a/tests/domain-detail.test.tsx
+++ b/tests/domain-detail.test.tsx
@@ -42,6 +42,7 @@ const baseDomain: DomainDetailData = {
   createdAt: new Date(Date.now() - 20 * 60 * 60 * 1000).toISOString(),
   clickTracking: false,
   openTracking: false,
+  trackingSubdomain: null,
   tls: "opportunistic",
   sendingEnabled: true,
   receivingEnabled: false,

--- a/tests/domain-dns-records.test.tsx
+++ b/tests/domain-dns-records.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next/navigation", () => ({
@@ -18,6 +18,7 @@ const domainWithRecords: DomainDetailData = {
   createdAt: new Date(Date.now() - 20 * 60 * 60 * 1000).toISOString(),
   clickTracking: false,
   openTracking: false,
+  trackingSubdomain: null,
   tls: "opportunistic",
   sendingEnabled: true,
   receivingEnabled: false,
@@ -50,6 +51,13 @@ const domainWithRecords: DomainDetailData = {
       name: "_dmarc.updates.foreverbrowsing.com",
       value: "v=DMARC1; p=none;",
       status: "verified",
+      ttl: "Auto",
+    },
+    {
+      type: "CNAME",
+      name: "links.updates.foreverbrowsing.com",
+      value: "track.opensend.example",
+      status: "pending",
       ttl: "Auto",
     },
   ],
@@ -115,6 +123,28 @@ describe("Domain DNS Records Tab (feature-025)", () => {
     const receivingToggle = screen.getByTestId("receiving-toggle");
     expect(receivingToggle).toBeTruthy();
     expect(receivingToggle.getAttribute("data-state")).toBe("unchecked");
+  });
+
+  it("renders Tracking CNAME as a copyable DNS section", () => {
+    render(<DomainDetail domain={domainWithRecords} />);
+    expect(screen.getByText("Tracking CNAME")).toBeTruthy();
+    expect(screen.getByText("links.updates.foreverbrowsing.com")).toBeTruthy();
+    expect(screen.getByText("track.opensend.example")).toBeTruthy();
+  });
+
+  it("calls the auto-configure API from the records tab", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true })));
+
+    render(<DomainDetail domain={domainWithRecords} />);
+    fireEvent.click(screen.getByRole("button", { name: "Auto configure" }));
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/domains/d1/auto-configure",
+      expect.objectContaining({ method: "POST" }),
+    );
+    fetchSpy.mockRestore();
   });
 
   it("renders MX record with priority 10", () => {

--- a/tests/domain-service.test.ts
+++ b/tests/domain-service.test.ts
@@ -133,17 +133,24 @@ describe("domain service", () => {
       invalidateDomainCaches,
     });
 
+    const previousTrackingTarget = process.env.TRACKING_CNAME_TARGET;
+    process.env.TRACKING_CNAME_TARGET = "track.opensend.example";
     const result = await service.createDomain({
       name: "Example.COM",
       region: "eu-west-1",
       customReturnPath: "outbound",
       openTracking: true,
       clickTracking: true,
-      trackingSubdomain: "track.example.com",
+      trackingSubdomain: "links",
       tls: "enforced",
       capabilities: [{ name: "sending", enabled: false }],
       userId: "user-1",
     });
+    if (previousTrackingTarget === undefined) {
+      process.env.TRACKING_CNAME_TARGET = undefined;
+    } else {
+      process.env.TRACKING_CNAME_TARGET = previousTrackingTarget;
+    }
 
     expect(createDomainIdentity).toHaveBeenCalledWith("example.com", {
       userId: "user-1",
@@ -156,7 +163,7 @@ describe("domain service", () => {
       customReturnPath: "outbound",
       trackOpens: true,
       trackClicks: true,
-      trackingSubdomain: "track.example.com",
+      trackingSubdomain: "links",
       tls: "enforced",
       capabilities: [{ name: "sending", enabled: false }],
       userId: "user-1",
@@ -195,6 +202,13 @@ describe("domain service", () => {
         type: "TXT",
         name: "_dmarc.example.com",
         value: "v=DMARC1; p=none;",
+        status: "pending",
+        ttl: "Auto",
+      },
+      {
+        type: "CNAME",
+        name: "links.example.com",
+        value: "track.opensend.example",
         status: "pending",
         ttl: "Auto",
       },

--- a/tests/domain-validation.test.ts
+++ b/tests/domain-validation.test.ts
@@ -1,4 +1,7 @@
-import { createDomainSchema } from "@/lib/validation/domains";
+import {
+  createDomainSchema,
+  updateDomainSchema,
+} from "@/lib/validation/domains";
 import { describe, expect, it } from "vitest";
 
 const basePayload = {
@@ -40,5 +43,40 @@ describe("domain validation", () => {
     });
 
     expect(result.success).toBe(false);
+  });
+
+  it("accepts a Resend-compatible tracking subdomain label", () => {
+    const result = createDomainSchema.safeParse({
+      ...basePayload,
+      tracking_subdomain: "links-1",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.tracking_subdomain).toBe("links-1");
+    }
+  });
+
+  it.each([
+    ["too long", "a".repeat(64)],
+    ["does not start with a letter", "1links"],
+    ["does not end with a letter or number", "links-"],
+    ["contains a dot", "links.example.com"],
+    ["contains an underscore", "link_track"],
+  ])("rejects a tracking subdomain label that %s", (_reason, label) => {
+    const result = createDomainSchema.safeParse({
+      ...basePayload,
+      tracking_subdomain: label,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("allows update callers to clear a tracking subdomain", () => {
+    const result = updateDomainSchema.safeParse({
+      tracking_subdomain: null,
+    });
+
+    expect(result.success).toBe(true);
   });
 });

--- a/tests/domains-page.test.tsx
+++ b/tests/domains-page.test.tsx
@@ -149,4 +149,39 @@ describe("Domains Page", () => {
     render(<DomainsPage domains={mockDomains} />);
     expect(screen.getByLabelText("Export")).toBeDefined();
   });
+
+  it("submits an advanced tracking subdomain label when adding a domain", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ id: "domain-new" }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    render(<DomainsPage domains={mockDomains} />);
+    fireEvent.click(screen.getByRole("button", { name: "Add domain" }));
+    fireEvent.change(screen.getByPlaceholderText("yourdomain.com"), {
+      target: { value: "example.com" },
+    });
+    fireEvent.click(screen.getByText("Advanced options"));
+    fireEvent.change(screen.getByPlaceholderText("links"), {
+      target: { value: "links" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/domains",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            name: "example.com",
+            tracking_subdomain: "links",
+          }),
+        }),
+      );
+    });
+
+    fetchSpy.mockRestore();
+  });
 });

--- a/tests/e2e/domain-create-auth.spec.ts
+++ b/tests/e2e/domain-create-auth.spec.ts
@@ -22,6 +22,8 @@ test("dashboard user can add a domain with session auth", async ({
 
     await authenticatedPage.getByRole("button", { name: "Add domain" }).click();
     await authenticatedPage.getByPlaceholder("yourdomain.com").fill(domainName);
+    await authenticatedPage.getByText("Advanced options").click();
+    await authenticatedPage.getByPlaceholder("links").fill("links");
     await authenticatedPage
       .getByRole("button", { name: "Add", exact: true })
       .click();
@@ -33,11 +35,25 @@ test("dashboard user can add a domain with session auth", async ({
       authenticatedPage.getByRole("heading", { name: domainName }),
     ).toBeVisible();
 
-    const { rows } = await e2eDb.query<{ user_id: string }>(
-      "select user_id from domains where name = $1",
+    const { rows } = await e2eDb.query<{
+      user_id: string;
+      tracking_subdomain: string | null;
+      records: Array<{ type: string; name: string }> | null;
+    }>(
+      "select user_id, tracking_subdomain, records from domains where name = $1",
       [domainName],
     );
-    expect(rows).toEqual([{ user_id: e2eUser.id }]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      user_id: e2eUser.id,
+      tracking_subdomain: "links",
+    });
+    expect(rows[0]?.records ?? []).toContainEqual(
+      expect.objectContaining({
+        type: "CNAME",
+        name: `links.${domainName}`,
+      }),
+    );
   } finally {
     await e2eDb.query("delete from domains where name = $1", [domainName]);
   }

--- a/tests/queue-worker.test.ts
+++ b/tests/queue-worker.test.ts
@@ -54,6 +54,15 @@ vi.mock("@opensend/core", () => ({
     findDueScheduled: mockFindDueScheduled,
     update: mockUpdateEmail,
   },
+  buildTrackingSubdomainRecordName: (
+    domainName: string,
+    trackingSubdomain?: string | null,
+  ) => {
+    if (!trackingSubdomain) return null;
+    return trackingSubdomain.includes(".")
+      ? trackingSubdomain
+      : `${trackingSubdomain}.${domainName}`;
+  },
   getEmailAddressDomain: (address: string) =>
     address.split("@").pop()?.replace(">", "").trim().toLowerCase() ?? "",
   getEmailTrackingBaseUrl: (input: { trackingSubdomain?: string | null }) =>


### PR DESCRIPTION
## Summary
- validate Resend-compatible `tracking_subdomain` labels on domain create/update and expand them into pending `<label>.<domain>` CNAME records
- include tracking CNAMEs in domain detail/dashboard DNS records and wire dashboard advanced controls plus auto-configure action
- add Cloudflare DNS record mapping/upsert reconciliation for CNAME/TXT/MX guidance, preserving customer-owned DMARC conflicts

## Tests
- `make check`
- `make test`
- `bun run test tests/domain-dns-records.test.tsx tests/api-domains.test.ts tests/domain-service.test.ts tests/domain-detail-service.test.ts tests/cloudflare.test.ts tests/domains-page.test.tsx tests/domain-config.test.tsx tests/domain-validation.test.ts tests/queue-worker.test.ts`
- `bun run test:e2e tests/e2e/domain-create-auth.spec.ts` (skipped by existing `DKIM_ENCRYPTION_KEY` gate)

## Residual risk
- Live Cloudflare mutation was not run locally; covered with mocked Cloudflare upsert/route tests.
- Live dashboard domain creation E2E skipped because local environment lacks `DKIM_ENCRYPTION_KEY`.

Closes #470