### PR TITLE
Align pricing with monthly quota tiers

### DIFF
--- a/agent_docs/learnings/active/2026-05-17-pricing-monthly-selector.md
+++ b/agent_docs/learnings/active/2026-05-17-pricing-monthly-selector.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-17
+issue: pricing-monthly-selector
+type: decision
+promoted_to: null
+---
+
+# Monthly-only pricing selector
+
+Decision: Cloud self-serve pricing uses one combined API + broadcast plan family with predefined monthly Stripe Price rows for volume ticks instead of a yearly toggle or separate transactional/marketing checkout tabs.
+
+Why: OpenSend currently gates quotas by emails, domains, and API keys. Broadcast/contact/automation-specific entitlements are not mature enough to support separate marketing SKU enforcement. Monthly predefined ticks keep Checkout simple, avoid dynamic pricing, and still mirror the Resend-style quota selector interaction.
+
+Implementation note: keep fixed public Stripe Prices for Starter 55k/100k and Growth 120k/250k/500k. Scale is contact-sales/custom until high-volume deliverability, retention, dedicated IP, and enterprise support packaging is explicit.

--- a/drizzle/0021_monthly_pricing_tiers_20260517.sql
+++ b/drizzle/0021_monthly_pricing_tiers_20260517.sql
@@ -1,0 +1,152 @@
+INSERT INTO "plans" (
+  "slug",
+  "name",
+  "monthly_price_cents",
+  "monthly_email_quota",
+  "max_domains",
+  "max_api_keys",
+  "stripe_price_id",
+  "is_public"
+)
+VALUES ('free', 'Free', 0, 5000, 1, 2, NULL, true)
+ON CONFLICT ("slug") DO UPDATE SET
+  "name" = EXCLUDED."name",
+  "monthly_price_cents" = EXCLUDED."monthly_price_cents",
+  "monthly_email_quota" = EXCLUDED."monthly_email_quota",
+  "max_domains" = EXCLUDED."max_domains",
+  "max_api_keys" = EXCLUDED."max_api_keys",
+  "stripe_price_id" = EXCLUDED."stripe_price_id",
+  "is_public" = EXCLUDED."is_public";--> statement-breakpoint
+WITH starter_candidate AS (
+  SELECT "id"
+  FROM "plans"
+  WHERE "slug" IN ('cloud_starter_55k_monthly', 'cloud_starter_monthly', 'starter')
+  ORDER BY CASE "slug"
+    WHEN 'cloud_starter_55k_monthly' THEN 0
+    WHEN 'cloud_starter_monthly' THEN 1
+    ELSE 2
+  END
+  LIMIT 1
+),
+starter_update AS (
+  UPDATE "plans"
+  SET
+    "slug" = 'cloud_starter_55k_monthly',
+    "name" = 'Starter',
+    "monthly_price_cents" = 1900,
+    "monthly_email_quota" = 55000,
+    "max_domains" = 10,
+    "max_api_keys" = 10,
+    "stripe_price_id" = 'price_1TXtMCQe1Ex4Xxd5rFHBIDm1',
+    "is_public" = true
+  WHERE "id" = (SELECT "id" FROM starter_candidate)
+  RETURNING "id"
+)
+INSERT INTO "plans" (
+  "slug",
+  "name",
+  "monthly_price_cents",
+  "monthly_email_quota",
+  "max_domains",
+  "max_api_keys",
+  "stripe_price_id",
+  "is_public"
+)
+SELECT 'cloud_starter_55k_monthly', 'Starter', 1900, 55000, 10, 10, 'price_1TXtMCQe1Ex4Xxd5rFHBIDm1', true
+WHERE NOT EXISTS (SELECT 1 FROM starter_update)
+ON CONFLICT ("slug") DO UPDATE SET
+  "name" = EXCLUDED."name",
+  "monthly_price_cents" = EXCLUDED."monthly_price_cents",
+  "monthly_email_quota" = EXCLUDED."monthly_email_quota",
+  "max_domains" = EXCLUDED."max_domains",
+  "max_api_keys" = EXCLUDED."max_api_keys",
+  "stripe_price_id" = EXCLUDED."stripe_price_id",
+  "is_public" = EXCLUDED."is_public";--> statement-breakpoint
+INSERT INTO "plans" (
+  "slug",
+  "name",
+  "monthly_price_cents",
+  "monthly_email_quota",
+  "max_domains",
+  "max_api_keys",
+  "stripe_price_id",
+  "is_public"
+)
+VALUES ('cloud_starter_100k_monthly', 'Starter', 3500, 100000, 10, 10, 'price_1TXtMCQe1Ex4Xxd515fpQX93', true)
+ON CONFLICT ("slug") DO UPDATE SET
+  "name" = EXCLUDED."name",
+  "monthly_price_cents" = EXCLUDED."monthly_price_cents",
+  "monthly_email_quota" = EXCLUDED."monthly_email_quota",
+  "max_domains" = EXCLUDED."max_domains",
+  "max_api_keys" = EXCLUDED."max_api_keys",
+  "stripe_price_id" = EXCLUDED."stripe_price_id",
+  "is_public" = EXCLUDED."is_public";--> statement-breakpoint
+WITH growth_candidate AS (
+  SELECT "id"
+  FROM "plans"
+  WHERE "slug" IN ('cloud_growth_120k_monthly', 'cloud_growth_monthly', 'growth')
+  ORDER BY CASE "slug"
+    WHEN 'cloud_growth_120k_monthly' THEN 0
+    WHEN 'cloud_growth_monthly' THEN 1
+    ELSE 2
+  END
+  LIMIT 1
+),
+growth_update AS (
+  UPDATE "plans"
+  SET
+    "slug" = 'cloud_growth_120k_monthly',
+    "name" = 'Growth',
+    "monthly_price_cents" = 9900,
+    "monthly_email_quota" = 120000,
+    "max_domains" = 1000,
+    "max_api_keys" = 25,
+    "stripe_price_id" = 'price_1TXtMDQe1Ex4Xxd5mggWy1I7',
+    "is_public" = true
+  WHERE "id" = (SELECT "id" FROM growth_candidate)
+  RETURNING "id"
+)
+INSERT INTO "plans" (
+  "slug",
+  "name",
+  "monthly_price_cents",
+  "monthly_email_quota",
+  "max_domains",
+  "max_api_keys",
+  "stripe_price_id",
+  "is_public"
+)
+SELECT 'cloud_growth_120k_monthly', 'Growth', 9900, 120000, 1000, 25, 'price_1TXtMDQe1Ex4Xxd5mggWy1I7', true
+WHERE NOT EXISTS (SELECT 1 FROM growth_update)
+ON CONFLICT ("slug") DO UPDATE SET
+  "name" = EXCLUDED."name",
+  "monthly_price_cents" = EXCLUDED."monthly_price_cents",
+  "monthly_email_quota" = EXCLUDED."monthly_email_quota",
+  "max_domains" = EXCLUDED."max_domains",
+  "max_api_keys" = EXCLUDED."max_api_keys",
+  "stripe_price_id" = EXCLUDED."stripe_price_id",
+  "is_public" = EXCLUDED."is_public";--> statement-breakpoint
+INSERT INTO "plans" (
+  "slug",
+  "name",
+  "monthly_price_cents",
+  "monthly_email_quota",
+  "max_domains",
+  "max_api_keys",
+  "stripe_price_id",
+  "is_public"
+)
+VALUES
+  ('cloud_growth_250k_monthly', 'Growth', 16000, 250000, 1000, 25, 'price_1TXtMDQe1Ex4Xxd512n1Bwl9', true),
+  ('cloud_growth_500k_monthly', 'Growth', 35000, 500000, 1000, 25, 'price_1TXtMEQe1Ex4Xxd5qF7r2872', true)
+ON CONFLICT ("slug") DO UPDATE SET
+  "name" = EXCLUDED."name",
+  "monthly_price_cents" = EXCLUDED."monthly_price_cents",
+  "monthly_email_quota" = EXCLUDED."monthly_email_quota",
+  "max_domains" = EXCLUDED."max_domains",
+  "max_api_keys" = EXCLUDED."max_api_keys",
+  "stripe_price_id" = EXCLUDED."stripe_price_id",
+  "is_public" = EXCLUDED."is_public";--> statement-breakpoint
+UPDATE "plans"
+SET "is_public" = false
+WHERE "slug" IN ('starter', 'cloud_starter_monthly', 'growth', 'cloud_growth_monthly', 'scale', 'cloud_scale_monthly');

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1778970539716,
       "tag": "0020_pricing_catalog_20260516",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1778976000000,
