### PR TITLE
Fix duplicate free billing plan cards

### DIFF
--- a/src/lib/billing/summary.ts
+++ b/src/lib/billing/summary.ts
@@ -25,6 +25,8 @@ export interface BillingPlanSummary {
   isPublic: boolean;
 }
 
+type BillingPlanRow = typeof plans.$inferSelect;
+
 export interface BillingSubscriptionSummary {
   id: string;
   status: SubscriptionStatus;
@@ -135,6 +137,12 @@ function toPlanSummary(row: {
   };
 }
 
+export function isApprovedPublicPlan(row: BillingPlanRow): boolean {
+  if (!row.isPublic) return false;
+  if (row.slug === FREE_PLAN_SLUG) return true;
+  return row.monthlyPriceCents > 0 && Boolean(row.stripePriceId?.trim());
+}
+
 async function loadPlanAndSubscription(userId: string) {
   const sub = await db.query.subscriptions.findFirst({
     where: eq(subscriptions.userId, userId),
@@ -221,8 +229,13 @@ export async function loadBillingSummary(
 export async function listPublicPlans(): Promise<BillingPlanSummary[]> {
   const rows = await db.select().from(plans).where(eq(plans.isPublic, true));
   return rows
+    .filter(isApprovedPublicPlan)
     .map(toPlanSummary)
-    .sort((a, b) => a.monthlyPriceCents - b.monthlyPriceCents);
+    .sort(
+      (a, b) =>
+        a.monthlyPriceCents - b.monthlyPriceCents ||
+        a.slug.localeCompare(b.slug),
+    );
 }
 
 function toPublicPlanResponse(plan: BillingPlanSummary): PublicPlanResponse {

--- a/src/lib/billing/summary.ts
+++ b/src/lib/billing/summary.ts
@@ -139,8 +139,14 @@ function toPlanSummary(row: {
 
 export function isApprovedPublicPlan(row: BillingPlanRow): boolean {
   if (!row.isPublic) return false;
-  if (row.slug === FREE_PLAN_SLUG) return true;
-  return row.monthlyPriceCents > 0 && Boolean(row.stripePriceId?.trim());
+  if (row.slug === FREE_PLAN_SLUG) return row.monthlyPriceCents === 0;
+  const stripePriceId = row.stripePriceId;
+  return (
+    row.monthlyPriceCents > 0 &&
+    stripePriceId !== null &&
+    stripePriceId !== "" &&
+    stripePriceId === stripePriceId.trim()
+  );
 }
 
 async function loadPlanAndSubscription(userId: string) {

--- a/tests/billing-public-plans.test.ts
+++ b/tests/billing-public-plans.test.ts
@@ -41,15 +41,29 @@ describe("public billing plan approval", () => {
     ).toBe(true);
   });
 
-  it.each([
-    { stripePriceId: "price_live_123" },
-    { stripePriceId: " price_live_123 " },
-  ])("allows public paid plans with a non-empty Stripe price ID %#", (row) => {
+  it.each([{ stripePriceId: "price_live_123" }])(
+    "allows public paid plans with a non-empty Stripe price ID %#",
+    (row) => {
+      expect(
+        isApprovedPublicPlan(
+          plan({ monthlyPriceCents: 2900, stripePriceId: row.stripePriceId }),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it("rejects a malformed paid row using the canonical free slug", () => {
     expect(
       isApprovedPublicPlan(
-        plan({ monthlyPriceCents: 2900, stripePriceId: row.stripePriceId }),
+        plan({
+          slug: "free",
+          name: "Free",
+          monthlyPriceCents: 2900,
+          stripePriceId: "price_live_123",
+          isPublic: true,
+        }),
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it.each([
@@ -57,6 +71,7 @@ describe("public billing plan approval", () => {
     { monthlyPriceCents: 2900, stripePriceId: null },
     { monthlyPriceCents: 2900, stripePriceId: "" },
     { monthlyPriceCents: 2900, stripePriceId: "   " },
+    { monthlyPriceCents: 2900, stripePriceId: " price_live_123 " },
     {
       monthlyPriceCents: 2900,
       stripePriceId: "price_live_123",

--- a/tests/billing-public-plans.test.ts
+++ b/tests/billing-public-plans.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@opensend/core", () => ({
+  FREE_PLAN_SLUG: "free",
+  createDashboardAggregateService: () => ({ getUsage: vi.fn() }),
+}));
+
+import { isApprovedPublicPlan } from "@/lib/billing/summary";
+
+type PlanRow = Parameters<typeof isApprovedPublicPlan>[0];
+
+const basePlan = {
+  id: "plan-test",
+  slug: "pro",
+  name: "Pro",
+  monthlyPriceCents: 2900,
+  monthlyEmailQuota: 50_000,
+  maxDomains: 10,
+  maxApiKeys: 20,
+  stripePriceId: "price_test_123",
+  isPublic: true,
+  createdAt: new Date("2026-05-01T00:00:00.000Z"),
+} satisfies PlanRow;
+
+function plan(overrides: Partial<PlanRow>): PlanRow {
+  return { ...basePlan, ...overrides };
+}
+
+describe("public billing plan approval", () => {
+  it("allows the canonical public free plan without a Stripe price", () => {
+    expect(
+      isApprovedPublicPlan(
+        plan({
+          slug: "free",
+          name: "Free",
+          monthlyPriceCents: 0,
+          stripePriceId: null,
+          isPublic: true,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    { stripePriceId: "price_live_123" },
+    { stripePriceId: " price_live_123 " },
+  ])("allows public paid plans with a non-empty Stripe price ID %#", (row) => {
+    expect(
+      isApprovedPublicPlan(
+        plan({ monthlyPriceCents: 2900, stripePriceId: row.stripePriceId }),
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    { monthlyPriceCents: 0, stripePriceId: "price_live_123" },
+    { monthlyPriceCents: 2900, stripePriceId: null },
+    { monthlyPriceCents: 2900, stripePriceId: "" },
+    { monthlyPriceCents: 2900, stripePriceId: "   " },
+    {
+      monthlyPriceCents: 2900,
+      stripePriceId: "price_live_123",
+      isPublic: false,
+    },
+  ])("rejects unapproved public paid/placeholder plans %#", (row) => {
+    expect(isApprovedPublicPlan(plan(row))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- harden public billing plan listing so only the canonical Free plan can be zero-price
- require public paid plans to have a positive price and non-empty Stripe price ID before pricing cards render them
- add focused regression coverage for placeholder/misconfigured public plan rows

## Root cause
The billing plans page renders every row returned by `listPublicPlans()`, and the pricing grid labels any zero-cent plan as `Free`. The `plans` table also defaults `monthly_price_cents = 0` and `is_public = true`, so a placeholder paid tier created without real price/Stripe config could leak into the public pricing grid as a second Free card.

## Validation
- `bunx vitest run tests/billing-public-plans.test.ts`
- `bun run test -- --run tests/billing-checkout-portal-service.test.ts tests/billing-cutover-preflight.test.ts tests/billing-plan-repo.test.ts tests/billing-public-plans.test.ts`
- `bun run check`
