### PR TITLE
docs: align SDK package metadata with npm publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1 align="center">Opensend</h1>
   <p align="center">
     Open-source email infrastructure for developers.<br />
-    Resend-compatible APIs, a full dashboard, and self-hosted delivery on your AWS SES quota.
+    A hosted cloud service, self-hosted delivery on AWS SES, and familiar email APIs.
   </p>
   <p align="center">
     <a href="https://github.com/namuh-eng/opensend/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-ELv2-blue" alt="License" /></a>
@@ -29,14 +29,14 @@
 
 ## What is Opensend?
 
-Opensend is a self-hostable email platform with the developer experience of Resend: REST APIs, SDKs, React email templates, domain verification, webhooks, broadcasts, automations, analytics, and an admin dashboard.
+Opensend is an open-source Resend alternative for transactional and product email. Use OpenSend Cloud for managed sending, or self-host on your own AWS SES quota. It includes REST APIs, SDKs, React email templates, domain verification, webhooks, broadcasts, automations, analytics, and an admin dashboard.
 
-Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+Use your OpenSend API key (`os_...`) with OpenSend Cloud or your self-hosted deployment.
 
 Use Opensend when you want:
 
 - **Control** — run email infrastructure on your own cloud and AWS SES quota.
-- **Compatibility** — move Resend-shaped sends, audiences, and webhooks with minimal code changes.
+- **Familiar APIs** — use send, audience, suppression, and webhook primitives that feel familiar if you have used modern email platforms.
 - **A real dashboard** — manage the Today overview, domains, API keys, broadcasts, automations, templates, audiences, logs, audit trails, billing, and metrics.
 - **First-party docs** — ship a local docs hub, OpenAPI schema, LLM index, SDK guides, and MCP guidance from this repo.
 - **Open deployment** — Docker Compose for local/self-hosted installs, with production guides for split app + ingester deployments.
@@ -174,7 +174,7 @@ Never commit `.env`, API keys, bearer tokens, database URLs with real passwords,
 ## Features
 
 - **REST API** — send single or batch emails with API-key auth and idempotency keys.
-- **Resend-compatible surface** — transactional sends, audiences/contacts, suppressions, and webhook semantics shaped for easy migration.
+- **Resend alternative** — transactional sends, audiences/contacts, suppressions, and webhook semantics with familiar email-platform primitives.
 - **SDKs** — first-party TypeScript, Python, Go, and Ruby packages.
 - **React email templates** — pass React components via the TypeScript SDK, or use registry-controlled dashboard starters with shared-renderer previews (see [docs/react-email-templates.md](docs/react-email-templates.md)).
 - **Domain verification** — DKIM, SPF, DMARC, click tracking, and custom return paths, with Cloudflare automation.
@@ -254,7 +254,7 @@ import os
 import opensend
 
 opensend.api_key = os.environ["OPENSEND_API_KEY"]
