### PR TITLE
deploy: inject webhook encryption key into app task

### DIFF
--- a/agent_docs/learnings/active/2026-05-13-issue-487-app-task-secret-injection.md
+++ b/agent_docs/learnings/active/2026-05-13-issue-487-app-task-secret-injection.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-13
+issue: "#487"
+type: decision
+promoted_to: null
+---
+
+## ECS app deploy must register a fresh task definition for new required secrets
+
+The production app deploy path previously only rebuilt/pushed the app image and forced a service redeploy, so a newly required startup secret could be omitted forever if the existing ECS task definition did not already contain it. For required app boot secrets such as `WEBHOOK_SECRET_ENCRYPTION_KEY`, the deploy script should render/register a new app task definition from the current one, preserve existing task/container settings, and upsert the missing `secrets[]` entry before `aws ecs update-service --task-definition ...`.
+
+Keep this path value-safe: resolve the AWS Secrets Manager ARN with `describe-secret`, but never fetch or print the secret value. Let operators override the secret id/ARN when bootstrap naming differs.

--- a/docs/ingester-deploy.md
+++ b/docs/ingester-deploy.md
@@ -231,6 +231,11 @@ already-processed notification returns `200 OK` and no-ops.
 Before pointing production SES SNS at a freshly stood-up ingester, verify:
 
 - The ingester image is built for `linux/amd64` and pushed to your registry.
+- The app ECS task definition injects `WEBHOOK_SECRET_ENCRYPTION_KEY` from the
+  deployment secret manager. For the repo deploy script, create or point
+  `WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ID` /
+  `WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ARN` at that AWS Secrets Manager secret
+  before running `scripts/deploy.sh app` or `scripts/deploy.sh all`.
 - The ingester service has the same `DATABASE_URL`, AWS credentials, SQS
   config, Redis URL, and `INGESTER_JOB_TOKEN` as the app.
 - The events host (`events.<your-domain>`) resolves and serves a 200 on

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -93,6 +93,7 @@ contributor-facing set; the table below adds the production-only entries.
 | --- | --- |
 | `DATABASE_URL` | Postgres connection string. In Docker Compose the app/migrator containers override this to use the internal `postgres` host. |
 | `BETTER_AUTH_SECRET` | Random 32-byte hex string for session signing. Generate with `openssl rand -hex 32`. |
+| `WEBHOOK_SECRET_ENCRYPTION_KEY` | Random secret, at least 16 characters, used to encrypt webhook signing secrets at rest. Production app startup fails when this is missing or too short. |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Better Auth Google OAuth credentials. Set the redirect URI to `https://<your-host>/api/auth/callback/google`. |
 
 ### Required for sending email
@@ -126,6 +127,17 @@ contributor-facing set; the table below adds the production-only entries.
 | `RATE_LIMIT_BACKEND` | `disabled` (single-process dev), or `redis` (production). |
 | `REDIS_URL` | TLS Redis endpoint, e.g. `rediss://default:<password>@<endpoint>:6379`. Used for rate limiting AND auth/domain metadata cache. |
 | `CLOUDWATCH_METRICS_NAMESPACE` | Override the default `Opensend` EMF metrics namespace. |
+
+### AWS ECS deploy secret wiring
+
+The repo deploy script registers a fresh app task definition before updating
+the ECS app service. It injects `WEBHOOK_SECRET_ENCRYPTION_KEY` from AWS
+Secrets Manager and never reads or prints the secret value. By default it looks
+up the secret named `opensend/webhook/secret-encryption-key` when
+`PRODUCT=opensend`; override that lookup with
+`WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ID` or pass an exact
+`WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ARN` when your bootstrap uses a different
+name.
 
 ### Hosted Stripe billing
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -38,6 +38,8 @@ MIGRATOR_IMAGE_TAG="${MIGRATOR_IMAGE_TAG:-${IMAGE_TAG}-migrator}"
 MIGRATOR_TASK_FAMILY="${MIGRATOR_TASK_FAMILY:-${PRODUCT}-migrator}"
 APP_LOG_GROUP="${APP_LOG_GROUP:-/ecs/${APP_SERVICE}}"
 APP_LOG_STREAM_PREFIX="${APP_LOG_STREAM_PREFIX:-app}"
+WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ID="${WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ID:-${PRODUCT}/webhook/secret-encryption-key}"
+WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ARN="${WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ARN:-}"
 
 ING_REPO="${PRODUCT}-ingester"
 ING_SERVICE="${PRODUCT}-ingester"
@@ -76,6 +78,19 @@ app_task_definition() {
     --output text
 }
 
+webhook_secret_encryption_key_secret_arn() {
+  if [[ -n "${WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ARN}" ]]; then
+    printf "%s\n" "${WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ARN}"
+    return
+  fi
+
+  aws secretsmanager describe-secret \
+    --secret-id "${WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ID}" \
+    --region "${AWS_REGION}" \
+    --query 'ARN' \
+    --output text
+}
+
 write_service_network_configuration() {
   local output_file="$1"
 
@@ -85,6 +100,90 @@ write_service_network_configuration() {
     --region "${AWS_REGION}" \
     --query 'services[0].networkConfiguration' \
     --output json > "${output_file}"
+}
+
+write_app_task_definition() {
+  local base_task_definition="$1" app_image="$2" webhook_secret_arn="$3" output_file="$4"
+  local base_task_file
+  base_task_file="$(mktemp)"
+
+  aws ecs describe-task-definition \
+    --task-definition "${base_task_definition}" \
+    --region "${AWS_REGION}" \
+    --query 'taskDefinition' \
+    --output json > "${base_task_file}"
+
+  python3 - "${base_task_file}" "${app_image}" "${APP_CONTAINER_NAME}" "${webhook_secret_arn}" > "${output_file}" <<'PY'
+import copy
+import json
+import sys
+
+base_task_file, app_image, container_name, webhook_secret_arn = sys.argv[1:5]
+with open(base_task_file, "r", encoding="utf-8") as handle:
+    task = json.load(handle)
+
+allowed_task_keys = [
+    "taskRoleArn",
+    "executionRoleArn",
+    "networkMode",
+    "volumes",
+    "placementConstraints",
+    "requiresCompatibilities",
+    "cpu",
+    "memory",
+    "runtimePlatform",
+    "ephemeralStorage",
+    "proxyConfiguration",
+    "inferenceAccelerators",
+    "pidMode",
+    "ipcMode",
+]
+
+definition = {"family": task.get("family")}
+for key in allowed_task_keys:
+    value = task.get(key)
+    if value not in (None, [], {}):
+        definition[key] = value
+
+containers = copy.deepcopy(task.get("containerDefinitions") or [])
+selected = next(
+    (container for container in containers if container.get("name") == container_name),
+    None,
+)
+if selected is None:
+    raise SystemExit(f"base task definition has no {container_name!r} container")
+
+selected["image"] = app_image
+secrets = selected.setdefault("secrets", [])
+required_secret = {
+    "name": "WEBHOOK_SECRET_ENCRYPTION_KEY",
+    "valueFrom": webhook_secret_arn,
+}
+for index, secret in enumerate(secrets):
+    if secret.get("name") == required_secret["name"]:
+        secrets[index] = required_secret
+        break
+else:
+    secrets.append(required_secret)
+
+definition["containerDefinitions"] = containers
+json.dump(definition, sys.stdout)
+PY
+}
+
+register_app_task_definition() {
+  local app_image="$1" base_task_definition webhook_secret_arn task_file
+  base_task_definition="$(app_task_definition)"
+  webhook_secret_arn="$(webhook_secret_encryption_key_secret_arn)"
+  task_file="$(mktemp)"
+
+  write_app_task_definition "${base_task_definition}" "${app_image}" "${webhook_secret_arn}" "${task_file}"
+
+  aws ecs register-task-definition \
+    --cli-input-json "file://${task_file}" \
+    --region "${AWS_REGION}" \
+    --query 'taskDefinition.taskDefinitionArn' \
+    --output text
 }
 
 write_migrator_task_definition() {
@@ -240,15 +339,23 @@ run_migrations() {
 }
 
 redeploy() {
-  local service="$1"
+  local service="$1" task_definition="${2:-}"
   info "→ Force redeploy ECS service: ${service}"
-  aws ecs update-service \
+  local args=(
+    ecs update-service
     --cluster "${CLUSTER}" \
     --service "${service}" \
     --force-new-deployment \
-    --region "${AWS_REGION}" \
+    --region "${AWS_REGION}"
+  )
+  if [[ -n "${task_definition}" ]]; then
+    args+=(--task-definition "${task_definition}")
+  fi
+  args+=(
     --query 'service.deployments[0].{status:status,desired:desiredCount}' \
     --output table
+  )
+  aws "${args[@]}"
 }
 
 wait_stable() {
@@ -272,7 +379,12 @@ wait_stable() {
 }
 
 deploy_app() {
+  local app_image="${ECR_BASE}/${APP_REPO}:${IMAGE_TAG}"
   build_and_push "${APP_REPO}" "${APP_DOCKERFILE}" "${APP_TARGET}"
+
+  info "→ Register ECS app task definition"
+  APP_TASK_DEFINITION="$(register_app_task_definition "${app_image}")"
+  ok "  registered ${APP_TASK_DEFINITION}"
 }
 
 deploy_ingester() {
@@ -285,7 +397,7 @@ case "${target}" in
   app)
     deploy_app
     run_migrations
-    redeploy "${APP_SERVICE}"
+    redeploy "${APP_SERVICE}" "${APP_TASK_DEFINITION}"
     wait_stable "${APP_SERVICE}"
     ;;
   ingester)
@@ -301,7 +413,7 @@ case "${target}" in
     deploy_app
     deploy_ingester
     run_migrations
-    redeploy "${APP_SERVICE}"
+    redeploy "${APP_SERVICE}" "${APP_TASK_DEFINITION}"
     redeploy "${ING_SERVICE}"
     wait_stable "${APP_SERVICE}" &
     APP_PID=$!

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -43,9 +43,20 @@ describe("deploy-001: ECS Fargate deployment configuration", () => {
     const script = readFileSync(scriptPath, "utf-8");
     expect(script).toContain("buildx build");
     expect(script).toContain("linux/amd64");
-    expect(script).toContain("aws ecs update-service");
+    expect(script).toContain("ecs update-service");
     expect(script).toContain("--force-new-deployment");
     expect(script).toContain("aws ecs wait services-stable");
+  });
+
+  it("deploy script injects required production app secrets into ECS task definitions", () => {
+    const script = readFileSync(join(root, "scripts", "deploy.sh"), "utf-8");
+    expect(script).toContain("WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ID");
+    expect(script).toContain("aws secretsmanager describe-secret");
+    expect(script).toContain('"name": "WEBHOOK_SECRET_ENCRYPTION_KEY"');
+    expect(script).toContain("register_app_task_definition");
+    expect(script).toContain(
+      'redeploy "${APP_SERVICE}" "${APP_TASK_DEFINITION}"',
+    );
   });
 
   it("deploy script runs migrations before ECS service redeploys", () => {


### PR DESCRIPTION
## Summary
- Register a fresh ECS app task definition during `scripts/deploy.sh app|all` and update the app service to that task definition.
- Upsert `WEBHOOK_SECRET_ENCRYPTION_KEY` into the app container `secrets[]` from AWS Secrets Manager without reading or printing the secret value.
- Document the required production secret and deploy-script override knobs, plus capture the deploy-task-definition pattern in learnings.

Closes #487

## Validation
- `bash -n scripts/deploy.sh`
- `bun run test -- tests/deploy.test.ts tests/security-startup-checks.test.ts`
- `make check && make test`
- Push hook guardrails: full-project typecheck + changed-file Biome passed

## Production notes
- Live ECS registration/deploy was intentionally not run from this agent lane.
- The current production app task definition was read-only inspected and is missing `WEBHOOK_SECRET_ENCRYPTION_KEY`.
- AWS Secrets Manager read-only listing did not show an existing `opensend/*webhook*encryption*` secret, so the deploy will need either the default `opensend/webhook/secret-encryption-key` secret created or `WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ID` / `WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ARN` set to the bootstrap name before the human-gated deploy.
