### PR TITLE
Release: staging to main SDK publish prep wave

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ Full docs: [`packages/go-sdk/README.md`](./packages/go-sdk/README.md) and [`docs
 cd packages/ruby-sdk
 gem build opensend.gemspec
 gem install ./opensend-0.1.0.gem
+# After the RubyGems publish is complete:
+# gem install opensend
 ```
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1 align="center">Opensend</h1>
   <p align="center">
     Open-source email infrastructure for developers.<br />
-    Resend-compatible APIs, a full dashboard, and self-hosted delivery on your AWS SES quota.
+    OpenSend APIs with familiar email primitives, a full dashboard, and self-hosted delivery on your AWS SES quota.
   </p>
   <p align="center">
     <a href="https://github.com/namuh-eng/opensend/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-ELv2-blue" alt="License" /></a>
@@ -28,14 +28,14 @@
 
 ## What is Opensend?
 
-Opensend is a self-hostable email platform with the developer experience of Resend: REST APIs, SDKs, React email templates, domain verification, webhooks, broadcasts, automations, analytics, and an admin dashboard.
+Opensend is a self-hostable email platform with REST APIs, SDKs, React email templates, domain verification, webhooks, broadcasts, automations, analytics, and an admin dashboard for teams that want an OpenSend-first Resend alternative.
 
-Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+Use your OpenSend API key (`os_...`) with OpenSend's familiar email API surface.
 
 Use Opensend when you want:
 
 - **Control** — run email infrastructure on your own cloud and AWS SES quota.
-- **Compatibility** — move Resend-shaped sends, audiences, and webhooks with minimal code changes.
+- **Familiar API** — move common sends, audiences, and webhooks with minimal code changes.
 - **A real dashboard** — manage domains, API keys, broadcasts, automations, templates, audiences, logs, and metrics.
 - **Open deployment** — Docker Compose for local/self-hosted installs, with production guides for split app + ingester deployments.
 
@@ -172,7 +172,7 @@ Never commit `.env`, API keys, bearer tokens, database URLs with real passwords,
 ## Features
 
 - **REST API** — send single or batch emails with API-key auth and idempotency keys.
-- **Resend-compatible surface** — transactional sends, audiences/contacts, suppressions, and webhook semantics shaped for easy migration.
+- **OpenSend-first familiar API** — transactional sends, audiences/contacts, suppressions, and webhook semantics shaped for teams choosing a Resend alternative.
 - **SDKs** — first-party TypeScript, Python, Go, and Ruby packages.
 - **React email templates** — pass React components via the TypeScript SDK, or use registry-controlled dashboard starters with shared-renderer previews (see [docs/react-email-templates.md](docs/react-email-templates.md)).
 - **Domain verification** — DKIM, SPF, DMARC, click tracking, and custom return paths, with Cloudflare automation.
@@ -256,7 +256,7 @@ Full docs: [`packages/python-sdk/README.md`](./packages/python-sdk/README.md) an
 ### Go SDK
 
 ```bash
-go get github.com/namuh-eng/opensend/packages/go-sdk
+go get github.com/namuh-eng/opensend/packages/go-sdk@v0.1.0
 ```
 
 ```go
@@ -435,7 +435,7 @@ ruby -I packages/ruby-sdk/lib packages/ruby-sdk/test/opensend_test.rb
 - [x] Team support with multi-tenant auth and organization invites
 - [x] Built-in open/click analytics
 - [x] Additional webhook event types: opened, clicked, complained, delivery delayed
-- [x] Resend-compatible audiences/contact slices
+- [x] Familiar audiences/contact API slices
 - [ ] SMTP relay support without AWS SES
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@
 
 Opensend is a self-hostable email platform with REST APIs, SDKs, React email templates, domain verification, webhooks, broadcasts, automations, analytics, and an admin dashboard for teams that want an OpenSend-first Resend alternative.
 
-Use your OpenSend API key (`os_...`) with OpenSend's familiar email API surface.
+Use your OpenSend API key (`os_...`) with OpenSend's familiar email API surface and selected compatibility aliases for migration-oriented code.
 
 Use Opensend when you want:
 
 - **Control** — run email infrastructure on your own cloud and AWS SES quota.
-- **Familiar API** — move common sends, audiences, and webhooks with minimal code changes.
+- **Familiar API** — move common sends, audiences, and webhooks with minimal code changes where compatibility aliases are implemented.
 - **A real dashboard** — manage domains, API keys, broadcasts, automations, templates, audiences, logs, and metrics.
 - **Open deployment** — Docker Compose for local/self-hosted installs, with production guides for split app + ingester deployments.
 
@@ -239,7 +239,7 @@ import os
 import opensend
 
 opensend.api_key = os.environ["OPENSEND_API_KEY"]
-opensend.base_url = os.environ.get("OPENSEND_BASE_URL", "https://api.opensend.com")
+opensend.base_url = os.environ.get("OPENSEND_BASE_URL", opensend.DEFAULT_BASE_URL)
 
 email = opensend.Emails.send({
     "from": "hello@yourdomain.com",

--- a/docs/sdk/go.md
+++ b/docs/sdk/go.md
@@ -1,15 +1,15 @@
 # Go SDK
 
 OpenSend includes a minimal first-party Go SDK package at
-[`packages/go-sdk`](../../packages/go-sdk) for Resend-shaped transactional email
-sends.
+[`packages/go-sdk`](../../packages/go-sdk) for transactional email sends
+through OpenSend's familiar email API.
 
-Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+Use your OpenSend API key (`os_...`) with OpenSend's familiar email API surface.
 
 ## Install
 
 ```bash
-go get github.com/namuh-eng/opensend/packages/go-sdk
+go get github.com/namuh-eng/opensend/packages/go-sdk@v0.1.0
 ```
 
 ## Configure
@@ -21,7 +21,7 @@ export OPENSEND_API_KEY="os_your_api_key"
 export OPENSEND_BASE_URL="http://localhost:3026" # optional for self-hosting
 ```
 
-If `OPENSEND_BASE_URL` is unset, the SDK targets `https://api.opensend.com`.
+If `OPENSEND_BASE_URL` is unset, the SDK targets `https://opensend.namuh.co`.
 
 ## Send
 

--- a/docs/sdk/python.md
+++ b/docs/sdk/python.md
@@ -1,21 +1,27 @@
 # Python SDK
 
 OpenSend includes a minimal first-party Python SDK package at
-[`packages/python-sdk`](../../packages/python-sdk) for Resend-shaped
-transactional email sends.
+[`packages/python-sdk`](../../packages/python-sdk) for transactional email sends
+with a familiar API surface.
 
-Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+Use your OpenSend API key (`os_...`) with OpenSend as a Resend alternative.
+Selected alias compatibility remains available for migration-oriented code.
 
 ## Install
 
-From this repository:
+From this repository before the PyPI release:
 
 ```bash
 python -m pip install ./packages/python-sdk
 ```
 
-The package metadata is prepared for future publishing as `opensend`, but this
-change does not publish to PyPI.
+After `opensend==0.1.0` is published to PyPI, install with:
+
+```bash
+python -m pip install opensend==0.1.0
+```
+
+Until that publish happens, use the repository install shown above.
 
 ## Configure
 
@@ -26,7 +32,7 @@ export OPENSEND_API_KEY="os_your_api_key"
 export OPENSEND_BASE_URL="http://localhost:3015" # optional for self-hosting
 ```
 
-If `OPENSEND_BASE_URL` is unset, the SDK targets `https://api.opensend.com`.
+If `OPENSEND_BASE_URL` is unset, the SDK targets `https://opensend.namuh.co`.
 
 ## Send
 

--- a/docs/sdk/ruby.md
+++ b/docs/sdk/ruby.md
@@ -1,10 +1,12 @@
 # Ruby SDK
 
 OpenSend includes a minimal first-party Ruby SDK package at
-[`packages/ruby-sdk`](../../packages/ruby-sdk) for Resend-shaped transactional
-email sends.
+[`packages/ruby-sdk`](../../packages/ruby-sdk) for transactional
+email sends through OpenSend.
 
-Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+Use your OpenSend API key (`os_...`) with OpenSend's Ruby API surface.
+Existing Resend-style send calls can migrate through the alias documented
+below.
 
 ## Install
 
@@ -16,8 +18,9 @@ gem build opensend.gemspec
 gem install ./opensend-0.1.0.gem
 ```
 
-The gem metadata is prepared for future publishing as `opensend`, but this
-change does not publish to RubyGems.
+The gem metadata is ready for publishing as `opensend`. Until the RubyGems
+publish is complete, install the built gem from this repository. After
+publication, use `gem install opensend`.
 
 ## Configure
 
@@ -28,7 +31,7 @@ export OPENSEND_API_KEY="os_your_api_key"
 export OPENSEND_BASE_URL="http://localhost:3015" # optional for self-hosting
 ```
 
-If `OPENSEND_BASE_URL` is unset, the SDK targets `https://api.opensend.com`.
+If `OPENSEND_BASE_URL` is unset, the SDK targets `https://opensend.namuh.co`.
 
 ## Send
 
@@ -48,8 +51,8 @@ email = OpenSend::Emails.send(
 puts email.fetch("id")
 ```
 
-For migration-oriented code, `Resend` is an alias for `OpenSend` after requiring
-this package:
+For existing send code migrating to OpenSend, `Resend` is an alias for
+`OpenSend` after requiring this package:
 
 ```ruby
 require "opensend"

--- a/packages/go-sdk/README.md
+++ b/packages/go-sdk/README.md
@@ -1,16 +1,16 @@
 # opensend Go SDK
 
 Minimal first-party Go SDK for OpenSend transactional email sends with a
-Resend-shaped first send surface.
+familiar first send surface for teams choosing OpenSend as a Resend alternative.
 
-Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+Use your OpenSend API key (`os_...`) with OpenSend's familiar email API surface.
 
 ## Installation
 
 From a Go module, install the package from this repository:
 
 ```bash
-go get github.com/namuh-eng/opensend/packages/go-sdk
+go get github.com/namuh-eng/opensend/packages/go-sdk@v0.1.0
 ```
 
 ## Setup
@@ -22,7 +22,7 @@ export OPENSEND_API_KEY="os_your_api_key"
 ```
 
 For self-hosted OpenSend, point the SDK at your deployment origin. The default
-hosted origin is `https://api.opensend.com`.
+hosted origin is `https://opensend.namuh.co`.
 
 ```bash
 export OPENSEND_BASE_URL="http://localhost:3026"
@@ -67,7 +67,7 @@ func main() {
 }
 ```
 
-`Send` posts to OpenSend's Resend-compatible `POST /emails` endpoint and returns
+`Send` posts to OpenSend's `POST /emails` endpoint and returns
 the accepted email id.
 
 ## Custom HTTP client
@@ -110,7 +110,7 @@ fmt.Println(email.ID)
 
 This first package intentionally does not implement attachments, templates,
 audiences, domains, framework examples, provider infrastructure, or the full
-Resend resource surface yet.
+broader email resource surface yet.
 
 ## Tests
 

--- a/packages/go-sdk/opensend.go
+++ b/packages/go-sdk/opensend.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// DefaultBaseURL is the hosted OpenSend API origin used when no base URL is configured.
-	DefaultBaseURL = "https://api.opensend.com"
+	DefaultBaseURL = "https://opensend.namuh.co"
 	userAgent      = "opensend-go/0.1.0"
 )
 
@@ -129,7 +129,7 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("opensend: API request failed with status %d", e.StatusCode)
 }
 
