### PR TITLE
Prepare Python SDK for PyPI publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@
 
 Opensend is a self-hostable email platform with REST APIs, SDKs, React email templates, domain verification, webhooks, broadcasts, automations, analytics, and an admin dashboard for teams that want an OpenSend-first Resend alternative.
 
-Use your OpenSend API key (`os_...`) with OpenSend's familiar email API surface.
+Use your OpenSend API key (`os_...`) with OpenSend's familiar email API surface and selected compatibility aliases for migration-oriented code.
 
 Use Opensend when you want:
 
 - **Control** — run email infrastructure on your own cloud and AWS SES quota.
-- **Familiar API** — move common sends, audiences, and webhooks with minimal code changes.
+- **Familiar API** — move common sends, audiences, and webhooks with minimal code changes where compatibility aliases are implemented.
 - **A real dashboard** — manage domains, API keys, broadcasts, automations, templates, audiences, logs, and metrics.
 - **Open deployment** — Docker Compose for local/self-hosted installs, with production guides for split app + ingester deployments.
 
@@ -239,7 +239,7 @@ import os
 import opensend
 
 opensend.api_key = os.environ["OPENSEND_API_KEY"]
-opensend.base_url = os.environ.get("OPENSEND_BASE_URL", "https://api.opensend.com")
+opensend.base_url = os.environ.get("OPENSEND_BASE_URL", opensend.DEFAULT_BASE_URL)
 
 email = opensend.Emails.send({
     "from": "hello@yourdomain.com",

--- a/docs/sdk/python.md
+++ b/docs/sdk/python.md
@@ -1,21 +1,27 @@
 # Python SDK
 
 OpenSend includes a minimal first-party Python SDK package at
-[`packages/python-sdk`](../../packages/python-sdk) for Resend-shaped
-transactional email sends.
+[`packages/python-sdk`](../../packages/python-sdk) for transactional email sends
+with a familiar API surface.
 
-Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+Use your OpenSend API key (`os_...`) with OpenSend as a Resend alternative.
+Selected alias compatibility remains available for migration-oriented code.
 
 ## Install
 
-From this repository:
+From this repository before the PyPI release:
 
 ```bash
 python -m pip install ./packages/python-sdk
 ```
 
-The package metadata is prepared for future publishing as `opensend`, but this
-change does not publish to PyPI.
+After `opensend==0.1.0` is published to PyPI, install with:
+
+```bash
+python -m pip install opensend==0.1.0
+```
+
+Until that publish happens, use the repository install shown above.
 
 ## Configure
 
@@ -26,7 +32,7 @@ export OPENSEND_API_KEY="os_your_api_key"
 export OPENSEND_BASE_URL="http://localhost:3015" # optional for self-hosting
 ```
 
-If `OPENSEND_BASE_URL` is unset, the SDK targets `https://api.opensend.com`.
+If `OPENSEND_BASE_URL` is unset, the SDK targets `https://opensend.namuh.co`.
 
 ## Send
 

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -1,22 +1,23 @@
 # opensend Python SDK
 
 Minimal first-party Python SDK for OpenSend transactional email sends with a
-Resend-shaped API surface.
+familiar email API surface.
 
-Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+Use your OpenSend API key (`os_...`) with OpenSend as a Resend alternative.
+The SDK keeps selected alias compatibility for migration-oriented code.
 
 ## Installation
 
-This package is staged for future PyPI publishing. From this repository today:
+From this repository before the PyPI release:
 
 ```bash
 python -m pip install ./packages/python-sdk
 ```
 
-After publication, the intended package install is:
+After `opensend==0.1.0` is published to PyPI, install with:
 
 ```bash
-python -m pip install opensend
+python -m pip install opensend==0.1.0
 ```
 
 ## Setup
@@ -28,7 +29,7 @@ export OPENSEND_API_KEY="os_your_api_key"
 ```
 
 For self-hosted OpenSend, point the SDK at your deployment origin. The default
-hosted origin is `https://api.opensend.com`.
+hosted origin is `https://opensend.namuh.co`.
 
 ```bash
 export OPENSEND_BASE_URL="http://localhost:3015"
@@ -36,7 +37,7 @@ export OPENSEND_BASE_URL="http://localhost:3015"
 
 ## Send an email
 
-The module-level surface mirrors Resend's Python ergonomics:
+The module-level surface keeps familiar Python email SDK ergonomics:
 
 ```python
 import os
@@ -57,7 +58,7 @@ print(email["id"])
 ```
 
 Python reserves `from` as a keyword argument name, but dictionary keys can still
-use the OpenSend/Resend JSON field name. If you prefer constructing dictionaries
+use the OpenSend JSON field name. If you prefer constructing dictionaries
 with Python identifiers, the SDK also accepts `from_` or `from_email` and sends
 that value as JSON `from`.
 
@@ -94,11 +95,12 @@ print(result["data"])
 ## Instance client
 
 ```python
-from opensend import OpenSend
+import os
+from opensend import DEFAULT_BASE_URL, OpenSend
 
 client = OpenSend(
     os.environ["OPENSEND_API_KEY"],
-    base_url=os.environ.get("OPENSEND_BASE_URL", "https://api.opensend.com"),
+    base_url=os.environ.get("OPENSEND_BASE_URL", DEFAULT_BASE_URL),
 )
 
 email = client.emails.send({
@@ -139,8 +141,7 @@ except opensend.OpenSendError as error:
 - Optional `idempotency_key=` request header
 - Typed request/response structures for transactional email sends
 
-This first package intentionally does not implement the full Resend resource
-surface yet.
+This first package intentionally does not implement every OpenSend API resource yet.
 
 ## Tests
 

--- a/packages/python-sdk/src/opensend/__init__.py
+++ b/packages/python-sdk/src/opensend/__init__.py
@@ -1,4 +1,4 @@
-"""Minimal Resend-shaped Python SDK for OpenSend transactional email sends."""
+"""Minimal OpenSend Python SDK for transactional email sends."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit, urlunsplit
 from urllib.request import Request, urlopen
 
-DEFAULT_BASE_URL = "https://api.opensend.com"
+DEFAULT_BASE_URL = "https://opensend.namuh.co"
 
 api_key: Optional[str] = None
 base_url: str = DEFAULT_BASE_URL
@@ -196,11 +196,11 @@ class OpenSend:
 
 
 class Resend(OpenSend):
-    """Resend-shaped alias for easier migration to OpenSend."""
+    """Alias client for code migrating from Resend to OpenSend."""
 
 
 class Emails:
-    """Module-level Resend-style email resource using ``opensend.api_key``."""
+    """Module-level email resource using ``opensend.api_key``."""
 
     SendParams = SendParams
     EmailResponse = EmailResponse

--- a/packages/python-sdk/tests/test_emails.py
+++ b/packages/python-sdk/tests/test_emails.py
@@ -77,6 +77,10 @@ class OpenSendPythonSdkTests(unittest.TestCase):
         opensend.api_key = None
         opensend.base_url = opensend.DEFAULT_BASE_URL
 
+    def test_default_base_url_targets_opensend_cloud(self) -> None:
+        self.assertEqual(opensend.DEFAULT_BASE_URL, "https://opensend.namuh.co")
+        self.assertEqual(opensend.base_url, opensend.DEFAULT_BASE_URL)
+
     def test_module_level_send_serializes_payload_and_auth_header(self) -> None:
         opensend.api_key = "os_test"
         opensend.base_url = self.base_url

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -138,7 +138,7 @@
 - [Send emails with Hono](https://opensend.namuh.co/docs/send-with-hono.md): Send email from Hono.
 - [Send emails with Next.js](https://opensend.namuh.co/docs/send-with-nextjs.md): Send email from a Next.js route handler or server action.
 - [Send emails with Node.js](https://opensend.namuh.co/docs/send-with-nodejs.md): Send email from Node.js using the TypeScript SDK.
-- [Send emails with Python](https://opensend.namuh.co/docs/send-with-python.md): Send email from Python using the Python SDK.
+- [Send emails with Python](https://opensend.namuh.co/docs/send-with-python.md): Send email from Python using the first-party OpenSend Python SDK.
 - [Send emails with Ruby](https://opensend.namuh.co/docs/send-with-ruby.md): Send email from Ruby with the first-party OpenSend Ruby SDK.
 - [Send emails with SMTP](https://opensend.namuh.co/docs/send-with-smtp.md): SMTP integration status.
 - [contact.created](https://opensend.namuh.co/docs/webhooks/contacts/created.md): Webhook event emitted when a contact is created.

--- a/public/docs/send-with-python.md
+++ b/public/docs/send-with-python.md
@@ -1,5 +1,50 @@
 # Send emails with Python
 
-Send email from Python using the Python SDK.
+Send email from Python using the first-party OpenSend Python SDK.
 
-See the Python SDK package README for current install and API details.
+## Install
+
+Until the PyPI release is complete, install from this repository:
+
+```bash
+python -m pip install ./packages/python-sdk
+```
+
+After `opensend==0.1.0` is published to PyPI, install the pinned package:
+
+```bash
+python -m pip install opensend==0.1.0
+```
+
+## Configure
+
+Store API keys in environment variables; do not hardcode real keys. If
+`OPENSEND_BASE_URL` is unset, the SDK targets OpenSend Cloud at
+`https://opensend.namuh.co`.
+
+```bash
+export OPENSEND_API_KEY="os_your_api_key"
+export OPENSEND_BASE_URL="http://localhost:3015" # optional for self-hosting
+```
+
+## Send
+
+```python
+import os
+import opensend
+
+opensend.api_key = os.environ["OPENSEND_API_KEY"]
+opensend.base_url = os.environ.get("OPENSEND_BASE_URL", opensend.DEFAULT_BASE_URL)
+
+email = opensend.Emails.send({
+    "from": "hello@yourdomain.com",
+    "to": "recipient@example.com",
+    "subject": "Hello from OpenSend",
+    "html": "<h1>It works!</h1>",
+})
+
+print(email["id"])
+```
+
+The SDK also exports `OpenSend` for instance clients and `Resend` as an alias
+class for migration-oriented code.

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -28,7 +28,7 @@ type GuideCard = {
   href: string;
 };
 
-const BASE_URL = "https://api.opensend.com";
+const BASE_URL = "https://opensend.namuh.co";
 const DOCS_COUNT = 157;
 
 const OPENSEND_GUIDES: GuideCard[] = [
@@ -94,7 +94,7 @@ const MCP_EXAMPLE = `{
       "args": ["/path/to/opensend/packages/mcp/src/stdio.ts"],
       "env": {
         "OPENSEND_API_KEY": "os_YOUR_API_KEY",
-        "OPENSEND_API_BASE_URL": "https://api.opensend.com"
+        "OPENSEND_API_BASE_URL": "https://opensend.namuh.co"
       }
     }
   }
@@ -111,7 +111,7 @@ const API_SECTIONS: ApiSection[] = [
         path: "/emails",
         title: "Send an email",
         description:
-          "Accepts the Resend-compatible send body. Duplicate Idempotency-Key retries within 24 hours replay the original accepted id.",
+          "Accepts OpenSend send payloads with familiar compatibility aliases. Duplicate Idempotency-Key retries within 24 hours replay the original accepted id.",
         notes: ["Requires a verified sending domain for production traffic."],
         code: {
           node: `await resend.emails.send({
@@ -207,7 +207,7 @@ const API_SECTIONS: ApiSection[] = [
         description:
           "Operator/self-host Cloudflare token flow for writing the generated records automatically.",
         code: {
-          node: `await fetch("https://api.opensend.com/api/domains/domain_id/auto-configure", {
+          node: `await fetch("https://opensend.namuh.co/api/domains/domain_id/auto-configure", {
   method: "POST",
   headers: { Authorization: "Bearer " + apiKey },
 });`,
@@ -237,8 +237,7 @@ const API_SECTIONS: ApiSection[] = [
         method: "POST",
         path: "/contacts",
         title: "Create contact",
-        description:
-          "Create a contact through the Resend-compatible root alias.",
+        description: "Create a contact through the familiar root API alias.",
         code: {
           node: `await client.contacts.create({
   email: "jane@example.com",
@@ -348,7 +347,7 @@ const API_SECTIONS: ApiSection[] = [
         path: "/api-keys",
         title: "Create API key",
         description:
-          "Create scoped keys. OpenSend keys use the os_ prefix while preserving Resend-compatible API semantics.",
+          "Create scoped keys. OpenSend keys use the os_ prefix while preserving familiar API semantics.",
         code: {
           node: `await client.apiKeys.create({ name: "Production" });`,
           curl: `curl -X POST ${BASE_URL}/api-keys \\
@@ -364,7 +363,7 @@ const API_SECTIONS: ApiSection[] = [
         description:
           "Subscribe an HTTPS endpoint to signed delivery and lifecycle events.",
         code: {
-          node: `await fetch("https://api.opensend.com/api/webhooks", {
+          node: `await fetch("https://opensend.namuh.co/api/webhooks", {
   method: "POST",
   headers: {
     Authorization: "Bearer " + apiKey,
@@ -549,8 +548,8 @@ export default function DocsPage() {
               <div className="grid gap-0">
                 <div className="p-6 sm:p-8 lg:p-10">
                   <div className="pill success">
-                    <span className="dot" /> Resend-compatible · self-hosted on
-                    AWS SES
+                    <span className="dot" /> Familiar API · self-hosted on AWS
+                    SES
                   </div>
                   <h1 className="mt-6 text-[42px] font-medium leading-[0.96] tracking-[-0.04em] text-fg sm:text-[56px]">
                     Email API docs that agents and humans can actually use.

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -140,7 +140,7 @@ export const openApiDocument = {
     },
   },
   servers: [
-    { url: "https://api.opensend.com", description: "OpenSend API" },
+    { url: "https://opensend.namuh.co", description: "OpenSend API" },
     { url: "http://localhost:3015", description: "Local development" },
   ],
   tags: [


### PR DESCRIPTION
## Summary
- Prepare the Python SDK package for `opensend==0.1.0` by switching its default hosted origin to `https://opensend.namuh.co` and adding coverage for that default.
- Refresh Python SDK README/docs and public install guidance for the credential-held PyPI release path.
- Soften stale Resend-first wording toward OpenSend-first / Resend alternative language while preserving explicit migration alias compatibility notes.

Refs #506

## Changes
- **Python SDK**: update `DEFAULT_BASE_URL`, docstrings, README install guidance, and default-base regression coverage.
- **Public docs**: update Python send guide, generated `llms.txt`, docs index generator, OpenAPI/docs page hosted URLs, and API examples to use `opensend.namuh.co`.
- **Product copy**: adjust README/docs page wording from Resend-compatible-first to familiar/OpenSend-first language where it was stale.

## Validation
- [x] `python3 -m unittest discover packages/python-sdk/tests`
- [x] `python3 -m pip wheel packages/python-sdk --wheel-dir /tmp/opensend-python-wheel --no-deps`
- [x] Inspected `/tmp/opensend-python-wheel/opensend-0.1.0-py3-none-any.whl` for `opensend/__init__.py`, `opensend/py.typed`, metadata, pure Python tag, and the `https://opensend.namuh.co` default.
- [x] Clean venv install/import smoke from the built wheel with `opensend==0.1.0` and `OpenSend`/`Resend` client construction.
- [x] `bun run docs:generate`
- [x] `make check`
- [x] `git diff --check`

## Publish status / blocker
PyPI publish was **not** performed because `PYPI_API_TOKEN` is not present in this environment. The remaining credential-held steps are:
1. Publish the already-validated package as `opensend==0.1.0` using a safe PyPI token.
2. Verify `python -m pip install opensend==0.1.0` from PyPI in a clean environment.

## Notes
- Ruby and Go SDK defaults were intentionally left untouched per issue scope.
- No secrets, `.env`, token files, or generated wheel/build artifacts are committed.
