### PR TITLE
feat(ses): route domains by SES region

### DIFF
--- a/agent_docs/learnings/active/2026-05-13-issue-17-region-aware-ses.md
+++ b/agent_docs/learnings/active/2026-05-13-issue-17-region-aware-ses.md
@@ -1,0 +1,18 @@
+---
+date: 2026-05-13
+issue: 17
+type: decision
+promoted_to: null
+---
+
+# Issue #17: region-aware SES is domain-routed, not transparent failover
+
+OpenSend's Phase 1 multi-region SES behavior should route SES identity and send
+operations to the configured domain region (`domains.region`) and fall back to
+`us-east-1` only when no sender-domain row can be resolved. Do not implement
+transparent same-domain failover or SES Global Endpoints in this slice.
+
+Operational docs need to make the region-scoped SES setup explicit: sandbox /
+production access, quotas, domain identity/DKIM, MAIL FROM MX
+`feedback-smtp.<region>.amazonses.com`, and SNS feedback topics are all per
+sending region.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -100,7 +100,7 @@ contributor-facing set; the table below adds the production-only entries.
 | Variable | Purpose |
 | --- | --- |
 | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | IAM credentials with SES + (optionally) S3, SQS, EventBridge permissions. Prefer IAM roles when available. |
-| `AWS_REGION` | SES region. Use `us-east-1` unless you have a reason to pick another. |
+| `AWS_REGION` | Default AWS region for non-domain-scoped AWS clients such as SQS/S3. SES sends and domain identity calls use the selected domain's region and fall back to `us-east-1` when no domain row is available. |
 
 ### Optional
 
@@ -185,10 +185,43 @@ migrations. Use it for local iteration; never for production.
 
 ## AWS SES
 
+### Region-aware sending
+
+OpenSend Phase 1 uses **domain-selected SES regions**, not transparent
+same-domain failover. Each sending domain has one configured SES region, and
+the background worker routes a queued send to the SES region for the `From`
+domain owned by that OpenSend user. If the sender has no matching domain row,
+delivery falls back to `us-east-1`.
+
+Supported dashboard/API domain regions:
+
+- `us-east-1`
+- `eu-west-1`
+- `sa-east-1`
+- `ap-northeast-1`
+
+Before selecting a non-default region for a domain, set up that SES region
+independently:
+
+1. Request SES production access or understand sandbox limitations for that
+   region.
+2. Confirm the region's sending quotas and rate limits are sufficient.
+3. Create/verify the domain identity and DKIM records in that same region
+   through OpenSend.
+4. Publish the MAIL FROM MX value rendered by OpenSend:
+   `feedback-smtp.<region>.amazonses.com`.
+5. Configure SNS/configuration-set feedback topics for each sending region and
+   point them at the ingester `/events/ses` endpoint.
+
+Backup-domain failover and SES Global Endpoints are not implemented in this
+phase; model regional resilience as separate domains until that Phase 2 work
+lands.
+
 ### Sandbox vs production
 
 New AWS accounts start in **SES sandbox mode** — emails only go to verified
-addresses. To send to anyone, request production access from the SES console:
+addresses. Sandbox/production status is region-scoped. To send to anyone,
+request production access from the SES console in every sending region:
 **Account dashboard → Request production access**.
 
 ### IAM minimum

--- a/packages/core/src/services/domain-detail.ts
+++ b/packages/core/src/services/domain-detail.ts
@@ -118,7 +118,10 @@ export type DomainDetailServiceDependencies = {
     id: string;
     userId: string;
   }) => Promise<{ id: string; name: string } | undefined>;
-  deleteDomainIdentity?: (domain: string) => Promise<void>;
+  deleteDomainIdentity?: (
+    domain: string,
+    options?: { region?: string },
+  ) => Promise<void>;
   listDNSRecords?: (input: { name: string }) => Promise<
     DomainDetailDnsRecord[]
   >;
@@ -126,6 +129,7 @@ export type DomainDetailServiceDependencies = {
   invalidateDomainCaches?: (domain: {
     id?: string | null;
     name?: string | null;
+    region?: string | null;
   }) => Promise<void>;
   logger?: Pick<Console, "warn">;
 };