-// Send posts req to OpenSend's Resend-compatible transactional send endpoint.
+// Send posts req to OpenSend's transactional send endpoint with a familiar /emails API shape.
 func (c *Client) Send(ctx context.Context, req SendRequest) (*SendResponse, error) {
 	if c == nil {
 		return nil, errors.New("opensend client is nil")

--- a/packages/go-sdk/opensend_test.go
+++ b/packages/go-sdk/opensend_test.go
@@ -109,8 +109,8 @@ func TestNewClientDefaultsToHostedBaseURL(t *testing.T) {
 	client, err := NewClient(
 		"os_default",
 		WithHTTPClient(testHTTPClient(t, func(req *http.Request) (*http.Response, error) {
-			if got := req.URL.String(); got != "https://api.opensend.com/emails" {
-				t.Fatalf("url = %s, want https://api.opensend.com/emails", got)
+			if got := req.URL.String(); got != "https://opensend.namuh.co/emails" {
+				t.Fatalf("url = %s, want https://opensend.namuh.co/emails", got)
 			}
 			return jsonResponse(http.StatusOK, `{"id":"email_default"}`), nil
 		})),

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -1,22 +1,23 @@
 # opensend Python SDK
 
 Minimal first-party Python SDK for OpenSend transactional email sends with a
-Resend-shaped API surface.
+familiar email API surface.
 
-Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+Use your OpenSend API key (`os_...`) with OpenSend as a Resend alternative.
+The SDK keeps selected alias compatibility for migration-oriented code.
 
 ## Installation
 
-This package is staged for future PyPI publishing. From this repository today:
+From this repository before the PyPI release:
 
 ```bash
 python -m pip install ./packages/python-sdk
 ```
 
-After publication, the intended package install is:
+After `opensend==0.1.0` is published to PyPI, install with:
 
 ```bash
-python -m pip install opensend
+python -m pip install opensend==0.1.0
 ```
 
 ## Setup
@@ -28,7 +29,7 @@ export OPENSEND_API_KEY="os_your_api_key"
 ```
 
 For self-hosted OpenSend, point the SDK at your deployment origin. The default
-hosted origin is `https://api.opensend.com`.
+hosted origin is `https://opensend.namuh.co`.
 
 ```bash
 export OPENSEND_BASE_URL="http://localhost:3015"
@@ -36,7 +37,7 @@ export OPENSEND_BASE_URL="http://localhost:3015"
 
 ## Send an email
 
-The module-level surface mirrors Resend's Python ergonomics:
+The module-level surface keeps familiar Python email SDK ergonomics:
 
 ```python
 import os
@@ -57,7 +58,7 @@ print(email["id"])
 ```
 
 Python reserves `from` as a keyword argument name, but dictionary keys can still
-use the OpenSend/Resend JSON field name. If you prefer constructing dictionaries
+use the OpenSend JSON field name. If you prefer constructing dictionaries
 with Python identifiers, the SDK also accepts `from_` or `from_email` and sends
 that value as JSON `from`.
 
@@ -94,11 +95,12 @@ print(result["data"])
 ## Instance client
 
 ```python
-from opensend import OpenSend
+import os
+from opensend import DEFAULT_BASE_URL, OpenSend
 
 client = OpenSend(
     os.environ["OPENSEND_API_KEY"],
-    base_url=os.environ.get("OPENSEND_BASE_URL", "https://api.opensend.com"),
+    base_url=os.environ.get("OPENSEND_BASE_URL", DEFAULT_BASE_URL),
 )
 
 email = client.emails.send({
@@ -139,8 +141,7 @@ except opensend.OpenSendError as error:
 - Optional `idempotency_key=` request header
 - Typed request/response structures for transactional email sends
 
-This first package intentionally does not implement the full Resend resource
-surface yet.
+This first package intentionally does not implement every OpenSend API resource yet.
 
 ## Tests
 

--- a/packages/python-sdk/src/opensend/__init__.py
+++ b/packages/python-sdk/src/opensend/__init__.py
@@ -1,4 +1,4 @@
-"""Minimal Resend-shaped Python SDK for OpenSend transactional email sends."""
+"""Minimal OpenSend Python SDK for transactional email sends."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit, urlunsplit
 from urllib.request import Request, urlopen
 
-DEFAULT_BASE_URL = "https://api.opensend.com"
+DEFAULT_BASE_URL = "https://opensend.namuh.co"
 
 api_key: Optional[str] = None
 base_url: str = DEFAULT_BASE_URL
@@ -196,11 +196,11 @@ class OpenSend:
 
 
 class Resend(OpenSend):
-    """Resend-shaped alias for easier migration to OpenSend."""
+    """Alias client for code migrating from Resend to OpenSend."""
 
 
 class Emails:
-    """Module-level Resend-style email resource using ``opensend.api_key``."""
+    """Module-level email resource using ``opensend.api_key``."""
 
     SendParams = SendParams
     EmailResponse = EmailResponse

--- a/packages/python-sdk/tests/test_emails.py
+++ b/packages/python-sdk/tests/test_emails.py
@@ -77,6 +77,10 @@ class OpenSendPythonSdkTests(unittest.TestCase):
         opensend.api_key = None
         opensend.base_url = opensend.DEFAULT_BASE_URL
 
+    def test_default_base_url_targets_opensend_cloud(self) -> None:
+        self.assertEqual(opensend.DEFAULT_BASE_URL, "https://opensend.namuh.co")
+        self.assertEqual(opensend.base_url, opensend.DEFAULT_BASE_URL)
+
     def test_module_level_send_serializes_payload_and_auth_header(self) -> None:
         opensend.api_key = "os_test"
         opensend.base_url = self.base_url

--- a/packages/ruby-sdk/README.md
+++ b/packages/ruby-sdk/README.md
@@ -1,14 +1,16 @@
 # opensend Ruby SDK
 
 Minimal first-party Ruby SDK for OpenSend transactional email sends with a
-Resend-shaped API surface.
+familiar API surface.
 
-Use your OpenSend API key (`os_...`) with the Resend-compatible API surface.
+Use your OpenSend API key (`os_...`) with OpenSend's Ruby API surface.
+Existing Resend-style send calls can migrate through the alias documented
+below.
 
 ## Installation
 
-This package is staged for future RubyGems publishing. From this repository
-today:
+This package is ready for RubyGems publishing. Until the RubyGems publish is
+complete, install the built gem from this repository:
 
 ```bash
 cd packages/ruby-sdk
@@ -16,7 +18,7 @@ gem build opensend.gemspec
 gem install ./opensend-0.1.0.gem
 ```
 
-After publication, the intended package install is:
+After `opensend` is published to RubyGems, install it with:
 
 ```bash
 gem install opensend
@@ -31,7 +33,7 @@ export OPENSEND_API_KEY="os_your_api_key"
 ```
 
 For self-hosted OpenSend, point the SDK at your deployment origin. The default
-hosted origin is `https://api.opensend.com`.
+hosted origin is `https://opensend.namuh.co`.
 
 ```bash
 export OPENSEND_BASE_URL="http://localhost:3015"
@@ -39,7 +41,8 @@ export OPENSEND_BASE_URL="http://localhost:3015"
 
 ## Send an email
 
-The module-level surface mirrors Resend's Ruby ergonomics:
+The module-level surface uses OpenSend while keeping familiar Ruby email-send
+ergonomics:
 
 ```ruby
 require "opensend"
@@ -57,7 +60,8 @@ email = OpenSend::Emails.send(
 puts email.fetch("id")
 ```
 
-`Resend` is also exported as an alias constant for migration-oriented code:
+`Resend` is also exported as an alias constant for existing send code migrating
+to OpenSend:
 
 ```ruby
 require "opensend"
@@ -108,10 +112,10 @@ end
 - Bearer API key auth
 - Configurable base URL
 - Structured API error envelope parsing
-- Resend alias constant for migration-oriented send code
+- Resend alias constant for existing send code migrating to OpenSend
 
 This first package intentionally does not implement batch sends, async jobs,
-attachments helpers, or the full Resend resource surface yet.
+attachments helpers, or full resource-surface parity yet.
 
 ## Tests
 

--- a/packages/ruby-sdk/lib/opensend.rb
+++ b/packages/ruby-sdk/lib/opensend.rb
@@ -7,7 +7,7 @@ require "uri"
 require_relative "opensend/version"
 
 module OpenSend
-  DEFAULT_BASE_URL = "https://api.opensend.com"
+  DEFAULT_BASE_URL = "https://opensend.namuh.co"
   USER_AGENT = "opensend-ruby/#{VERSION}"
 
   class << self

--- a/packages/ruby-sdk/opensend.gemspec
+++ b/packages/ruby-sdk/opensend.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name = "opensend"
   spec.version = OpenSend::VERSION
   spec.summary = "Ruby SDK for the OpenSend email API"
-  spec.description = "Minimal first-party Ruby SDK for OpenSend transactional email sends with a Resend-shaped API surface."
+  spec.description = "Minimal first-party Ruby SDK for OpenSend transactional email sends with a familiar API surface."
   spec.authors = ["OpenSend"]
   spec.homepage = "https://github.com/namuh-eng/opensend"
   # RubyGems 3.0 does not recognize Elastic-2.0 as SPDX, so keep builds warning-free

--- a/packages/ruby-sdk/test/opensend_test.rb
+++ b/packages/ruby-sdk/test/opensend_test.rb
@@ -44,6 +44,14 @@ class OpenSendRubySdkTest < Minitest::Test
     OpenSend.base_url = OpenSend::DEFAULT_BASE_URL
   end
 
+  def test_default_base_url_targets_opensend_cloud
+    assert_equal("https://opensend.namuh.co", OpenSend::DEFAULT_BASE_URL)
+    assert_equal(OpenSend::DEFAULT_BASE_URL, OpenSend.base_url)
+
+    client = OpenSend::Client.new(api_key: "os_default")
+    assert_equal(OpenSend::DEFAULT_BASE_URL, client.base_url)
+  end
+
   def test_module_level_send_serializes_payload_and_auth_header
     OpenSend.api_key "os_test"
     OpenSend.base_url @base_url

--- a/public/docs/api-reference/emails/send-batch-emails.md
+++ b/public/docs/api-reference/emails/send-batch-emails.md
@@ -21,7 +21,7 @@ Send an array of email payloads. Use an `Idempotency-Key` header to make retries
 ## Example
 
 ```bash
-curl -X POST https://api.opensend.com/emails/batch \
+curl -X POST https://opensend.namuh.co/emails/batch \
   -H "Authorization: Bearer os_YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '[{"from":"Acme <news@example.com>","to":["a@example.com"],"subject":"A","html":"<p>A</p>"}]'

--- a/public/docs/api-reference/emails/send-email.md
+++ b/public/docs/api-reference/emails/send-email.md
@@ -30,7 +30,7 @@ Optional fields include `cc`, `bcc`, `reply_to`, `headers`, `attachments`, `tags
 ## Example
 
 ```bash
-curl -X POST https://api.opensend.com/emails \
+curl -X POST https://opensend.namuh.co/emails \
   -H "Authorization: Bearer os_YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -H "Idempotency-Key: welcome-001" \

--- a/public/docs/api-reference/introduction.md
+++ b/public/docs/api-reference/introduction.md
@@ -7,7 +7,7 @@ OpenSend is a REST API for sending, receiving, and operating email on infrastruc
 ## Base URL
 
 ```txt
-https://api.opensend.com
+https://opensend.namuh.co
 ```
 
 For local development, use the port configured by your app, usually:

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -2,168 +2,168 @@
 
 ## Docs
 
-- [Introduction](https://api.opensend.com/docs/api-reference/introduction.md): Core concepts for the OpenSend API.
-- [Authentication](https://api.opensend.com/docs/api-reference/authentication.md): How API key authentication works in OpenSend.
-- [Pagination](https://api.opensend.com/docs/api-reference/pagination.md): Pagination behavior for list endpoints.
-- [Errors](https://api.opensend.com/docs/api-reference/errors.md): Common OpenSend API error shapes and status codes.
-- [Usage Limits](https://api.opensend.com/docs/api-reference/rate-limit.md): Rate limits, quotas, and operational limits.
-- [Agent Email Inbox Skill](https://api.opensend.com/docs/agent-email-inbox-skill.md): Give agents an email inbox backed by OpenSend receiving flows.
-- [AI Onboarding](https://api.opensend.com/docs/ai-onboarding.md): Onboard coding agents to OpenSend.
-- [Create API Key](https://api.opensend.com/docs/api-reference/api-keys/create-api-key.md): Create a new API key.
-- [Delete API Key](https://api.opensend.com/docs/api-reference/api-keys/delete-api-key.md): Delete an API key.
-- [List API Keys](https://api.opensend.com/docs/api-reference/api-keys/list-api-keys.md): List API keys for the authenticated tenant.
-- [Create Broadcast](https://api.opensend.com/docs/api-reference/broadcasts/create-broadcast.md): Create a broadcast draft.
-- [Delete Broadcast](https://api.opensend.com/docs/api-reference/broadcasts/delete-broadcast.md): Delete a broadcast.
-- [Retrieve Broadcast](https://api.opensend.com/docs/api-reference/broadcasts/get-broadcast.md): Retrieve a broadcast.
-- [List Broadcasts](https://api.opensend.com/docs/api-reference/broadcasts/list-broadcasts.md): List broadcasts.
-- [Send Broadcast](https://api.opensend.com/docs/api-reference/broadcasts/send-broadcast.md): Send or schedule a broadcast.
-- [Update Broadcast](https://api.opensend.com/docs/api-reference/broadcasts/update-broadcast.md): Update a broadcast.
-- [Create Contact Property](https://api.opensend.com/docs/api-reference/contact-properties/create-contact-property.md): Create a custom contact property.
-- [Delete Contact Property](https://api.opensend.com/docs/api-reference/contact-properties/delete-contact-property.md): Delete a contact property.
-- [Retrieve Contact Property](https://api.opensend.com/docs/api-reference/contact-properties/get-contact-property.md): Retrieve a contact property.
-- [List Contact Properties](https://api.opensend.com/docs/api-reference/contact-properties/list-contact-properties.md): List contact properties.
-- [Update Contact Property](https://api.opensend.com/docs/api-reference/contact-properties/update-contact-property.md): Update a contact property.
-- [Add Contact to Segment](https://api.opensend.com/docs/api-reference/contacts/add-contact-to-segment.md): Add a contact to a segment.
-- [Create Contact](https://api.opensend.com/docs/api-reference/contacts/create-contact.md): Create an audience contact.
-- [Delete Contact Segment](https://api.opensend.com/docs/api-reference/contacts/delete-contact-segment.md): Remove a contact from a segment.
-- [Delete Contact](https://api.opensend.com/docs/api-reference/contacts/delete-contact.md): Delete a contact.
-- [Retrieve Contact Topics](https://api.opensend.com/docs/api-reference/contacts/get-contact-topics.md): Get topic subscriptions for a contact.
-- [Retrieve Contact](https://api.opensend.com/docs/api-reference/contacts/get-contact.md): Retrieve a contact by id or email where supported.
-- [List Contact Segments](https://api.opensend.com/docs/api-reference/contacts/list-contact-segments.md): List segments for a contact.
-- [List Contacts](https://api.opensend.com/docs/api-reference/contacts/list-contacts.md): List contacts.
-- [Update Contact Topics](https://api.opensend.com/docs/api-reference/contacts/update-contact-topics.md): Update topic subscriptions for a contact.
-- [Update Contact](https://api.opensend.com/docs/api-reference/contacts/update-contact.md): Update contact fields.
-- [Auto Configure Domain](https://api.opensend.com/docs/api-reference/domains/auto-configure-domain.md): Write DNS records through configured Cloudflare credentials.
-- [Create Domain](https://api.opensend.com/docs/api-reference/domains/create-domain.md): Add a sending domain.
-- [Delete Domain](https://api.opensend.com/docs/api-reference/domains/delete-domain.md): Delete a domain.
-- [Retrieve Domain](https://api.opensend.com/docs/api-reference/domains/get-domain.md): Retrieve a domain.
-- [List Domains](https://api.opensend.com/docs/api-reference/domains/list-domains.md): List domains.
-- [Update Domain](https://api.opensend.com/docs/api-reference/domains/update-domain.md): Update domain settings.
-- [Verify Domain](https://api.opensend.com/docs/api-reference/domains/verify-domain.md): Re-check DNS verification state.
-- [Cancel Email](https://api.opensend.com/docs/api-reference/emails/cancel-email.md): Cancel a scheduled email.
-- [List Sent Email Attachments](https://api.opensend.com/docs/api-reference/emails/list-email-attachments.md): List attachments for a sent email.
-- [List Sent Emails](https://api.opensend.com/docs/api-reference/emails/list-emails.md): List sent and queued emails for the authenticated tenant.
-- [List Received Email Attachments](https://api.opensend.com/docs/api-reference/emails/list-received-email-attachments.md): List attachments from a received email.
-- [List Received Emails](https://api.opensend.com/docs/api-reference/emails/list-received-emails.md): List inbound emails received by OpenSend.
-- [Retrieve Sent Email Attachment](https://api.opensend.com/docs/api-reference/emails/retrieve-email-attachment.md): Download or retrieve a sent email attachment.
-- [Retrieve Sent Email](https://api.opensend.com/docs/api-reference/emails/retrieve-email.md): Retrieve one sent email and its current state.
-- [Retrieve Received Email Attachment](https://api.opensend.com/docs/api-reference/emails/retrieve-received-email-attachment.md): Retrieve an inbound attachment.
-- [Retrieve Received Email](https://api.opensend.com/docs/api-reference/emails/retrieve-received-email.md): Retrieve one inbound email.
-- [Send Batch Emails](https://api.opensend.com/docs/api-reference/emails/send-batch-emails.md): Queue up to 100 emails in one request.
-- [Send Email](https://api.opensend.com/docs/api-reference/emails/send-email.md): Send one email through OpenSend.
-- [Update Scheduled Email](https://api.opensend.com/docs/api-reference/emails/update-email.md): Update a scheduled email before it is sent.
-- [List Events](https://api.opensend.com/docs/api-reference/events/list-events.md): List custom events.
-- [Send Custom Event](https://api.opensend.com/docs/api-reference/events/send.md): Send a custom event into OpenSend.
-- [List Logs](https://api.opensend.com/docs/api-reference/logs/list-logs.md): List API request logs.
-- [Retrieve Log](https://api.opensend.com/docs/api-reference/logs/retrieve-log.md): Retrieve one API request log.
-- [Create Segment](https://api.opensend.com/docs/api-reference/segments/create-segment.md): Create a segment.
-- [Delete Segment](https://api.opensend.com/docs/api-reference/segments/delete-segment.md): Delete a segment.
-- [Retrieve Segment](https://api.opensend.com/docs/api-reference/segments/get-segment.md): Retrieve a segment.
-- [List Segment Contacts](https://api.opensend.com/docs/api-reference/segments/list-segment-contacts.md): List contacts in a segment.
-- [List Segments](https://api.opensend.com/docs/api-reference/segments/list-segments.md): List segments.
-- [Delete Suppression](https://api.opensend.com/docs/api-reference/suppressions/delete-suppression.md): Remove a recipient from suppressions.
-- [List Suppressions](https://api.opensend.com/docs/api-reference/suppressions/list-suppressions.md): List suppressed recipients.
-- [Create Template](https://api.opensend.com/docs/api-reference/templates/create-template.md): Create a reusable template.
-- [Delete Template](https://api.opensend.com/docs/api-reference/templates/delete-template.md): Delete a template.
-- [Duplicate Template](https://api.opensend.com/docs/api-reference/templates/duplicate-template.md): Duplicate a template.
-- [Get Template](https://api.opensend.com/docs/api-reference/templates/get-template.md): Retrieve a template by id or alias.
-- [List Templates](https://api.opensend.com/docs/api-reference/templates/list-templates.md): List templates.
-- [Publish Template](https://api.opensend.com/docs/api-reference/templates/publish-template.md): Publish a draft template.
-- [Update Template](https://api.opensend.com/docs/api-reference/templates/update-template.md): Update a template.
-- [Create Topic](https://api.opensend.com/docs/api-reference/topics/create-topic.md): Create a subscription topic.
-- [Delete Topic](https://api.opensend.com/docs/api-reference/topics/delete-topic.md): Delete a topic.
-- [Retrieve Topic](https://api.opensend.com/docs/api-reference/topics/get-topic.md): Retrieve a topic.
-- [List Topics](https://api.opensend.com/docs/api-reference/topics/list-topics.md): List topics.
-- [Update Topic](https://api.opensend.com/docs/api-reference/topics/update-topic.md): Update a topic.
-- [Create Webhook](https://api.opensend.com/docs/api-reference/webhooks/create-webhook.md): Create a webhook endpoint.
-- [Delete Webhook](https://api.opensend.com/docs/api-reference/webhooks/delete-webhook.md): Delete a webhook.
-- [Retrieve Webhook](https://api.opensend.com/docs/api-reference/webhooks/get-webhook.md): Retrieve a webhook.
-- [List Webhooks](https://api.opensend.com/docs/api-reference/webhooks/list-webhooks.md): List webhook endpoints.
-- [Update Webhook](https://api.opensend.com/docs/api-reference/webhooks/update-webhook.md): Update a webhook.
-- [OpenSend CLI](https://api.opensend.com/docs/cli.md): Command-line workflows for OpenSend.
-- [Custom Event Schemas](https://api.opensend.com/docs/custom-event-schemas.md): Define and validate custom event payloads.
-- [Managing API Keys](https://api.opensend.com/docs/dashboard/api-keys/introduction.md): Manage OpenSend API keys in the dashboard.
-- [Managing Contacts](https://api.opensend.com/docs/dashboard/audiences/contacts.md): Manage contacts in the dashboard.
-- [Managing Unsubscribed Contacts](https://api.opensend.com/docs/dashboard/audiences/managing-unsubscribe-list.md): Understand unsubscribed contacts.
-- [Contact Properties](https://api.opensend.com/docs/dashboard/audiences/properties.md): Use custom properties on contacts.
-- [Condition](https://api.opensend.com/docs/dashboard/automations/condition.md): Branch automation runs.
-- [Delay](https://api.opensend.com/docs/dashboard/automations/delay.md): Pause automation execution.
-- [Using Automations](https://api.opensend.com/docs/dashboard/automations/introduction.md): Automate email workflows with custom events.
-- [Runs](https://api.opensend.com/docs/dashboard/automations/runs.md): Monitor automation executions.
-- [Send Email](https://api.opensend.com/docs/dashboard/automations/send-email.md): Send from an automation.
-- [Trigger](https://api.opensend.com/docs/dashboard/automations/trigger.md): Start automation runs.
-- [Wait for Event](https://api.opensend.com/docs/dashboard/automations/wait-for-event.md): Pause until an event arrives.
-- [Managing Broadcasts](https://api.opensend.com/docs/dashboard/broadcasts/introduction.md): Create, schedule, and inspect broadcasts.
-- [Broadcast Performance Tracking](https://api.opensend.com/docs/dashboard/broadcasts/performance-tracking.md): Track broadcast sends and metrics.
-- [DMARC](https://api.opensend.com/docs/dashboard/domains/dmarc.md): DMARC setup for sender domains.
-- [Managing Domains](https://api.opensend.com/docs/dashboard/domains/introduction.md): Domain verification and DNS setup.
-- [Open and Click Tracking](https://api.opensend.com/docs/dashboard/domains/tracking.md): Configure tracking domains and tracking behavior.
-- [Attachments](https://api.opensend.com/docs/dashboard/emails/attachments.md): How to send and inspect attachments.
-- [Custom Headers](https://api.opensend.com/docs/dashboard/emails/custom-headers.md): Attach custom headers to outbound email.
-- [Email Bounces](https://api.opensend.com/docs/dashboard/emails/email-bounces.md): Understand bounce handling.
-- [Email Suppressions](https://api.opensend.com/docs/dashboard/emails/email-suppressions.md): Understand suppressed recipients.
-- [Idempotency Keys](https://api.opensend.com/docs/dashboard/emails/idempotency-keys.md): Safely retry send requests.
-- [Schedule Email](https://api.opensend.com/docs/dashboard/emails/schedule-email.md): Schedule email delivery for later.
-- [Tags](https://api.opensend.com/docs/dashboard/emails/tags.md): Attach searchable identifiers to emails.
-- [Logs](https://api.opensend.com/docs/dashboard/logs/introduction.md): Troubleshoot API requests.
-- [Managing Segments](https://api.opensend.com/docs/dashboard/segments/introduction.md): Create and manage audience segments.
-- [Using Templates](https://api.opensend.com/docs/dashboard/templates/introduction.md): Store and reuse email templates.
-- [Template Variables](https://api.opensend.com/docs/dashboard/templates/template-variables.md): Use variables in templates.
-- [Template Version History](https://api.opensend.com/docs/dashboard/templates/version-history.md): Template lifecycle guidance.
-- [Topics](https://api.opensend.com/docs/dashboard/topics/introduction.md): Give recipients subscription preferences.
-- [Email Best Practices Skill](https://api.opensend.com/docs/email-best-practices-skill.md): Guardrails for production email systems.
-- [Examples](https://api.opensend.com/docs/examples.md): Example application patterns.
-- [Ingester Deployment](https://api.opensend.com/docs/ingester-deploy.md): Deploy the SES/SNS ingester and queue worker.
-- [Integrations](https://api.opensend.com/docs/integrations.md): Integration guidance.
-- [Cloudflare](https://api.opensend.com/docs/knowledge-base/cloudflare.md): Verify and configure domains with Cloudflare.
-- [GoDaddy](https://api.opensend.com/docs/knowledge-base/godaddy.md): Verify domains hosted on GoDaddy.
-- [How to Handle API Keys](https://api.opensend.com/docs/knowledge-base/how-to-handle-api-keys.md): API key storage guidance.
-- [Namecheap](https://api.opensend.com/docs/knowledge-base/namecheap.md): Verify domains hosted on Namecheap.
-- [AWS Route 53](https://api.opensend.com/docs/knowledge-base/route53.md): Verify domains hosted on Route 53.
-- [Domain and IP Warm-up Guide](https://api.opensend.com/docs/knowledge-base/warming-up.md): Warm up sending reputation.
-- [Unsupported Attachment Types](https://api.opensend.com/docs/knowledge-base/what-attachment-types-are-not-supported.md): Attachment safety guidance.
-- [What Counts as Email Consent?](https://api.opensend.com/docs/knowledge-base/what-counts-as-email-consent.md): Consent guidance for marketing sends.
-- [What if my domain is not verifying?](https://api.opensend.com/docs/knowledge-base/what-if-my-domain-is-not-verifying.md): Troubleshoot DNS verification.
-- [What Sending Feature Should I Use?](https://api.opensend.com/docs/knowledge-base/what-sending-feature-to-use.md): Choose emails, broadcasts, or automations.
-- [Why Are My Emails Going to Spam?](https://api.opensend.com/docs/knowledge-base/why-are-my-emails-going-to-spam.md): Deliverability troubleshooting.
-- [MCP Server](https://api.opensend.com/docs/mcp-server.md): Use OpenSend from MCP-compatible AI clients.
-- [Observability](https://api.opensend.com/docs/observability.md): Operate OpenSend in production.
-- [React Email Skill](https://api.opensend.com/docs/react-email-skill.md): Build HTML email with React components.
-- [Official SDKs](https://api.opensend.com/docs/sdks.md): OpenSend SDKs and packages.
-- [Security](https://api.opensend.com/docs/security.md): Security model overview.
-- [Self Hosting](https://api.opensend.com/docs/self-hosting.md): Run OpenSend yourself.
-- [Send emails with Bun](https://api.opensend.com/docs/send-with-bun.md): Use the TypeScript SDK from Bun.
-- [Send emails with Express](https://api.opensend.com/docs/send-with-express.md): Send email from an Express API route.
-- [Send emails with Go](https://api.opensend.com/docs/send-with-go.md): Send email from Go with the first-party OpenSend Go SDK.
-- [Send emails with Hono](https://api.opensend.com/docs/send-with-hono.md): Send email from Hono.
-- [Send emails with Next.js](https://api.opensend.com/docs/send-with-nextjs.md): Send email from a Next.js route handler or server action.
-- [Send emails with Node.js](https://api.opensend.com/docs/send-with-nodejs.md): Send email from Node.js using the TypeScript SDK.
-- [Send emails with Python](https://api.opensend.com/docs/send-with-python.md): Send email from Python using the Python SDK.
-- [Send emails with Ruby](https://api.opensend.com/docs/send-with-ruby.md): Send email from Ruby where the Ruby SDK package is available.
-- [Send emails with SMTP](https://api.opensend.com/docs/send-with-smtp.md): SMTP integration status.
-- [contact.created](https://api.opensend.com/docs/webhooks/contacts/created.md): Webhook event emitted when a contact is created.
-- [contact.deleted](https://api.opensend.com/docs/webhooks/contacts/deleted.md): Webhook event emitted when a contact is deleted.
-- [contact.updated](https://api.opensend.com/docs/webhooks/contacts/updated.md): Webhook event emitted when a contact is updated.
-- [domain.created](https://api.opensend.com/docs/webhooks/domains/created.md): Webhook event emitted when a domain is created.
-- [domain.deleted](https://api.opensend.com/docs/webhooks/domains/deleted.md): Webhook event emitted when a domain is deleted.
-- [domain.updated](https://api.opensend.com/docs/webhooks/domains/updated.md): Webhook event emitted when a domain changes.
-- [email.bounced](https://api.opensend.com/docs/webhooks/emails/bounced.md): Webhook event emitted when an email bounces.
-- [email.clicked](https://api.opensend.com/docs/webhooks/emails/clicked.md): Webhook event emitted when tracking records a click.
-- [email.complained](https://api.opensend.com/docs/webhooks/emails/complained.md): Webhook event emitted when a recipient reports spam.
-- [email.delivered](https://api.opensend.com/docs/webhooks/emails/delivered.md): Webhook event emitted when delivery is confirmed.
-- [email.failed](https://api.opensend.com/docs/webhooks/emails/failed.md): Webhook event emitted when sending fails.
-- [email.opened](https://api.opensend.com/docs/webhooks/emails/opened.md): Webhook event emitted when tracking records an open.
-- [email.received](https://api.opensend.com/docs/webhooks/emails/received.md): Webhook event emitted when inbound email is received.
-- [email.sent](https://api.opensend.com/docs/webhooks/emails/sent.md): Webhook event emitted when an email is sent.
-- [Event Types](https://api.opensend.com/docs/webhooks/event-types.md): Supported webhook event names.
-- [Managing Webhooks](https://api.opensend.com/docs/webhooks/introduction.md): Receive real-time event notifications.
-- [Retries and Replays](https://api.opensend.com/docs/webhooks/retries-and-replays.md): Handle webhook delivery failures.
-- [Verify Webhook Requests](https://api.opensend.com/docs/webhooks/verify-webhooks-requests.md): Verify webhook signatures before trusting events.
+- [Introduction](https://opensend.namuh.co/docs/api-reference/introduction.md): Core concepts for the OpenSend API.
+- [Authentication](https://opensend.namuh.co/docs/api-reference/authentication.md): How API key authentication works in OpenSend.
+- [Pagination](https://opensend.namuh.co/docs/api-reference/pagination.md): Pagination behavior for list endpoints.
+- [Errors](https://opensend.namuh.co/docs/api-reference/errors.md): Common OpenSend API error shapes and status codes.
+- [Usage Limits](https://opensend.namuh.co/docs/api-reference/rate-limit.md): Rate limits, quotas, and operational limits.
+- [Agent Email Inbox Skill](https://opensend.namuh.co/docs/agent-email-inbox-skill.md): Give agents an email inbox backed by OpenSend receiving flows.
+- [AI Onboarding](https://opensend.namuh.co/docs/ai-onboarding.md): Onboard coding agents to OpenSend.
+- [Create API Key](https://opensend.namuh.co/docs/api-reference/api-keys/create-api-key.md): Create a new API key.
+- [Delete API Key](https://opensend.namuh.co/docs/api-reference/api-keys/delete-api-key.md): Delete an API key.
+- [List API Keys](https://opensend.namuh.co/docs/api-reference/api-keys/list-api-keys.md): List API keys for the authenticated tenant.
+- [Create Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/create-broadcast.md): Create a broadcast draft.
+- [Delete Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/delete-broadcast.md): Delete a broadcast.
+- [Retrieve Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/get-broadcast.md): Retrieve a broadcast.
+- [List Broadcasts](https://opensend.namuh.co/docs/api-reference/broadcasts/list-broadcasts.md): List broadcasts.
+- [Send Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/send-broadcast.md): Send or schedule a broadcast.
+- [Update Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/update-broadcast.md): Update a broadcast.
+- [Create Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/create-contact-property.md): Create a custom contact property.
+- [Delete Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/delete-contact-property.md): Delete a contact property.
+- [Retrieve Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/get-contact-property.md): Retrieve a contact property.
+- [List Contact Properties](https://opensend.namuh.co/docs/api-reference/contact-properties/list-contact-properties.md): List contact properties.
+- [Update Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/update-contact-property.md): Update a contact property.
+- [Add Contact to Segment](https://opensend.namuh.co/docs/api-reference/contacts/add-contact-to-segment.md): Add a contact to a segment.
+- [Create Contact](https://opensend.namuh.co/docs/api-reference/contacts/create-contact.md): Create an audience contact.
+- [Delete Contact Segment](https://opensend.namuh.co/docs/api-reference/contacts/delete-contact-segment.md): Remove a contact from a segment.
+- [Delete Contact](https://opensend.namuh.co/docs/api-reference/contacts/delete-contact.md): Delete a contact.
+- [Retrieve Contact Topics](https://opensend.namuh.co/docs/api-reference/contacts/get-contact-topics.md): Get topic subscriptions for a contact.
+- [Retrieve Contact](https://opensend.namuh.co/docs/api-reference/contacts/get-contact.md): Retrieve a contact by id or email where supported.
+- [List Contact Segments](https://opensend.namuh.co/docs/api-reference/contacts/list-contact-segments.md): List segments for a contact.
+- [List Contacts](https://opensend.namuh.co/docs/api-reference/contacts/list-contacts.md): List contacts.
+- [Update Contact Topics](https://opensend.namuh.co/docs/api-reference/contacts/update-contact-topics.md): Update topic subscriptions for a contact.
+- [Update Contact](https://opensend.namuh.co/docs/api-reference/contacts/update-contact.md): Update contact fields.
+- [Auto Configure Domain](https://opensend.namuh.co/docs/api-reference/domains/auto-configure-domain.md): Write DNS records through configured Cloudflare credentials.
+- [Create Domain](https://opensend.namuh.co/docs/api-reference/domains/create-domain.md): Add a sending domain.
+- [Delete Domain](https://opensend.namuh.co/docs/api-reference/domains/delete-domain.md): Delete a domain.
+- [Retrieve Domain](https://opensend.namuh.co/docs/api-reference/domains/get-domain.md): Retrieve a domain.
+- [List Domains](https://opensend.namuh.co/docs/api-reference/domains/list-domains.md): List domains.
+- [Update Domain](https://opensend.namuh.co/docs/api-reference/domains/update-domain.md): Update domain settings.
+- [Verify Domain](https://opensend.namuh.co/docs/api-reference/domains/verify-domain.md): Re-check DNS verification state.
+- [Cancel Email](https://opensend.namuh.co/docs/api-reference/emails/cancel-email.md): Cancel a scheduled email.
+- [List Sent Email Attachments](https://opensend.namuh.co/docs/api-reference/emails/list-email-attachments.md): List attachments for a sent email.
+- [List Sent Emails](https://opensend.namuh.co/docs/api-reference/emails/list-emails.md): List sent and queued emails for the authenticated tenant.
+- [List Received Email Attachments](https://opensend.namuh.co/docs/api-reference/emails/list-received-email-attachments.md): List attachments from a received email.
+- [List Received Emails](https://opensend.namuh.co/docs/api-reference/emails/list-received-emails.md): List inbound emails received by OpenSend.
+- [Retrieve Sent Email Attachment](https://opensend.namuh.co/docs/api-reference/emails/retrieve-email-attachment.md): Download or retrieve a sent email attachment.
+- [Retrieve Sent Email](https://opensend.namuh.co/docs/api-reference/emails/retrieve-email.md): Retrieve one sent email and its current state.
+- [Retrieve Received Email Attachment](https://opensend.namuh.co/docs/api-reference/emails/retrieve-received-email-attachment.md): Retrieve an inbound attachment.
+- [Retrieve Received Email](https://opensend.namuh.co/docs/api-reference/emails/retrieve-received-email.md): Retrieve one inbound email.
+- [Send Batch Emails](https://opensend.namuh.co/docs/api-reference/emails/send-batch-emails.md): Queue up to 100 emails in one request.
+- [Send Email](https://opensend.namuh.co/docs/api-reference/emails/send-email.md): Send one email through OpenSend.
+- [Update Scheduled Email](https://opensend.namuh.co/docs/api-reference/emails/update-email.md): Update a scheduled email before it is sent.
+- [List Events](https://opensend.namuh.co/docs/api-reference/events/list-events.md): List custom events.
+- [Send Custom Event](https://opensend.namuh.co/docs/api-reference/events/send.md): Send a custom event into OpenSend.
+- [List Logs](https://opensend.namuh.co/docs/api-reference/logs/list-logs.md): List API request logs.
+- [Retrieve Log](https://opensend.namuh.co/docs/api-reference/logs/retrieve-log.md): Retrieve one API request log.
+- [Create Segment](https://opensend.namuh.co/docs/api-reference/segments/create-segment.md): Create a segment.
+- [Delete Segment](https://opensend.namuh.co/docs/api-reference/segments/delete-segment.md): Delete a segment.
+- [Retrieve Segment](https://opensend.namuh.co/docs/api-reference/segments/get-segment.md): Retrieve a segment.
+- [List Segment Contacts](https://opensend.namuh.co/docs/api-reference/segments/list-segment-contacts.md): List contacts in a segment.
+- [List Segments](https://opensend.namuh.co/docs/api-reference/segments/list-segments.md): List segments.
+- [Delete Suppression](https://opensend.namuh.co/docs/api-reference/suppressions/delete-suppression.md): Remove a recipient from suppressions.
+- [List Suppressions](https://opensend.namuh.co/docs/api-reference/suppressions/list-suppressions.md): List suppressed recipients.
+- [Create Template](https://opensend.namuh.co/docs/api-reference/templates/create-template.md): Create a reusable template.
+- [Delete Template](https://opensend.namuh.co/docs/api-reference/templates/delete-template.md): Delete a template.
+- [Duplicate Template](https://opensend.namuh.co/docs/api-reference/templates/duplicate-template.md): Duplicate a template.
+- [Get Template](https://opensend.namuh.co/docs/api-reference/templates/get-template.md): Retrieve a template by id or alias.
+- [List Templates](https://opensend.namuh.co/docs/api-reference/templates/list-templates.md): List templates.
+- [Publish Template](https://opensend.namuh.co/docs/api-reference/templates/publish-template.md): Publish a draft template.
+- [Update Template](https://opensend.namuh.co/docs/api-reference/templates/update-template.md): Update a template.
+- [Create Topic](https://opensend.namuh.co/docs/api-reference/topics/create-topic.md): Create a subscription topic.
+- [Delete Topic](https://opensend.namuh.co/docs/api-reference/topics/delete-topic.md): Delete a topic.
+- [Retrieve Topic](https://opensend.namuh.co/docs/api-reference/topics/get-topic.md): Retrieve a topic.
+- [List Topics](https://opensend.namuh.co/docs/api-reference/topics/list-topics.md): List topics.
+- [Update Topic](https://opensend.namuh.co/docs/api-reference/topics/update-topic.md): Update a topic.
+- [Create Webhook](https://opensend.namuh.co/docs/api-reference/webhooks/create-webhook.md): Create a webhook endpoint.
+- [Delete Webhook](https://opensend.namuh.co/docs/api-reference/webhooks/delete-webhook.md): Delete a webhook.
+- [Retrieve Webhook](https://opensend.namuh.co/docs/api-reference/webhooks/get-webhook.md): Retrieve a webhook.
+- [List Webhooks](https://opensend.namuh.co/docs/api-reference/webhooks/list-webhooks.md): List webhook endpoints.
+- [Update Webhook](https://opensend.namuh.co/docs/api-reference/webhooks/update-webhook.md): Update a webhook.
+- [OpenSend CLI](https://opensend.namuh.co/docs/cli.md): Command-line workflows for OpenSend.
+- [Custom Event Schemas](https://opensend.namuh.co/docs/custom-event-schemas.md): Define and validate custom event payloads.
+- [Managing API Keys](https://opensend.namuh.co/docs/dashboard/api-keys/introduction.md): Manage OpenSend API keys in the dashboard.
+- [Managing Contacts](https://opensend.namuh.co/docs/dashboard/audiences/contacts.md): Manage contacts in the dashboard.
+- [Managing Unsubscribed Contacts](https://opensend.namuh.co/docs/dashboard/audiences/managing-unsubscribe-list.md): Understand unsubscribed contacts.
+- [Contact Properties](https://opensend.namuh.co/docs/dashboard/audiences/properties.md): Use custom properties on contacts.
+- [Condition](https://opensend.namuh.co/docs/dashboard/automations/condition.md): Branch automation runs.
+- [Delay](https://opensend.namuh.co/docs/dashboard/automations/delay.md): Pause automation execution.
+- [Using Automations](https://opensend.namuh.co/docs/dashboard/automations/introduction.md): Automate email workflows with custom events.
+- [Runs](https://opensend.namuh.co/docs/dashboard/automations/runs.md): Monitor automation executions.
+- [Send Email](https://opensend.namuh.co/docs/dashboard/automations/send-email.md): Send from an automation.
+- [Trigger](https://opensend.namuh.co/docs/dashboard/automations/trigger.md): Start automation runs.
+- [Wait for Event](https://opensend.namuh.co/docs/dashboard/automations/wait-for-event.md): Pause until an event arrives.
+- [Managing Broadcasts](https://opensend.namuh.co/docs/dashboard/broadcasts/introduction.md): Create, schedule, and inspect broadcasts.
+- [Broadcast Performance Tracking](https://opensend.namuh.co/docs/dashboard/broadcasts/performance-tracking.md): Track broadcast sends and metrics.
+- [DMARC](https://opensend.namuh.co/docs/dashboard/domains/dmarc.md): DMARC setup for sender domains.
+- [Managing Domains](https://opensend.namuh.co/docs/dashboard/domains/introduction.md): Domain verification and DNS setup.
+- [Open and Click Tracking](https://opensend.namuh.co/docs/dashboard/domains/tracking.md): Configure tracking domains and tracking behavior.
+- [Attachments](https://opensend.namuh.co/docs/dashboard/emails/attachments.md): How to send and inspect attachments.
+- [Custom Headers](https://opensend.namuh.co/docs/dashboard/emails/custom-headers.md): Attach custom headers to outbound email.
+- [Email Bounces](https://opensend.namuh.co/docs/dashboard/emails/email-bounces.md): Understand bounce handling.
+- [Email Suppressions](https://opensend.namuh.co/docs/dashboard/emails/email-suppressions.md): Understand suppressed recipients.
+- [Idempotency Keys](https://opensend.namuh.co/docs/dashboard/emails/idempotency-keys.md): Safely retry send requests.
+- [Schedule Email](https://opensend.namuh.co/docs/dashboard/emails/schedule-email.md): Schedule email delivery for later.
+- [Tags](https://opensend.namuh.co/docs/dashboard/emails/tags.md): Attach searchable identifiers to emails.
+- [Logs](https://opensend.namuh.co/docs/dashboard/logs/introduction.md): Troubleshoot API requests.
+- [Managing Segments](https://opensend.namuh.co/docs/dashboard/segments/introduction.md): Create and manage audience segments.
+- [Using Templates](https://opensend.namuh.co/docs/dashboard/templates/introduction.md): Store and reuse email templates.
+- [Template Variables](https://opensend.namuh.co/docs/dashboard/templates/template-variables.md): Use variables in templates.
+- [Template Version History](https://opensend.namuh.co/docs/dashboard/templates/version-history.md): Template lifecycle guidance.
+- [Topics](https://opensend.namuh.co/docs/dashboard/topics/introduction.md): Give recipients subscription preferences.
+- [Email Best Practices Skill](https://opensend.namuh.co/docs/email-best-practices-skill.md): Guardrails for production email systems.
+- [Examples](https://opensend.namuh.co/docs/examples.md): Example application patterns.
+- [Ingester Deployment](https://opensend.namuh.co/docs/ingester-deploy.md): Deploy the SES/SNS ingester and queue worker.
+- [Integrations](https://opensend.namuh.co/docs/integrations.md): Integration guidance.
+- [Cloudflare](https://opensend.namuh.co/docs/knowledge-base/cloudflare.md): Verify and configure domains with Cloudflare.
+- [GoDaddy](https://opensend.namuh.co/docs/knowledge-base/godaddy.md): Verify domains hosted on GoDaddy.
+- [How to Handle API Keys](https://opensend.namuh.co/docs/knowledge-base/how-to-handle-api-keys.md): API key storage guidance.
+- [Namecheap](https://opensend.namuh.co/docs/knowledge-base/namecheap.md): Verify domains hosted on Namecheap.
+- [AWS Route 53](https://opensend.namuh.co/docs/knowledge-base/route53.md): Verify domains hosted on Route 53.
+- [Domain and IP Warm-up Guide](https://opensend.namuh.co/docs/knowledge-base/warming-up.md): Warm up sending reputation.
+- [Unsupported Attachment Types](https://opensend.namuh.co/docs/knowledge-base/what-attachment-types-are-not-supported.md): Attachment safety guidance.
+- [What Counts as Email Consent?](https://opensend.namuh.co/docs/knowledge-base/what-counts-as-email-consent.md): Consent guidance for marketing sends.
+- [What if my domain is not verifying?](https://opensend.namuh.co/docs/knowledge-base/what-if-my-domain-is-not-verifying.md): Troubleshoot DNS verification.
+- [What Sending Feature Should I Use?](https://opensend.namuh.co/docs/knowledge-base/what-sending-feature-to-use.md): Choose emails, broadcasts, or automations.
+- [Why Are My Emails Going to Spam?](https://opensend.namuh.co/docs/knowledge-base/why-are-my-emails-going-to-spam.md): Deliverability troubleshooting.
+- [MCP Server](https://opensend.namuh.co/docs/mcp-server.md): Use OpenSend from MCP-compatible AI clients.
+- [Observability](https://opensend.namuh.co/docs/observability.md): Operate OpenSend in production.
+- [React Email Skill](https://opensend.namuh.co/docs/react-email-skill.md): Build HTML email with React components.
+- [Official SDKs](https://opensend.namuh.co/docs/sdks.md): OpenSend SDKs and packages.
+- [Security](https://opensend.namuh.co/docs/security.md): Security model overview.
+- [Self Hosting](https://opensend.namuh.co/docs/self-hosting.md): Run OpenSend yourself.
+- [Send emails with Bun](https://opensend.namuh.co/docs/send-with-bun.md): Use the TypeScript SDK from Bun.
+- [Send emails with Express](https://opensend.namuh.co/docs/send-with-express.md): Send email from an Express API route.
+- [Send emails with Go](https://opensend.namuh.co/docs/send-with-go.md): Send email from Go with the first-party OpenSend Go SDK.
+- [Send emails with Hono](https://opensend.namuh.co/docs/send-with-hono.md): Send email from Hono.
+- [Send emails with Next.js](https://opensend.namuh.co/docs/send-with-nextjs.md): Send email from a Next.js route handler or server action.
+- [Send emails with Node.js](https://opensend.namuh.co/docs/send-with-nodejs.md): Send email from Node.js using the TypeScript SDK.
+- [Send emails with Python](https://opensend.namuh.co/docs/send-with-python.md): Send email from Python using the Python SDK.
+- [Send emails with Ruby](https://opensend.namuh.co/docs/send-with-ruby.md): Send email from Ruby with the first-party OpenSend Ruby SDK.
+- [Send emails with SMTP](https://opensend.namuh.co/docs/send-with-smtp.md): SMTP integration status.
+- [contact.created](https://opensend.namuh.co/docs/webhooks/contacts/created.md): Webhook event emitted when a contact is created.
+- [contact.deleted](https://opensend.namuh.co/docs/webhooks/contacts/deleted.md): Webhook event emitted when a contact is deleted.
+- [contact.updated](https://opensend.namuh.co/docs/webhooks/contacts/updated.md): Webhook event emitted when a contact is updated.
+- [domain.created](https://opensend.namuh.co/docs/webhooks/domains/created.md): Webhook event emitted when a domain is created.
+- [domain.deleted](https://opensend.namuh.co/docs/webhooks/domains/deleted.md): Webhook event emitted when a domain is deleted.
+- [domain.updated](https://opensend.namuh.co/docs/webhooks/domains/updated.md): Webhook event emitted when a domain changes.
+- [email.bounced](https://opensend.namuh.co/docs/webhooks/emails/bounced.md): Webhook event emitted when an email bounces.
+- [email.clicked](https://opensend.namuh.co/docs/webhooks/emails/clicked.md): Webhook event emitted when tracking records a click.
+- [email.complained](https://opensend.namuh.co/docs/webhooks/emails/complained.md): Webhook event emitted when a recipient reports spam.
+- [email.delivered](https://opensend.namuh.co/docs/webhooks/emails/delivered.md): Webhook event emitted when delivery is confirmed.
+- [email.failed](https://opensend.namuh.co/docs/webhooks/emails/failed.md): Webhook event emitted when sending fails.
+- [email.opened](https://opensend.namuh.co/docs/webhooks/emails/opened.md): Webhook event emitted when tracking records an open.
+- [email.received](https://opensend.namuh.co/docs/webhooks/emails/received.md): Webhook event emitted when inbound email is received.
+- [email.sent](https://opensend.namuh.co/docs/webhooks/emails/sent.md): Webhook event emitted when an email is sent.
+- [Event Types](https://opensend.namuh.co/docs/webhooks/event-types.md): Supported webhook event names.
+- [Managing Webhooks](https://opensend.namuh.co/docs/webhooks/introduction.md): Receive real-time event notifications.
+- [Retries and Replays](https://opensend.namuh.co/docs/webhooks/retries-and-replays.md): Handle webhook delivery failures.
+- [Verify Webhook Requests](https://opensend.namuh.co/docs/webhooks/verify-webhooks-requests.md): Verify webhook signatures before trusting events.
 
 ## OpenAPI Specs
 
-- [OpenAPI JSON](https://api.opensend.com/openapi.json)
-- [LLM Docs Index](https://api.opensend.com/docs/llms.txt)
+- [OpenAPI JSON](https://opensend.namuh.co/openapi.json)
+- [LLM Docs Index](https://opensend.namuh.co/docs/llms.txt)
 
 ## Agent guidance
 

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -138,7 +138,7 @@
 - [Send emails with Hono](https://opensend.namuh.co/docs/send-with-hono.md): Send email from Hono.
 - [Send emails with Next.js](https://opensend.namuh.co/docs/send-with-nextjs.md): Send email from a Next.js route handler or server action.
 - [Send emails with Node.js](https://opensend.namuh.co/docs/send-with-nodejs.md): Send email from Node.js using the TypeScript SDK.
-- [Send emails with Python](https://opensend.namuh.co/docs/send-with-python.md): Send email from Python using the Python SDK.
+- [Send emails with Python](https://opensend.namuh.co/docs/send-with-python.md): Send email from Python using the first-party OpenSend Python SDK.
 - [Send emails with Ruby](https://opensend.namuh.co/docs/send-with-ruby.md): Send email from Ruby with the first-party OpenSend Ruby SDK.
 - [Send emails with SMTP](https://opensend.namuh.co/docs/send-with-smtp.md): SMTP integration status.
 - [contact.created](https://opensend.namuh.co/docs/webhooks/contacts/created.md): Webhook event emitted when a contact is created.

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -134,7 +134,7 @@
 - [Self Hosting](https://api.opensend.com/docs/self-hosting.md): Run OpenSend yourself.
 - [Send emails with Bun](https://api.opensend.com/docs/send-with-bun.md): Use the TypeScript SDK from Bun.
 - [Send emails with Express](https://api.opensend.com/docs/send-with-express.md): Send email from an Express API route.
-- [Send emails with Go](https://api.opensend.com/docs/send-with-go.md): Send email from Go where the Go SDK package is available.
+- [Send emails with Go](https://api.opensend.com/docs/send-with-go.md): Send email from Go with the first-party OpenSend Go SDK.
 - [Send emails with Hono](https://api.opensend.com/docs/send-with-hono.md): Send email from Hono.
 - [Send emails with Next.js](https://api.opensend.com/docs/send-with-nextjs.md): Send email from a Next.js route handler or server action.
 - [Send emails with Node.js](https://api.opensend.com/docs/send-with-nodejs.md): Send email from Node.js using the TypeScript SDK.

--- a/public/docs/sdks.md
+++ b/public/docs/sdks.md
@@ -2,4 +2,9 @@
 
 OpenSend SDKs and packages.
 
-Supported SDK docs include TypeScript, Python, Go, and Ruby package pages where present in the repository.
+Supported SDK docs include TypeScript, Python, Go, and Ruby package pages where
+present in the repository. The Go SDK is available from this repository module:
+
+```bash
+go get github.com/namuh-eng/opensend/packages/go-sdk@v0.1.0
+```

--- a/public/docs/send-with-go.md
+++ b/public/docs/send-with-go.md
@@ -1,5 +1,15 @@
 # Send emails with Go
 
-Send email from Go where the Go SDK package is available.
+Send email from Go with the first-party OpenSend Go SDK.
+
+Install the tagged module version from a Go module:
+
+```bash
+go get github.com/namuh-eng/opensend/packages/go-sdk@v0.1.0
+```
+
+If `OPENSEND_BASE_URL` is unset, the SDK targets `https://opensend.namuh.co`.
+Set `OPENSEND_BASE_URL` only when pointing the SDK at a self-hosted OpenSend
+origin.
 
 See `packages/go-sdk/README.md` for current status and examples.

--- a/public/docs/send-with-python.md
+++ b/public/docs/send-with-python.md
@@ -1,5 +1,50 @@
 # Send emails with Python
 
-Send email from Python using the Python SDK.
+Send email from Python using the first-party OpenSend Python SDK.
 
-See the Python SDK package README for current install and API details.
+## Install
+
+Until the PyPI release is complete, install from this repository:
+
+```bash
+python -m pip install ./packages/python-sdk
+```
+
+After `opensend==0.1.0` is published to PyPI, install the pinned package:
+
+```bash
+python -m pip install opensend==0.1.0
+```
+
+## Configure
+
+Store API keys in environment variables; do not hardcode real keys. If
+`OPENSEND_BASE_URL` is unset, the SDK targets OpenSend Cloud at
+`https://opensend.namuh.co`.
+
+```bash
+export OPENSEND_API_KEY="os_your_api_key"
+export OPENSEND_BASE_URL="http://localhost:3015" # optional for self-hosting
+```
+
+## Send
+
+```python
+import os
+import opensend
+
+opensend.api_key = os.environ["OPENSEND_API_KEY"]
+opensend.base_url = os.environ.get("OPENSEND_BASE_URL", opensend.DEFAULT_BASE_URL)
+
+email = opensend.Emails.send({
+    "from": "hello@yourdomain.com",
+    "to": "recipient@example.com",
+    "subject": "Hello from OpenSend",
+    "html": "<h1>It works!</h1>",
+})
+
+print(email["id"])
+```
+
+The SDK also exports `OpenSend` for instance clients and `Resend` as an alias
+class for migration-oriented code.

--- a/public/docs/send-with-ruby.md
+++ b/public/docs/send-with-ruby.md
@@ -1,5 +1,49 @@
 # Send emails with Ruby
 
-Send email from Ruby where the Ruby SDK package is available.
+Send email from Ruby with the first-party OpenSend Ruby SDK.
 
-See `packages/ruby-sdk/README.md` for current status and examples.
+## Install
+
+The `opensend` gem package is ready for RubyGems publishing. Until the
+RubyGems release is available, build and install it from this repository:
+
+```bash
+cd packages/ruby-sdk
+gem build opensend.gemspec
+gem install ./opensend-0.1.0.gem
+```
+
+After publication, use:
+
+```bash
+gem install opensend
+```
+
+## Configure
+
+```bash
+export OPENSEND_API_KEY="os_your_api_key"
+```
+
+If `OPENSEND_BASE_URL` is unset, the SDK targets `https://opensend.namuh.co`.
+Set `OPENSEND_BASE_URL` only when using a self-hosted OpenSend deployment.
+
+## Send
+
+```ruby
+require "opensend"
+
+OpenSend.api_key ENV.fetch("OPENSEND_API_KEY")
+OpenSend.base_url ENV.fetch("OPENSEND_BASE_URL", OpenSend::DEFAULT_BASE_URL)
+
+email = OpenSend::Emails.send(
+  from: "hello@yourdomain.com",
+  to: "recipient@example.com",
+  subject: "Hello from OpenSend",
+  html: "<h1>It works!</h1>"
+)
+
+puts email.fetch("id")
+```
+
+See `packages/ruby-sdk/README.md` for the full API surface and migration alias.

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -28,7 +28,7 @@ type GuideCard = {
   href: string;
 };
 
-const BASE_URL = "https://api.opensend.com";
+const BASE_URL = "https://opensend.namuh.co";
 const DOCS_COUNT = 157;
 
 const OPENSEND_GUIDES: GuideCard[] = [
@@ -94,7 +94,7 @@ const MCP_EXAMPLE = `{
       "args": ["/path/to/opensend/packages/mcp/src/stdio.ts"],
       "env": {
         "OPENSEND_API_KEY": "os_YOUR_API_KEY",
-        "OPENSEND_API_BASE_URL": "https://api.opensend.com"
+        "OPENSEND_API_BASE_URL": "https://opensend.namuh.co"
       }
     }
   }
@@ -111,7 +111,7 @@ const API_SECTIONS: ApiSection[] = [
         path: "/emails",
         title: "Send an email",
         description:
-          "Accepts the Resend-compatible send body. Duplicate Idempotency-Key retries within 24 hours replay the original accepted id.",
+          "Accepts OpenSend send payloads with familiar compatibility aliases. Duplicate Idempotency-Key retries within 24 hours replay the original accepted id.",
         notes: ["Requires a verified sending domain for production traffic."],
         code: {
           node: `await resend.emails.send({
@@ -207,7 +207,7 @@ const API_SECTIONS: ApiSection[] = [
         description:
           "Operator/self-host Cloudflare token flow for writing the generated records automatically.",
         code: {
-          node: `await fetch("https://api.opensend.com/api/domains/domain_id/auto-configure", {
+          node: `await fetch("https://opensend.namuh.co/api/domains/domain_id/auto-configure", {
   method: "POST",
   headers: { Authorization: "Bearer " + apiKey },
 });`,
@@ -237,8 +237,7 @@ const API_SECTIONS: ApiSection[] = [
         method: "POST",
         path: "/contacts",
         title: "Create contact",
-        description:
-          "Create a contact through the Resend-compatible root alias.",
+        description: "Create a contact through the familiar root API alias.",
         code: {
           node: `await client.contacts.create({
   email: "jane@example.com",
@@ -348,7 +347,7 @@ const API_SECTIONS: ApiSection[] = [
         path: "/api-keys",
         title: "Create API key",
         description:
-          "Create scoped keys. OpenSend keys use the os_ prefix while preserving Resend-compatible API semantics.",
+          "Create scoped keys. OpenSend keys use the os_ prefix while preserving familiar API semantics.",
         code: {
           node: `await client.apiKeys.create({ name: "Production" });`,
           curl: `curl -X POST ${BASE_URL}/api-keys \\
@@ -364,7 +363,7 @@ const API_SECTIONS: ApiSection[] = [
         description:
           "Subscribe an HTTPS endpoint to signed delivery and lifecycle events.",
         code: {
-          node: `await fetch("https://api.opensend.com/api/webhooks", {
+          node: `await fetch("https://opensend.namuh.co/api/webhooks", {
   method: "POST",
   headers: {
     Authorization: "Bearer " + apiKey,
@@ -549,8 +548,8 @@ export default function DocsPage() {
               <div className="grid gap-0">
                 <div className="p-6 sm:p-8 lg:p-10">
                   <div className="pill success">
-                    <span className="dot" /> Resend-compatible · self-hosted on
-                    AWS SES
+                    <span className="dot" /> Familiar API · self-hosted on AWS
+                    SES
                   </div>
                   <h1 className="mt-6 text-[42px] font-medium leading-[0.96] tracking-[-0.04em] text-fg sm:text-[56px]">
                     Email API docs that agents and humans can actually use.

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -140,7 +140,7 @@ export const openApiDocument = {
     },
   },
   servers: [
-    { url: "https://api.opensend.com", description: "OpenSend API" },
+    { url: "https://opensend.namuh.co", description: "OpenSend API" },
     { url: "http://localhost:3015", description: "Local development" },
   ],
   tags: [

--- a/tools/generate-docs-index.mjs
+++ b/tools/generate-docs-index.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 
 const docsRoot = path.join(process.cwd(), "public", "docs");
 const publicBaseUrl =
-  process.env.OPENSEND_DOCS_PUBLIC_BASE_URL ?? "https://api.opensend.com/docs";
+  process.env.OPENSEND_DOCS_PUBLIC_BASE_URL ?? "https://opensend.namuh.co/docs";
 
 async function walk(dir) {
   const entries = await readdir(dir, { withFileTypes: true });
@@ -91,8 +91,8 @@ lines.push(
   "",
   "## OpenAPI Specs",
   "",
-  "- [OpenAPI JSON](https://api.opensend.com/openapi.json)",
-  "- [LLM Docs Index](https://api.opensend.com/docs/llms.txt)",
+  "- [OpenAPI JSON](https://opensend.namuh.co/openapi.json)",
+  "- [LLM Docs Index](https://opensend.namuh.co/docs/llms.txt)",
   "",
   "## Agent guidance",
   "",


### PR DESCRIPTION
## Release note

This is the staging → main release candidate for the SDK publish-prep wave on 2026-05-17.

### What is included
- **Go SDK install readiness** — keeps the first Go module tag/install docs and generated docs index updates from #512.
- **Ruby SDK publish prep** — updates Ruby SDK hosted defaults/docs and validates the local gem artifact from #511. Actual RubyGems publish remains credential-held until a valid RubyGems token is available and remote install is proven.
- **Python SDK publish prep** — updates Python SDK hosted defaults/docs/OpenAPI-facing examples and validates the local wheel from #513. Actual PyPI publish remains credential-held until `PYPI_API_TOKEN` is available and remote install is proven.

### Conflict resolution notes
- `README.md` conflicted between the main README/dashboard refresh and staging SDK copy refresh.
- Resolution preserved main's expanded dashboard/first-party-docs bullets and staging's safer "Familiar API" wording.
- No code/docs deletion beyond conflict-marker cleanup.

## Validation evidence
- `bun install --ignore-scripts` ✅
- `git diff --check` ✅
- `make check` ✅
- `make test` ✅ — 173 files / 1386 tests passed
- Next dev boot on `PORT=3016` ✅
- HTTP probes ✅:
  - `/status` 200
  - `/docs` 200
  - `/docs/llms.txt` 200
  - `/` 200
- Ever UI validation: **blocked** — `ever start` fails with `Invalid or expired API key`, while `ever doctor` shows local daemon/API healthy. I did not claim browser proof.
- Focused Playwright/E2E: not run; payload is SDK/docs/OpenAPI/public docs copy, no dashboard/auth behavior changed in this release diff.

## Merge status

Main-target release PR. Do not merge without Jaeyun authorization. GitHub checks should be read against the current head SHA after this PR opens.