+      "tag": "0021_monthly_pricing_tiers_20260517",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,5 +1,4 @@
 import { PricingPage } from "@/components/landing/pricing-page";
-import type { BillingPeriod } from "@/components/landing/pricing-page";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -25,22 +24,6 @@ export const metadata: Metadata = {
   },
 };
 
-type PricingRouteProps = {
-  searchParams?: Promise<{
-    billing?: string | string[];
-  }>;
-};
-
-function parseBillingPeriod(
-  value: string | string[] | undefined,
-): BillingPeriod {
-  const billing = Array.isArray(value) ? value[0] : value;
-  return billing === "yearly" ? "yearly" : "monthly";
-}
-
-export default async function PricingRoute({
-  searchParams,
-}: PricingRouteProps = {}) {
-  const params = searchParams ? await searchParams : {};
-  return <PricingPage billing={parseBillingPeriod(params.billing)} />;
+export default function PricingRoute() {
+  return <PricingPage />;
 }

--- a/src/components/billing/pricing-grid.tsx
+++ b/src/components/billing/pricing-grid.tsx
@@ -1,6 +1,18 @@
 "use client";
 
-import { useState } from "react";
+import {
+  PricingPlanCard,
+  PricingTierSelector,
+} from "@/components/pricing/pricing-card";
+import {
+  DEFAULT_PRICING_TIER_SLUG,
+  type PricingDisplayPlan,
+  type PricingTierSlug,
+  findPricingTier,
+  getPricingCardsForSelection,
+  isPricingTierSlug,
+} from "@/components/pricing/pricing-catalog";
+import { useMemo, useState } from "react";
 
 export interface PricingPlan {
   id: string;
@@ -17,97 +29,32 @@ interface PricingGridProps {
   currentPlanId: string | null;
 }
 
-type PlanCopy = {
-  kicker: string;
-  blurb: string;
-  perks: string[];
-};
-
-const PLAN_COPY: Record<string, PlanCopy> = {
-  free: {
-    kicker: "Free",
-    blurb: "For tinkering and side projects.",
-    perks: [
-      "Resend-compatible REST API",
-      "TypeScript SDK + React Email",
-      "HMAC-signed webhooks",
-      "Open/click analytics",
-      "Community support",
-    ],
-  },
-  starter: {
-    kicker: "Starter",
-    blurb: "For small teams shipping production email.",
-    perks: [
-      "Everything in Free",
-      "API sends + broadcast fanout",
-      "Contacts, segments, and broadcasts",
-      "Email automations",
-      "Email support · 48h",
-    ],
-  },
-  growth: {
-    kicker: "Growth",
-    blurb: "For domain-heavy teams growing broadcast and API volume.",
-    perks: [
-      "Everything in Starter",
-      "Advanced broadcast and audience workflows",
-      "Custom Return-Path domains",
-      "Audit log & SSO (Google)",
-      "Priority support · 12h",
-    ],
-  },
-  scale: {
-    kicker: "Scale",
-    blurb: "High-volume, regulated, custom needs.",
-    perks: [
-      "Everything in Growth",
-      "BYO AWS account",
-      "Dedicated infra & VPC peering",
-      "BAA / SOC 2 assistance",
-      "Slack channel · 1h SLA",
-    ],
-  },
-};
-
-function getPlanCopy(plan: PricingPlan): PlanCopy {
-  return (
-    PLAN_COPY[plan.slug] ?? {
-      kicker: plan.name,
-      blurb: "For teams growing their sending volume.",
-      perks: [
-        "Transactional email sending",
-        "Dashboard usage visibility",
-        "API keys and domain management",
-        "API sends + broadcast fanout",
-      ],
-    }
-  );
+function formatPrice(plan: PricingDisplayPlan) {
+  if (plan.monthlyPrice === null) return "custom";
+  if (plan.monthlyPrice === 0) return "Free";
+  return `$${plan.monthlyPrice}`;
 }
 
-function formatPrice(cents: number) {
-  if (cents === 0) return "Free";
-  return `$${(cents / 100).toFixed(0)}`;
-}
-
-function formatNumber(n: number) {
-  return n.toLocaleString("en-US");
-}
-
-function ctaLabel(plan: PricingPlan, isCurrent: boolean, isPending: boolean) {
-  if (isCurrent) return "Current plan";
-  if (isPending) return "Opening checkout…";
-  if (plan.monthlyPriceCents === 0) return "Change to Free";
-  return `Change to ${formatPrice(plan.monthlyPriceCents)} / mo`;
-}
-
-function isFeaturedPlan(plan: PricingPlan) {
-  return plan.slug === "growth";
+function defaultSelectedTier(
+  plans: PricingPlan[],
+  currentPlanId: string | null,
+) {
+  const current = plans.find((plan) => plan.id === currentPlanId);
+  if (current && isPricingTierSlug(current.slug)) return current.slug;
+  return DEFAULT_PRICING_TIER_SLUG;
 }
 
 export function PricingGrid({ plans, currentPlanId }: PricingGridProps) {
   const [pendingPlanId, setPendingPlanId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [selectedTierSlug, setSelectedTierSlug] = useState<PricingTierSlug>(
+    () => defaultSelectedTier(plans, currentPlanId),
+  );
+
+  const plansBySlug = useMemo(
+    () => new Map(plans.map((plan) => [plan.slug, plan] as const)),
+    [plans],
+  );
 
   if (plans.length === 0) {
     return (
@@ -155,139 +102,53 @@ export function PricingGrid({ plans, currentPlanId }: PricingGridProps) {
   };
 
   return (
-    <div className="space-y-4" data-testid="pricing-grid">
+    <div
+      className="landing-root space-y-8"
+      data-testid="pricing-grid"
+      style={{ background: "transparent", minHeight: "auto" }}
+    >
+      <div className="flex justify-center">
+        <PricingTierSelector
+          selectedSlug={selectedTierSlug}
+          onChange={setSelectedTierSlug}
+        />
+      </div>
       <div className="grid gap-5 lg:grid-cols-2 xl:grid-cols-4">
-        {plans.map((plan) => {
-          const isCurrent = plan.id === currentPlanId;
-          const isPending = pendingPlanId === plan.id;
-          const copy = getPlanCopy(plan);
-          const featured = isFeaturedPlan(plan);
+        {getPricingCardsForSelection(selectedTierSlug).map((displayPlan) => {
+          const dbPlan = plansBySlug.get(displayPlan.slug);
+          const current = dbPlan?.id === currentPlanId;
+          const pending = dbPlan ? pendingPlanId === dbPlan.id : false;
+          const persistedPlan = findPricingTier(displayPlan.slug);
+          const checkoutDisabled =
+            displayPlan.checkoutKind === "stripe" && !dbPlan;
+          const ctaLabel = current
+            ? "Current plan"
+            : checkoutDisabled
+              ? "Unavailable"
+              : displayPlan.checkoutKind === "stripe"
+                ? `Change to ${displayPlan.name} (${formatPrice(displayPlan)} / mo)`
+                : displayPlan.checkoutKind === "free"
+                  ? "Contact support"
+                  : displayPlan.cta;
+          const onAction = current
+            ? () => undefined
+            : dbPlan && displayPlan.checkoutKind === "stripe"
+              ? () => handleUpgrade(dbPlan.id)
+              : displayPlan.checkoutKind === "free"
+                ? () => undefined
+                : undefined;
+
           return (
-            <article
-              key={plan.id}
-              className={`relative flex min-h-[560px] flex-col overflow-visible rounded-[18px] border p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] ${
-                featured
-                  ? "border-[#C9FF66]/70 bg-[radial-gradient(circle_at_50%_0%,rgba(201,255,102,0.14),rgba(15,17,15,0.82)_34%,rgba(12,13,15,0.86)_100%)]"
-                  : isCurrent
-                    ? "border-purple-500/60 bg-[radial-gradient(circle_at_50%_0%,rgba(126,65,255,0.16),rgba(13,10,18,0.84)_40%,rgba(12,13,15,0.86)_100%)]"
-                    : "border-[rgba(176,199,217,0.145)] bg-[linear-gradient(180deg,rgba(24,25,28,0.7),rgba(12,13,15,0.86))]"
-              }`}
-              data-testid={`pricing-card-${plan.slug}`}
-              data-current={isCurrent ? "true" : undefined}
-            >
-              {featured ? (
-                <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-[#C9FF66] px-4 py-1 font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-[#08090A] shadow-[0_0_24px_rgba(201,255,102,0.45)]">
-                  Most popular
-                </div>
-              ) : null}
-
-              <header className="mb-5 space-y-3">
-                <div className="flex items-start justify-between gap-3">
-                  <p
-                    className={`font-mono text-[11px] font-semibold uppercase tracking-[0.22em] ${
-                      featured ? "text-[#C9FF66]" : "text-[#777D80]"
-                    }`}
-                  >
-                    {copy.kicker}
-                  </p>
-                  {isCurrent ? (
-                    <span
-                      className="rounded-full bg-purple-500/20 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-purple-200"
-                      data-testid={`pricing-card-${plan.slug}-current-badge`}
-                    >
-                      Current
-                    </span>
-                  ) : null}
-                </div>
-                <div>
-                  <h3 className="text-[22px] font-semibold tracking-[-0.02em] text-[#F0F0F0]">
-                    {plan.name}
-                  </h3>
-                  <p className="mt-2 min-h-[40px] text-[14px] leading-5 text-[#A1A4A5]">
-                    {copy.blurb}
-                  </p>
-                </div>
-              </header>
-
-              <div className="mb-5 flex items-end gap-2">
-                {plan.monthlyPriceCents === 0 ? (
-                  <>
-                    <span className="text-[13px] text-[#777D80]">$</span>
-                    <span className="text-5xl font-semibold tracking-[-0.06em] text-[#F0F0F0]">
-                      0
-                    </span>
-                    <span className="pb-1 text-[13px] text-[#777D80]">/mo</span>
-                  </>
-                ) : (
-                  <>
-                    <span className="text-[13px] text-[#777D80]">$</span>
-                    <span className="text-5xl font-semibold tracking-[-0.06em] text-[#F0F0F0]">
-                      {(plan.monthlyPriceCents / 100).toFixed(0)}
-                    </span>
-                    <span className="pb-1 text-[13px] text-[#777D80]">/mo</span>
-                  </>
-                )}
-              </div>
-
-              <dl className="mb-6 overflow-hidden rounded-xl border border-[rgba(176,199,217,0.09)] bg-[rgba(8,9,10,0.35)] text-[13px]">
-                <div className="grid grid-cols-[88px_1fr] border-b border-[rgba(176,199,217,0.09)]">
-                  <dt className="px-3 py-2 font-mono text-[#777D80]">quota</dt>
-                  <dd
-                    className={`px-3 py-2 text-right font-mono ${
-                      featured ? "text-[#C9FF66]" : "text-[#F0F0F0]"
-                    }`}
-                  >
-                    {formatNumber(plan.monthlyEmailQuota)} API + broadcast
-                    emails/mo
-                  </dd>
-                </div>
-                <div className="grid grid-cols-[88px_1fr] border-b border-[rgba(176,199,217,0.09)]">
-                  <dt className="px-3 py-2 font-mono text-[#777D80]">
-                    domains
-                  </dt>
-                  <dd className="px-3 py-2 text-right font-mono text-[#F0F0F0]">
-                    {formatNumber(plan.maxDomains)} verified{" "}
-                    {plan.maxDomains === 1 ? "domain" : "domains"}
-                  </dd>
-                </div>
-                <div className="grid grid-cols-[88px_1fr]">
-                  <dt className="px-3 py-2 font-mono text-[#777D80]">keys</dt>
-                  <dd className="px-3 py-2 text-right font-mono text-[#F0F0F0]">
-                    {formatNumber(plan.maxApiKeys)} API{" "}
-                    {plan.maxApiKeys === 1 ? "key" : "keys"}
-                  </dd>
-                </div>
-              </dl>
-
-              <ul className="mb-8 flex-1 space-y-3 text-[14px] text-[#A1A4A5]">
-                {copy.perks.map((perk) => (
-                  <li className="flex gap-3" key={perk}>
-                    <span
-                      className={`mt-0.5 ${
-                        featured ? "text-[#C9FF66]" : "text-[#F0F0F0]"
-                      }`}
-                    >
-                      ✓
-                    </span>
-                    <span>{perk}</span>
-                  </li>
-                ))}
-              </ul>
-
-              <button
-                type="button"
-                disabled={isCurrent || isPending}
-                onClick={() => handleUpgrade(plan.id)}
-                className={`mt-auto rounded-lg px-3 py-3 text-[14px] font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-55 ${
-                  featured
-                    ? "bg-[#C9FF66] text-[#08090A] hover:bg-[#D6FF84]"
-                    : "border border-[rgba(176,199,217,0.145)] bg-[rgba(24,25,28,0.88)] text-[#F0F0F0] hover:bg-[rgba(24,25,28,1)]"
-                }`}
-                data-testid={`pricing-card-${plan.slug}-upgrade`}
-              >
-                {ctaLabel(plan, isCurrent, isPending)}
-              </button>
-            </article>
+            <PricingPlanCard
+              key={displayPlan.family}
+              plan={persistedPlan ?? displayPlan}
+              current={current}
+              pending={pending}
+              disabled={checkoutDisabled || displayPlan.checkoutKind === "free"}
+              ctaLabel={ctaLabel}
+              onAction={onAction}
+              testId={`pricing-card-${displayPlan.family}`}
+            />
           );
         })}
       </div>

--- a/src/components/landing/pricing-page.tsx
+++ b/src/components/landing/pricing-page.tsx
@@ -1,5 +1,14 @@
 "use client";
 
+import {
+  PricingPlanCard,
+  PricingTierSelector,
+} from "@/components/pricing/pricing-card";
+import {
+  DEFAULT_PRICING_TIER_SLUG,
+  type PricingTierSlug,
+  getPricingCardsForSelection,
+} from "@/components/pricing/pricing-catalog";
 import Link from "next/link";
 import { useState } from "react";
 
@@ -7,110 +16,6 @@ const GITHUB_URL = "https://github.com/namuh-eng/opensend";
 const DOCS_URL = "/docs";
 const HOSTED_SIGNIN_URL = "/auth";
 const SELF_HOST_URL = `${GITHUB_URL}#self-host`;
-const CONTACT_URL = "mailto:hello@opensend.namuh.co";
-
-type Plan = {
-  slug: string;
-  name: string;
-  blurb: string;
-  monthly: number | string;
-  yearly: number | string;
-  quota: string;
-  domains: string;
-  keys: string;
-  cta: string;
-  ctaStyle: "primary" | "ghost";
-  ctaHref: string;
-  featured?: boolean;
-  perks: string[];
-};
-
-export type BillingPeriod = "monthly" | "yearly";
-
-const PLANS: Plan[] = [
-  {
-    slug: "free",
-    name: "Free",
-    blurb: "For tinkering and side projects.",
-    monthly: 0,
-    yearly: 0,
-    quota: "5,000 API + broadcast emails/mo",
-    domains: "1 verified domain",
-    keys: "2 API keys",
-    cta: "Get started",
-    ctaStyle: "ghost",
-    ctaHref: HOSTED_SIGNIN_URL,
-    perks: [
-      "Resend-compatible REST API",
-      "TypeScript SDK + React Email",
-      "HMAC-signed webhooks",
-      "Open/click analytics",
-      "Community support",
-    ],
-  },
-  {
-    slug: "starter",
-    name: "Starter",
-    blurb: "For small teams shipping production email.",
-    monthly: 19,
-    yearly: 15,
-    quota: "55,000 API + broadcast emails/mo",
-    domains: "10 verified domains",
-    keys: "10 API keys",
-    cta: "Start Starter",
-    ctaStyle: "ghost",
-    ctaHref: HOSTED_SIGNIN_URL,
-    perks: [
-      "Everything in Free",
-      "API sends + broadcast fanout",
-      "Contacts, segments, and broadcasts",
-      "Email automations",
-      "Email support · 48h",
-    ],
-  },
-  {
-    slug: "growth",
-    name: "Growth",
-    blurb: "For domain-heavy teams growing broadcast and API volume.",
-    monthly: 99,
-    yearly: 79,
-    quota: "120,000 API + broadcast emails/mo",
-    domains: "1,000 verified domains",
-    keys: "25 API keys",
-    cta: "Start Growth",
-    ctaStyle: "primary",
-    ctaHref: HOSTED_SIGNIN_URL,
-    featured: true,
-    perks: [
-      "Everything in Starter",
-      "Advanced broadcast and audience workflows",
-      "Custom Return-Path domains",
-      "Audit log & SSO (Google)",
-      "Priority support · 12h",
-    ],
-  },
-  {
-    slug: "scale",
-    name: "Scale",
-    blurb: "High-volume, regulated, custom needs.",
-    monthly: "Custom",
-    yearly: "Custom",
-    quota: "Unlimited (your SES)",
-    domains: "Unlimited",
-    keys: "Unlimited",
-    cta: "Talk to us",
-    ctaStyle: "ghost",
-    ctaHref: CONTACT_URL,
-    perks: [
-      "Everything in Growth",
-      "BYO AWS account",
-      "Dedicated infra & VPC peering",
-      "BAA / SOC 2 assistance",
-      "Slack channel · 1h SLA",
-    ],
-  },
-];
-
 const FAQ: Array<[string, string]> = [
   [
     "What happens if I exceed my quota?",
@@ -130,7 +35,7 @@ const FAQ: Array<[string, string]> = [
   ],
   [
     "Is there a yearly discount?",
-    "Yes — paying yearly saves roughly 20% on Starter and Growth. Toggle the switch above the plans.",
+    "Self-serve Cloud tiers are monthly so you can move with usage. Annual terms are handled through custom Scale agreements.",
   ],
   [
     "How do I cancel?",
@@ -139,7 +44,7 @@ const FAQ: Array<[string, string]> = [
 ];
 
 const COMPARE_ROWS: string[][] = [
-  ["Monthly emails", "5k", "55k", "120k", "Unlimited"],
+  ["Monthly emails", "5k", "55k-100k", "120k-500k", "Unlimited"],
   ["Verified domains", "1", "10", "1,000", "Unlimited"],
   ["API keys", "2", "10", "25", "Unlimited"],
   ["Webhooks", "✓", "✓", "✓", "✓"],
@@ -268,283 +173,6 @@ function TopNav() {
         </nav>
       </div>
     </header>
-  );
-}
-
-function CheckIcon({ accent }: { accent: boolean }) {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 14 14"
-      style={{
-        flex: "none",
-        marginTop: 3,
-        color: accent ? "var(--accent)" : "var(--fg)",
-      }}
-      aria-hidden="true"
-      focusable="false"
-    >
-      <title>included</title>
-      <path
-        d="M3 7.5l2.5 2.5L11 4"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function PlanCard({
-  plan,
-  billing,
-}: {
-  plan: Plan;
-  billing: BillingPeriod;
-}) {
-  const isCustom = typeof plan.monthly === "string";
-  const eff =
-    billing === "yearly" && typeof plan.yearly === "number"
-      ? plan.yearly
-      : plan.monthly;
-  const showSave =
-    billing === "yearly" &&
-    typeof plan.yearly === "number" &&
-    typeof plan.monthly === "number" &&
-    plan.yearly < plan.monthly;
-
-  const ctaIsExternal =
-    plan.ctaHref.startsWith("mailto:") || plan.ctaHref.startsWith("http");
-
-  return (
-    <div
-      data-testid={`plan-${plan.slug}`}
-      style={{
-        position: "relative",
-        borderRadius: 14,
-        border: plan.featured
-          ? "1px solid color-mix(in oklch, var(--accent) 60%, transparent)"
-          : "1px solid var(--line-2)",
-        background: plan.featured
-          ? "linear-gradient(180deg, rgba(196,255,90,0.04) 0%, rgba(13,13,16,0.85) 60%)"
-          : "linear-gradient(180deg, #131318 0%, #0d0d11 100%)",
-        padding: "28px 26px 26px",
-        display: "flex",
-        flexDirection: "column",
-        gap: 18,
-        minHeight: 480,
-        boxShadow: plan.featured
-          ? "0 30px 60px -30px rgba(196,255,90,0.25)"
-          : "0 30px 60px -40px rgba(0,0,0,0.6)",
-      }}
-    >
-      {plan.featured && (
-        <span
-          style={{
-            position: "absolute",
-            top: -12,
-            right: 20,
-            padding: "4px 10px",
-            borderRadius: 99,
-            background: "var(--accent)",
-            color: "var(--accent-ink)",
-            fontFamily: "var(--landing-mono)",
-            fontSize: 11,
-            letterSpacing: "0.06em",
-            textTransform: "uppercase",
-            boxShadow:
-              "0 0 0 1px rgba(196,255,90,0.35), 0 0 24px -4px rgba(196,255,90,0.5)",
-          }}
-        >
-          most popular
-        </span>
-      )}
-      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-        <span
-          className="mono"
-          style={{
-            fontSize: 11,
-            letterSpacing: "0.12em",
-            textTransform: "uppercase",
-            color: plan.featured ? "var(--accent)" : "var(--fg-3)",
-          }}
-        >
-          {plan.name.toLowerCase()}
-        </span>
-        <h3
-          style={{
-            margin: 0,
-            fontSize: 22,
-            fontWeight: 500,
-            letterSpacing: "-0.015em",
-          }}
-        >
-          {plan.name}
-        </h3>
-        <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 13.5 }}>
-          {plan.blurb}
-        </p>
-      </div>
-
-      <div
-        style={{
-          display: "flex",
-          alignItems: "baseline",
-          gap: 8,
-          minHeight: 56,
-        }}
-      >
-        {isCustom ? (
-          <span
-            className="serif"
-            style={{ fontSize: 44, lineHeight: 1, letterSpacing: "-0.02em" }}
-          >
-            Let's talk
-          </span>
-        ) : (
-          <>
-            <span
-              style={{
-                fontSize: 12,
-                color: "var(--fg-3)",
-                fontFamily: "var(--landing-mono)",
-              }}
-            >
-              $
-            </span>
-            <span
-              style={{
-                fontSize: 44,
-                fontWeight: 500,
-                letterSpacing: "-0.025em",
-                lineHeight: 1,
-              }}
-            >
-              {eff}
-            </span>
-            <span
-              className="mono"
-              style={{ fontSize: 12, color: "var(--fg-3)" }}
-            >
-              /mo
-            </span>
-            {showSave && (
-              <span
-                style={{
-                  marginLeft: "auto",
-                  alignSelf: "center",
-                  fontFamily: "var(--landing-mono)",
-                  fontSize: 11,
-                  padding: "3px 8px",
-                  borderRadius: 6,
-                  background: "rgba(196,255,90,0.12)",
-                  color: "var(--accent)",
-                  border: "1px solid rgba(196,255,90,0.25)",
-                }}
-              >
-                billed yearly
-              </span>
-            )}
-          </>
-        )}
-      </div>
-
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "1fr",
-          border: "1px solid var(--line)",
-          borderRadius: 10,
-          background: "rgba(255,255,255,0.015)",
-          overflow: "hidden",
-        }}
-      >
-        {[plan.quota, plan.domains, plan.keys].map((row, i) => {
-          const labels = ["quota", "domains", "keys"];
-          return (
-            <div
-              key={labels[i]}
-              className="mono"
-              style={{
-                padding: "9px 12px",
-                fontSize: 12,
-                color: "var(--fg-2)",
-                borderTop: i ? "1px solid var(--line)" : "none",
-                display: "flex",
-                justifyContent: "space-between",
-              }}
-            >
-              <span style={{ color: "var(--fg-3)" }}>{labels[i]}</span>
-              <span
-                style={{
-                  color:
-                    plan.featured && i === 0 ? "var(--accent)" : "var(--fg)",
-                }}
-              >
-                {row}
-              </span>
-            </div>
-          );
-        })}
-      </div>
-
-      <ul
-        style={{
-          listStyle: "none",
-          padding: 0,
-          margin: 0,
-          display: "flex",
-          flexDirection: "column",
-          gap: 9,
-        }}
-      >
-        {plan.perks.map((p) => (
-          <li
-            key={p}
-            style={{
-              display: "flex",
-              gap: 10,
-              alignItems: "flex-start",
-              fontSize: 13.5,
-              color: "var(--fg-2)",
-            }}
-          >
-            <CheckIcon accent={!!plan.featured} />
-            <span>{p}</span>
-          </li>
-        ))}
-      </ul>
-
-      <div style={{ marginTop: "auto" }}>
-        {ctaIsExternal ? (
-          <a
-            href={plan.ctaHref}
-            className={`btn btn-${plan.ctaStyle}`}
-            style={{ width: "100%" }}
-            rel={
-              plan.ctaHref.startsWith("http")
-                ? "noreferrer noopener"
-                : undefined
-            }
-            target={plan.ctaHref.startsWith("http") ? "_blank" : undefined}
-          >
-            {plan.cta}
-          </a>
-        ) : (
-          <Link
-            href={plan.ctaHref}
-            className={`btn btn-${plan.ctaStyle}`}
-            style={{ width: "100%" }}
-            data-testid={`cta-${plan.slug}`}
-          >
-            {plan.cta}
-          </Link>
-        )}
-      </div>
-    </div>
   );
 }
 
@@ -918,9 +546,11 @@ function MiniFooter() {
   );
 }
 
-export function PricingPage({
-  billing = "monthly",
-}: { billing?: BillingPeriod }) {
+export function PricingPage() {
+  const [selectedTierSlug, setSelectedTierSlug] = useState<PricingTierSlug>(
+    DEFAULT_PRICING_TIER_SLUG,
+  );
+
   return (
     <div className="landing-root">
       <div className="grain" aria-hidden="true" />
@@ -970,53 +600,10 @@ export function PricingPage({
               either way.
             </p>
 
-            <form
-              aria-label="Billing period"
-              action="/pricing"
-              method="get"
-              style={{
-                display: "inline-flex",
-                padding: 4,
-                borderRadius: 999,
-                border: "1px solid var(--line-2)",
-                background: "rgba(255,255,255,0.02)",
-                marginTop: 8,
-                marginInline: 0,
-                minWidth: 0,
-              }}
-            >
-              {(
-                [
-                  ["monthly", "Monthly"],
-                  ["yearly", "Yearly · save 20%"],
-                ] as const
-              ).map(([k, label]) => {
-                const active = billing === k;
-                return (
-                  <button
-                    key={k}
-                    type="submit"
-                    name="billing"
-                    value={k}
-                    aria-pressed={active}
-                    data-testid={`billing-${k}`}
-                    style={{
-                      padding: "7px 16px",
-                      borderRadius: 999,
-                      cursor: "pointer",
-                      border: "none",
-                      background: active ? "var(--fg)" : "transparent",
-                      color: active ? "var(--bg)" : "var(--fg-2)",
-                      fontSize: 13,
-                      fontWeight: 500,
-                      transition: "background 150ms ease, color 150ms ease",
-                    }}
-                  >
-                    {label}
-                  </button>
-                );
-              })}
-            </form>
+            <PricingTierSelector
+              selectedSlug={selectedTierSlug}
+              onChange={setSelectedTierSlug}
+            />
           </div>
         </section>
 
@@ -1030,8 +617,12 @@ export function PricingPage({
                 gap: 18,
               }}
             >
-              {PLANS.map((p) => (
-                <PlanCard key={p.slug} plan={p} billing={billing} />
+              {getPricingCardsForSelection(selectedTierSlug).map((plan) => (
+                <PricingPlanCard
+                  key={plan.family}
+                  plan={plan}
+                  testId={`plan-${plan.family}`}
+                />
               ))}
             </div>
             <SelfHostLane />

--- a/src/components/pricing/pricing-card.tsx
+++ b/src/components/pricing/pricing-card.tsx
@@ -1,0 +1,433 @@
+"use client";
+
+import Link from "next/link";
+import {
+  PRICING_SELECTOR_TIERS,
+  type PricingDisplayPlan,
+  type PricingTierSlug,
+} from "./pricing-catalog";
+
+function CheckIcon({ accent = false }: { accent?: boolean }) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      style={{
+        flex: "none",
+        marginTop: 3,
+        color: accent ? "var(--accent)" : "var(--fg)",
+      }}
+      aria-hidden="true"
+      focusable="false"
+    >
+      <title>included</title>
+      <path
+        d="M3 7.5l2.5 2.5L11 4"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.6"
+      />
+    </svg>
+  );
+}
+
+interface PricingTierSelectorProps {
+  selectedSlug: PricingTierSlug;
+  onChange: (slug: PricingTierSlug) => void;
+}
+
+export function PricingTierSelector({
+  selectedSlug,
+  onChange,
+}: PricingTierSelectorProps) {
+  const selectedIndex = Math.max(
+    0,
+    PRICING_SELECTOR_TIERS.findIndex((tier) => tier.slug === selectedSlug),
+  );
+
+  return (
+    <div
+      aria-label="Included monthly volume"
+      style={{
+        width: "min(720px, 100%)",
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+      }}
+    >
+      <div
+        style={{
+          position: "relative",
+          height: 28,
+          display: "grid",
+          gridTemplateColumns: `repeat(${PRICING_SELECTOR_TIERS.length}, 1fr)`,
+          alignItems: "center",
+        }}
+      >
+        <div
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            top: "50%",
+            height: 1,
+            background: "var(--line-2)",
+          }}
+        />
+        <div
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            left: 0,
+            top: "50%",
+            height: 1,
+            width: `${(selectedIndex / (PRICING_SELECTOR_TIERS.length - 1)) * 100}%`,
+            background: "var(--fg-2)",
+          }}
+        />
+        {PRICING_SELECTOR_TIERS.map((tier) => {
+          const active = tier.slug === selectedSlug;
+          return (
+            <button
+              key={tier.slug}
+              type="button"
+              aria-pressed={active}
+              data-testid={`pricing-tier-${tier.slug}`}
+              onClick={() => onChange(tier.slug)}
+              style={{
+                position: "relative",
+                zIndex: 1,
+                justifySelf: "center",
+                width: active ? 12 : 7,
+                height: active ? 12 : 7,
+                padding: 0,
+                borderRadius: 99,
+                border: active
+                  ? "2px solid var(--fg)"
+                  : "1px solid var(--fg-2)",
+                background: active ? "var(--fg)" : "var(--bg)",
+                cursor: "pointer",
+                boxShadow: active ? "0 0 0 4px rgba(255,255,255,0.08)" : "none",
+              }}
+            >
+              <span className="sr-only">{tier.selectorLabel}</span>
+            </button>
+          );
+        })}
+      </div>
+      <div
+        className="mono"
+        style={{
+          display: "grid",
+          gridTemplateColumns: `repeat(${PRICING_SELECTOR_TIERS.length}, 1fr)`,
+          gap: 8,
+          fontSize: 10,
+          color: "var(--fg-3)",
+          textAlign: "center",
+          textTransform: "uppercase",
+        }}
+      >
+        {PRICING_SELECTOR_TIERS.map((tier) => (
+          <button
+            key={tier.slug}
+            type="button"
+            onClick={() => onChange(tier.slug)}
+            style={{
+              border: "none",
+              background: "transparent",
+              color: tier.slug === selectedSlug ? "var(--fg)" : "var(--fg-3)",
+              cursor: "pointer",
+              fontSize: 10,
+              textTransform: "uppercase",
+            }}
+          >
+            {tier.selectorLabel}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface PricingPlanCardProps {
+  plan: PricingDisplayPlan;
+  current?: boolean;
+  pending?: boolean;
+  disabled?: boolean;
+  ctaLabel?: string;
+  onAction?: () => void;
+  testId?: string;
+}
+
+export function PricingPlanCard({
+  plan,
+  current = false,
+  pending = false,
+  disabled = false,
+  ctaLabel,
+  onAction,
+  testId,
+}: PricingPlanCardProps) {
+  const isCustom = plan.monthlyPrice === null;
+  const buttonLabel = ctaLabel ?? plan.cta;
+  const actionDisabled = current || pending || disabled;
+  const ctaIsExternal =
+    plan.ctaHref.startsWith("mailto:") || plan.ctaHref.startsWith("http");
+
+  const ctaClassName = `btn btn-${plan.ctaStyle}`;
+  const ctaStyle = { width: "100%" };
+
+  return (
+    <div
+      data-current={current ? "true" : undefined}
+      data-testid={testId ?? `plan-${plan.family}`}
+      style={{
+        position: "relative",
+        borderRadius: 14,
+        border: plan.featured
+          ? "1px solid color-mix(in oklch, var(--accent) 60%, transparent)"
+          : "1px solid var(--line-2)",
+        background: plan.featured
+          ? "linear-gradient(180deg, rgba(196,255,90,0.04) 0%, rgba(13,13,16,0.85) 60%)"
+          : "linear-gradient(180deg, #131318 0%, #0d0d11 100%)",
+        padding: "28px 26px 26px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 18,
+        minHeight: 480,
+        boxShadow: plan.featured
+          ? "0 30px 60px -30px rgba(196,255,90,0.25)"
+          : "0 30px 60px -40px rgba(0,0,0,0.6)",
+      }}
+    >
+      {plan.featured ? (
+        <span
+          style={{
+            position: "absolute",
+            top: -12,
+            right: 20,
+            padding: "4px 10px",
+            borderRadius: 99,
+            background: "var(--accent)",
+            color: "var(--accent-ink)",
+            fontFamily: "var(--landing-mono)",
+            fontSize: 11,
+            letterSpacing: "0.06em",
+            textTransform: "uppercase",
+            boxShadow:
+              "0 0 0 1px rgba(196,255,90,0.35), 0 0 24px -4px rgba(196,255,90,0.5)",
+          }}
+        >
+          most popular
+        </span>
+      ) : null}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        <div
+          style={{ display: "flex", justifyContent: "space-between", gap: 12 }}
+        >
+          <span
+            className="mono"
+            style={{
+              fontSize: 11,
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              color: plan.featured ? "var(--accent)" : "var(--fg-3)",
+            }}
+          >
+            {plan.name.toLowerCase()}
+          </span>
+          {current ? (
+            <span
+              className="mono"
+              style={{
+                borderRadius: 99,
+                background: "rgba(177,140,255,0.18)",
+                color: "var(--violet)",
+                padding: "2px 8px",
+                fontSize: 10,
+                textTransform: "uppercase",
+              }}
+            >
+              current
+            </span>
+          ) : null}
+        </div>
+        <h3
+          style={{
+            margin: 0,
+            fontSize: 22,
+            fontWeight: 500,
+            letterSpacing: "-0.015em",
+          }}
+        >
+          {plan.name}
+        </h3>
+        <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 13.5 }}>
+          {plan.blurb}
+        </p>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          gap: 8,
+          minHeight: 56,
+        }}
+      >
+        {isCustom ? (
+          <span
+            className="serif"
+            style={{ fontSize: 44, lineHeight: 1, letterSpacing: "-0.02em" }}
+          >
+            Let&apos;s talk
+          </span>
+        ) : (
+          <>
+            <span
+              style={{
+                fontSize: 12,
+                color: "var(--fg-3)",
+                fontFamily: "var(--landing-mono)",
+              }}
+            >
+              $
+            </span>
+            <span
+              style={{
+                fontSize: 44,
+                fontWeight: 500,
+                letterSpacing: "-0.025em",
+                lineHeight: 1,
+              }}
+            >
+              {plan.monthlyPrice}
+            </span>
+            <span
+              className="mono"
+              style={{ fontSize: 12, color: "var(--fg-3)" }}
+            >
+              /mo
+            </span>
+          </>
+        )}
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr",
+          border: "1px solid var(--line)",
+          borderRadius: 10,
+          background: "rgba(255,255,255,0.015)",
+          overflow: "hidden",
+        }}
+      >
+        {[plan.quota, plan.domains, plan.keys].map((row, i) => {
+          const labels = ["quota", "domains", "keys"];
+          return (
+            <div
+              key={labels[i]}
+              className="mono"
+              style={{
+                padding: "9px 12px",
+                fontSize: 12,
+                color: "var(--fg-2)",
+                borderTop: i ? "1px solid var(--line)" : "none",
+                display: "flex",
+                justifyContent: "space-between",
+                gap: 12,
+              }}
+            >
+              <span style={{ color: "var(--fg-3)" }}>{labels[i]}</span>
+              <span
+                style={{
+                  color:
+                    plan.featured && i === 0 ? "var(--accent)" : "var(--fg)",
+                  textAlign: "right",
+                }}
+              >
+                {row}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      <ul
+        style={{
+          listStyle: "none",
+          padding: 0,
+          margin: 0,
+          display: "flex",
+          flexDirection: "column",
+          gap: 9,
+        }}
+      >
+        {plan.perks.map((perk) => (
+          <li
+            key={perk}
+            style={{
+              display: "flex",
+              gap: 10,
+              alignItems: "flex-start",
+              fontSize: 13.5,
+              color: "var(--fg-2)",
+            }}
+          >
+            <CheckIcon accent={!!plan.featured} />
+            <span>{perk}</span>
+          </li>
+        ))}
+      </ul>
+
+      <div style={{ marginTop: "auto" }}>
+        {onAction ? (
+          <button
+            type="button"
+            className={ctaClassName}
+            data-testid={`pricing-card-${plan.family}-upgrade`}
+            disabled={actionDisabled}
+            onClick={onAction}
+            style={{
+              ...ctaStyle,
+              opacity: actionDisabled ? 0.55 : 1,
+              cursor: actionDisabled ? "not-allowed" : "pointer",
+            }}
+          >
+            {pending ? "Opening checkout…" : buttonLabel}
+          </button>
+        ) : ctaIsExternal ? (
+          <a
+            href={plan.ctaHref}
+            className={ctaClassName}
+            data-testid={`cta-${plan.family}`}
+            rel={
+              plan.ctaHref.startsWith("http")
+                ? "noreferrer noopener"
+                : undefined
+            }
+            style={ctaStyle}
+            target={plan.ctaHref.startsWith("http") ? "_blank" : undefined}
+          >
+            {buttonLabel}
+          </a>
+        ) : (
+          <Link
+            href={plan.ctaHref}
+            className={ctaClassName}
+            data-testid={`cta-${plan.family}`}
+            style={ctaStyle}
+          >
+            {buttonLabel}
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/pricing/pricing-catalog.ts
+++ b/src/components/pricing/pricing-catalog.ts
@@ -1,0 +1,210 @@
+export const PRICING_CONTACT_URL = "mailto:hello@opensend.namuh.co";
+export const PRICING_AUTH_URL = "/auth";
+
+export type PricingPlanFamily = "free" | "starter" | "growth" | "scale";
+
+export type PricingTierSlug =
+  | "free"
+  | "cloud_starter_55k_monthly"
+  | "cloud_starter_100k_monthly"
+  | "cloud_growth_120k_monthly"
+  | "cloud_growth_250k_monthly"
+  | "cloud_growth_500k_monthly"
+  | "scale_custom";
+
+export type PricingCtaStyle = "primary" | "ghost";
+export type PricingCheckoutKind = "free" | "stripe" | "contact";
+
+export interface PricingDisplayPlan {
+  slug: PricingTierSlug;
+  family: PricingPlanFamily;
+  name: string;
+  blurb: string;
+  monthlyPrice: number | null;
+  quota: string;
+  quotaValue: number | null;
+  domains: string;
+  maxDomains: number | null;
+  keys: string;
+  maxApiKeys: number | null;
+  cta: string;
+  ctaStyle: PricingCtaStyle;
+  ctaHref: string;
+  checkoutKind: PricingCheckoutKind;
+  featured?: boolean;
+  selectorLabel: string;
+  perks: string[];
+}
+
+const FREE_PLAN: PricingDisplayPlan = {
+  slug: "free",
+  family: "free",
+  name: "Free",
+  blurb: "For tinkering and side projects.",
+  monthlyPrice: 0,
+  quota: "5,000 API + broadcast emails/mo",
+  quotaValue: 5000,
+  domains: "1 verified domain",
+  maxDomains: 1,
+  keys: "2 API keys",
+  maxApiKeys: 2,
+  cta: "Get started",
+  ctaStyle: "ghost",
+  ctaHref: PRICING_AUTH_URL,
+  checkoutKind: "free",
+  selectorLabel: "5k",
+  perks: [
+    "Resend-compatible REST API",
+    "TypeScript SDK + React Email",
+    "HMAC-signed webhooks",
+    "Open/click analytics",
+    "Community support",
+  ],
+};
+
+const STARTER_55K: PricingDisplayPlan = {
+  slug: "cloud_starter_55k_monthly",
+  family: "starter",
+  name: "Starter",
+  blurb: "For small teams shipping production email.",
+  monthlyPrice: 19,
+  quota: "55,000 API + broadcast emails/mo",
+  quotaValue: 55000,
+  domains: "10 verified domains",
+  maxDomains: 10,
+  keys: "10 API keys",
+  maxApiKeys: 10,
+  cta: "Start Starter",
+  ctaStyle: "ghost",
+  ctaHref: PRICING_AUTH_URL,
+  checkoutKind: "stripe",
+  selectorLabel: "55k",
+  perks: [
+    "Everything in Free",
+    "API sends + broadcast fanout",
+    "Contacts, segments, and broadcasts",
+    "Email automations",
+    "Email support · 48h",
+  ],
+};
+
+const STARTER_100K: PricingDisplayPlan = {
+  ...STARTER_55K,
+  slug: "cloud_starter_100k_monthly",
+  monthlyPrice: 35,
+  quota: "100,000 API + broadcast emails/mo",
+  quotaValue: 100000,
+  selectorLabel: "100k",
+};
+
+const GROWTH_120K: PricingDisplayPlan = {
+  slug: "cloud_growth_120k_monthly",
+  family: "growth",
+  name: "Growth",
+  blurb: "For domain-heavy teams growing broadcast and API volume.",
+  monthlyPrice: 99,
+  quota: "120,000 API + broadcast emails/mo",
+  quotaValue: 120000,
+  domains: "1,000 verified domains",
+  maxDomains: 1000,
+  keys: "25 API keys",
+  maxApiKeys: 25,
+  cta: "Start Growth",
+  ctaStyle: "primary",
+  ctaHref: PRICING_AUTH_URL,
+  checkoutKind: "stripe",
+  featured: true,
+  selectorLabel: "120k",
+  perks: [
+    "Everything in Starter",
+    "Advanced broadcast and audience workflows",
+    "Custom Return-Path domains",
+    "Audit log & SSO (Google)",
+    "Priority support · 12h",
+  ],
+};
+
+const GROWTH_250K: PricingDisplayPlan = {
+  ...GROWTH_120K,
+  slug: "cloud_growth_250k_monthly",
+  monthlyPrice: 160,
+  quota: "250,000 API + broadcast emails/mo",
+  quotaValue: 250000,
+  selectorLabel: "250k",
+};
+
+const GROWTH_500K: PricingDisplayPlan = {
+  ...GROWTH_120K,
+  slug: "cloud_growth_500k_monthly",
+  monthlyPrice: 350,
+  quota: "500,000 API + broadcast emails/mo",
+  quotaValue: 500000,
+  selectorLabel: "500k",
+};
+
+const SCALE_CUSTOM: PricingDisplayPlan = {
+  slug: "scale_custom",
+  family: "scale",
+  name: "Scale",
+  blurb: "High-volume, regulated, custom needs.",
+  monthlyPrice: null,
+  quota: "Unlimited (your SES)",
+  quotaValue: null,
+  domains: "Unlimited",
+  maxDomains: null,
+  keys: "Unlimited",
+  maxApiKeys: null,
+  cta: "Talk to us",
+  ctaStyle: "ghost",
+  ctaHref: PRICING_CONTACT_URL,
+  checkoutKind: "contact",
+  selectorLabel: "custom",
+  perks: [
+    "Everything in Growth",
+    "BYO AWS account",
+    "Dedicated infra & VPC peering",
+    "BAA / SOC 2 assistance",
+    "Slack channel · 1h SLA",
+  ],
+};
+
+export const PRICING_TIERS: PricingDisplayPlan[] = [
+  FREE_PLAN,
+  STARTER_55K,
+  STARTER_100K,
+  GROWTH_120K,
+  GROWTH_250K,
+  GROWTH_500K,
+  SCALE_CUSTOM,
+];
+
+export const DEFAULT_PRICING_TIER_SLUG: PricingTierSlug =
+  "cloud_growth_120k_monthly";
+
+export const PRICING_SELECTOR_TIERS = PRICING_TIERS;
+
+export function isPricingTierSlug(value: string): value is PricingTierSlug {
+  return PRICING_TIERS.some((tier) => tier.slug === value);
+}
+
+export function findPricingTier(slug: string): PricingDisplayPlan | null {
+  return PRICING_TIERS.find((tier) => tier.slug === slug) ?? null;
+}
+
+export function defaultTierForFamily(
+  family: PricingPlanFamily,
+): PricingDisplayPlan {
+  if (family === "starter") return STARTER_55K;
+  if (family === "growth") return GROWTH_120K;
+  if (family === "scale") return SCALE_CUSTOM;
+  return FREE_PLAN;
+}
+
+export function getPricingCardsForSelection(
+  selectedSlug: PricingTierSlug,
+): PricingDisplayPlan[] {
+  const selected = findPricingTier(selectedSlug) ?? GROWTH_120K;
+  const starter = selected.family === "starter" ? selected : STARTER_55K;
+  const growth = selected.family === "growth" ? selected : GROWTH_120K;
+  return [FREE_PLAN, starter, growth, SCALE_CUSTOM];
+}

--- a/tests/e2e/landing-page.spec.ts
+++ b/tests/e2e/landing-page.spec.ts
@@ -61,31 +61,35 @@ test("hosted CTA navigates to the auth page", async ({ page }) => {
   await expect(page).toHaveURL(/\/auth$/);
 });
 
-test("pricing billing toggle updates selected period and plan prices", async ({
+test("pricing quota selector updates predefined monthly tiers", async ({
   page,
 }) => {
   await page.goto("/pricing");
 
-  await expect(page.getByTestId("billing-monthly")).toHaveAttribute(
-    "aria-pressed",
-    "true",
-  );
   await expect(page.getByTestId("plan-starter")).toContainText(
     /\$\s*19\s*\/mo/,
   );
   await expect(page.getByTestId("plan-growth")).toContainText(/\$\s*99\s*\/mo/);
+  await expect(page.getByTestId("plan-growth")).toContainText(
+    "120,000 API + broadcast emails/mo",
+  );
+  await expect(page.getByTestId("billing-yearly")).toHaveCount(0);
 
-  await page.getByTestId("billing-yearly").click();
-
-  await expect(page).toHaveURL(/\/pricing\?billing=yearly$/);
-  await expect(page.getByTestId("billing-yearly")).toHaveAttribute(
-    "aria-pressed",
-    "true",
+  await page.getByTestId("pricing-tier-cloud_starter_100k_monthly").click();
+  await expect(page.getByTestId("plan-starter")).toContainText(
+    /\$\s*35\s*\/mo/,
   );
   await expect(page.getByTestId("plan-starter")).toContainText(
-    /\$\s*15\s*\/mo/,
+    "100,000 API + broadcast emails/mo",
   );
-  await expect(page.getByTestId("plan-growth")).toContainText(/\$\s*79\s*\/mo/);
+
+  await page.getByTestId("pricing-tier-cloud_growth_250k_monthly").click();
+  await expect(page.getByTestId("plan-growth")).toContainText(
+    /\$\s*160\s*\/mo/,
+  );
+  await expect(page.getByTestId("plan-growth")).toContainText(
+    "250,000 API + broadcast emails/mo",
+  );
 });
 
 test("unauthenticated dashboard routes remain protected", async ({ page }) => {

--- a/tests/pricing-grid.test.tsx
+++ b/tests/pricing-grid.test.tsx
@@ -21,7 +21,7 @@ const plans: PricingPlan[] = [
   },
   {
     id: "plan_starter",
-    slug: "starter",
+    slug: "cloud_starter_55k_monthly",
     name: "Starter",
     monthlyPriceCents: 1900,
     monthlyEmailQuota: 55000,
@@ -68,7 +68,7 @@ describe("PricingGrid", () => {
       "5,000 API + broadcast emails/mo",
     );
     expect(screen.getByTestId("pricing-card-starter").textContent).toContain(
-      "Change to $19 / mo",
+      "Change to Starter ($19 / mo)",
     );
   });
 });


### PR DESCRIPTION
## Summary
- remove the public yearly pricing toggle and replace it with a monthly predefined quota selector
- share the landing pricing catalogue/card treatment with the authenticated billing chooser
- add live Stripe Price-backed plan rows for Starter 55k/100k and Growth 120k/250k/500k
- hide legacy Scale/fixed old cloud plan rows from public checkout and keep Scale as contact-sales/custom
- record the pricing decision in `agent_docs/learnings`

## Stripe live Prices
- `opensend_cloud_starter_55k_monthly` → `price_1TXtMCQe1Ex4Xxd5rFHBIDm1`
- `opensend_cloud_starter_100k_monthly` → `price_1TXtMCQe1Ex4Xxd515fpQX93`
- `opensend_cloud_growth_120k_monthly` → `price_1TXtMDQe1Ex4Xxd5mggWy1I7`
- `opensend_cloud_growth_250k_monthly` → `price_1TXtMDQe1Ex4Xxd512n1Bwl9`
- `opensend_cloud_growth_500k_monthly` → `price_1TXtMEQe1Ex4Xxd5qF7r2872`

## Validation
- `make check`
- `make test`
- `bunx playwright test tests/e2e/landing-page.spec.ts`

## Notes
- The business-strategy memo in `/Users/jaeyunha/dev/namuh/namuh-labs/opensend-business-strategy.md` was updated locally with the same monthly-only strategy and live Price IDs; that file is outside this repo/PR.
