### PR TITLE
ci: make PR size label reruns race-safe

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -45,14 +45,28 @@ jobs:
               .map(l => l.name)
               .filter(n => n.startsWith('size/'));
 
-            for (const old of existing) {
-              if (old !== label) {
+            async function removeStaleSizeLabel(name) {
+              try {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: context.issue.number,
-                  name: old,
+                  name,
                 });
+              } catch (error) {
+                // Reruns/races can make payload labels stale; 404 means the old size label is already gone.
+                if (error.status === 404) {
+                  core.notice(`Stale size label ${name} was already absent; continuing.`);
+                  return;
+                }
+
+                throw error;
+              }
+            }
+
+            for (const old of existing) {
+              if (old !== label) {
+                await removeStaleSizeLabel(old);
               }
             }
 


### PR DESCRIPTION
## Summary
- Makes the PR Size Label workflow tolerate stale pull_request payload labels during reruns/races.
- Ignores only 404s from removing old `size/*` labels that are already absent, while rethrowing unexpected label API failures.

Closes #515

## Changes
- **CI**: Added a `removeStaleSizeLabel` helper with an inline rerun/race comment around stale size-label removal.

## How to Test
- [x] `ruby -rpsych -e 'Psych.parse_file(".github/workflows/pr-check.yml"); puts "YAML syntax OK"'`
- [x] Extracted the `github-script` body and ran `node --check` on it.
- [x] Ran a mocked script execution verifying stale remove-label 404 is ignored and unexpected 500 still throws.

## Notes
- Scope intentionally stays limited to `.github/workflows/pr-check.yml`.