@@ -285,8 +289,8 @@ export function createDomainDetailService({
   getDomainById = (id: string) => domainRepo.findById(id),
   updateDomainForUser = defaultUpdateDomainForUser,
   deleteDomainForUser = defaultDeleteDomainForUser,
-  deleteDomainIdentity = (domain: string) =>
-    domainIdentityProvider.deleteDomainIdentity(domain),
+  deleteDomainIdentity = (domain: string, options?: { region?: string }) =>
+    domainIdentityProvider.deleteDomainIdentity(domain, options),
   listDNSRecords = (input: { name: string }) =>
     cloudflareDnsCleanupProvider.listDNSRecords(input),
   deleteDNSRecord = (id: string) =>
@@ -345,11 +349,16 @@ export function createDomainDetailService({
         await invalidateDomainCaches({
           id: input.id,
           name: existingDomain.name,
+          region: existingDomain.region,
         });
         throw new DomainDetailServiceError("not_found", "Not found");
       }
 
-      await invalidateDomainCaches({ id: updated.id, name: updated.name });
+      await invalidateDomainCaches({
+        id: updated.id,
+        name: updated.name,
+        region: updated.region,
+      });
 
       return {
         response: {
@@ -372,7 +381,7 @@ export function createDomainDetailService({
       const domain = await getExistingForUser(input.id, input.userId);
 
       try {
-        await deleteDomainIdentity(domain.name);
+        await deleteDomainIdentity(domain.name, { region: domain.region });
       } catch (sesErr) {
         logger.warn(
           `Failed to delete SES identity for ${domain.name}:`,
@@ -399,7 +408,11 @@ export function createDomainDetailService({
         userId: input.userId,
       });
 
-      await invalidateDomainCaches({ id: input.id, name: domain.name });
+      await invalidateDomainCaches({
+        id: input.id,
+        name: domain.name,
+        region: domain.region,
+      });
 
       if (!deleted) {
         throw new DomainDetailServiceError("not_found", "Not found");

--- a/packages/core/src/services/domain-providers.ts
+++ b/packages/core/src/services/domain-providers.ts
@@ -71,8 +71,10 @@ async function readCloudflareResult<T>(response: Response): Promise<T> {
 export const domainIdentityProvider: DomainIdentityProvider = {
   createDomainIdentity: (domain, options) =>
     emailProvider.createDomainIdentity(domain, options),
-  getDomainIdentity: (domain) => emailProvider.getDomainIdentity(domain),
-  deleteDomainIdentity: (domain) => emailProvider.deleteDomainIdentity(domain),
+  getDomainIdentity: (domain, options) =>
+    emailProvider.getDomainIdentity(domain, options),
+  deleteDomainIdentity: (domain, options) =>
+    emailProvider.deleteDomainIdentity(domain, options),
 };
 
 export const cloudflareDnsCleanupProvider: DomainDnsCleanupProvider = {

--- a/packages/core/src/services/domain.ts
+++ b/packages/core/src/services/domain.ts
@@ -210,13 +210,20 @@ export type DomainServiceDependencies = {
   repository?: DomainRepository;
   createDomainIdentity?: (
     domain: string,
-    options?: { userId?: string },
+    options?: { userId?: string; region?: string },
   ) => Promise<CreateDomainIdentityResult>;
-  getDomainIdentity?: (domain: string) => Promise<{ verified?: boolean }>;
-  deleteDomainIdentity?: (domain: string) => Promise<void>;
+  getDomainIdentity?: (
+    domain: string,
+    options?: { region?: string },
+  ) => Promise<{ verified?: boolean }>;
+  deleteDomainIdentity?: (
+    domain: string,
+    options?: { region?: string },
+  ) => Promise<void>;
   invalidateDomainCaches?: (domain: {
     id: string;
     name: string;
+    region?: string | null;
   }) => Promise<void>;
 };
 
@@ -331,12 +338,14 @@ function toDomainServiceListItem(row: DomainRow): DomainServiceListItem {
 
 export function createDomainService({
   repository = domainRepo,
-  createDomainIdentity = (domain: string, options?: { userId?: string }) =>
-    domainIdentityProvider.createDomainIdentity(domain, options),
-  getDomainIdentity = (domain: string) =>
-    domainIdentityProvider.getDomainIdentity(domain),
-  deleteDomainIdentity = (domain: string) =>
-    domainIdentityProvider.deleteDomainIdentity(domain),
+  createDomainIdentity = (
+    domain: string,
+    options?: { userId?: string; region?: string },
+  ) => domainIdentityProvider.createDomainIdentity(domain, options),
+  getDomainIdentity = (domain: string, options?: { region?: string }) =>
+    domainIdentityProvider.getDomainIdentity(domain, options),
+  deleteDomainIdentity = (domain: string, options?: { region?: string }) =>
+    domainIdentityProvider.deleteDomainIdentity(domain, options),
   invalidateDomainCaches = async () => {},
 }: DomainServiceDependencies = {}) {
   return {
@@ -362,6 +371,7 @@ export function createDomainService({
       const region = input.region ?? "us-east-1";
       const identity = await createDomainIdentity(domainName, {
         userId: input.userId ?? undefined,
+        region,
       });
       const records = buildDomainRecords(
         domainName,
@@ -395,7 +405,11 @@ export function createDomainService({
         dkimPrivateKeyIv: identity.dkimPrivateKeyEnc?.iv ?? null,
       });
 
-      await invalidateDomainCaches({ id: row.id, name: row.name });
+      await invalidateDomainCaches({
+        id: row.id,
+        name: row.name,
+        region: row.region,
+      });
 
       return toDomainDetail(row);
     },
@@ -404,7 +418,9 @@ export function createDomainService({
       const domain = await repository.findById(id);
       if (!domain) return { status: "not_found" };
 
-      const identity = await getDomainIdentity(domain.name);
+      const identity = await getDomainIdentity(domain.name, {
+        region: domain.region,
+      });
       const nextStatus: "pending" | "verified" = identity.verified
         ? "verified"
         : "pending";
@@ -435,11 +451,19 @@ export function createDomainService({
       });
 
       if (!updated) {
-        await invalidateDomainCaches({ id, name: domain.name });
+        await invalidateDomainCaches({
+          id,
+          name: domain.name,
+          region: domain.region,
+        });
         return { status: "not_found" };
       }
 
-      await invalidateDomainCaches({ id: updated.id, name: updated.name });
+      await invalidateDomainCaches({
+        id: updated.id,
+        name: updated.name,
+        region: updated.region,
+      });
 
       if (!statusChanged) {
         return { status: "unchanged", domain: updated };
@@ -505,7 +529,7 @@ export function createDomainService({
     async delete(id: string) {
       const domain = await repository.findById(id);
       if (domain) {
-        await deleteDomainIdentity(domain.name);
+        await deleteDomainIdentity(domain.name, { region: domain.region });
       }
       return await repository.delete(id);
     },

--- a/packages/core/src/services/emailProvider.ts
+++ b/packages/core/src/services/emailProvider.ts
@@ -25,6 +25,7 @@ type EmailAttachment = {
 
 type EmailProviderCreateDomainIdentityOptions = {
   userId?: string;
+  region?: string;
 };
 
 type EmailProviderCreateDomainIdentityResult = {
@@ -50,15 +51,24 @@ const hasAwsCredentials =
 const useDomainDevStub =
   process.env.NODE_ENV === "development" && !hasAwsCredentials;
 
-export class EmailProviderService {
-  private client: SESv2Client | null = null;
+const DEFAULT_SES_REGION = "us-east-1";
 
-  private getClient() {
-    if (this.client) return this.client;
-    this.client = new SESv2Client({
-      region: process.env.AWS_REGION ?? "us-east-1",
-    });
-    return this.client;
+function normalizeSesRegion(region: string | null | undefined): string {
+  const trimmed = region?.trim();
+  return trimmed || DEFAULT_SES_REGION;
+}
+
+export class EmailProviderService {
+  private readonly clients = new Map<string, SESv2Client>();
+
+  private getClient(region?: string | null) {
+    const resolvedRegion = normalizeSesRegion(region);
+    const cached = this.clients.get(resolvedRegion);
+    if (cached) return cached;
+
+    const client = new SESv2Client({ region: resolvedRegion });
+    this.clients.set(resolvedRegion, client);
+    return client;
   }
 
   async sendEmail(params: {
@@ -72,6 +82,7 @@ export class EmailProviderService {
     replyTo?: string[];
     headers?: Record<string, string>;
     attachments?: EmailAttachment[];
+    region?: string;
   }) {
     const command =
       params.attachments && params.attachments.length > 0
@@ -109,17 +120,18 @@ export class EmailProviderService {
 
     if (!process.env.AWS_ACCESS_KEY_ID) {
       console.log(
-        `[DEV] SES send skipped: ${params.subject} to ${params.to.join(", ")}`,
+        `[DEV] SES send skipped in ${normalizeSesRegion(params.region)}: ${params.subject} to ${params.to.join(", ")}`,
       );
       return { id: `dev-${Date.now()}` };
     }
 
-    const res = await this.getClient().send(command);
+    const res = await this.getClient(params.region).send(command);
     return { id: res.MessageId };
   }
 
   async getDomainIdentity(
     domain: string,
+    options: { region?: string } = {},
   ): Promise<EmailProviderGetDomainIdentityResult> {
     if (!domain) throw new Error("domain is required");
 
@@ -127,7 +139,7 @@ export class EmailProviderService {
       return { verified: false, dkimStatus: "NOT_STARTED", dkimTokens: [] };
     }
 
-    const res = await this.getClient().send(
+    const res = await this.getClient(options.region).send(
       new GetEmailIdentityCommand({ EmailIdentity: domain }),
     );
 
@@ -138,15 +150,20 @@ export class EmailProviderService {
     };
   }
 
-  async deleteDomainIdentity(domain: string): Promise<void> {
+  async deleteDomainIdentity(
+    domain: string,
+    options: { region?: string } = {},
+  ): Promise<void> {
     if (!domain) throw new Error("domain is required");
 
     if (useDomainDevStub) {
-      console.log(`[DEV] Would delete SES identity for domain: ${domain}`);
+      console.log(
+        `[DEV] Would delete SES identity for domain: ${domain} in ${normalizeSesRegion(options.region)}`,
+      );
       return;
     }
 
-    await this.getClient().send(
+    await this.getClient(options.region).send(
       new DeleteEmailIdentityCommand({ EmailIdentity: domain }),
     );
   }
@@ -158,21 +175,26 @@ export class EmailProviderService {
     if (!domain) throw new Error("domain is required");
 
     if (options.userId) {
-      return this.createExternalDkimIdentity(domain, options.userId);
+      return this.createExternalDkimIdentity(
+        domain,
+        options.userId,
+        options.region,
+      );
     }
 
-    return this.createSesManagedIdentity(domain);
+    return this.createSesManagedIdentity(domain, options.region);
   }
 
   private async createExternalDkimIdentity(
     domain: string,
     userId: string,
+    region?: string,
   ): Promise<EmailProviderCreateDomainIdentityResult> {
     const keypair = generateDkimKeypair(userId);
 
     if (useDomainDevStub) {
       console.log(
-        `[DEV] Would create SES EXTERNAL identity for ${domain} (selector ${keypair.selector})`,
+        `[DEV] Would create SES EXTERNAL identity for ${domain} in ${normalizeSesRegion(region)} (selector ${keypair.selector})`,
       );
       return {
         dkimOrigin: "EXTERNAL",
@@ -188,9 +210,10 @@ export class EmailProviderService {
       DomainSigningSelector: keypair.selector,
       DomainSigningPrivateKey: pemToBase64Body(privateKeyPem),
     };
+    const client = this.getClient(region);
 
     try {
-      const res = await this.getClient().send(
+      const res = await client.send(
         new CreateEmailIdentityCommand({
           EmailIdentity: domain,
           DkimSigningAttributes: signingAttributes,
@@ -205,7 +228,7 @@ export class EmailProviderService {
       };
     } catch (error) {
       if (!isAlreadyExistsError(error)) throw error;
-      await this.getClient().send(
+      await client.send(
         new PutEmailIdentityDkimSigningAttributesCommand({
           EmailIdentity: domain,
           SigningAttributesOrigin: "EXTERNAL",
@@ -224,18 +247,22 @@ export class EmailProviderService {
 
   private async createSesManagedIdentity(
     domain: string,
+    region?: string,
   ): Promise<EmailProviderCreateDomainIdentityResult> {
     if (useDomainDevStub) {
-      console.log(`[DEV] Would create SES identity for domain: ${domain}`);
+      console.log(
+        `[DEV] Would create SES identity for domain: ${domain} in ${normalizeSesRegion(region)}`,
+      );
       return {
         dkimOrigin: "AWS_SES",
         dkimTokens: ["dev-token-1", "dev-token-2", "dev-token-3"],
         status: "PENDING",
       };
     }
+    const client = this.getClient(region);
 
     try {
-      const res = await this.getClient().send(
+      const res = await client.send(
         new CreateEmailIdentityCommand({ EmailIdentity: domain }),
       );
       return {
@@ -245,7 +272,7 @@ export class EmailProviderService {
       };
     } catch (error) {
       if (!isAlreadyExistsError(error)) throw error;
-      const res = await this.getClient().send(
+      const res = await client.send(
         new GetEmailIdentityCommand({ EmailIdentity: domain }),
       );
       return {

--- a/packages/ingester/src/queue-worker.ts
+++ b/packages/ingester/src/queue-worker.ts
@@ -46,6 +46,7 @@ const MAX_EMAIL_ATTACHMENT_RAW_BYTES = Math.floor(
   (MAX_EMAIL_ATTACHMENT_BASE64_BYTES / 4) * 3,
 );
 const ATTACHMENT_FETCH_TIMEOUT_MS = 10_000;
+const DEFAULT_SES_REGION = "us-east-1";
 
 type QueueWorkerOptions = {
   queueUrl?: string | null;
@@ -427,16 +428,21 @@ export class QueueWorker {
       });
     }
 
+    const deliveryDomain = await resolveDeliveryDomainForEmail(email);
+    const sesRegion = deliveryDomain?.region ?? DEFAULT_SES_REGION;
     const sesSpan = startTelemetrySpan(telemetry, {
       operation: "ses.send",
-      attributes: { email_id: email.id },
+      attributes: { email_id: email.id, ses_region: sesRegion },
     });
     try {
       // Tracking is intentionally rendered at worker-time: validation, template,
       // and managed-unsubscribe rendering already happened when the email row was
       // accepted, while stored bodies remain unchanged for disabled parity and
       // auditability. The provider payload is the only mutated boundary.
-      const trackedHtml = await renderTrackedHtmlForDelivery(email);
+      const trackedHtml = await renderTrackedHtmlForDelivery(
+        email,
+        deliveryDomain,
+      );
 
       await emailProvider.sendEmail({
         from: email.from,
@@ -449,6 +455,7 @@ export class QueueWorker {
         replyTo: email.replyTo ?? undefined,
         headers: email.headers ?? undefined,
         attachments: await normalizeAttachmentsForSend(email.attachments),
+        region: sesRegion,
       });
       const sendDurationMs = finishTelemetrySpan(sesSpan, { status: "ok" });
 
@@ -461,6 +468,7 @@ export class QueueWorker {
       emitSendMetric(telemetry, {
         durationMs: sendDurationMs,
         outcome: "sent",
+        sesRegion,
       });
       return { status: "sent" };
     } catch (error) {
@@ -505,10 +513,12 @@ export class QueueWorker {
         email_id: email.id,
         provider_attempt_count: attemptCount,
         provider_retries_exhausted: exhausted,
+        ses_region: sesRegion,
       });
       emitSendMetric(telemetry, {
         durationMs: 0,
         outcome: "failed",
+        sesRegion,
       });
 
       if (exhausted) {
@@ -522,14 +532,11 @@ export class QueueWorker {
 
 async function renderTrackedHtmlForDelivery(
   email: SandboxEmailRecord,
+  domain: SenderDomainRecord | null,
 ): Promise<string | null | undefined> {
   if (!email.html || !email.userId) return email.html;
 
   const userId = email.userId;
-  const fromDomain = getEmailAddressDomain(email.from);
-  if (!fromDomain) return email.html;
-
-  const domain = await domainRepo.findByNameForUser(fromDomain, userId);
   if (!domain || (!domain.trackClicks && !domain.trackOpens)) {
     return email.html;
   }
@@ -585,6 +592,20 @@ function getTerminalEmailSkipReason(status: string): string | null {
 type SandboxEmailRecord = NonNullable<
   Awaited<ReturnType<typeof emailRepo.findById>>
 >;
+type SenderDomainRecord = NonNullable<
+  Awaited<ReturnType<typeof domainRepo.findByNameForUser>>
+>;
+
+async function resolveDeliveryDomainForEmail(
+  email: SandboxEmailRecord,
+): Promise<SenderDomainRecord | null> {
+  if (!email.userId) return null;
+
+  const fromDomain = getEmailAddressDomain(email.from);
+  if (!fromDomain) return null;
+
+  return (await domainRepo.findByNameForUser(fromDomain, email.userId)) ?? null;
+}
 
 async function simulateSandboxTestOutcome(input: {
   email: SandboxEmailRecord;
@@ -816,7 +837,7 @@ function emitWorkerJobMetric(
 
 function emitSendMetric(
   telemetry: TelemetryContext,
-  input: { durationMs: number; outcome: "sent" | "failed" },
+  input: { durationMs: number; outcome: "sent" | "failed"; sesRegion?: string },
 ): void {
   emitCloudWatchMetric(telemetry, {
     metrics: [
@@ -831,6 +852,7 @@ function emitSendMetric(
       Service: "worker",
       Operation: "ses.send",
       Outcome: input.outcome,
+      ...(input.sesRegion ? { SesRegion: input.sesRegion } : {}),
     },
   });
 }

--- a/src/app/api/domains/[id]/verify/route.ts
+++ b/src/app/api/domains/[id]/verify/route.ts
@@ -61,12 +61,20 @@ export async function POST(
     const result = await domainService.reconcileVerification(id);
 
     if (result.status === "not_found") {
-      await invalidateDomainCaches({ id, name: domain.name });
+      await invalidateDomainCaches({
+        id,
+        name: domain.name,
+        region: domain.region,
+      });
       return Response.json({ error: "Domain not found" }, { status: 404 });
     }
 
     const reconciled = result.domain;
-    await invalidateDomainCaches({ id: reconciled.id, name: reconciled.name });
+    await invalidateDomainCaches({
+      id: reconciled.id,
+      name: reconciled.name,
+      region: reconciled.region,
+    });
 
     if (result.status === "updated") {
       await queueEvent({

--- a/src/lib/domain-cache.ts
+++ b/src/lib/domain-cache.ts
@@ -2,6 +2,7 @@ import { deleteCache, readCache, writeCache } from "@/lib/cache/redis";
 import { db } from "@/lib/db";
 import { domains } from "@/lib/db/schema";
 import { type GetDomainResult, getDomainIdentity } from "@/lib/ses";
+import { validDomainRegions } from "@/lib/validation/domains";
 import { eq } from "drizzle-orm";
 
 const DOMAIN_DB_CACHE_TTL_SECONDS = 300;
@@ -13,8 +14,22 @@ function getDomainByIdCacheKey(id: string): string {
   return `domain:by-id:${id}`;
 }
 
-function getDomainIdentityCacheKey(domainName: string): string {
+const DEFAULT_SES_REGION = "us-east-1";
+
+function normalizeSesRegion(region: string | null | undefined): string {
+  const trimmed = region?.trim();
+  return trimmed || DEFAULT_SES_REGION;
+}
+
+function getLegacyDomainIdentityCacheKey(domainName: string): string {
   return `domain:identity:${domainName.trim().toLowerCase()}`;
+}
+
+function getDomainIdentityCacheKey(
+  domainName: string,
+  region?: string,
+): string {
+  return `domain:identity:${normalizeSesRegion(region)}:${domainName.trim().toLowerCase()}`;
 }
 
 function logDomainCache(
@@ -67,17 +82,25 @@ export async function getCachedDomainById(
 
 export async function getCachedDomainIdentity(
   domainName: string,
+  region?: string,
 ): Promise<GetDomainResult> {
   const normalizedName = domainName.trim().toLowerCase();
-  const cacheKey = getDomainIdentityCacheKey(normalizedName);
+  const normalizedRegion = normalizeSesRegion(region);
+  const cacheKey = getDomainIdentityCacheKey(normalizedName, normalizedRegion);
   const cached = await readCache<GetDomainResult>(cacheKey);
-  logDomainCache("identity", cached.status, normalizedName);
+  logDomainCache(
+    "identity",
+    cached.status,
+    `${normalizedName}:${normalizedRegion}`,
+  );
 
   if (cached.status === "hit" && cached.value) {
     return cached.value;
   }
 
-  const identity = await getDomainIdentity(normalizedName);
+  const identity = await getDomainIdentity(normalizedName, {
+    region: normalizedRegion,
+  });
   const writeStatus = await writeCache(
     cacheKey,
     identity,
@@ -90,7 +113,7 @@ export async function getCachedDomainIdentity(
       : writeStatus === "unavailable"
         ? "unavailable"
         : "error",
-    normalizedName,
+    `${normalizedName}:${normalizedRegion}`,
   );
   return identity;
 }
@@ -110,30 +133,45 @@ export async function invalidateDomainByIdCache(id: string): Promise<void> {
 
 export async function invalidateDomainIdentityCache(
   domainName: string | null | undefined,
+  region?: string | null,
 ): Promise<void> {
   if (!domainName) return;
 
   const normalizedName = domainName.trim().toLowerCase();
-  const status = await deleteCache(getDomainIdentityCacheKey(normalizedName));
-  logDomainCache(
-    "identity",
-    status === "deleted"
-      ? "invalidate"
-      : status === "unavailable"
-        ? "unavailable"
-        : "error",
-    normalizedName,
+  const cacheKeys = region
+    ? [getDomainIdentityCacheKey(normalizedName, region)]
+    : [
+        getLegacyDomainIdentityCacheKey(normalizedName),
+        ...validDomainRegions.map((candidate) =>
+          getDomainIdentityCacheKey(normalizedName, candidate),
+        ),
+      ];
+
+  await Promise.all(
+    cacheKeys.map(async (cacheKey) => {
+      const status = await deleteCache(cacheKey);
+      logDomainCache(
+        "identity",
+        status === "deleted"
+          ? "invalidate"
+          : status === "unavailable"
+            ? "unavailable"
+            : "error",
+        `${normalizedName}:${region ? normalizeSesRegion(region) : "all-regions"}`,
+      );
+    }),
   );
 }
 
 export async function invalidateDomainCaches(params: {
   id?: string | null;
   name?: string | null;
+  region?: string | null;
 }): Promise<void> {
   await Promise.all([
     params.id ? invalidateDomainByIdCache(params.id) : Promise.resolve(),
     params.name
-      ? invalidateDomainIdentityCache(params.name)
+      ? invalidateDomainIdentityCache(params.name, params.region)
       : Promise.resolve(),
   ]);
 }

--- a/src/lib/ses.ts
+++ b/src/lib/ses.ts
@@ -52,6 +52,7 @@ export interface SendEmailInput {
     content_type?: string;
     content_id?: string;
   }>;
+  region?: string;
 }
 
 export interface SendEmailResult {
@@ -77,6 +78,7 @@ export interface CreateDomainIdentityOptions {
   // key never leaves our DB, and we publish a single TXT record. Without a
   // userId we fall back to legacy SES-managed signing (3 CNAMEs).
   userId?: string;
+  region?: string;
 }
 
 export interface GetDomainResult {
@@ -87,7 +89,23 @@ export interface GetDomainResult {
 
 // ── Client ─────────────────────────────────────────────────────────
 
-const ses = new SESv2Client({ region: process.env.AWS_REGION ?? "us-east-1" });
+const DEFAULT_SES_REGION = "us-east-1";
+const sesClients = new Map<string, SESv2Client>();
+
+function normalizeSesRegion(region: string | null | undefined): string {
+  const trimmed = region?.trim();
+  return trimmed || DEFAULT_SES_REGION;
+}
+
+function getSesClient(region?: string | null): SESv2Client {
+  const resolvedRegion = normalizeSesRegion(region);
+  const cached = sesClients.get(resolvedRegion);
+  if (cached) return cached;
+
+  const client = new SESv2Client({ region: resolvedRegion });
+  sesClients.set(resolvedRegion, client);
+  return client;
+}
 
 // ── Email Sending ──────────────────────────────────────────────────
 
@@ -130,7 +148,7 @@ export async function sendEmail(
         },
       },
     });
-    const response = await ses.send(command);
+    const response = await getSesClient(input.region).send(command);
     return { id: response.MessageId ?? "" };
   }
 
@@ -164,7 +182,7 @@ export async function sendEmail(
     },
   });
 
-  const response = await ses.send(command);
+  const response = await getSesClient(input.region).send(command);
   return { id: response.MessageId ?? "" };
 }
 
@@ -180,23 +198,24 @@ export async function createDomainIdentity(
   // key we hand it; the public key goes into one DNS TXT record. This is
   // the path Resend uses and what the dashboard takes for new domains.
   if (options.userId) {
-    return createExternalDkimIdentity(domain, options.userId);
+    return createExternalDkimIdentity(domain, options.userId, options.region);
   }
 
   // Legacy SES-managed signing — kept for SDK callers that don't pass a
   // userId yet, and for any pre-BYO rows already in production.
-  return createSesManagedIdentity(domain);
+  return createSesManagedIdentity(domain, options.region);
 }
 
 async function createExternalDkimIdentity(
   domain: string,
   userId: string,
+  region?: string,
 ): Promise<CreateDomainResult> {
   const keypair = generateDkimKeypair(userId);
 
   if (useDevStub) {
     console.log(
-      `[DEV] Would create SES EXTERNAL identity for ${domain} (selector ${keypair.selector})`,
+      `[DEV] Would create SES EXTERNAL identity for ${domain} in ${normalizeSesRegion(region)} (selector ${keypair.selector})`,
     );
     return {
       dkimOrigin: "EXTERNAL",
@@ -214,9 +233,10 @@ async function createExternalDkimIdentity(
     DomainSigningSelector: keypair.selector,
     DomainSigningPrivateKey: privateKeyForSes,
   };
+  const client = getSesClient(region);
 
   try {
-    const response = await ses.send(
+    const response = await client.send(
       new CreateEmailIdentityCommand({
         EmailIdentity: domain,
         DkimSigningAttributes: signingAttributes,
@@ -236,7 +256,7 @@ async function createExternalDkimIdentity(
     // dashboard add yields a fresh keypair instead of inheriting whatever
     // was there before.
     if (!isAlreadyExistsError(error)) throw error;
-    await ses.send(
+    await client.send(
       new PutEmailIdentityDkimSigningAttributesCommand({
         EmailIdentity: domain,
         SigningAttributesOrigin: "EXTERNAL",
@@ -255,18 +275,22 @@ async function createExternalDkimIdentity(
 
 async function createSesManagedIdentity(
   domain: string,
+  region?: string,
 ): Promise<CreateDomainResult> {
   if (useDevStub) {
-    console.log(`[DEV] Would create SES identity for domain: ${domain}`);
+    console.log(
+      `[DEV] Would create SES identity for domain: ${domain} in ${normalizeSesRegion(region)}`,
+    );
     return {
       dkimOrigin: "AWS_SES",
       dkimTokens: ["dev-token-1", "dev-token-2", "dev-token-3"],
       status: "PENDING",
     };
   }
+  const client = getSesClient(region);
 
   try {
-    const response = await ses.send(
+    const response = await client.send(
       new CreateEmailIdentityCommand({ EmailIdentity: domain }),
     );
     return {
@@ -276,7 +300,7 @@ async function createSesManagedIdentity(
     };
   } catch (error) {
     if (!isAlreadyExistsError(error)) throw error;
-    const response = await ses.send(
+    const response = await client.send(
       new GetEmailIdentityCommand({ EmailIdentity: domain }),
     );
     return {
@@ -306,6 +330,7 @@ function isAlreadyExistsError(error: unknown): boolean {
 
 export async function getDomainIdentity(
   domain: string,
+  options: { region?: string } = {},
 ): Promise<GetDomainResult> {
   if (!domain) throw new Error("domain is required");
 
@@ -317,7 +342,7 @@ export async function getDomainIdentity(
     EmailIdentity: domain,
   });
 
-  const response = await ses.send(command);
+  const response = await getSesClient(options.region).send(command);
 
   return {
     verified: response.VerifiedForSendingStatus ?? false,
@@ -326,11 +351,16 @@ export async function getDomainIdentity(
   };
 }
 
-export async function deleteDomainIdentity(domain: string): Promise<void> {
+export async function deleteDomainIdentity(
+  domain: string,
+  options: { region?: string } = {},
+): Promise<void> {
   if (!domain) throw new Error("domain is required");
 
   if (useDevStub) {
-    console.log(`[DEV] Would delete SES identity for domain: ${domain}`);
+    console.log(
+      `[DEV] Would delete SES identity for domain: ${domain} in ${normalizeSesRegion(options.region)}`,
+    );
     return;
   }
 
@@ -338,7 +368,7 @@ export async function deleteDomainIdentity(domain: string): Promise<void> {
     EmailIdentity: domain,
   });
 
-  await ses.send(command);
+  await getSesClient(options.region).send(command);
 }
 
 // ── MIME Builder (for attachments) ─────────────────────────────────

--- a/tests/core-email-provider.test.ts
+++ b/tests/core-email-provider.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockSend } = vi.hoisted(() => ({
+const { mockSend, mockSesClient } = vi.hoisted(() => ({
   mockSend: vi.fn(),
+  mockSesClient: vi.fn(),
 }));
 
 vi.mock("@aws-sdk/client-sesv2", () => ({
-  SESv2Client: vi.fn().mockImplementation(() => ({
+  SESv2Client: mockSesClient.mockImplementation(() => ({
     send: mockSend,
   })),
   SendEmailCommand: vi.fn().mockImplementation((input) => ({
@@ -24,6 +25,12 @@ vi.mock("@aws-sdk/client-sesv2", () => ({
     ...input,
     _type: "DeleteEmailIdentityCommand",
   })),
+  PutEmailIdentityDkimSigningAttributesCommand: vi
+    .fn()
+    .mockImplementation((input) => ({
+      ...input,
+      _type: "PutEmailIdentityDkimSigningAttributesCommand",
+    })),
 }));
 
 describe("EmailProviderService", () => {
@@ -32,6 +39,7 @@ describe("EmailProviderService", () => {
   beforeEach(() => {
     vi.resetModules();
     mockSend.mockReset();
+    mockSesClient.mockClear();
     process.env.AWS_ACCESS_KEY_ID = "test-key";
   });
 
@@ -76,5 +84,52 @@ describe("EmailProviderService", () => {
     expect(raw).toContain("Content-ID: <logo>");
     expect(raw).toContain('Content-Disposition: inline; filename="logo.bin"');
     expect(raw).toContain("aW1hZ2U=");
+  });
+
+  it("creates and reuses SES clients per requested region", async () => {
+    mockSend
+      .mockResolvedValueOnce({ MessageId: "eu-message" })
+      .mockResolvedValueOnce({
+        DkimAttributes: { Tokens: [], Status: "PENDING" },
+      })
+      .mockResolvedValueOnce({ VerifiedForSendingStatus: true })
+      .mockResolvedValueOnce({});
+
+    const { EmailProviderService } = await import(
+      "../packages/core/src/services/emailProvider"
+    );
+    const provider = new EmailProviderService();
+
+    await provider.sendEmail({
+      from: "hello@example.com",
+      to: ["user@example.com"],
+      subject: "Hello",
+      html: "<p>Hello</p>",
+      region: "eu-west-1",
+    });
+    await provider.createDomainIdentity("example.com", { region: "eu-west-1" });
+    await provider.getDomainIdentity("example.com", { region: "eu-west-1" });
+    await provider.deleteDomainIdentity("example.com", { region: "eu-west-1" });
+
+    expect(mockSesClient).toHaveBeenCalledTimes(1);
+    expect(mockSesClient).toHaveBeenCalledWith({ region: "eu-west-1" });
+    expect(mockSend).toHaveBeenCalledTimes(4);
+  });
+
+  it("defaults SES client selection to us-east-1", async () => {
+    mockSend.mockResolvedValueOnce({ MessageId: "default-message" });
+    const { EmailProviderService } = await import(
+      "../packages/core/src/services/emailProvider"
+    );
+    const provider = new EmailProviderService();
+
+    await provider.sendEmail({
+      from: "hello@example.com",
+      to: ["user@example.com"],
+      subject: "Hello",
+      html: "<p>Hello</p>",
+    });
+
+    expect(mockSesClient).toHaveBeenCalledWith({ region: "us-east-1" });
   });
 });

--- a/tests/domain-cache.test.ts
+++ b/tests/domain-cache.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockReadCache = vi.hoisted(() => vi.fn());
+const mockWriteCache = vi.hoisted(() => vi.fn());
+const mockDeleteCache = vi.hoisted(() => vi.fn());
+const mockGetDomainIdentity = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/cache/redis", () => ({
+  readCache: mockReadCache,
+  writeCache: mockWriteCache,
+  deleteCache: mockDeleteCache,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      domains: {
+        findFirst: vi.fn(),
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/ses", () => ({
+  getDomainIdentity: mockGetDomainIdentity,
+}));
+
+describe("domain cache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReadCache.mockResolvedValue({ status: "miss" });
+    mockWriteCache.mockResolvedValue("written");
+    mockDeleteCache.mockResolvedValue("deleted");
+    mockGetDomainIdentity.mockResolvedValue({
+      verified: true,
+      dkimStatus: "SUCCESS",
+      dkimTokens: [],
+    });
+  });
+
+  it("keys SES identity cache by domain and region", async () => {
+    const { getCachedDomainIdentity } = await import("@/lib/domain-cache");
+
+    await getCachedDomainIdentity("Example.COM", "eu-west-1");
+
+    expect(mockReadCache).toHaveBeenCalledWith(
+      "domain:identity:eu-west-1:example.com",
+    );
+    expect(mockGetDomainIdentity).toHaveBeenCalledWith("example.com", {
+      region: "eu-west-1",
+    });
+    expect(mockWriteCache).toHaveBeenCalledWith(
+      "domain:identity:eu-west-1:example.com",
+      { verified: true, dkimStatus: "SUCCESS", dkimTokens: [] },
+      120,
+    );
+  });
+
+  it("defaults SES identity cache keys to us-east-1", async () => {
+    const { getCachedDomainIdentity } = await import("@/lib/domain-cache");
+
+    await getCachedDomainIdentity("example.com");
+
+    expect(mockReadCache).toHaveBeenCalledWith(
+      "domain:identity:us-east-1:example.com",
+    );
+    expect(mockGetDomainIdentity).toHaveBeenCalledWith("example.com", {
+      region: "us-east-1",
+    });
+  });
+
+  it("invalidates all supported regional SES identity cache keys when region is unknown", async () => {
+    const { invalidateDomainIdentityCache } = await import(
+      "@/lib/domain-cache"
+    );
+
+    await invalidateDomainIdentityCache("Example.COM");
+
+    expect(mockDeleteCache).toHaveBeenCalledWith("domain:identity:example.com");
+    expect(mockDeleteCache).toHaveBeenCalledWith(
+      "domain:identity:us-east-1:example.com",
+    );
+    expect(mockDeleteCache).toHaveBeenCalledWith(
+      "domain:identity:eu-west-1:example.com",
+    );
+    expect(mockDeleteCache).toHaveBeenCalledWith(
+      "domain:identity:sa-east-1:example.com",
+    );
+    expect(mockDeleteCache).toHaveBeenCalledWith(
+      "domain:identity:ap-northeast-1:example.com",
+    );
+  });
+});

--- a/tests/domain-detail-service.test.ts
+++ b/tests/domain-detail-service.test.ts
@@ -128,7 +128,11 @@ describe("domain detail service", () => {
       vi.fn<(_input: DomainUpdateInput) => Promise<DomainRow | undefined>>();
     const invalidateDomainCaches =
       vi.fn<
-        (_input: { id?: string | null; name?: string | null }) => Promise<void>
+        (_input: {
+          id?: string | null;
+          name?: string | null;
+          region?: string | null;
+        }) => Promise<void>
       >();
     const service = createDomainDetailService({
       getDomainById: async () => domainRow({ trackOpens: true }),
@@ -170,7 +174,11 @@ describe("domain detail service", () => {
     const updateCalls: DomainUpdateInput[] = [];
     const invalidateDomainCaches =
       vi.fn<
-        (_input: { id?: string | null; name?: string | null }) => Promise<void>
+        (_input: {
+          id?: string | null;
+          name?: string | null;
+          region?: string | null;
+        }) => Promise<void>
       >();
     const service = createDomainDetailService({
       getDomainById: async () => existing,
@@ -206,6 +214,7 @@ describe("domain detail service", () => {
     expect(invalidateDomainCaches).toHaveBeenCalledWith({
       id: existing.id,
       name: "example.com",
+      region: "us-east-1",
     });
     expect(result).toEqual({
       response: { object: "domain", id: existing.id },
@@ -306,7 +315,11 @@ describe("domain detail service", () => {
   it("invalidates stale caches when a user-scoped update races with deletion", async () => {
     const invalidateDomainCaches =
       vi.fn<
-        (_input: { id?: string | null; name?: string | null }) => Promise<void>
+        (_input: {
+          id?: string | null;
+          name?: string | null;
+          region?: string | null;
+        }) => Promise<void>
       >();
     const service = createDomainDetailService({
       getDomainById: async () => domainRow(),
@@ -324,6 +337,7 @@ describe("domain detail service", () => {
     expect(invalidateDomainCaches).toHaveBeenCalledWith({
       id: "11111111-1111-4111-8111-111111111111",
       name: "example.com",
+      region: "us-east-1",
     });
   });
 
@@ -364,7 +378,9 @@ describe("domain detail service", () => {
       });
 
       expect(result.response.deleted).toBe(true);
-      expect(deleteDomainIdentity).toHaveBeenCalledWith("example.com");
+      expect(deleteDomainIdentity).toHaveBeenCalledWith("example.com", {
+        region: "us-east-1",
+      });
       expect(listDNSRecords).toHaveBeenCalledWith({ name: "example.com" });
       expect(deleteDNSRecord).toHaveBeenCalledWith("spf");
       expect(deleteDNSRecord).toHaveBeenCalledTimes(1);
@@ -381,7 +397,11 @@ describe("domain detail service", () => {
     const deleteDNSRecord = vi.fn<(_: string) => Promise<void>>();
     const invalidateDomainCaches =
       vi.fn<
-        (_input: { id?: string | null; name?: string | null }) => Promise<void>
+        (_input: {
+          id?: string | null;
+          name?: string | null;
+          region?: string | null;
+        }) => Promise<void>
       >();
     const service = createDomainDetailService({
       getDomainById: async () => domainRow(),
@@ -412,7 +432,9 @@ describe("domain detail service", () => {
       userId: "user-1",
     });
 
-    expect(deleteDomainIdentity).toHaveBeenCalledWith("example.com");
+    expect(deleteDomainIdentity).toHaveBeenCalledWith("example.com", {
+      region: "us-east-1",
+    });
     expect(deleteDNSRecord).toHaveBeenCalledTimes(2);
     expect(deleteDNSRecord).toHaveBeenCalledWith("spf");
     expect(deleteDNSRecord).toHaveBeenCalledWith("dkim");
@@ -422,6 +444,7 @@ describe("domain detail service", () => {
     expect(invalidateDomainCaches).toHaveBeenCalledWith({
       id: "11111111-1111-4111-8111-111111111111",
       name: "example.com",
+      region: "us-east-1",
     });
     expect(result).toEqual({
       response: {

--- a/tests/domain-service.test.ts
+++ b/tests/domain-service.test.ts
@@ -85,6 +85,7 @@ describe("domain service", () => {
 
       expect(createDomainIdentity).toHaveBeenCalledWith("example.com", {
         userId: "user-1",
+        region: "us-east-1",
       });
       expect(inserted[0]).toMatchObject({
         name: "example.com",
@@ -113,7 +114,13 @@ describe("domain service", () => {
       status: "PENDING",
     }));
     const invalidateDomainCaches =
-      vi.fn<(_: { id: string; name: string }) => Promise<void>>();
+      vi.fn<
+        (_: {
+          id: string;
+          name: string;
+          region?: string | null;
+        }) => Promise<void>
+      >();
     const repository = createRepository({
       async create(data) {
         inserted.push(data);
@@ -154,6 +161,7 @@ describe("domain service", () => {
 
     expect(createDomainIdentity).toHaveBeenCalledWith("example.com", {
       userId: "user-1",
+      region: "eu-west-1",
     });
     expect(inserted[0]).toMatchObject({
       name: "example.com",
@@ -224,6 +232,7 @@ describe("domain service", () => {
     expect(invalidateDomainCaches).toHaveBeenCalledWith({
       id: "created-domain",
       name: "example.com",
+      region: "eu-west-1",
     });
   });
 
@@ -286,6 +295,7 @@ describe("domain service", () => {
     const existingDomain = domainRow({
       id: "dom-1",
       name: "example.com",
+      region: "ap-northeast-1",
       status: "pending",
       records: [
         {
@@ -304,6 +314,7 @@ describe("domain service", () => {
         },
       ],
     });
+    const getDomainIdentity = vi.fn(async () => ({ verified: true }));
     const repository = createRepository({
       async findById() {
         return existingDomain;
@@ -316,11 +327,14 @@ describe("domain service", () => {
 
     const service = createDomainService({
       repository,
-      getDomainIdentity: async () => ({ verified: true }),
+      getDomainIdentity,
     });
 
     const result = await service.reconcileVerification("dom-1");
 
+    expect(getDomainIdentity).toHaveBeenCalledWith("example.com", {
+      region: "ap-northeast-1",
+    });
     expect(result.status).toBe("updated");
     expect(updates).toHaveLength(1);
     expect(updates[0].data.status).toBe("verified");

--- a/tests/queue-worker.test.ts
+++ b/tests/queue-worker.test.ts
@@ -190,6 +190,7 @@ describe("QueueWorker", () => {
         from: "sender@example.com",
         to: ["user@example.com"],
         attachments: [{ filename: "inline.txt", content: "aGVsbG8=" }],
+        region: "us-east-1",
       }),
     );
     expect(mockUpdateEmail).toHaveBeenNthCalledWith(2, "email-1", {
@@ -198,6 +199,101 @@ describe("QueueWorker", () => {
       providerNextRetryAt: null,
       providerDeadLetteredAt: null,
     });
+  });
+
+  it("routes queued sends through the From domain SES region", async () => {
+    mockFindById.mockResolvedValue({
+      id: "email-eu",
+      from: "Sender <hello@example.com>",
+      to: ["user@example.com"],
+      cc: [],
+      bcc: [],
+      replyTo: [],
+      subject: "Hello",
+      html: "<p>Hello</p>",
+      text: "",
+      headers: {},
+      attachments: [],
+      status: "queued",
+      scheduledAt: null,
+      userId: "user-1",
+    });
+    mockFindDomainByNameForUser.mockResolvedValue({
+      id: "domain-eu",
+      name: "example.com",
+      userId: "user-1",
+      region: "eu-west-1",
+      trackClicks: false,
+      trackOpens: false,
+      trackingSubdomain: null,
+    });
+
+    const { QueueWorker } = await import(
+      "../packages/ingester/src/queue-worker"
+    );
+    const worker = new QueueWorker({ queueUrl: null });
+
+    await expect(
+      worker.processJob({
+        id: "email.send:email-eu",
+        type: "email.send",
+        source: "api",
+        requestedAt: "2026-04-28T00:00:00.000Z",
+        emailId: "email-eu",
+      }),
+    ).resolves.toEqual({ status: "sent" });
+
+    expect(mockFindDomainByNameForUser).toHaveBeenCalledTimes(1);
+    expect(mockFindDomainByNameForUser).toHaveBeenCalledWith(
+      "example.com",
+      "user-1",
+    );
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ region: "eu-west-1" }),
+    );
+  });
+
+  it("falls back to us-east-1 when no From-domain row exists", async () => {
+    mockFindById.mockResolvedValue({
+      id: "email-default-region",
+      from: "sender@example.com",
+      to: ["user@example.com"],
+      cc: [],
+      bcc: [],
+      replyTo: [],
+      subject: "Hello",
+      html: "<p>Hello</p>",
+      text: "",
+      headers: {},
+      attachments: [],
+      status: "queued",
+      scheduledAt: null,
+      userId: "user-1",
+    });
+    mockFindDomainByNameForUser.mockResolvedValue(null);
+
+    const { QueueWorker } = await import(
+      "../packages/ingester/src/queue-worker"
+    );
+    const worker = new QueueWorker({ queueUrl: null });
+
+    await expect(
+      worker.processJob({
+        id: "email.send:email-default-region",
+        type: "email.send",
+        source: "api",
+        requestedAt: "2026-04-28T00:00:00.000Z",
+        emailId: "email-default-region",
+      }),
+    ).resolves.toEqual({ status: "sent" });
+
+    expect(mockFindDomainByNameForUser).toHaveBeenCalledWith(
+      "example.com",
+      "user-1",
+    );
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ region: "us-east-1" }),
+    );
   });
 
   it("applies domain tracking only to the provider payload", async () => {

--- a/tests/ses.test.ts
+++ b/tests/ses.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock the AWS SES SDK — vi.hoisted ensures mockSend is available during mock factory
-const { mockSend } = vi.hoisted(() => ({
+const { mockSend, mockSesClient } = vi.hoisted(() => ({
   mockSend: vi.fn(),
+  mockSesClient: vi.fn(),
 }));
 
 vi.mock("@aws-sdk/client-sesv2", () => ({
-  SESv2Client: vi.fn().mockImplementation(() => ({
+  SESv2Client: mockSesClient.mockImplementation(() => ({
     send: mockSend,
   })),
   SendEmailCommand: vi.fn().mockImplementation((input) => ({
@@ -47,6 +48,7 @@ import {
 describe("SES Client", () => {
   beforeEach(() => {
     mockSend.mockReset();
+    mockSesClient.mockClear();
   });
 
   describe("sendEmail", () => {
@@ -397,6 +399,31 @@ describe("SES Client", () => {
       await expect(deleteDomainIdentity("")).rejects.toThrow(
         "domain is required",
       );
+    });
+  });
+
+  describe("region-aware domain identity operations", () => {
+    it("uses one SES client for create, verify, and delete in the requested region", async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          DkimAttributes: {
+            Tokens: ["token-sa"],
+            Status: "PENDING",
+          },
+        })
+        .mockResolvedValueOnce({
+          VerifiedForSendingStatus: true,
+          DkimAttributes: { Tokens: ["token-sa"], Status: "SUCCESS" },
+        })
+        .mockResolvedValueOnce({});
+
+      await createDomainIdentity("regional.example", { region: "sa-east-1" });
+      await getDomainIdentity("regional.example", { region: "sa-east-1" });
+      await deleteDomainIdentity("regional.example", { region: "sa-east-1" });
+
+      expect(mockSesClient).toHaveBeenCalledTimes(1);
+      expect(mockSesClient).toHaveBeenCalledWith({ region: "sa-east-1" });
+      expect(mockSend).toHaveBeenCalledTimes(3);
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #17 for Phase 1 scope only.

- Route SES identity create/get/delete and email sends through the selected domain SES region.
- Cache SES clients and domain identity cache entries per region, with `us-east-1` fallback when no sender-domain row is available.
- Resolve queued send region from the email `From` domain for the sending user without duplicating the tracking domain lookup.
- Document supported regions and required per-region SES setup; no transparent failover or SES Global Endpoints are included.

## Validation

- `bun run test tests/core-email-provider.test.ts tests/ses.test.ts tests/domain-service.test.ts tests/domain-detail-service.test.ts tests/domain-cache.test.ts tests/queue-worker.test.ts`
- `bun run test tests/domain-cache.test.ts`
- `make check`
- `make test`

## Notes / risks

- No broad email schema migration was added; SES region is visible in send telemetry/metrics but not persisted per email row.
- Live AWS SES identity operations and real sends were not executed from this environment.
- Backup-domain failover remains Phase 2/out of scope.
