### PR TITLE
Stabilize Go SDK module installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1 align="center">Opensend</h1>
   <p align="center">
     Open-source email infrastructure for developers.<br />
-    Resend-compatible APIs, a full dashboard, and self-hosted delivery on your AWS SES quota.
+    OpenSend APIs with familiar email primitives, a full dashboard, and self-hosted delivery on your AWS SES quota.
   </p>
   <p align="center">
     <a href="https://github.com/namuh-eng/opensend/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-ELv2-blue" alt="License" /></a>
@@ -28,14 +28,14 @@
 
 ## What is Opensend?
 
-Opensend is a self-hostable email platform with the developer experience of Resend: REST APIs, SDKs, React email templates, domain verification, webhooks, broadcasts, automations, analytics, and an admin dashboard.
+Opensend is a self-hostable email platform with REST APIs, SDKs, React email templates, domain verification, webhooks, broadcasts, automations, analytics, and an admin dashboard for teams that want an OpenSend-first Resend alternative.
 
-Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+Use your OpenSend API key (`os_...`) with OpenSend's familiar email API surface.
 
 Use Opensend when you want:
 
 - **Control** — run email infrastructure on your own cloud and AWS SES quota.
-- **Compatibility** — move Resend-shaped sends, audiences, and webhooks with minimal code changes.
+- **Familiar API** — move common sends, audiences, and webhooks with minimal code changes.
 - **A real dashboard** — manage domains, API keys, broadcasts, automations, templates, audiences, logs, and metrics.
 - **Open deployment** — Docker Compose for local/self-hosted installs, with production guides for split app + ingester deployments.
 
@@ -172,7 +172,7 @@ Never commit `.env`, API keys, bearer tokens, database URLs with real passwords,
 ## Features
 
 - **REST API** — send single or batch emails with API-key auth and idempotency keys.
-- **Resend-compatible surface** — transactional sends, audiences/contacts, suppressions, and webhook semantics shaped for easy migration.
+- **OpenSend-first familiar API** — transactional sends, audiences/contacts, suppressions, and webhook semantics shaped for teams choosing a Resend alternative.
 - **SDKs** — first-party TypeScript, Python, Go, and Ruby packages.
 - **React email templates** — pass React components via the TypeScript SDK, or use registry-controlled dashboard starters with shared-renderer previews (see [docs/react-email-templates.md](docs/react-email-templates.md)).
 - **Domain verification** — DKIM, SPF, DMARC, click tracking, and custom return paths, with Cloudflare automation.
@@ -256,7 +256,7 @@ Full docs: [`packages/python-sdk/README.md`](./packages/python-sdk/README.md) an
 ### Go SDK
 
 ```bash
-go get github.com/namuh-eng/opensend/packages/go-sdk
+go get github.com/namuh-eng/opensend/packages/go-sdk@v0.1.0
 ```
 
 ```go
@@ -435,7 +435,7 @@ ruby -I packages/ruby-sdk/lib packages/ruby-sdk/test/opensend_test.rb
 - [x] Team support with multi-tenant auth and organization invites
 - [x] Built-in open/click analytics
 - [x] Additional webhook event types: opened, clicked, complained, delivery delayed
-- [x] Resend-compatible audiences/contact slices
+- [x] Familiar audiences/contact API slices
 - [ ] SMTP relay support without AWS SES
 
 ## Contributing

--- a/docs/sdk/go.md
+++ b/docs/sdk/go.md
@@ -1,15 +1,15 @@
 # Go SDK
 
 OpenSend includes a minimal first-party Go SDK package at
-[`packages/go-sdk`](../../packages/go-sdk) for Resend-shaped transactional email
-sends.
+[`packages/go-sdk`](../../packages/go-sdk) for transactional email sends
+through OpenSend's familiar email API.
 
-Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+Use your OpenSend API key (`os_...`) with OpenSend's familiar email API surface.
 
 ## Install
 
 ```bash
-go get github.com/namuh-eng/opensend/packages/go-sdk
+go get github.com/namuh-eng/opensend/packages/go-sdk@v0.1.0
 ```
 
 ## Configure
@@ -21,7 +21,7 @@ export OPENSEND_API_KEY="os_your_api_key"
 export OPENSEND_BASE_URL="http://localhost:3026" # optional for self-hosting
 ```
 
-If `OPENSEND_BASE_URL` is unset, the SDK targets `https://api.opensend.com`.
+If `OPENSEND_BASE_URL` is unset, the SDK targets `https://opensend.namuh.co`.
 
 ## Send
 

--- a/packages/go-sdk/README.md
+++ b/packages/go-sdk/README.md
@@ -1,16 +1,16 @@
 # opensend Go SDK
 
 Minimal first-party Go SDK for OpenSend transactional email sends with a
-Resend-shaped first send surface.
+familiar first send surface for teams choosing OpenSend as a Resend alternative.
 
-Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+Use your OpenSend API key (`os_...`) with OpenSend's familiar email API surface.
 
 ## Installation
 
 From a Go module, install the package from this repository:
 
 ```bash
-go get github.com/namuh-eng/opensend/packages/go-sdk
+go get github.com/namuh-eng/opensend/packages/go-sdk@v0.1.0
 ```
 
 ## Setup
