### PR TITLE
architecture: extract template preview service boundary

### DIFF
--- a/agent_docs/learnings/active/2026-05-13-issue-477-preview-boundary-id-scope.md
+++ b/agent_docs/learnings/active/2026-05-13-issue-477-preview-boundary-id-scope.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-13
+issue: "#477"
+type: decision
+promoted_to: null
+---
+
+## Template preview service keeps ID-only lookup while sharing renderer semantics
+
+The dashboard preview endpoint is a route for `/api/templates/:id/preview`, so its service boundary should preserve ID-only lookup instead of reusing `findByIdOrAlias`. Reusing the broader public template service lookup would silently add alias support to preview routes and change existing route behavior.
+
+Keep preview orchestration behind a preview-specific service/repository boundary: the route owns only auth, params, HTTP JSON, and error status mapping; the service owns template lookup, `mode: "preview"` variable resolution, registry-controlled React Email rendering, and the existing response DTO shape.

--- a/packages/core/src/db/repositories/templateRepo.ts
+++ b/packages/core/src/db/repositories/templateRepo.ts
@@ -9,6 +9,14 @@ export const templateRepo = {
     });
   },
 
+  async findByIdForUser(id: string, userId?: string) {
+    return await db.query.templates.findFirst({
+      where: userId
+        ? and(eq(templates.id, id), eq(templates.userId, userId))
+        : eq(templates.id, id),
+    });
+  },
+
   async findByAlias(alias: string) {
     return await db.query.templates.findFirst({
       where: eq(templates.alias, alias),

--- a/src/app/api/templates/[id]/preview/route.ts
+++ b/src/app/api/templates/[id]/preview/route.ts
@@ -1,17 +1,17 @@
-import { db } from "@/lib/db";
-import { templates } from "@/lib/db/schema";
 import {
   StoredTemplateRendererConfigError,
-  getStoredTemplateRendererConfig,
-  renderStoredTemplateContent,
-  resolveStoredTemplateRenderVariables,
-} from "@/lib/templates/stored-renderer";
+  TemplatePreviewServiceError,
+  createTemplatePreviewService,
+} from "@/lib/templates/preview-service";
 import { TemplateRendererError } from "@opensend/core";
-import { and, eq } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 import { authorizeTemplateRoute } from "../../auth";
 
 function previewErrorResponse(error: unknown) {
+  if (error instanceof TemplatePreviewServiceError) {
+    return NextResponse.json({ error: error.message }, { status: 404 });
+  }
+
   if (
     error instanceof TemplateRendererError ||
     error instanceof StoredTemplateRendererConfigError
@@ -26,6 +26,10 @@ function previewErrorResponse(error: unknown) {
   );
 }
 
+function templatePreviewService() {
+  return createTemplatePreviewService();
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -37,54 +41,11 @@ export async function GET(
 
   try {
     const { id } = await params;
-    const template = await db.query.templates.findFirst({
-      where: auth.userId
-        ? and(eq(templates.id, id), eq(templates.userId, auth.userId))
-        : eq(templates.id, id),
+    const preview = await templatePreviewService().renderPreview(id, {
+      userId: auth.userId,
     });
 
-    if (!template) {
-      return NextResponse.json(
-        { error: "Template not found" },
-        { status: 404 },
-      );
-    }
-
-    const rendererConfig = getStoredTemplateRendererConfig(template.document);
-    const variableResult = resolveStoredTemplateRenderVariables({
-      storedVariables: template.variables,
-      mode: "preview",
-    });
-    const storedSubject =
-      typeof template.subject === "string" && template.subject.length > 0
-        ? template.subject
-        : null;
-    const rendered = await renderStoredTemplateContent({
-      template,
-      subject:
-        storedSubject ??
-        (rendererConfig.kind === "legacy"
-          ? (template.subject ?? "")
-          : undefined),
-      variables: variableResult.variables,
-    });
-
-    return NextResponse.json({
-      object: "template_preview",
-      id: template.id,
-      rendering: {
-        kind: rendererConfig.kind,
-        template_key:
-          rendererConfig.kind === "react_email"
-            ? rendererConfig.templateKey
-            : null,
-      },
-      subject: rendered.subject,
-      html: rendered.html,
-      text: rendered.text,
-      variables: variableResult.resolutions,
-      warnings: variableResult.warnings,
-    });
+    return NextResponse.json(preview);
   } catch (error) {
     return previewErrorResponse(error);
   }

--- a/src/lib/templates/preview-service.ts
+++ b/src/lib/templates/preview-service.ts
@@ -1,0 +1,120 @@
+import { templateRepo } from "@opensend/core";
+import type { templates } from "@opensend/core";
+import {
+  type StoredTemplateRenderVariableResolution,
+  StoredTemplateRendererConfigError,
+  getStoredTemplateRendererConfig,
+  renderStoredTemplateContent,
+  resolveStoredTemplateRenderVariables,
+} from "./stored-renderer";
+
+type TemplateRow = typeof templates.$inferSelect;
+
+export type TemplatePreviewRendering =
+  | { kind: "legacy"; template_key: null }
+  | { kind: "react_email"; template_key: string };
+
+export type TemplatePreviewResult = {
+  object: "template_preview";
+  id: string;
+  rendering: TemplatePreviewRendering;
+  subject: string;
+  html: string;
+  text: string;
+  variables: StoredTemplateRenderVariableResolution[];
+  warnings: string[];
+};
+
+export type TemplatePreviewRepository = {
+  findByIdForPreview(input: {
+    id: string;
+    userId?: string;
+  }): Promise<TemplateRow | undefined>;
+};
+
+type TemplatePreviewOptions = {
+  userId?: string;
+};
+
+export type TemplatePreviewServiceDependencies = {
+  repository?: TemplatePreviewRepository;
+};
+
+export class TemplatePreviewServiceError extends Error {
+  constructor(
+    readonly code: "not_found",
+    message: string,
+  ) {
+    super(message);
+    this.name = "TemplatePreviewServiceError";
+  }
+}
+
+const defaultTemplatePreviewRepository: TemplatePreviewRepository = {
+  async findByIdForPreview({ id, userId }) {
+    return await templateRepo.findByIdForUser(id, userId);
+  },
+};
+
+function previewRenderingResponse(
+  rendererConfig: ReturnType<typeof getStoredTemplateRendererConfig>,
+): TemplatePreviewRendering {
+  return rendererConfig.kind === "react_email"
+    ? { kind: "react_email", template_key: rendererConfig.templateKey }
+    : { kind: "legacy", template_key: null };
+}
+
+export function createTemplatePreviewService({
+  repository = defaultTemplatePreviewRepository,
+}: TemplatePreviewServiceDependencies = {}) {
+  return {
+    async renderPreview(
+      id: string,
+      options: TemplatePreviewOptions = {},
+    ): Promise<TemplatePreviewResult> {
+      const template = await repository.findByIdForPreview({
+        id,
+        userId: options.userId,
+      });
+
+      if (!template) {
+        throw new TemplatePreviewServiceError(
+          "not_found",
+          "Template not found",
+        );
+      }
+
+      const rendererConfig = getStoredTemplateRendererConfig(template.document);
+      const variableResult = resolveStoredTemplateRenderVariables({
+        storedVariables: template.variables,
+        mode: "preview",
+      });
+      const storedSubject =
+        typeof template.subject === "string" && template.subject.length > 0
+          ? template.subject
+          : null;
+      const rendered = await renderStoredTemplateContent({
+        template,
+        subject:
+          storedSubject ??
+          (rendererConfig.kind === "legacy"
+            ? (template.subject ?? "")
+            : undefined),
+        variables: variableResult.variables,
+      });
+
+      return {
+        object: "template_preview",
+        id: template.id,
+        rendering: previewRenderingResponse(rendererConfig),
+        subject: rendered.subject,
+        html: rendered.html,
+        text: rendered.text,
+        variables: variableResult.resolutions,
+        warnings: variableResult.warnings,
+      };
+    },
+  };
+}
+
+export { StoredTemplateRendererConfigError };

--- a/tests/api-template-preview.test.ts
+++ b/tests/api-template-preview.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
 const mockGetServerSession = vi.hoisted(() => vi.fn());
-const mockFindFirst = vi.hoisted(() => vi.fn());
+const mockFindByIdForUser = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/api-auth", () => ({
   authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
@@ -15,15 +15,16 @@ vi.mock("@/lib/api-key-permissions", () => ({
   requireFullAccessApiKey: () => null,
 }));
 
-vi.mock("@/lib/db", () => ({
-  db: {
-    query: {
-      templates: {
-        findFirst: mockFindFirst,
-      },
+vi.mock("@opensend/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@opensend/core")>();
+  return {
+    ...actual,
+    templateRepo: {
+      ...actual.templateRepo,
+      findByIdForUser: mockFindByIdForUser,
     },
-  },
-}));
+  };
+});
 
 describe("GET /api/templates/:id/preview", () => {
   beforeEach(() => {
@@ -33,8 +34,8 @@ describe("GET /api/templates/:id/preview", () => {
     mockGetServerSession.mockResolvedValue({ user: { id: "user-1" } });
   });
 
-  it("renders React Email starters through the stored-template renderer with variable diagnostics", async () => {
-    mockFindFirst.mockResolvedValue({
+  it("renders React Email starters through the preview service with variable diagnostics", async () => {
+    mockFindByIdForUser.mockResolvedValue({
       id: "tmpl-1",
       userId: "user-1",
       subject: null,
@@ -70,6 +71,7 @@ describe("GET /api/templates/:id/preview", () => {
       { params: Promise.resolve({ id: "tmpl-1" }) },
     );
 
+    expect(mockFindByIdForUser).toHaveBeenCalledWith("tmpl-1", "user-1");
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body).toMatchObject({
@@ -100,7 +102,7 @@ describe("GET /api/templates/:id/preview", () => {
   });
 
   it("returns a validation error for unknown registry keys", async () => {
-    mockFindFirst.mockResolvedValue({
+    mockFindByIdForUser.mockResolvedValue({
       id: "tmpl-1",
       userId: "user-1",
       subject: null,
@@ -124,6 +126,22 @@ describe("GET /api/templates/:id/preview", () => {
     expect(response.status).toBe(422);
     await expect(response.json()).resolves.toEqual({
       error: "Unknown React Email template key: tenant-provided-tsx-string",
+    });
+  });
+
+  it("preserves the route not-found response when the preview service cannot find the template", async () => {
+    mockFindByIdForUser.mockResolvedValue(undefined);
+
+    const { GET } = await import("@/app/api/templates/[id]/preview/route");
+    const response = await GET(
+      new Request("http://localhost/api/templates/missing/preview") as never,
+      { params: Promise.resolve({ id: "missing" }) },
+    );
+
+    expect(mockFindByIdForUser).toHaveBeenCalledWith("missing", "user-1");
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Template not found",
     });
   });
 });


### PR DESCRIPTION
## Summary
- Extracted `/api/templates/:id/preview` lookup/render orchestration into `src/lib/templates/preview-service.ts`.
- Added an ID-only core template repository helper so the preview route keeps existing path semantics without direct Drizzle imports.
- Updated focused preview route tests to exercise the service boundary, React Email registry rendering, preview diagnostics, and not-found mapping.
- Added a learning note for the ID-only preview boundary rule.

## Validation
- `make check`
- `bun run test -- tests/api-template-preview.test.ts`
- `make test`
- `git diff --check`

## Residual risk
- No browser dashboard preview E2E was run; coverage is focused on route/service behavior and shared renderer semantics.

Closes #477