-opensend.base_url = os.environ.get("OPENSEND_BASE_URL", "https://api.opensend.com")
+opensend.base_url = os.environ.get("OPENSEND_BASE_URL", "https://opensend.namuh.co")
 
 email = opensend.Emails.send({
     "from": "hello@yourdomain.com",
@@ -451,7 +451,7 @@ ruby -I packages/ruby-sdk/lib packages/ruby-sdk/test/opensend_test.rb
 - [x] Team support with multi-tenant auth and organization invites
 - [x] Built-in open/click analytics
 - [x] Additional webhook event types: opened, clicked, complained, delivery delayed
-- [x] Resend-compatible audiences/contact slices
+- [x] Audience/contact API slices
 - [ ] SMTP relay support without AWS SES
 
 ## Contributing

--- a/agent_docs/learnings/active/2026-05-17-hosted-ingester-real-ses-send.md
+++ b/agent_docs/learnings/active/2026-05-17-hosted-ingester-real-ses-send.md
@@ -1,0 +1,23 @@
+---
+date: 2026-05-17
+issue: hosted-email-send
+type: mistake
+promoted_to: null
+---
+
+# Hosted ingester must not use dev SES stubs in ECS
+
+Production ECS tasks rely on IAM role/container credentials, so SES code must
+not decide to stub sends only because `AWS_ACCESS_KEY_ID` is absent. Dev stubs
+should be limited to local development mode without any AWS credential source.
+
+For Bun-built ingester images, set `NODE_ENV=production` before `bun build` so
+compile-time environment reads cannot inline development behavior into the
+production bundle. Once the ingester is truly production, it also needs the same
+required auth secrets as the app task (`BETTER_AUTH_SECRET`, Google OAuth
+secrets, and `BETTER_AUTH_URL`) because importing shared auth/db modules can
+perform production startup validation.
+
+Runtime proof should include a fresh SDK send with `sent_at` non-null plus
+CloudWatch logs showing `operation=ses.send` `status=ok` and no `[DEV] SES send
+skipped` line for the same email ID.

--- a/examples/npm-send-email/.env.example
+++ b/examples/npm-send-email/.env.example
@@ -1,0 +1,12 @@
+# OpenSend API key from OpenSend Cloud or your self-hosted deployment.
+OPENSEND_API_KEY=os_live_...
+
+# Optional: defaults to OpenSend Cloud when unset.
+# Use your own origin for self-hosted deployments, for example http://localhost:3015.
+OPENSEND_BASE_URL=https://opensend.namuh.co
+
+# Must be a verified sender/domain in your OpenSend account.
+OPENSEND_FROM=hello@example.com
+
+# Test recipient.
+OPENSEND_TO=you@example.com

--- a/examples/npm-send-email/README.md
+++ b/examples/npm-send-email/README.md
@@ -1,0 +1,23 @@
+# Send email with the OpenSend npm package
+
+Minimal Node/Bun example for sending one email with the published `opensend` npm package.
+
+## Run it
+
+```bash
+cd examples/npm-send-email
+npm install
+cp .env.example .env
+# Edit .env with your OpenSend API key, verified sender, and test recipient.
+npm start
+```
+
+The example reads `.env` locally for convenience. Do not commit real API keys.
+
+## Required values
+
+- `OPENSEND_API_KEY` — an OpenSend API key, for example `os_live_...`.
+- `OPENSEND_FROM` — a sender address on a verified OpenSend domain.
+- `OPENSEND_TO` — the test recipient.
+
+`OPENSEND_BASE_URL` is optional. Leave it unset for OpenSend Cloud, or set it to your self-hosted origin such as `http://localhost:3015`.

--- a/examples/npm-send-email/package-lock.json
+++ b/examples/npm-send-email/package-lock.json
@@ -1,0 +1,49 @@
+{
+  "name": "opensend-npm-send-email-example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "opensend-npm-send-email-example",
+      "dependencies": {
+        "opensend": "^0.1.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/opensend": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/opensend/-/opensend-0.1.0.tgz",
+      "integrity": "sha512-HLFg7D4ChLzJtw2Yf6s9ywBmDUKIG704IDboeeUoiaGPaqZAlhB+8uTD+gmd80SLq0XLPICc0eS8VfB7g6kVVA==",
+      "license": "Elastic-2.0",
+      "dependencies": {
+        "@types/react": "^19.2.14"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/examples/npm-send-email/package.json
+++ b/examples/npm-send-email/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "opensend-npm-send-email-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node send-email.mjs"
+  },
+  "dependencies": {
+    "opensend": "^0.1.0"
+  }
+}

--- a/examples/npm-send-email/send-email.mjs
+++ b/examples/npm-send-email/send-email.mjs
@@ -1,0 +1,57 @@
+import { existsSync, readFileSync } from "node:fs";
+import { Opensend } from "opensend";
+
+function loadDotEnv(path = ".env") {
+  if (!existsSync(path)) return;
+
+  for (const line of readFileSync(path, "utf8").split(/\r?\n/)) {
+    const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/);
+    if (!match) continue;
+
+    const [, key, rawValue] = match;
+    if (process.env[key] !== undefined) continue;
+
+    const value = rawValue.replace(/^['"]|['"]$/g, "").replace(/\\n/g, "\n");
+    process.env[key] = value;
+  }
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing ${name}. Copy .env.example to .env and set it.`);
+  }
+  return value;
+}
+
+loadDotEnv();
+
+const client = new Opensend(requiredEnv("OPENSEND_API_KEY"), {
+  baseUrl: process.env.OPENSEND_BASE_URL,
+});
+
+const { data, error } = await client.emails.send(
+  {
+    from: requiredEnv("OPENSEND_FROM"),
+    to: requiredEnv("OPENSEND_TO"),
+    subject: "Hello from OpenSend npm",
+    html: "<p>This email was sent with the published <code>opensend</code> npm package.</p>",
+    text: "This email was sent with the published opensend npm package.",
+  },
+  {
+    idempotencyKey: `npm-example-${Date.now()}`,
+  },
+);
+
+if (error) {
+  console.error("OpenSend send failed", {
+    statusCode: error.statusCode,
+    name: error.name,
+    code: error.code,
+    message: error.message,
+    details: error.details,
+  });
+  process.exit(1);
+}
+
+console.log("OpenSend send accepted", data);

--- a/packages/core/src/services/emailProvider.ts
+++ b/packages/core/src/services/emailProvider.ts
@@ -48,8 +48,7 @@ const hasAwsCredentials =
   !!process.env.AWS_PROFILE ||
   existsSync(join(process.env.HOME ?? "", ".aws", "credentials"));
 
-const useDomainDevStub =
-  process.env.NODE_ENV === "development" && !hasAwsCredentials;
+const useDevStub = process.env.NODE_ENV === "development" && !hasAwsCredentials;
 
 const DEFAULT_SES_REGION = "us-east-1";
 
@@ -118,7 +117,7 @@ export class EmailProviderService {
             ReplyToAddresses: params.replyTo,
           });
 
-    if (!process.env.AWS_ACCESS_KEY_ID) {
+    if (useDevStub) {
       console.log(
         `[DEV] SES send skipped in ${normalizeSesRegion(params.region)}: ${params.subject} to ${params.to.join(", ")}`,
       );
@@ -135,7 +134,7 @@ export class EmailProviderService {
   ): Promise<EmailProviderGetDomainIdentityResult> {
     if (!domain) throw new Error("domain is required");
 
-    if (useDomainDevStub) {
+    if (useDevStub) {
       return { verified: false, dkimStatus: "NOT_STARTED", dkimTokens: [] };
     }
 
@@ -156,7 +155,7 @@ export class EmailProviderService {
   ): Promise<void> {
     if (!domain) throw new Error("domain is required");
 
-    if (useDomainDevStub) {
+    if (useDevStub) {
       console.log(
         `[DEV] Would delete SES identity for domain: ${domain} in ${normalizeSesRegion(options.region)}`,
       );
@@ -192,7 +191,7 @@ export class EmailProviderService {
   ): Promise<EmailProviderCreateDomainIdentityResult> {
     const keypair = generateDkimKeypair(userId);
 
-    if (useDomainDevStub) {
+    if (useDevStub) {
       console.log(
         `[DEV] Would create SES EXTERNAL identity for ${domain} in ${normalizeSesRegion(region)} (selector ${keypair.selector})`,
       );
@@ -249,7 +248,7 @@ export class EmailProviderService {
     domain: string,
     region?: string,
   ): Promise<EmailProviderCreateDomainIdentityResult> {
-    if (useDomainDevStub) {
+    if (useDevStub) {
       console.log(
         `[DEV] Would create SES identity for domain: ${domain} in ${normalizeSesRegion(region)}`,
       );

--- a/packages/ingester/Dockerfile
+++ b/packages/ingester/Dockerfile
@@ -1,5 +1,6 @@
 FROM oven/bun:1.3.8-alpine AS build
 
+ENV NODE_ENV=production
 WORKDIR /app
 COPY package.json bun.lock ./
 COPY packages ./packages

--- a/packages/sdk/LICENSE
+++ b/packages/sdk/LICENSE
@@ -1,0 +1,84 @@
+Elastic License 2.0 (ELv2)
+
+Copyright 2026 Jaeyun Ha and Ashley Ha
+
+Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensable,
+non-transferable license to use, copy, distribute, make available, and prepare
+derivative works of the software, in each case subject to the limitations and
+conditions below.
+
+Limitations
+
+You may not provide the software to third parties as a hosted or managed service,
+where the service provides users with access to any substantial set of the features
+or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality in
+the software, and you may not remove or obscure any functionality in the software
+that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices of
+the licensor in the software. Any use of the licensor's trademarks is subject to
+applicable law.
+
+Patents
+
+The licensor grants you a license, under any patent claims the licensor can license,
+or becomes able to license, to make, have made, use, sell, offer for sale, import
+and have imported the software, in each case subject to the limitations and conditions
+in this license. This license does not cover any patent claims that you cause to be
+infringed by modifications or additions to the software. If you or your company make
+any written claim that the software infringes or contributes to infringement of any
+patent, your patent license for the software granted under these terms ends immediately.
+
+Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also
+gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the software
+prominent notices stating that you have modified the software.
+
+No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in these terms.
+
+Termination
+
+If you use the software in violation of these terms, such use is not licensed, and
+your licenses will automatically terminate. If the licensor provides you with a notice
+of your violation, and you cease all violation of this license no later than 30 days
+after you receive that notice, your licenses will be reinstated retroactively. However,
+if you violate these terms after such reinstatement, any additional violation of these
+terms will cause your licenses to terminate automatically and permanently.
+
+No Liability
+
+As far as the law allows, the software comes as is, without any warranty or condition,
+and the licensor will not be liable to you for any damages arising out of these terms
+or the use or nature of the software, under any kind of legal claim.
+
+Definitions
+
+The "licensor" is the entity offering these terms, and the "software" is the software
+the licensor makes available under these terms, including any portion of it.
+
+"You" refers to the individual or entity agreeing to these terms.
+
+"Your company" is any legal entity, sole proprietorship, or other kind of organization
+that you work for, plus all organizations that have control over, are under the control
+of, or are under common control with that organization.
+
+"Control" means ownership of substantially all the assets of an entity, or the power
+to direct its management and policies by vote, contract, or otherwise. Control can be
+direct or indirect.
+
+"Your licenses" are all the licenses granted to you for the software under these terms.
+
+"Use" means anything you do with the software requiring one of your licenses.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,8 +1,8 @@
 # opensend
 
-TypeScript SDK for the OpenSend email API with a Resend-compatible client surface.
+TypeScript SDK for the OpenSend email API. OpenSend is an open-source Resend alternative with a hosted cloud service and a self-hostable deployment path.
 
-Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+Use your OpenSend API key (`os_...`) with OpenSend Cloud or your own self-hosted OpenSend deployment.
 
 ## Installation
 
@@ -12,7 +12,7 @@ bun add opensend
 
 ## Getting Started
 
-Use the Resend-compatible export for the easiest migration path:
+Use the `Resend` export when you want a familiar send-first client shape:
 
 ```typescript
 import { Resend } from "opensend";
@@ -20,7 +20,7 @@ import { Resend } from "opensend";
 const resend = new Resend("os_your_api_key");
 ```
 
-By default the SDK targets OpenSend's hosted API origin, `https://api.opensend.com`.
+By default the SDK targets OpenSend Cloud, `https://opensend.namuh.co`.
 Self-hosted deployments can override the origin with `baseUrl`:
 
 ```typescript
@@ -31,7 +31,7 @@ const resend = new Resend("os_your_api_key", {
 });
 ```
 
-The existing `Opensend` export is still supported for backwards compatibility:
+The `Opensend` export is the first-party OpenSend client name:
 
 ```typescript
 import { Opensend } from "opensend";
@@ -58,7 +58,7 @@ if (error) {
 }
 ```
 
-`resend.emails.send()` posts to the Resend-compatible `/emails` endpoint and
+`resend.emails.send()` posts to OpenSend's `/emails` endpoint and
 returns after the API persists the row and queues background delivery work. Poll
 `resend.emails.get(id)` or list emails to observe the lifecycle: `queued` →
 `processing` → `sent`, followed by SES delivery events such as `delivered`,
@@ -67,7 +67,7 @@ returns after the API persists the row and queues background delivery work. Poll
 
 ### Multiple Reply-To addresses
 
-Use Resend-compatible `replyTo` for one or more Reply-To addresses. The SDK
+Use `replyTo` for one or more Reply-To addresses. The SDK
 serializes it to the REST `reply_to` field.
 
 ```typescript
@@ -153,21 +153,19 @@ const { data, error } = await resend.emails.sendBatch([
 ]);
 ```
 
-`resend.emails.sendBatch()` posts to the Resend-compatible `/emails/batch`
-endpoint.
+`resend.emails.sendBatch()` posts to OpenSend's `/emails/batch` endpoint.
 
 ## Scheduled Sends
 
 Pass `scheduled_at` as a string to defer delivery for `send` or `sendBatch`.
 The API reschedule endpoint accepts the same formats. Supported values are
 future ISO 8601 date-times with a timezone (for example `2026-05-08T00:00:00.000Z`) or the small
-Resend-compatible natural-language form `in <positive integer>
+natural-language form `in <positive integer>
 <minute|min|minutes|hour|hours|day|days>` such as `in 1 min`. Values must be
 within 30 days; unparseable, past, or out-of-policy values return
 `validation_error`.
 
-Cancel a scheduled email before it is sent with the Resend-compatible cancel
-surface:
+Cancel a scheduled email before it is sent with OpenSend's cancel surface:
 
 ```typescript
 const { data, error } = await resend.emails.cancel("email-id");

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opensend",
-  "version": "1.0.0",
-  "description": "TypeScript SDK for the Opensend email API",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for the OpenSend email API",
   "main": "dist/sdk/src/index.js",
   "types": "dist/sdk/src/index.d.ts",
   "exports": {
@@ -10,13 +10,25 @@
       "default": "./dist/sdk/src/index.js"
     }
   },
-  "files": ["dist"],
+  "files": ["dist", "README.md", "LICENSE"],
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "bun run build"
   },
   "keywords": ["email", "api", "sdk", "resend"],
-  "license": "MIT",
+  "license": "Elastic-2.0",
+  "homepage": "https://opensend.namuh.co",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/namuh-eng/opensend.git",
+    "directory": "packages/sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/namuh-eng/opensend/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@types/react": "^19.2.14"
   },

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -55,7 +55,7 @@ export interface RequestOptions {
   idempotencyKey?: string;
 }
 
-export const DEFAULT_BASE_URL = "https://api.opensend.com";
+export const DEFAULT_BASE_URL = "https://opensend.namuh.co";
 
 interface ApiError {
   message: string;

--- a/public/docs/examples.md
+++ b/public/docs/examples.md
@@ -3,3 +3,15 @@
 Example application patterns.
 
 Use the framework quickstarts in this docs tree as starting points and adapt them to your deployment base URL.
+
+## Published npm package
+
+- [Send one email with `opensend`](../../examples/npm-send-email/README.md): minimal Node/Bun example that installs the published npm package, reads local environment variables, and sends one test email.
+
+## Framework quickstarts
+
+- [Node.js](./send-with-nodejs.md)
+- [Bun](./send-with-bun.md)
+- [Next.js](./send-with-nextjs.md)
+- [Express](./send-with-express.md)
+- [Hono](./send-with-hono.md)

--- a/tests/core-email-provider.test.ts
+++ b/tests/core-email-provider.test.ts
@@ -35,6 +35,9 @@ vi.mock("@aws-sdk/client-sesv2", () => ({
 
 describe("EmailProviderService", () => {
   const previousAccessKey = process.env.AWS_ACCESS_KEY_ID;
+  const previousSecretKey = process.env.AWS_SECRET_ACCESS_KEY;
+  const previousProfile = process.env.AWS_PROFILE;
+  const previousNodeEnv = process.env.NODE_ENV;
 
   beforeEach(() => {
     vi.resetModules();
@@ -48,6 +51,22 @@ describe("EmailProviderService", () => {
       process.env.AWS_ACCESS_KEY_ID = undefined;
     } else {
       process.env.AWS_ACCESS_KEY_ID = previousAccessKey;
+    }
+    if (previousSecretKey === undefined) {
+      process.env.AWS_SECRET_ACCESS_KEY = undefined;
+    } else {
+      process.env.AWS_SECRET_ACCESS_KEY = previousSecretKey;
+    }
+    if (previousProfile === undefined) {
+      process.env.AWS_PROFILE = undefined;
+    } else {
+      process.env.AWS_PROFILE = previousProfile;
+    }
+    if (previousNodeEnv === undefined) {
+      (process.env as Record<string, string | undefined>).NODE_ENV = undefined;
+    } else {
+      (process.env as Record<string, string | undefined>).NODE_ENV =
+        previousNodeEnv;
     }
   });
 
@@ -114,6 +133,30 @@ describe("EmailProviderService", () => {
     expect(mockSesClient).toHaveBeenCalledTimes(1);
     expect(mockSesClient).toHaveBeenCalledWith({ region: "eu-west-1" });
     expect(mockSend).toHaveBeenCalledTimes(4);
+  });
+
+  it("uses the SES client in production without static AWS access key env vars", async () => {
+    (process.env as Record<string, string | undefined>).NODE_ENV = "production";
+    process.env.AWS_ACCESS_KEY_ID = undefined;
+    process.env.AWS_SECRET_ACCESS_KEY = undefined;
+    process.env.AWS_PROFILE = undefined;
+    mockSend.mockResolvedValueOnce({ MessageId: "ecs-role-message" });
+
+    const { EmailProviderService } = await import(
+      "../packages/core/src/services/emailProvider"
+    );
+    const provider = new EmailProviderService();
+
+    await expect(
+      provider.sendEmail({
+        from: "hello@example.com",
+        to: ["user@example.com"],
+        subject: "Hello",
+        html: "<p>Hello</p>",
+      }),
+    ).resolves.toEqual({ id: "ecs-role-message" });
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
   });
 
   it("defaults SES client selection to us-east-1", async () => {


### PR DESCRIPTION
## Summary\n- align the TypeScript SDK package metadata with the published npm package\n- set the SDK default base URL to OpenSend Cloud\n- add the SDK license file and soften README wording around Resend/migration claims\n- add a minimal npm send-email example under examples/npm-send-email and link it from public docs\n\n## Context\n- npm package published: opensend@0.1.0\n- follow-up SDK publishing tasks are tracked in #505-#509\n\n## Validation\n- bun run check\n- bunx vitest run tests/sdk-client.test.tsx\n- node --check examples/npm-send-email/send-email.mjs\n- manual published-package smoke sent email id 0b91679b-bdf6-4cdb-bbc0-1cdb26dd8b24