@@ -22,7 +22,7 @@ export OPENSEND_API_KEY="os_your_api_key"
 ```
 
 For self-hosted OpenSend, point the SDK at your deployment origin. The default
-hosted origin is `https://api.opensend.com`.
+hosted origin is `https://opensend.namuh.co`.
 
 ```bash
 export OPENSEND_BASE_URL="http://localhost:3026"
@@ -67,7 +67,7 @@ func main() {
 }
 ```
 
-`Send` posts to OpenSend's Resend-compatible `POST /emails` endpoint and returns
+`Send` posts to OpenSend's `POST /emails` endpoint and returns
 the accepted email id.
 
 ## Custom HTTP client
@@ -110,7 +110,7 @@ fmt.Println(email.ID)
 
 This first package intentionally does not implement attachments, templates,
 audiences, domains, framework examples, provider infrastructure, or the full
-Resend resource surface yet.
+broader email resource surface yet.
 
 ## Tests
 

--- a/packages/go-sdk/opensend.go
+++ b/packages/go-sdk/opensend.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// DefaultBaseURL is the hosted OpenSend API origin used when no base URL is configured.
-	DefaultBaseURL = "https://api.opensend.com"
+	DefaultBaseURL = "https://opensend.namuh.co"
 	userAgent      = "opensend-go/0.1.0"
 )
 
@@ -129,7 +129,7 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("opensend: API request failed with status %d", e.StatusCode)
 }
 
-// Send posts req to OpenSend's Resend-compatible transactional send endpoint.
+// Send posts req to OpenSend's transactional send endpoint with a familiar /emails API shape.
 func (c *Client) Send(ctx context.Context, req SendRequest) (*SendResponse, error) {
 	if c == nil {
 		return nil, errors.New("opensend client is nil")

--- a/packages/go-sdk/opensend_test.go
+++ b/packages/go-sdk/opensend_test.go
@@ -109,8 +109,8 @@ func TestNewClientDefaultsToHostedBaseURL(t *testing.T) {
 	client, err := NewClient(
 		"os_default",
 		WithHTTPClient(testHTTPClient(t, func(req *http.Request) (*http.Response, error) {
-			if got := req.URL.String(); got != "https://api.opensend.com/emails" {
-				t.Fatalf("url = %s, want https://api.opensend.com/emails", got)
+			if got := req.URL.String(); got != "https://opensend.namuh.co/emails" {
+				t.Fatalf("url = %s, want https://opensend.namuh.co/emails", got)
 			}
 			return jsonResponse(http.StatusOK, `{"id":"email_default"}`), nil
 		})),

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -134,7 +134,7 @@
 - [Self Hosting](https://api.opensend.com/docs/self-hosting.md): Run OpenSend yourself.
 - [Send emails with Bun](https://api.opensend.com/docs/send-with-bun.md): Use the TypeScript SDK from Bun.
 - [Send emails with Express](https://api.opensend.com/docs/send-with-express.md): Send email from an Express API route.
-- [Send emails with Go](https://api.opensend.com/docs/send-with-go.md): Send email from Go where the Go SDK package is available.
+- [Send emails with Go](https://api.opensend.com/docs/send-with-go.md): Send email from Go with the first-party OpenSend Go SDK.
 - [Send emails with Hono](https://api.opensend.com/docs/send-with-hono.md): Send email from Hono.
 - [Send emails with Next.js](https://api.opensend.com/docs/send-with-nextjs.md): Send email from a Next.js route handler or server action.
 - [Send emails with Node.js](https://api.opensend.com/docs/send-with-nodejs.md): Send email from Node.js using the TypeScript SDK.

--- a/public/docs/sdks.md
+++ b/public/docs/sdks.md
@@ -2,4 +2,9 @@
 
 OpenSend SDKs and packages.
 
-Supported SDK docs include TypeScript, Python, Go, and Ruby package pages where present in the repository.
+Supported SDK docs include TypeScript, Python, Go, and Ruby package pages where
+present in the repository. The Go SDK is available from this repository module:
+
+```bash
+go get github.com/namuh-eng/opensend/packages/go-sdk@v0.1.0
+```

--- a/public/docs/send-with-go.md
+++ b/public/docs/send-with-go.md
@@ -1,5 +1,15 @@
 # Send emails with Go
 
-Send email from Go where the Go SDK package is available.
+Send email from Go with the first-party OpenSend Go SDK.
+
+Install the tagged module version from a Go module:
+
+```bash
+go get github.com/namuh-eng/opensend/packages/go-sdk@v0.1.0
+```
+
+If `OPENSEND_BASE_URL` is unset, the SDK targets `https://opensend.namuh.co`.
+Set `OPENSEND_BASE_URL` only when pointing the SDK at a self-hosted OpenSend
+origin.
 
 See `packages/go-sdk/README.md` for current status and examples.


### PR DESCRIPTION
## Summary\n- update the Go SDK hosted default from https://api.opensend.com to https://opensend.namuh.co\n- document the stable Go module install as `github.com/namuh-eng/opensend/packages/go-sdk@v0.1.0`\n- soften Go SDK/shared README wording toward OpenSend-first familiar API / Resend alternative language\n\nCloses #509 after the module tag is published.\n\n## Validation\n- `cd packages/go-sdk && go test ./...`\n- `bun run docs:generate`\n- `bun run check`\n- `git diff --check`\n- `make check`\n- `make test`\n\n## Tag plan\nAfter this commit is selected as the tag target, publish `packages/go-sdk/v0.1.0` so consumers can run `go get github.com/namuh-eng/opensend/packages/go-sdk@v0.1.0`.