### PR TITLE
Release: reconcile staging to main 2026-05-19

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -45,14 +45,28 @@ jobs:
               .map(l => l.name)
               .filter(n => n.startsWith('size/'));
 
-            for (const old of existing) {
-              if (old !== label) {
+            async function removeStaleSizeLabel(name) {
+              try {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: context.issue.number,
-                  name: old,
+                  name,
                 });
+              } catch (error) {
+                // Reruns/races can make payload labels stale; 404 means the old size label is already gone.
+                if (error.status === 404) {
+                  core.notice(`Stale size label ${name} was already absent; continuing.`);
+                  return;
+                }
+
+                throw error;
+              }
+            }
+
+            for (const old of existing) {
+              if (old !== label) {
+                await removeStaleSizeLabel(old);
               }
             }
 


### PR DESCRIPTION
## Release note

This is a staging → main reconciliation PR for the 2026-05-19 supervisor tick. It brings the current `origin/staging` tip into `main` so the staging CI workflow fix is covered by an explicit main-target release PR instead of lingering as unreleased staging history.

### What is included
- **CI workflow resilience** — includes staging commit `fbdfe758eee28522d10eb4c3dedf867294ab4504` from #516: `ci: make PR size label reruns race-safe`, which makes the PR size-label rerun path idempotent against stale label removal races.

### Conflict resolution notes
- Merge source: fresh `origin/main` (`4aead0061a1513fdb8337849d3f075792c446085`) + `origin/staging` (`fbdfe758eee28522d10eb4c3dedf867294ab4504`).
- Conflicts: none.
- Runtime/UI payload: no app runtime, public-route, dashboard, schema, SDK, or docs content changes in this merge commit; changed file is `.github/workflows/pr-check.yml`.

## Validation evidence
- `bun install --ignore-scripts` ✅
- `git diff --check` ✅
- `make check` ✅
- `make test` ✅ — 174 files / 1391 tests passed.
- `bun run build` ✅ — Next app compiled successfully. Build emitted existing Next 16 warnings about `experimental.nodeMiddleware` and middleware/proxy naming, but exited 0.
- Local Next boot + HTTP probes ✅ — `PORT=3015 bun run dev`; `GET /status` → 200; `GET /` → 200.
- Ever CLI UI validation ⚠️ not completed: local Ever API server is unreachable (`API server not reachable at http://localhost:8080`). Because this release payload is CI-only and the HTTP/build probes passed, there is no known UI-specific blocker, but this PR should not be treated as Ever-validated.
- Focused Playwright/E2E: not run; diff is CI workflow-only and no app/user flow changed.

## Merge status
- Main-target PR: human-gated. Do not merge without Jaeyun authorization.
