### PR TITLE
docs: add styled docs shell

### DIFF
--- a/agent_docs/learnings/active/2026-05-19-docs-shell-pretty-routes.md
+++ b/agent_docs/learnings/active/2026-05-19-docs-shell-pretty-routes.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-19
+issue: docs-refresh
+type: decision
+promoted_to: null
+---
+
+# Render human docs on pretty routes while preserving raw markdown
+
+Public markdown stays under `public/docs/**/*.md` for the first-party LLM corpus and `/docs/llms.txt`. Because those `.md` files are static public assets, the human docs shell should link to pretty routes like `/docs/self-hosting` and `/docs/api-reference/introduction`, while exposing a `Raw markdown` link back to `/docs/self-hosting.md` for agents and users who want source text.
+
+The docs shell reads the public markdown corpus, builds sidebar navigation and table-of-contents data, and renders styled markdown without adding an MDX dependency. When adding docs links in app UI, prefer the pretty route for humans unless the target is explicitly the raw LLM corpus.

--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
-  "organizeImports": { "enabled": true },
+  "organizeImports": {
+    "enabled": true
+  },
   "linter": {
     "enabled": true,
     "rules": {
@@ -19,6 +21,7 @@
     "ignore": [
       "node_modules",
       ".next",
+      ".scratch",
       "dist",
       "drizzle",
       "packages/sdk/dist",

--- a/public/docs/api-reference/introduction.md
+++ b/public/docs/api-reference/introduction.md
@@ -2,7 +2,7 @@
 
 Core concepts for the OpenSend API.
 
-OpenSend is a REST API for sending, receiving, and operating email on infrastructure you control.
+OpenSend is a REST API for sending, receiving, and operating email on infrastructure you control. You can use OpenSend Cloud at `https://opensend.namuh.co` or run the same API surface on your own deployment.
 
 ## Base URL
 
@@ -16,7 +16,6 @@ For local development, use the port configured by your app, usually:
 http://localhost:3015
 ```
 
-
 ## Authentication
 
 Use an OpenSend API key in the Authorization header.
@@ -25,8 +24,17 @@ Use an OpenSend API key in the Authorization header.
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+Dashboard session cookies are not API credentials. Create API keys from the dashboard or API key endpoints, scope them narrowly, and rotate keys when they leave your control.
 
+## First production send
+
+A production send needs three things:
+
+1. An `os_` API key.
+2. A verified sending domain.
+3. A request to `/emails`, `/emails/batch`, a broadcast send route, or an SDK method that calls those APIs.
+
+Use idempotency keys for retryable send requests so duplicate network retries replay the original accepted response instead of creating extra sends.
 
 ## Response codes
 
@@ -44,3 +52,4 @@ Dashboard session cookies are not API credentials.
 
 - OpenAPI: `/openapi.json`
 - LLM docs index: `/docs/llms.txt`
+- Styled human docs: `/docs`

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -129,9 +129,9 @@
 - [MCP Server](https://opensend.namuh.co/docs/mcp-server.md): Use OpenSend from MCP-compatible AI clients.
 - [Observability](https://opensend.namuh.co/docs/observability.md): Operate OpenSend in production.
 - [React Email Skill](https://opensend.namuh.co/docs/react-email-skill.md): Build HTML email with React components.
-- [Official SDKs](https://opensend.namuh.co/docs/sdks.md): OpenSend SDKs and packages.
+- [Official SDKs](https://opensend.namuh.co/docs/sdks.md): OpenSend ships first-party SDK packages for application code and keeps /openapi.json available for generated clients.
 - [Security](https://opensend.namuh.co/docs/security.md): Security model overview.
-- [Self Hosting](https://opensend.namuh.co/docs/self-hosting.md): Run OpenSend yourself.
+- [Self Hosting](https://opensend.namuh.co/docs/self-hosting.md): Run OpenSend on your own infrastructure with Docker Compose, PostgreSQL, AWS SES/S3, and the standalone ingester service.
 - [Send emails with Bun](https://opensend.namuh.co/docs/send-with-bun.md): Use the TypeScript SDK from Bun.
 - [Send emails with Express](https://opensend.namuh.co/docs/send-with-express.md): Send email from an Express API route.
 - [Send emails with Go](https://opensend.namuh.co/docs/send-with-go.md): Send email from Go with the first-party OpenSend Go SDK.

--- a/public/docs/sdks.md
+++ b/public/docs/sdks.md
@@ -1,10 +1,66 @@
 # Official SDKs
 
-OpenSend SDKs and packages.
+OpenSend ships first-party SDK packages for application code and keeps `/openapi.json` available for generated clients.
 
-Supported SDK docs include TypeScript, Python, Go, and Ruby package pages where
-present in the repository. The Go SDK is available from this repository module:
+## TypeScript and JavaScript
+
+Install the npm package:
+
+```bash
+npm install opensend
+```
+
+Send an email:
+
+```ts
+import { Resend } from "opensend";
+
+const resend = new Resend(process.env.OPENSEND_API_KEY);
+
+await resend.emails.send({
+  from: "OpenSend <onboarding@updates.example.com>",
+  to: ["user@example.com"],
+  subject: "Hello from OpenSend",
+  html: "<strong>It works.</strong>",
+});
+```
+
+The TypeScript SDK intentionally exposes a familiar `Resend` client shape for migration-oriented integrations while targeting OpenSend's hosted or self-hosted base URL.
+
+## Python
+
+Use the Python SDK package when publishing credentials are configured for your environment. Keep the API key in `OPENSEND_API_KEY`, not in source code.
+
+```py
+from opensend import OpenSend
+
+client = OpenSend(api_key=os.environ["OPENSEND_API_KEY"])
+client.emails.send(
+    from_="OpenSend <onboarding@updates.example.com>",
+    to=["user@example.com"],
+    subject="Hello from OpenSend",
+    html="<strong>It works.</strong>",
+)
+```
+
+## Go
+
+The Go SDK is available from this repository module:
 
 ```bash
 go get github.com/namuh-eng/opensend/packages/go-sdk@v0.1.0
 ```
+
+## Ruby
+
+Use the Ruby SDK package for Ruby and Rails applications once RubyGems publishing credentials are configured for your deployment lane.
+
+## OpenAPI clients
+
+If you need another language, generate a client from:
+
+```txt
+https://opensend.namuh.co/openapi.json
+```
+
+Prefer the OpenAPI contract for exact schemas and route availability, then use these docs for workflow and operational context.

--- a/public/docs/self-hosting.md
+++ b/public/docs/self-hosting.md
@@ -1,5 +1,94 @@
 # Self Hosting
 
-Run OpenSend yourself.
+Run OpenSend on your own infrastructure with Docker Compose, PostgreSQL, AWS SES/S3, and the standalone ingester service.
 
-Docker Compose is the reference deployment path. Configure Postgres, AWS SES/S3, Cloudflare DNS if used, and run migrations before app code that expects new schema.
+## Reference topology
+
+Docker Compose is the reference deployment path for self-hosters:
+
+- `app` — Next.js dashboard and public API on port `3015`.
+- `postgres` — OpenSend application database.
+- `migrate` — one-shot Drizzle migration runner.
+- `ingester` — SES/SNS event receiver and scheduled worker on port `3016`.
+- `scheduler` — scheduled job trigger sidecar.
+
+Production deployments can split these into separate services, but keep the same boundaries: app traffic goes to the Next.js service, and SES/SNS event webhooks go to the ingester.
+
+## Quick start
+
+```bash
+git clone https://github.com/namuh-eng/opensend.git
+cd opensend
+cp .env.example .env
+# Edit .env for real Google OAuth, SES, S3, and Cloudflare DNS.
+docker compose up -d
+```
+
+Open `http://localhost:3015`.
+
+## Required configuration
+
+Minimum local development values:
+
+```env
+DATABASE_URL=postgres://...
+BETTER_AUTH_SECRET=...
+BETTER_AUTH_URL=http://localhost:3015
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+S3_BUCKET_NAME=...
+```
+
+For Google sign-in, add your Google OAuth client ID and secret. For automatic DNS setup, add Cloudflare credentials. Production deployments should inject secrets at runtime from a secrets manager instead of baking them into images.
+
+## Migrations
+
+Run database migrations before deploying app code that expects new tables or columns:
+
+```bash
+bun run db:migrate
+```
+
+For local schema sync during development, use:
+
+```bash
+bun run db:push
+```
+
+If list pages work but detail pages 404 or return empty data after a deploy, check for a swallowed schema mismatch before assuming a route is missing.
+
+## SES and ingester wiring
+
+OpenSend sends through AWS SES v2. SES/SNS events should be delivered to the ingester service, not the app service:
+
+```txt
+https://YOUR_INGESTER_HOST/events/ses
+```
+
+The ingester handles delivery, bounce, complaint, open, click, received-email, and scheduled-send processing. See [Ingester Deploy](/docs/ingester-deploy) for the dedicated deployment checklist.
+
+## Domain verification
+
+Sending domains need DNS records for DKIM, SPF, DMARC, bounce handling, and optional tracking. You can copy records manually from the dashboard, or configure Cloudflare credentials for automatic setup where supported.
+
+## Build and deploy notes
+
+- Build Linux production images for `linux/amd64` unless your runtime explicitly uses another platform.
+- Use `bun install --ignore-scripts` in Docker dependency stages if postinstall scripts are unavailable there.
+- Keep Next.js middleware on the Node runtime when importing node-only packages such as Redis clients.
+- Keep `/docs`, `/docs/llms.txt`, and `/openapi.json` publicly reachable.
+
+## Validation checklist
+
+Before cutting over production traffic:
+
+1. `make check`
+2. `make test`
+3. `bun run build`
+4. `bun run db:migrate` against the target database
+5. `GET /api/health` returns healthy
+6. A real SES-backed send produces a non-null `sent_at`
+7. CloudWatch or service logs show SES send success, not a development stub
+8. SES/SNS events reach the ingester `/events/ses` endpoint
+

--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -1,0 +1,97 @@
+import { DocsShell } from "@/components/docs/docs-shell";
+import { MarkdownContent } from "@/components/docs/markdown-content";
+import {
+  getAllDocs,
+  getDocPage,
+  getDocsNav,
+  relPathFromSlugParts,
+} from "@/lib/docs";
+import { notFound, redirect } from "next/navigation";
+
+type DocsRouteProps = {
+  params: Promise<{ slug: string[] }>;
+};
+
+export async function generateStaticParams() {
+  const docs = await getAllDocs();
+  return docs.map((doc) => ({ slug: doc.slug.split("/") }));
+}
+
+export async function generateMetadata({ params }: DocsRouteProps) {
+  const { slug } = await params;
+  const relPath = relPathFromSlugParts(slug);
+  if (!relPath) return { title: "OpenSend Docs" };
+  const page = await getDocPage(relPath);
+  if (!page) return { title: "OpenSend Docs" };
+  return {
+    title: `${page.title} · OpenSend Docs`,
+    description: page.summary,
+  };
+}
+
+export default async function DocsMarkdownPage({ params }: DocsRouteProps) {
+  const { slug } = await params;
+  const relPath = relPathFromSlugParts(slug);
+  if (!relPath) notFound();
+
+  if (relPath.endsWith(".md")) {
+    const pretty = relPath.replace(/\.md$/, "");
+    if (slug.join("/").endsWith(".md")) redirect(`/docs/${pretty}`);
+  }
+
+  const [nav, page] = await Promise.all([getDocsNav(), getDocPage(relPath)]);
+  if (!page) notFound();
+
+  return (
+    <DocsShell nav={nav} activeSlug={page.slug} headings={page.headings}>
+      <article className="rounded-[24px] border border-line bg-bg-card p-6 shadow-[0_40px_120px_-90px_rgba(196,255,90,0.6)] sm:p-8 lg:p-10">
+        <div className="mb-8 flex flex-col gap-4 border-b border-line pb-6 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <p className="kicker">OpenSend docs</p>
+            <h1 className="mt-3 max-w-3xl text-[40px] font-medium leading-tight tracking-[-0.035em] text-fg sm:text-[52px]">
+              {page.title}
+            </h1>
+            <p className="mt-4 max-w-2xl text-[15px] leading-7 text-fg-2">
+              {page.summary}
+            </p>
+          </div>
+          <a className="btn btn-ghost btn-sm" href={page.rawHref}>
+            Raw markdown
+          </a>
+        </div>
+
+        <MarkdownContent markdown={page.markdown} skipFirstH1 />
+
+        <nav
+          className="mt-10 grid gap-3 border-t border-line pt-6 sm:grid-cols-2"
+          aria-label="Previous and next docs"
+        >
+          {page.previous ? (
+            <a
+              href={page.previous.href}
+              className="rounded-card border border-line bg-white/[0.02] p-4 transition hover:border-line-2 hover:bg-white/[0.04]"
+            >
+              <p className="kicker">Previous</p>
+              <p className="mt-2 text-[14px] font-medium text-fg">
+                {page.previous.title}
+              </p>
+            </a>
+          ) : (
+            <div />
+          )}
+          {page.next ? (
+            <a
+              href={page.next.href}
+              className="rounded-card border border-line bg-white/[0.02] p-4 text-right transition hover:border-line-2 hover:bg-white/[0.04]"
+            >
+              <p className="kicker">Next</p>
+              <p className="mt-2 text-[14px] font-medium text-fg">
+                {page.next.title}
+              </p>
+            </a>
+          ) : null}
+        </nav>
+      </article>
+    </DocsShell>
+  );
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,66 +1,7 @@
-"use client";
-
-import { useMemo, useState } from "react";
-
-type Method = "GET" | "POST" | "PATCH" | "DELETE";
-type Language = "node" | "curl";
-
-type Endpoint = {
-  method: Method;
-  path: string;
-  title: string;
-  description: string;
-  notes?: string[];
-  code: Record<Language, string>;
-};
-
-type ApiSection = {
-  id: string;
-  label: string;
-  description: string;
-  endpoints: Endpoint[];
-};
-
-type GuideCard = {
-  title: string;
-  eyebrow: string;
-  description: string;
-  href: string;
-};
+import { DocsShell } from "@/components/docs/docs-shell";
+import { getAllDocs, getDocsNav } from "@/lib/docs";
 
 const BASE_URL = "https://opensend.namuh.co";
-const DOCS_COUNT = 157;
-
-const OPENSEND_GUIDES: GuideCard[] = [
-  {
-    eyebrow: "REST basics",
-    title: "Authentication, base URL, and response codes",
-    description:
-      "Use os_ API keys with Bearer auth. Dashboard sessions are separate from API authentication.",
-    href: "/docs/api-reference/authentication.md",
-  },
-  {
-    eyebrow: "Sending",
-    title: "Send Email request model",
-    description:
-      "Send HTML or text email, schedule delivery, attach metadata, and protect retries with idempotency keys.",
-    href: "/docs/api-reference/emails/send-email.md",
-  },
-  {
-    eyebrow: "SDK",
-    title: "TypeScript SDK quickstart",
-    description:
-      "Install the opensend package, initialize the client, and send email from your application code.",
-    href: "/docs/send-with-nodejs.md",
-  },
-  {
-    eyebrow: "AI clients",
-    title: "LLM and MCP integration",
-    description:
-      "Use llms.txt, OpenAPI, and the MCP server to give agents a stable OpenSend control surface.",
-    href: "/docs/mcp-server.md",
-  },
-];
 
 const QUICKSTART_NODE = `import { Resend } from "opensend";
 
@@ -74,7 +15,7 @@ const { data, error } = await resend.emails.send({
 });
 
 if (error) throw error;
-console.log(data); // { id: "..." }`;
+console.log(data);`;
 
 const QUICKSTART_CURL = `curl -X POST ${BASE_URL}/emails \\
   -H "Authorization: Bearer os_YOUR_API_KEY" \\
@@ -87,717 +28,250 @@ const QUICKSTART_CURL = `curl -X POST ${BASE_URL}/emails \\
     "html": "<strong>It works.</strong>"
   }'`;
 
-const MCP_EXAMPLE = `{
-  "mcpServers": {
-    "opensend": {
-      "command": "bun",
-      "args": ["/path/to/opensend/packages/mcp/src/stdio.ts"],
-      "env": {
-        "OPENSEND_API_KEY": "os_YOUR_API_KEY",
-        "OPENSEND_API_BASE_URL": "https://opensend.namuh.co"
-      }
-    }
-  }
-}`;
-
-const API_SECTIONS: ApiSection[] = [
+const STARTER_CARDS = [
   {
-    id: "emails",
-    label: "Emails",
-    description: "Send, batch, cancel, and inspect delivery state.",
-    endpoints: [
-      {
-        method: "POST",
-        path: "/emails",
-        title: "Send an email",
-        description:
-          "Accepts OpenSend send payloads with familiar compatibility aliases. Duplicate Idempotency-Key retries within 24 hours replay the original accepted id.",
-        notes: ["Requires a verified sending domain for production traffic."],
-        code: {
-          node: `await resend.emails.send({
-  from: "Acme <onboarding@example.com>",
-  to: ["user@example.com"],
-  subject: "Welcome",
-  html: "<p>Hello world</p>",
-});`,
-          curl: `curl -X POST ${BASE_URL}/emails \\
-  -H "Authorization: Bearer os_YOUR_API_KEY" \\
-  -H "Content-Type: application/json" \\
-  -H "Idempotency-Key: welcome-user-123" \\
-  -d '{ "from": "Acme <onboarding@example.com>", "to": ["user@example.com"], "subject": "Welcome", "html": "<p>Hello world</p>" }'`,
-        },
-      },
-      {
-        method: "POST",
-        path: "/emails/batch",
-        title: "Send a batch",
-        description:
-          "Queue multiple messages in one request. The batch idempotency key protects the whole accepted envelope.",
-        code: {
-          node: `await resend.emails.sendBatch([
-  {
-    from: "Acme <news@example.com>",
-    to: ["a@example.com"],
-    subject: "For A",
-    html: "<p>A</p>",
-  },
-  {
-    from: "Acme <news@example.com>",
-    to: ["b@example.com"],
-    subject: "For B",
-    html: "<p>B</p>",
-  },
-]);`,
-          curl: `curl -X POST ${BASE_URL}/emails/batch \\
-  -H "Authorization: Bearer os_YOUR_API_KEY" \\
-  -H "Content-Type: application/json" \\
-  -H "Idempotency-Key: batch-campaign-123" \\
-  -d '[{"from":"Acme <news@example.com>","to":["a@example.com"],"subject":"For A","html":"<p>A</p>"}]'`,
-        },
-      },
-      {
-        method: "POST",
-        path: "/emails/:email_id/cancel",
-        title: "Cancel scheduled email",
-        description: "Cancel a scheduled message before it leaves the queue.",
-        code: {
-          node: `await resend.emails.cancel("email_id");`,
-          curl: `curl -X POST ${BASE_URL}/emails/email_id/cancel \\
-  -H "Authorization: Bearer os_YOUR_API_KEY"`,
-        },
-      },
-      {
-        method: "GET",
-        path: "/api/emails/:id",
-        title: "Retrieve email details",
-        description:
-          "OpenSend dashboard/API detail route for status, metadata, and lifecycle events.",
-        code: {
-          node: `const email = await client.emails.get("email_id");`,
-          curl: `curl ${BASE_URL}/api/emails/email_id \\
-  -H "Authorization: Bearer os_YOUR_API_KEY"`,
-        },
-      },
-    ],
-  },
-  {
-    id: "domains",
-    label: "Domains",
+    eyebrow: "1 · API key",
+    title: "Authenticate requests",
     description:
-      "Add sender domains and verify DKIM, SPF, DMARC, and tracking DNS.",
-    endpoints: [
-      {
-        method: "POST",
-        path: "/api/domains",
-        title: "Create domain",
-        description:
-          "Add a domain and receive the DNS records required for SES-backed sending.",
-        code: {
-          node: `await client.domains.create({ name: "updates.example.com" });`,
-          curl: `curl -X POST ${BASE_URL}/api/domains \\
-  -H "Authorization: Bearer os_YOUR_API_KEY" \\
-  -H "Content-Type: application/json" \\
-  -d '{ "name": "updates.example.com" }'`,
-        },
-      },
-      {
-        method: "POST",
-        path: "/api/domains/:id/auto-configure",
-        title: "Auto-configure DNS",
-        description:
-          "Operator/self-host Cloudflare token flow for writing the generated records automatically.",
-        code: {
-          node: `await fetch("https://opensend.namuh.co/api/domains/domain_id/auto-configure", {
-  method: "POST",
-  headers: { Authorization: "Bearer " + apiKey },
-});`,
-          curl: `curl -X POST ${BASE_URL}/api/domains/domain_id/auto-configure \\
-  -H "Authorization: Bearer os_YOUR_API_KEY"`,
-        },
-      },
-      {
-        method: "GET",
-        path: "/api/domains/:id",
-        title: "Retrieve domain",
-        description: "Inspect verification status and copy DNS records.",
-        code: {
-          node: `const domain = await client.domains.get("domain_id");`,
-          curl: `curl ${BASE_URL}/api/domains/domain_id \\
-  -H "Authorization: Bearer os_YOUR_API_KEY"`,
-        },
-      },
-    ],
+      "Create an os_ API key and use Bearer auth. Dashboard cookies are not API credentials.",
+    href: "/docs/api-reference/authentication",
   },
   {
-    id: "audience",
-    label: "Audience",
-    description: "Contacts, segments, topics, and contact properties.",
-    endpoints: [
-      {
-        method: "POST",
-        path: "/contacts",
-        title: "Create contact",
-        description: "Create a contact through the familiar root API alias.",
-        code: {
-          node: `await client.contacts.create({
-  email: "jane@example.com",
-  firstName: "Jane",
-});`,
-          curl: `curl -X POST ${BASE_URL}/contacts \\
-  -H "Authorization: Bearer os_YOUR_API_KEY" \\
-  -H "Content-Type: application/json" \\
-  -d '{ "email": "jane@example.com", "first_name": "Jane" }'`,
-        },
-      },
-      {
-        method: "POST",
-        path: "/segments",
-        title: "Create segment",
-        description:
-          "Create a named audience segment for filtering contacts and campaigns.",
-        code: {
-          node: `await client.segments.create({ name: "Active users" });`,
-          curl: `curl -X POST ${BASE_URL}/segments \\
-  -H "Authorization: Bearer os_YOUR_API_KEY" \\
-  -H "Content-Type: application/json" \\
-  -d '{ "name": "Active users" }'`,
-        },
-      },
-      {
-        method: "GET",
-        path: "/segments/:id/contacts",
-        title: "List segment contacts",
-        description: "Fetch contacts that currently match a segment.",
-        code: {
-          node: `const contacts = await client.segments.listContacts("segment_id");`,
-          curl: `curl ${BASE_URL}/segments/segment_id/contacts \\
-  -H "Authorization: Bearer os_YOUR_API_KEY"`,
-        },
-      },
-    ],
+    eyebrow: "2 · Domain",
+    title: "Verify a sending domain",
+    description:
+      "Add DNS records for DKIM, SPF, DMARC, bounce handling, and optional tracking.",
+    href: "/docs/api-reference/domains/create-domain",
   },
   {
-    id: "campaigns",
-    label: "Campaigns",
-    description: "Broadcasts and reusable templates for one-to-many sends.",
-    endpoints: [
-      {
-        method: "POST",
-        path: "/broadcasts",
-        title: "Create broadcast",
-        description:
-          "Create a draft broadcast with sender, subject, segment, and preview text.",
-        code: {
-          node: `await client.broadcasts.create({
-  name: "March newsletter",
-  from: "Acme <news@example.com>",
-  subject: "March updates",
-  segmentId: "segment_id",
-});`,
-          curl: `curl -X POST ${BASE_URL}/broadcasts \\
-  -H "Authorization: Bearer os_YOUR_API_KEY" \\
-  -H "Content-Type: application/json" \\
-  -d '{ "name": "March newsletter", "from": "Acme <news@example.com>", "subject": "March updates", "segment_id": "segment_id" }'`,
-        },
-      },
-      {
-        method: "POST",
-        path: "/broadcasts/:id/send",
-        title: "Send broadcast",
-        description:
-          "Send immediately or schedule with the same narrow natural-language window as email sends.",
-        code: {
-          node: `await client.broadcasts.send("broadcast_id", {
-  scheduledAt: "in 1 hour",
-});`,
-          curl: `curl -X POST ${BASE_URL}/broadcasts/broadcast_id/send \\
-  -H "Authorization: Bearer os_YOUR_API_KEY" \\
-  -H "Content-Type: application/json" \\
-  -d '{ "scheduled_at": "in 1 hour" }'`,
-        },
-      },
-      {
-        method: "POST",
-        path: "/templates",
-        title: "Create template",
-        description:
-          "Store versioned HTML templates that can be rendered for future sends.",
-        code: {
-          node: `await client.templates.create({
-  name: "Welcome",
-  alias: "welcome",
-  subject: "Welcome",
-  html: "<p>Hi {{name}}</p>",
-});`,
-          curl: `curl -X POST ${BASE_URL}/templates \\
-  -H "Authorization: Bearer os_YOUR_API_KEY" \\
-  -H "Content-Type: application/json" \\
-  -d '{ "name": "Welcome", "alias": "welcome", "subject": "Welcome", "html": "<p>Hi {{name}}</p>" }'`,
-        },
-      },
-    ],
+    eyebrow: "3 · Send",
+    title: "Send your first email",
+    description:
+      "Use the OpenSend API or SDK to send, schedule, batch, tag, and inspect messages.",
+    href: "/docs/api-reference/emails/send-email",
   },
   {
-    id: "platform",
-    label: "Platform",
-    description: "API keys, webhooks, OpenAPI, and MCP integrations.",
-    endpoints: [
-      {
-        method: "POST",
-        path: "/api-keys",
-        title: "Create API key",
-        description:
-          "Create scoped keys. OpenSend keys use the os_ prefix while preserving familiar API semantics.",
-        code: {
-          node: `await client.apiKeys.create({ name: "Production" });`,
-          curl: `curl -X POST ${BASE_URL}/api-keys \\
-  -H "Authorization: Bearer os_YOUR_API_KEY" \\
-  -H "Content-Type: application/json" \\
-  -d '{ "name": "Production" }'`,
-        },
-      },
-      {
-        method: "POST",
-        path: "/api/webhooks",
-        title: "Create webhook",
-        description:
-          "Subscribe an HTTPS endpoint to signed delivery and lifecycle events.",
-        code: {
-          node: `await fetch("https://opensend.namuh.co/api/webhooks", {
-  method: "POST",
-  headers: {
-    Authorization: "Bearer " + apiKey,
-    "Content-Type": "application/json",
-  },
-  body: JSON.stringify({
-    endpoint: "https://example.com/webhooks/opensend",
-    events: ["email.delivered"],
-  }),
-});`,
-          curl: `curl -X POST ${BASE_URL}/api/webhooks \\
-  -H "Authorization: Bearer os_YOUR_API_KEY" \\
-  -H "Content-Type: application/json" \\
-  -d '{ "endpoint": "https://example.com/webhooks/opensend", "events": ["email.delivered"] }'`,
-        },
-      },
-      {
-        method: "GET",
-        path: "/openapi.json",
-        title: "OpenAPI document",
-        description:
-          "Unauthenticated OpenAPI 3.0 contract for SDKs, generated clients, and audits.",
-        code: {
-          node: `const spec = await fetch("${BASE_URL}/openapi.json").then((res) => res.json());`,
-          curl: `curl ${BASE_URL}/openapi.json`,
-        },
-      },
-    ],
+    eyebrow: "4 · Observe",
+    title: "Watch logs and webhooks",
+    description:
+      "Track lifecycle events, signed webhook deliveries, retries, and API request logs.",
+    href: "/docs/webhooks/introduction",
   },
 ];
 
-const METHOD_STYLES: Record<Method, string> = {
-  GET: "border-blue/30 bg-blue/10 text-blue",
-  POST: "border-accent/30 bg-accent-soft text-accent",
-  PATCH: "border-amber/30 bg-amber/10 text-amber",
-  DELETE: "border-red/30 bg-red/10 text-red",
-};
+const COLLECTIONS = [
+  [
+    "API reference",
+    "/docs/api-reference/introduction",
+    "Endpoint contracts, auth, pagination, errors, limits, and OpenAPI.",
+  ],
+  [
+    "SDKs",
+    "/docs/sdks",
+    "TypeScript, Python, Go, Ruby, and framework-specific send examples.",
+  ],
+  [
+    "Domains",
+    "/docs/dashboard/domains/introduction",
+    "DNS setup, Cloudflare automation, DMARC, tracking, and provider guidance.",
+  ],
+  [
+    "Audience",
+    "/docs/dashboard/audiences/contacts",
+    "Contacts, segments, topics, properties, preferences, and suppressions.",
+  ],
+  [
+    "Broadcasts and templates",
+    "/docs/dashboard/broadcasts/introduction",
+    "Campaign creation, template variables, versioning, and performance tracking.",
+  ],
+  [
+    "Self-hosting",
+    "/docs/self-hosting",
+    "Docker Compose, migrations, SES/SNS ingester, security, and observability.",
+  ],
+] as const;
 
-function copyText(value: string) {
-  void navigator.clipboard?.writeText(value);
-}
+const POPULAR_ENDPOINTS = [
+  ["POST", "/emails", "Send one email"],
+  ["POST", "/emails/batch", "Queue a batch"],
+  ["POST", "/emails/:email_id/cancel", "Cancel scheduled email"],
+  ["POST", "/contacts", "Create contact"],
+  ["POST", "/broadcasts/:id/send", "Send broadcast"],
+  ["POST", "/api/webhooks", "Create webhook"],
+] as const;
 
-function CodeBlock({ value }: { value: string }) {
+function CodePanel({ title, code }: { title: string; code: string }) {
   return (
-    <div className="group relative overflow-hidden rounded-card border border-line bg-[#08080a]">
-      <button
-        type="button"
-        onClick={() => copyText(value)}
-        className="mono absolute right-2 top-2 z-10 rounded-md border border-line-2 bg-white/[0.04] px-2 py-1 text-[10.5px] text-fg-3 opacity-0 transition group-hover:opacity-100 hover:text-fg"
-      >
-        copy
-      </button>
-      <pre className="mono overflow-x-auto p-4 pr-14 text-[12px] leading-6 text-fg-2">
-        <code>{value}</code>
+    <div className="overflow-hidden rounded-card border border-line bg-[#08080a]">
+      <div className="border-b border-line bg-white/[0.03] px-4 py-2 font-mono text-[11px] uppercase tracking-[0.16em] text-fg-3">
+        {title}
+      </div>
+      <pre className="overflow-x-auto p-4 text-[12.5px] leading-6 text-fg-2">
+        <code>{code}</code>
       </pre>
     </div>
   );
 }
 
-function MethodBadge({ method }: { method: Method }) {
-  return (
-    <span
-      className={`mono inline-flex h-6 min-w-14 items-center justify-center rounded-md border px-2 text-[10.5px] font-semibold ${METHOD_STYLES[method]}`}
-    >
-      {method}
-    </span>
-  );
-}
-
-function EndpointCard({
-  endpoint,
-  language,
-}: { endpoint: Endpoint; language: Language }) {
-  return (
-    <article className="rounded-card border border-line bg-bg-card p-4 shadow-[0_18px_70px_-55px_rgba(196,255,90,0.55)] transition hover:border-line-2">
-      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <MethodBadge method={endpoint.method} />
-            <code className="mono rounded-md bg-white/[0.03] px-2 py-1 text-[13px] text-fg">
-              {endpoint.path}
-            </code>
-          </div>
-          <h3 className="mt-3 text-[17px] font-medium tracking-tight text-fg">
-            {endpoint.title}
-          </h3>
-          <p className="mt-1 max-w-2xl text-[13px] leading-6 text-fg-2">
-            {endpoint.description}
-          </p>
-          {endpoint.notes && endpoint.notes.length > 0 && (
-            <ul className="mt-3 space-y-1 text-[12px] leading-5 text-fg-3">
-              {endpoint.notes.map((note) => (
-                <li key={note} className="flex gap-2">
-                  <span className="text-accent">•</span>
-                  <span>{note}</span>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-      </div>
-      <div className="mt-4">
-        <CodeBlock value={endpoint.code[language]} />
-      </div>
-    </article>
-  );
-}
-
-function Sidebar({ sections }: { sections: ApiSection[] }) {
-  return (
-    <aside className="hidden 2xl:block">
-      <div className="sticky top-8 rounded-card border border-line bg-white/[0.02] p-3 backdrop-blur">
-        <p className="kicker px-2 py-2">On this page</p>
-        <nav className="space-y-1">
-          {[
-            "start",
-            "guides",
-            ...sections.map((section) => section.id),
-            "llms",
-          ].map((id) => (
-            <a
-              key={id}
-              href={`#${id}`}
-              className="block rounded-md px-2 py-1.5 text-[12.5px] capitalize text-fg-3 transition hover:bg-white/[0.04] hover:text-fg"
-            >
-              {id === "llms" ? "LLMs" : id}
-            </a>
-          ))}
-        </nav>
-      </div>
-    </aside>
-  );
-}
-
-export default function DocsPage() {
-  const [language, setLanguage] = useState<Language>("node");
-  const highlightedEndpointCount = useMemo(
-    () =>
-      API_SECTIONS.reduce((sum, section) => sum + section.endpoints.length, 0),
-    [],
-  );
-  const quickstart = language === "node" ? QUICKSTART_NODE : QUICKSTART_CURL;
+export default async function DocsPage() {
+  const [nav, docs] = await Promise.all([getDocsNav(), getAllDocs()]);
 
   return (
-    <main className="landing-root min-h-screen">
-      <div className="grain" aria-hidden />
-      <div className="ambient" aria-hidden />
-      <div className="landing-content">
-        <header className="border-b border-line bg-bg/70 backdrop-blur-xl">
-          <div className="mx-auto flex h-16 w-full max-w-[1500px] items-center justify-between px-6 lg:px-8">
-            <a
-              href="/"
-              className="flex items-center gap-2 text-[14px] font-semibold tracking-tight text-fg"
-            >
-              <span className="flex h-7 w-7 items-center justify-center rounded-md bg-accent text-accent-ink">
-                O
-              </span>
-              OpenSend Docs
-            </a>
-            <nav className="hidden items-center gap-5 text-[13px] text-fg-3 md:flex">
-              <a className="transition hover:text-fg" href="/openapi.json">
-                OpenAPI
-              </a>
-              <a className="transition hover:text-fg" href="/docs/llms.txt">
-                llms.txt
-              </a>
-              <a className="transition hover:text-fg" href="/auth">
-                Dashboard
-              </a>
-            </nav>
-          </div>
-        </header>
-
-        <div className="mx-auto grid w-full max-w-[1500px] gap-8 px-6 py-10 lg:px-8 2xl:grid-cols-[220px_minmax(0,1fr)_260px]">
-          <Sidebar sections={API_SECTIONS} />
-
-          <div className="min-w-0 space-y-12">
-            <section
-              id="start"
-              className="overflow-hidden rounded-[24px] border border-line bg-bg-card shadow-[0_40px_120px_-80px_rgba(196,255,90,0.9)]"
-            >
-              <div className="grid gap-0">
-                <div className="p-6 sm:p-8 lg:p-10">
-                  <div className="pill success">
-                    <span className="dot" /> Familiar API · self-hosted on AWS
-                    SES
-                  </div>
-                  <h1 className="mt-6 text-[42px] font-medium leading-[0.96] tracking-[-0.04em] text-fg sm:text-[56px]">
-                    Email API docs that agents and humans can actually use.
-                  </h1>
-                  <p className="mt-5 max-w-xl text-[16px] leading-7 text-fg-2">
-                    OpenSend keeps the familiar Resend API shape, swaps in{" "}
-                    <code className="mono text-fg">os_</code> keys, and runs on
-                    your own infrastructure. Start with the send path, then
-                    expand into domains, audience, broadcasts, webhooks,
-                    OpenAPI, and MCP.
-                  </p>
-                  <div className="mt-7 flex flex-wrap gap-3">
-                    <a className="btn btn-primary" href="#quickstart">
-                      Send your first email
-                    </a>
-                    <a className="btn btn-ghost" href="/openapi.json">
-                      View OpenAPI
-                    </a>
-                  </div>
-                </div>
-                <div
-                  id="quickstart"
-                  className="border-t border-line bg-[#08080a] p-4 sm:p-5"
-                >
-                  <div className="mb-3 flex items-center justify-between gap-3">
-                    <div>
-                      <p className="kicker">Quickstart</p>
-                      <p className="mt-1 text-[13px] text-fg-3">
-                        Base URL:{" "}
-                        <code className="mono text-fg">{BASE_URL}</code>
-                      </p>
-                    </div>
-                    <div className="inline-flex rounded-md border border-line bg-white/[0.03] p-1">
-                      {(["node", "curl"] as const).map((tab) => (
-                        <button
-                          key={tab}
-                          type="button"
-                          onClick={() => setLanguage(tab)}
-                          className={`mono rounded px-2.5 py-1 text-[11px] transition ${language === tab ? "bg-accent text-accent-ink" : "text-fg-3 hover:text-fg"}`}
-                        >
-                          {tab === "node" ? "Node.js" : "cURL"}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  <CodeBlock value={quickstart} />
-                  <p className="mt-3 text-[12px] leading-5 text-fg-3">
-                    For production, verify a sending domain first. Use a real
-                    recipient only after your domain records are healthy.
-                  </p>
-                </div>
+    <DocsShell nav={nav}>
+      <div className="space-y-10">
+        <section className="overflow-hidden rounded-[24px] border border-line bg-bg-card shadow-[0_40px_120px_-80px_rgba(196,255,90,0.9)]">
+          <div className="grid gap-0 lg:grid-cols-[1.04fr_0.96fr]">
+            <div className="p-6 sm:p-8 lg:p-10">
+              <div className="pill success">
+                <span className="dot" /> First-party docs · human and LLM ready
               </div>
-            </section>
-
-            <section id="guides" className="space-y-4">
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-                <div>
-                  <p className="kicker">OpenSend guides</p>
-                  <h2 className="title-m mt-2">
-                    Everything you need to integrate OpenSend
-                  </h2>
-                </div>
-                <a className="btn btn-ghost btn-sm" href="/docs/llms.txt">
-                  OpenSend llms.txt
-                </a>
-              </div>
-              <div className="grid gap-3 md:grid-cols-2">
-                {OPENSEND_GUIDES.map((reference) => (
-                  <a
-                    key={reference.href}
-                    href={reference.href}
-                    className="rounded-card border border-line bg-white/[0.02] p-4 transition hover:border-line-2 hover:bg-white/[0.04]"
-                  >
-                    <p className="kicker">{reference.eyebrow}</p>
-                    <h3 className="mt-2 text-[15px] font-medium text-fg">
-                      {reference.title}
-                    </h3>
-                    <p className="mt-2 text-[13px] leading-6 text-fg-2">
-                      {reference.description}
-                    </p>
-                  </a>
-                ))}
-              </div>
-            </section>
-
-            <section className="rounded-card border border-line bg-white/[0.02] p-5">
-              <div className="grid gap-4 sm:grid-cols-3">
-                <div>
-                  <p className="mono text-[28px] text-accent">{DOCS_COUNT}</p>
-                  <p className="text-[12px] text-fg-3">markdown docs</p>
-                </div>
-                <div>
-                  <p className="mono text-[28px] text-blue">OpenAPI 3.0</p>
-                  <p className="text-[12px] text-fg-3">
-                    machine-readable contract
-                  </p>
-                </div>
-                <div>
-                  <p className="mono text-[28px] text-violet">
-                    {highlightedEndpointCount}
-                  </p>
-                  <p className="text-[12px] text-fg-3">
-                    highlighted API examples
-                  </p>
-                </div>
-              </div>
-            </section>
-
-            <section className="space-y-4">
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-                <div>
-                  <p className="kicker">Docs corpus</p>
-                  <h2 className="title-m mt-2">
-                    Browse the full first-party markdown set
-                  </h2>
-                </div>
-                <a className="btn btn-ghost btn-sm" href="/docs/llms.txt">
-                  Full index
-                </a>
-              </div>
-              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-                {[
-                  [
-                    "API reference",
-                    "/docs/api-reference/introduction.md",
-                    "Endpoints, auth, pagination, errors, quotas, and resource operations.",
-                  ],
-                  [
-                    "Email operations",
-                    "/docs/api-reference/emails/send-email.md",
-                    "Sending, batch, scheduling, attachments, receiving, tags, and idempotency.",
-                  ],
-                  [
-                    "Audience",
-                    "/docs/dashboard/audiences/contacts.md",
-                    "Contacts, segments, topics, properties, unsubscribes, and preferences.",
-                  ],
-                  [
-                    "Campaigns",
-                    "/docs/dashboard/broadcasts/introduction.md",
-                    "Broadcasts, templates, variables, versioning, and performance tracking.",
-                  ],
-                  [
-                    "Webhooks",
-                    "/docs/webhooks/introduction.md",
-                    "Event types, signed requests, retries, replays, and lifecycle payloads.",
-                  ],
-                  [
-                    "Operations",
-                    "/docs/self-hosting.md",
-                    "Self-hosting, ingester deploys, observability, security, and troubleshooting.",
-                  ],
-                ].map(([title, href, description]) => (
-                  <a
-                    key={href}
-                    href={href}
-                    className="rounded-card border border-line bg-bg-card p-4 transition hover:border-line-2 hover:bg-white/[0.04]"
-                  >
-                    <h3 className="text-[15px] font-medium text-fg">{title}</h3>
-                    <p className="mt-2 text-[13px] leading-6 text-fg-2">
-                      {description}
-                    </p>
-                  </a>
-                ))}
-              </div>
-            </section>
-
-            {API_SECTIONS.map((section) => (
-              <section
-                key={section.id}
-                id={section.id}
-                className="scroll-mt-8 space-y-4"
-              >
-                <div>
-                  <p className="kicker">{section.label}</p>
-                  <h2 className="title-m mt-2">{section.description}</h2>
-                </div>
-                <div className="space-y-3">
-                  {section.endpoints.map((endpoint) => (
-                    <EndpointCard
-                      key={`${endpoint.method}-${endpoint.path}`}
-                      endpoint={endpoint}
-                      language={language}
-                    />
-                  ))}
-                </div>
-              </section>
-            ))}
-
-            <section
-              id="llms"
-              className="rounded-[20px] border border-accent/20 bg-accent-soft p-5 sm:p-6"
-            >
-              <p className="kicker text-accent">LLM docs</p>
-              <h2 className="mt-2 text-[24px] font-medium tracking-tight text-fg">
-                Give agents a small, stable map first.
-              </h2>
-              <p className="mt-3 max-w-2xl text-[14px] leading-7 text-fg-2">
-                OpenSend exposes the canonical LLM entrypoint at{" "}
-                <a
-                  className="text-fg underline decoration-line-3 underline-offset-4"
-                  href="/docs/llms.txt"
-                >
-                  /docs/llms.txt
-                </a>{" "}
-                so coding agents can discover the API, SDKs, MCP server,
-                operational setup, and parity notes before generating
-                integration code.
+              <h1 className="mt-6 max-w-3xl text-[42px] font-medium leading-[0.96] tracking-[-0.04em] text-fg sm:text-[60px]">
+                Email infrastructure docs without the guesswork.
+              </h1>
+              <p className="mt-5 max-w-2xl text-[16px] leading-7 text-fg-2">
+                Start with a verified domain and one send, then expand into
+                audiences, broadcasts, templates, webhooks, receiving, MCP, and
+                self-hosted operations. This docs shell renders the same
+                markdown corpus that powers{" "}
+                <code className="mono text-fg">/docs/llms.txt</code>.
               </p>
-              <div className="mt-5">
-                <CodeBlock value={MCP_EXAMPLE} />
+              <div className="mt-7 flex flex-wrap gap-3">
+                <a
+                  className="btn btn-primary"
+                  href="/docs/api-reference/emails/send-email"
+                >
+                  Send your first email
+                </a>
+                <a className="btn btn-ghost" href="/docs/self-hosting">
+                  Self-hosting guide
+                </a>
+                <a className="btn btn-ghost" href="/openapi.json">
+                  OpenAPI
+                </a>
               </div>
-            </section>
-          </div>
-
-          <aside className="hidden 2xl:block">
-            <div className="sticky top-8 space-y-3">
-              <div className="rounded-card border border-line bg-bg-card p-4">
-                <p className="kicker">Auth</p>
-                <p className="mt-2 text-[13px] leading-6 text-fg-2">
-                  Use{" "}
-                  <code className="mono text-fg">
-                    Authorization: Bearer os_...
-                  </code>
-                  . Dashboard cookies are never API credentials.
-                </p>
-              </div>
-              <div className="rounded-card border border-line bg-bg-card p-4">
-                <p className="kicker">Contracts</p>
-                <div className="mt-3 space-y-2 text-[13px]">
-                  <a
-                    className="block text-fg-2 transition hover:text-fg"
-                    href="/openapi.json"
-                  >
-                    OpenAPI JSON
-                  </a>
-                  <a
-                    className="block text-fg-2 transition hover:text-fg"
-                    href="/docs/llms.txt"
-                  >
-                    Docs llms.txt
-                  </a>
+              <div className="mt-8 grid gap-3 sm:grid-cols-3">
+                <div className="rounded-card border border-line bg-white/[0.02] p-4">
+                  <p className="font-mono text-[26px] text-accent">
+                    {docs.length}
+                  </p>
+                  <p className="text-[12px] text-fg-3">markdown guides</p>
+                </div>
+                <div className="rounded-card border border-line bg-white/[0.02] p-4">
+                  <p className="font-mono text-[26px] text-blue">OpenAPI</p>
+                  <p className="text-[12px] text-fg-3">schema source</p>
+                </div>
+                <div className="rounded-card border border-line bg-white/[0.02] p-4">
+                  <p className="font-mono text-[26px] text-violet">MCP</p>
+                  <p className="text-[12px] text-fg-3">agent tooling</p>
                 </div>
               </div>
             </div>
-          </aside>
-        </div>
+            <div
+              id="quickstart"
+              className="border-t border-line bg-[#08080a] p-4 sm:p-5 lg:border-l lg:border-t-0"
+            >
+              <p className="kicker">Quickstart</p>
+              <p className="mt-2 text-[13px] leading-6 text-fg-3">
+                Base URL: <code className="mono text-fg">{BASE_URL}</code>
+              </p>
+              <div className="mt-4 space-y-4">
+                <CodePanel title="Node.js" code={QUICKSTART_NODE} />
+                <CodePanel title="cURL" code={QUICKSTART_CURL} />
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <div>
+            <p className="kicker">Recommended path</p>
+            <h2 className="title-m mt-2">Do these four things first</h2>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            {STARTER_CARDS.map((card) => (
+              <a
+                key={card.href}
+                href={card.href}
+                className="rounded-card border border-line bg-bg-card p-4 transition hover:border-line-2 hover:bg-white/[0.04]"
+              >
+                <p className="kicker">{card.eyebrow}</p>
+                <h3 className="mt-3 text-[16px] font-medium text-fg">
+                  {card.title}
+                </h3>
+                <p className="mt-2 text-[13px] leading-6 text-fg-2">
+                  {card.description}
+                </p>
+              </a>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="kicker">Docs library</p>
+              <h2 className="title-m mt-2">Browse by job to be done</h2>
+            </div>
+            <a className="btn btn-ghost btn-sm" href="/docs/llms.txt">
+              Raw LLM index
+            </a>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {COLLECTIONS.map(([title, href, description]) => (
+              <a
+                key={href}
+                href={href}
+                className="rounded-card border border-line bg-bg-card p-4 transition hover:border-line-2 hover:bg-white/[0.04]"
+              >
+                <h3 className="text-[15px] font-medium text-fg">{title}</h3>
+                <p className="mt-2 text-[13px] leading-6 text-fg-2">
+                  {description}
+                </p>
+              </a>
+            ))}
+          </div>
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-[0.9fr_1.1fr]">
+          <div className="rounded-[20px] border border-line bg-bg-card p-5">
+            <p className="kicker">Popular endpoints</p>
+            <h2 className="mt-2 text-[22px] font-medium tracking-tight text-fg">
+              Common API surface
+            </h2>
+            <p className="mt-2 text-[13px] leading-6 text-fg-2">
+              Use the styled reference for humans and{" "}
+              <a
+                className="text-accent underline decoration-accent/30 underline-offset-4"
+                href="/openapi.json"
+              >
+                OpenAPI
+              </a>{" "}
+              for exact schemas.
+            </p>
+          </div>
+          <div className="rounded-[20px] border border-line bg-bg-card p-3">
+            <div className="grid gap-2 sm:grid-cols-2">
+              {POPULAR_ENDPOINTS.map(([method, route, label]) => (
+                <div
+                  key={route}
+                  className="rounded-card border border-line bg-white/[0.02] p-3"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-[11px] font-semibold text-accent">
+                      {method}
+                    </span>
+                    <code className="font-mono text-[12px] text-fg">
+                      {route}
+                    </code>
+                  </div>
+                  <p className="mt-2 text-[12.5px] text-fg-3">{label}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
       </div>
-    </main>
+    </DocsShell>
   );
 }

--- a/src/components/docs/docs-shell.tsx
+++ b/src/components/docs/docs-shell.tsx
@@ -1,0 +1,168 @@
+import type { DocsHeading, DocsNavSection } from "@/lib/docs";
+import type { ReactNode } from "react";
+
+type DocsShellProps = {
+  nav: DocsNavSection[];
+  activeSlug?: string;
+  headings?: DocsHeading[];
+  children: ReactNode;
+};
+
+function groupLabel(relPath: string) {
+  const parts = relPath.split("/");
+  if (parts.length <= 2) return null;
+  return parts[1]?.replace(/-/g, " ") ?? null;
+}
+
+export function DocsShell({
+  nav,
+  activeSlug,
+  headings = [],
+  children,
+}: DocsShellProps) {
+  return (
+    <main className="landing-root min-h-screen">
+      <div className="grain" aria-hidden />
+      <div className="ambient" aria-hidden />
+      <div className="landing-content">
+        <header className="sticky top-0 z-30 border-b border-line bg-bg/85 backdrop-blur-xl">
+          <div className="mx-auto flex h-16 w-full max-w-[1500px] items-center justify-between px-5 lg:px-8">
+            <a
+              href="/docs"
+              className="flex items-center gap-2 text-[14px] font-semibold tracking-tight text-fg"
+            >
+              <span className="flex h-7 w-7 items-center justify-center rounded-md bg-accent text-accent-ink">
+                O
+              </span>
+              OpenSend Docs
+            </a>
+            <nav className="hidden items-center gap-5 text-[13px] text-fg-3 md:flex">
+              <a
+                className="transition hover:text-fg"
+                href="/docs/api-reference/introduction"
+              >
+                API reference
+              </a>
+              <a
+                className="transition hover:text-fg"
+                href="/docs/send-with-nodejs"
+              >
+                SDKs
+              </a>
+              <a className="transition hover:text-fg" href="/openapi.json">
+                OpenAPI
+              </a>
+              <a className="transition hover:text-fg" href="/docs/llms.txt">
+                llms.txt
+              </a>
+              <a
+                className="rounded-md border border-line-2 px-3 py-1.5 text-fg transition hover:border-line-3"
+                href="/auth"
+              >
+                Dashboard
+              </a>
+            </nav>
+          </div>
+        </header>
+
+        <div className="mx-auto grid w-full max-w-[1500px] gap-7 px-5 py-8 lg:px-8 xl:grid-cols-[286px_minmax(0,1fr)] 2xl:grid-cols-[286px_minmax(0,1fr)_240px]">
+          <aside className="hidden xl:block">
+            <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto pr-2">
+              <a
+                href="/docs"
+                className={`mb-3 block rounded-card border px-3 py-3 transition ${activeSlug ? "border-line bg-white/[0.02] text-fg-2 hover:text-fg" : "border-accent/25 bg-accent-soft text-accent"}`}
+              >
+                <span className="kicker">Overview</span>
+                <span className="mt-1 block text-[13px] font-medium">
+                  Start here
+                </span>
+              </a>
+              <nav className="space-y-4" aria-label="Documentation">
+                {nav.map((section) => (
+                  <section
+                    key={section.id}
+                    className="rounded-card border border-line bg-white/[0.018] p-3"
+                  >
+                    <div className="px-1 pb-2">
+                      <p className="kicker">{section.title}</p>
+                      <p className="mt-1 text-[11.5px] leading-5 text-fg-3">
+                        {section.description}
+                      </p>
+                    </div>
+                    <div className="space-y-0.5">
+                      {section.items.map((item) => {
+                        const active = item.slug === activeSlug;
+                        const label = groupLabel(item.relPath);
+                        return (
+                          <a
+                            key={item.relPath}
+                            href={item.href}
+                            className={`block rounded-md px-2.5 py-2 text-[12.5px] leading-5 transition ${active ? "bg-accent text-accent-ink" : "text-fg-3 hover:bg-white/[0.04] hover:text-fg"}`}
+                          >
+                            {label ? (
+                              <span
+                                className={`mb-0.5 block text-[10px] capitalize ${active ? "text-accent-ink/70" : "text-fg-4"}`}
+                              >
+                                {label}
+                              </span>
+                            ) : null}
+                            <span>{item.title}</span>
+                          </a>
+                        );
+                      })}
+                    </div>
+                  </section>
+                ))}
+              </nav>
+            </div>
+          </aside>
+
+          <div className="min-w-0">{children}</div>
+
+          <aside className="hidden 2xl:block">
+            <div className="sticky top-24 space-y-3">
+              <div className="rounded-card border border-line bg-bg-card p-4">
+                <p className="kicker">On this page</p>
+                {headings.length > 0 ? (
+                  <nav className="mt-3 space-y-1" aria-label="Page sections">
+                    {headings.slice(0, 18).map((heading) => (
+                      <a
+                        key={heading.id}
+                        href={`#${heading.id}`}
+                        className={`block rounded-md py-1.5 text-[12.5px] leading-5 text-fg-3 transition hover:text-fg ${heading.depth === 3 ? "pl-4" : "pl-0"}`}
+                      >
+                        {heading.text}
+                      </a>
+                    ))}
+                  </nav>
+                ) : (
+                  <p className="mt-3 text-[12.5px] leading-6 text-fg-3">
+                    Choose a guide from the sidebar or start with the first
+                    email path.
+                  </p>
+                )}
+              </div>
+              <div className="rounded-card border border-line bg-bg-card p-4">
+                <p className="kicker">Contracts</p>
+                <div className="mt-3 space-y-2 text-[13px]">
+                  <a
+                    className="block text-fg-2 transition hover:text-fg"
+                    href="/openapi.json"
+                  >
+                    OpenAPI JSON
+                  </a>
+                  <a
+                    className="block text-fg-2 transition hover:text-fg"
+                    href="/docs/llms.txt"
+                  >
+                    LLM docs index
+                  </a>
+                </div>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/docs/markdown-content.tsx
+++ b/src/components/docs/markdown-content.tsx
@@ -1,0 +1,361 @@
+import { headingId } from "@/lib/docs";
+import type { ReactNode } from "react";
+
+type MarkdownBlock =
+  | { kind: "heading"; depth: 1 | 2 | 3 | 4; text: string; id: string }
+  | { kind: "paragraph"; text: string }
+  | { kind: "code"; language: string; code: string }
+  | { kind: "list"; ordered: boolean; items: string[] }
+  | { kind: "blockquote"; text: string }
+  | { kind: "table"; headers: string[]; rows: string[][] }
+  | { kind: "rule" };
+
+function stripInlineMarkers(value: string) {
+  return value.replace(/\*\*([^*]+)\*\*/g, "$1").replace(/_([^_]+)_/g, "$1");
+}
+
+function parseInline(text: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  const pattern = /(\[[^\]]+\]\([^\)]+\)|`[^`]+`|\*\*[^*]+\*\*|_[^_]+_)/g;
+  let lastIndex = 0;
+  let match = pattern.exec(text);
+
+  while (match !== null) {
+    if (match.index > lastIndex) nodes.push(text.slice(lastIndex, match.index));
+    const token = match[0];
+    const key = `${match.index}-${token}`;
+
+    if (token.startsWith("`")) {
+      nodes.push(
+        <code
+          key={key}
+          className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[0.88em] text-fg"
+        >
+          {token.slice(1, -1)}
+        </code>,
+      );
+    } else if (token.startsWith("**")) {
+      nodes.push(
+        <strong key={key} className="font-semibold text-fg">
+          {stripInlineMarkers(token.slice(2, -2))}
+        </strong>,
+      );
+    } else if (token.startsWith("_")) {
+      nodes.push(
+        <em key={key} className="text-fg">
+          {stripInlineMarkers(token.slice(1, -1))}
+        </em>,
+      );
+    } else {
+      const linkMatch = /^\[([^\]]+)\]\(([^\)]+)\)$/.exec(token);
+      if (linkMatch) {
+        const href = linkMatch[2];
+        nodes.push(
+          <a
+            key={key}
+            href={href}
+            className="text-accent underline decoration-accent/30 underline-offset-4 transition hover:text-accent-2"
+          >
+            {linkMatch[1]}
+          </a>,
+        );
+      }
+    }
+    lastIndex = pattern.lastIndex;
+    match = pattern.exec(text);
+  }
+
+  if (lastIndex < text.length) nodes.push(text.slice(lastIndex));
+  return nodes;
+}
+
+function isTableSeparator(line: string) {
+  return /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/.test(line);
+}
+
+function splitTableRow(line: string) {
+  return line
+    .trim()
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => cell.trim());
+}
+
+function makeHeadingId(text: string, seen: Map<string, number>) {
+  const base = headingId(text) || "section";
+  const count = seen.get(base) ?? 0;
+  seen.set(base, count + 1);
+  return count === 0 ? base : `${base}-${count + 1}`;
+}
+
+function parseMarkdown(markdown: string): MarkdownBlock[] {
+  const lines = markdown.replace(/\r\n/g, "\n").split("\n");
+  const blocks: MarkdownBlock[] = [];
+  const headingIds = new Map<string, number>();
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index];
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      index += 1;
+      continue;
+    }
+
+    if (trimmed.startsWith("```")) {
+      const language = trimmed.slice(3).trim();
+      const codeLines: string[] = [];
+      index += 1;
+      while (index < lines.length && !lines[index].trim().startsWith("```")) {
+        codeLines.push(lines[index]);
+        index += 1;
+      }
+      blocks.push({ kind: "code", language, code: codeLines.join("\n") });
+      index += 1;
+      continue;
+    }
+
+    const headingMatch = /^(#{1,4})\s+(.+)$/.exec(trimmed);
+    if (headingMatch) {
+      const depth = headingMatch[1].length as 1 | 2 | 3 | 4;
+      const text = headingMatch[2].replace(/\s+#+$/, "").trim();
+      blocks.push({
+        kind: "heading",
+        depth,
+        text,
+        id: makeHeadingId(text, headingIds),
+      });
+      index += 1;
+      continue;
+    }
+
+    if (/^---+$/.test(trimmed)) {
+      blocks.push({ kind: "rule" });
+      index += 1;
+      continue;
+    }
+
+    if (trimmed.startsWith(">")) {
+      const quoteLines: string[] = [];
+      while (index < lines.length && lines[index].trim().startsWith(">")) {
+        quoteLines.push(lines[index].trim().replace(/^>\s?/, ""));
+        index += 1;
+      }
+      blocks.push({ kind: "blockquote", text: quoteLines.join(" ") });
+      continue;
+    }
+
+    if (
+      index + 1 < lines.length &&
+      trimmed.includes("|") &&
+      isTableSeparator(lines[index + 1])
+    ) {
+      const headers = splitTableRow(trimmed);
+      const rows: string[][] = [];
+      index += 2;
+      while (index < lines.length && lines[index].trim().includes("|")) {
+        rows.push(splitTableRow(lines[index]));
+        index += 1;
+      }
+      blocks.push({ kind: "table", headers, rows });
+      continue;
+    }
+
+    const unorderedMatch = /^[-*]\s+(.+)$/.exec(trimmed);
+    const orderedMatch = /^\d+\.\s+(.+)$/.exec(trimmed);
+    if (unorderedMatch || orderedMatch) {
+      const ordered = Boolean(orderedMatch);
+      const items: string[] = [];
+      while (index < lines.length) {
+        const itemLine = lines[index].trim();
+        const itemMatch = ordered
+          ? /^\d+\.\s+(.+)$/.exec(itemLine)
+          : /^[-*]\s+(.+)$/.exec(itemLine);
+        if (!itemMatch) break;
+        items.push(itemMatch[1]);
+        index += 1;
+      }
+      blocks.push({ kind: "list", ordered, items });
+      continue;
+    }
+
+    const paragraphLines: string[] = [trimmed];
+    index += 1;
+    while (index < lines.length) {
+      const next = lines[index].trim();
+      if (
+        !next ||
+        next.startsWith("#") ||
+        next.startsWith("```") ||
+        next.startsWith(">") ||
+        /^[-*]\s+/.test(next) ||
+        /^\d+\.\s+/.test(next) ||
+        /^---+$/.test(next)
+      ) {
+        break;
+      }
+      paragraphLines.push(next);
+      index += 1;
+    }
+    blocks.push({ kind: "paragraph", text: paragraphLines.join(" ") });
+  }
+
+  return blocks;
+}
+
+function Heading({
+  block,
+}: { block: Extract<MarkdownBlock, { kind: "heading" }> }) {
+  const content = parseInline(block.text);
+  if (block.depth === 1) {
+    return (
+      <h1 className="text-[40px] font-medium leading-tight tracking-[-0.035em] text-fg sm:text-[52px]">
+        {content}
+      </h1>
+    );
+  }
+  if (block.depth === 2) {
+    return (
+      <h2
+        id={block.id}
+        className="scroll-mt-28 pt-7 text-[28px] font-medium tracking-[-0.025em] text-fg"
+      >
+        {content}
+      </h2>
+    );
+  }
+  if (block.depth === 3) {
+    return (
+      <h3
+        id={block.id}
+        className="scroll-mt-28 pt-4 text-[20px] font-medium tracking-[-0.015em] text-fg"
+      >
+        {content}
+      </h3>
+    );
+  }
+  return <h4 className="pt-3 text-[16px] font-semibold text-fg">{content}</h4>;
+}
+
+export function MarkdownContent({
+  markdown,
+  skipFirstH1 = false,
+}: {
+  markdown: string;
+  skipFirstH1?: boolean;
+}) {
+  const parsedBlocks = parseMarkdown(markdown);
+  let blocks = parsedBlocks;
+  if (
+    skipFirstH1 &&
+    parsedBlocks[0]?.kind === "heading" &&
+    parsedBlocks[0].depth === 1
+  ) {
+    blocks = parsedBlocks.slice(1);
+    if (blocks[0]?.kind === "paragraph") {
+      blocks = blocks.slice(1);
+    }
+  }
+  return (
+    <div className="space-y-5">
+      {blocks.map((block, index) => {
+        const key = `${block.kind}-${index}`;
+        if (block.kind === "heading")
+          return <Heading key={key} block={block} />;
+        if (block.kind === "paragraph") {
+          return (
+            <p key={key} className="max-w-3xl text-[15px] leading-7 text-fg-2">
+              {parseInline(block.text)}
+            </p>
+          );
+        }
+        if (block.kind === "code") {
+          return (
+            <div
+              key={key}
+              className="overflow-hidden rounded-card border border-line bg-[#08080a]"
+            >
+              {block.language ? (
+                <div className="border-b border-line bg-white/[0.03] px-4 py-2 font-mono text-[11px] uppercase tracking-[0.16em] text-fg-3">
+                  {block.language}
+                </div>
+              ) : null}
+              <pre className="overflow-x-auto p-4 text-[12.5px] leading-6 text-fg-2">
+                <code>{block.code}</code>
+              </pre>
+            </div>
+          );
+        }
+        if (block.kind === "list") {
+          const ListTag = block.ordered ? "ol" : "ul";
+          return (
+            <ListTag
+              key={key}
+              className={`max-w-3xl space-y-2 pl-5 text-[15px] leading-7 text-fg-2 ${block.ordered ? "list-decimal" : "list-disc"}`}
+            >
+              {block.items.map((item) => (
+                <li key={item}>{parseInline(item)}</li>
+              ))}
+            </ListTag>
+          );
+        }
+        if (block.kind === "blockquote") {
+          return (
+            <blockquote
+              key={key}
+              className="max-w-3xl rounded-card border border-accent/20 bg-accent-soft px-4 py-3 text-[14px] leading-7 text-fg-2"
+            >
+              {parseInline(block.text)}
+            </blockquote>
+          );
+        }
+        if (block.kind === "table") {
+          return (
+            <div
+              key={key}
+              className="overflow-x-auto rounded-card border border-line"
+            >
+              <table className="w-full min-w-[560px] border-collapse text-left text-[13px] text-fg-2">
+                <thead className="bg-white/[0.03] text-fg">
+                  <tr>
+                    {block.headers.map((header) => (
+                      <th
+                        key={header}
+                        className="border-b border-line px-4 py-3 font-medium"
+                      >
+                        {parseInline(header)}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {block.rows.map((row) => {
+                    const rowKey = row.join("|");
+                    return (
+                      <tr
+                        key={`${key}-row-${rowKey}`}
+                        className="border-b border-line last:border-0"
+                      >
+                        {row.map((cell) => (
+                          <td
+                            key={`${key}-cell-${rowKey}-${cell}`}
+                            className="px-4 py-3 align-top"
+                          >
+                            {parseInline(cell)}
+                          </td>
+                        ))}
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          );
+        }
+        return <hr key={key} className="border-line" />;
+      })}
+    </div>
+  );
+}

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,0 +1,275 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+export type DocsNavItem = {
+  title: string;
+  summary: string;
+  relPath: string;
+  slug: string;
+  href: string;
+  rawHref: string;
+};
+
+export type DocsNavSection = {
+  id: string;
+  title: string;
+  description: string;
+  items: DocsNavItem[];
+};
+
+export type DocsHeading = {
+  id: string;
+  depth: 2 | 3;
+  text: string;
+};
+
+export type DocsPage = DocsNavItem & {
+  markdown: string;
+  headings: DocsHeading[];
+  previous: DocsNavItem | null;
+  next: DocsNavItem | null;
+};
+
+const DOCS_ROOT = path.join(process.cwd(), "public", "docs");
+
+const SECTION_META: Record<string, { title: string; description: string }> = {
+  "start-here": {
+    title: "Start here",
+    description: "Quickstarts, SDKs, MCP, examples, and operating modes.",
+  },
+  "api-reference": {
+    title: "API reference",
+    description: "Authentication, errors, limits, and endpoint contracts.",
+  },
+  dashboard: {
+    title: "Dashboard guides",
+    description:
+      "How to operate domains, audiences, templates, broadcasts, and logs.",
+  },
+  webhooks: {
+    title: "Webhooks",
+    description:
+      "Signed event delivery, retries, replays, and lifecycle events.",
+  },
+  "knowledge-base": {
+    title: "Knowledge base",
+    description: "DNS providers, consent, deliverability, and troubleshooting.",
+  },
+  operations: {
+    title: "Operations",
+    description: "Self-hosting, ingester deploys, security, and observability.",
+  },
+};
+
+const SECTION_ORDER = [
+  "start-here",
+  "api-reference",
+  "dashboard",
+  "webhooks",
+  "knowledge-base",
+  "operations",
+];
+
+const DOC_ORDER = [
+  "api-reference/introduction.md",
+  "api-reference/authentication.md",
+  "api-reference/pagination.md",
+  "api-reference/errors.md",
+  "api-reference/rate-limit.md",
+  "sdks.md",
+  "send-with-nodejs.md",
+  "send-with-python.md",
+  "send-with-go.md",
+  "send-with-ruby.md",
+  "self-hosting.md",
+  "ingester-deploy.md",
+  "webhooks/introduction.md",
+  "webhooks/event-types.md",
+  "webhooks/verify-webhooks-requests.md",
+];
+
+async function walk(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walk(fullPath)));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+export function slugFromRelPath(relPath: string) {
+  return relPath.replace(/\.md$/, "");
+}
+
+export function relPathFromSlugParts(slugParts: string[]) {
+  const joined = slugParts.join("/");
+  if (!joined || joined.includes("..")) return null;
+  if (joined.endsWith(".md")) return joined;
+  return `${joined}.md`;
+}
+
+export function docsHrefFromRelPath(relPath: string) {
+  return `/docs/${slugFromRelPath(relPath)}`;
+}
+
+function cleanMarkdownText(value: string) {
+  return value
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^\)]+\)/g, "$1")
+    .replace(/<[^>]+>/g, "")
+    .replace(/[*_#>]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractTitleAndSummary(markdown: string, relPath: string) {
+  const lines = markdown.split(/\r?\n/);
+  const titleIndex = lines.findIndex((line) => line.startsWith("# "));
+  const titleLine = titleIndex >= 0 ? lines[titleIndex] : null;
+  const title = titleLine ? cleanMarkdownText(titleLine.slice(2)) : relPath;
+  const summary =
+    lines
+      .slice(titleIndex >= 0 ? titleIndex + 1 : 0)
+      .map((line) => line.trim())
+      .find(
+        (line) =>
+          line &&
+          !line.startsWith("#") &&
+          !line.startsWith("`") &&
+          !line.startsWith("---") &&
+          !line.startsWith("<!--"),
+      ) ?? "OpenSend documentation.";
+
+  return { title, summary: cleanMarkdownText(summary) };
+}
+
+function orderIndex(relPath: string) {
+  const index = DOC_ORDER.indexOf(relPath);
+  return index === -1 ? 10_000 : index;
+}
+
+function compareDocs(a: DocsNavItem, b: DocsNavItem) {
+  const sectionDelta =
+    SECTION_ORDER.indexOf(sectionIdForRelPath(a.relPath)) -
+    SECTION_ORDER.indexOf(sectionIdForRelPath(b.relPath));
+  if (sectionDelta !== 0) return sectionDelta;
+
+  const orderDelta = orderIndex(a.relPath) - orderIndex(b.relPath);
+  if (orderDelta !== 0) return orderDelta;
+
+  return a.relPath.localeCompare(b.relPath);
+}
+
+function sectionIdForRelPath(relPath: string) {
+  if (relPath.startsWith("api-reference/")) return "api-reference";
+  if (relPath.startsWith("dashboard/")) return "dashboard";
+  if (relPath.startsWith("webhooks/")) return "webhooks";
+  if (relPath.startsWith("knowledge-base/")) return "knowledge-base";
+  if (
+    relPath === "self-hosting.md" ||
+    relPath === "ingester-deploy.md" ||
+    relPath === "observability.md" ||
+    relPath === "security.md"
+  ) {
+    return "operations";
+  }
+  return "start-here";
+}
+
+export function headingId(value: string) {
+  return cleanMarkdownText(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export function extractHeadings(markdown: string): DocsHeading[] {
+  const seen = new Map<string, number>();
+  const headings: DocsHeading[] = [];
+  let inFence = false;
+
+  for (const line of markdown.split(/\r?\n/)) {
+    if (line.startsWith("```")) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const match = /^(#{2,3})\s+(.+)$/.exec(line);
+    if (!match) continue;
+    const depth = match[1].length as 2 | 3;
+    const text = cleanMarkdownText(match[2]);
+    const baseId = headingId(text) || "section";
+    const count = seen.get(baseId) ?? 0;
+    seen.set(baseId, count + 1);
+    headings.push({
+      id: count === 0 ? baseId : `${baseId}-${count + 1}`,
+      depth,
+      text,
+    });
+  }
+
+  return headings;
+}
+
+export async function getAllDocs(): Promise<DocsNavItem[]> {
+  const files = await walk(DOCS_ROOT);
+  const docs: DocsNavItem[] = [];
+
+  for (const file of files) {
+    const relPath = path.relative(DOCS_ROOT, file).split(path.sep).join("/");
+    const markdown = await readFile(file, "utf8");
+    const { title, summary } = extractTitleAndSummary(markdown, relPath);
+    const slug = slugFromRelPath(relPath);
+    docs.push({
+      title,
+      summary,
+      relPath,
+      slug,
+      href: docsHrefFromRelPath(relPath),
+      rawHref: `/docs/${relPath}`,
+    });
+  }
+
+  return docs.sort(compareDocs);
+}
+
+export async function getDocsNav(): Promise<DocsNavSection[]> {
+  const docs = await getAllDocs();
+  return SECTION_ORDER.map((id) => {
+    const meta = SECTION_META[id];
+    return {
+      id,
+      title: meta.title,
+      description: meta.description,
+      items: docs.filter((doc) => sectionIdForRelPath(doc.relPath) === id),
+    };
+  }).filter((section) => section.items.length > 0);
+}
+
+export async function getDocPage(relPath: string): Promise<DocsPage | null> {
+  if (!relPath.endsWith(".md") || relPath.includes("..")) return null;
+  const docs = await getAllDocs();
+  const currentIndex = docs.findIndex((doc) => doc.relPath === relPath);
+  if (currentIndex === -1) return null;
+
+  const filePath = path.join(DOCS_ROOT, relPath);
+  const markdown = await readFile(filePath, "utf8");
+  return {
+    ...docs[currentIndex],
+    markdown,
+    headings: extractHeadings(markdown),
+    previous: currentIndex > 0 ? docs[currentIndex - 1] : null,
+    next: currentIndex < docs.length - 1 ? docs[currentIndex + 1] : null,
+  };
+}

--- a/tests/docs-content.test.ts
+++ b/tests/docs-content.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  docsHrefFromRelPath,
+  extractHeadings,
+  getAllDocs,
+  getDocPage,
+  getDocsNav,
+  relPathFromSlugParts,
+} from "@/lib/docs";
+import { describe, expect, it } from "vitest";
+
+describe("docs content shell", () => {
+  it("builds pretty human docs routes while preserving raw markdown paths", async () => {
+    const docs = await getAllDocs();
+    const sendDoc = docs.find(
+      (doc) => doc.relPath === "api-reference/emails/send-email.md",
+    );
+
+    expect(sendDoc).toBeDefined();
+    expect(sendDoc?.href).toBe("/docs/api-reference/emails/send-email");
+    expect(sendDoc?.rawHref).toBe("/docs/api-reference/emails/send-email.md");
+    expect(docsHrefFromRelPath("self-hosting.md")).toBe("/docs/self-hosting");
+    expect(relPathFromSlugParts(["self-hosting"])).toBe("self-hosting.md");
+    expect(
+      relPathFromSlugParts(["api-reference", "emails", "send-email"]),
+    ).toBe("api-reference/emails/send-email.md");
+  });
+
+  it("groups docs into navigable sections with a rendered page payload", async () => {
+    const nav = await getDocsNav();
+    const page = await getDocPage("self-hosting.md");
+
+    expect(nav.map((section) => section.id)).toContain("api-reference");
+    expect(nav.map((section) => section.id)).toContain("operations");
+    expect(page?.title).toBe("Self Hosting");
+    expect(page?.href).toBe("/docs/self-hosting");
+    expect(
+      page?.headings.some((heading) => heading.text === "Reference topology"),
+    ).toBe(true);
+    expect(page?.markdown).toContain(
+      "SES/SNS events should be delivered to the ingester service",
+    );
+  });
+
+  it("keeps generated llms.txt on the OpenSend-owned hosted domain", () => {
+    const llms = readFileSync(
+      path.join(process.cwd(), "public/docs/llms.txt"),
+      "utf8",
+    );
+
+    expect(llms).toContain(
+      "https://opensend.namuh.co/docs/api-reference/introduction.md",
+    );
+    expect(llms).not.toContain("api.opensend.com");
+  });
+
+  it("extracts unique heading anchors for table of contents", () => {
+    const headings = extractHeadings(
+      "# Title\n\n## Setup\n\n### DNS\n\n## Setup\n",
+    );
+
+    expect(headings).toEqual([
+      { depth: 2, id: "setup", text: "Setup" },
+      { depth: 3, id: "dns", text: "DNS" },
+      { depth: 2, id: "setup-2", text: "Setup" },
+    ]);
+  });
+});

--- a/tests/e2e/openapi.spec.ts
+++ b/tests/e2e/openapi.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test("publishes the OpenAPI contract without sign-in", async ({
+test("publishes public OpenAPI and styled docs without sign-in", async ({
   page,
   request,
 }) => {
@@ -17,5 +17,32 @@ test("publishes the OpenAPI contract without sign-in", async ({
   expect(document.paths).toHaveProperty("/api/domains");
 
   await page.goto("/docs");
-  await expect(page.getByRole("link", { name: "/openapi.json" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Email infrastructure docs" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "OpenAPI" }).first(),
+  ).toHaveAttribute("href", "/openapi.json");
+  await expect(
+    page.getByRole("link", { name: "Self-hosting guide" }),
+  ).toHaveAttribute("href", "/docs/self-hosting");
+
+  await page.goto("/docs/self-hosting");
+  await expect(
+    page.getByRole("heading", { name: "Self Hosting" }).first(),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Reference topology" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "Raw markdown" }),
+  ).toHaveAttribute("href", "/docs/self-hosting.md");
+
+  const llms = await request.get("/docs/llms.txt");
+  expect(llms.status()).toBe(200);
+  const llmsText = await llms.text();
+  expect(llmsText).toContain(
+    "https://opensend.namuh.co/docs/api-reference/introduction.md",
+  );
+  expect(llmsText).not.toContain("api.opensend.com");
 });


### PR DESCRIPTION
## Summary
- Replace the hand-coded docs sampler with a styled docs shell that renders the first-party markdown corpus on pretty `/docs/*` routes.
- Keep raw markdown and `/docs/llms.txt` available for LLM/tooling consumers while fixing hosted OpenSend URLs.
- Expand the self-hosting, SDK, and API introduction pages so the first-run docs path is useful immediately.

## Changes
- **Docs shell**: sidebar navigation, table-of-contents anchors, previous/next docs, raw markdown links, and code/table/list rendering.
- **Docs content**: refresh `/docs`, `self-hosting`, `sdks`, and API introduction; regenerate `public/docs/llms.txt`.
- **Validation**: add docs helper unit coverage and strengthen Playwright proof for public docs/OpenAPI access.

## How to Test
- [x] `make check`
- [x] `make test`
- [x] `bun run build`
- [x] `bunx playwright test tests/e2e/openapi.spec.ts`
- [x] Local smoke: `/docs`, `/docs/self-hosting`, `/docs/api-reference/introduction`, and `/docs/llms.txt` return 200 with no `api.opensend.com` in local output.

## Notes
- Human docs now prefer pretty routes such as `/docs/self-hosting`; raw markdown remains available at `/docs/self-hosting.md`.
- `.scratch` is added to Biome ignores because ignored scratch deploy artifacts were causing full `make check` to fail.
