### PR TITLE
fix(dedicated-ips): remove erroneous "use client" from server page

### DIFF
--- a/src/app/(dashboard)/settings/dedicated-ips/page.tsx
+++ b/src/app/(dashboard)/settings/dedicated-ips/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { plans, subscriptions } from "@/lib/db/schema";


### PR DESCRIPTION
## Hotfix for failing Deploy on main

The /settings/dedicated-ips page (added in #522) was marked `"use client"` despite being an async server component that imports pg via `db.query.*` and `dedicatedIpPoolRepo`. Turbopack chunked it for the browser, then failed to resolve `tls` and `node:fs` from the pg driver — the production build for ECS broke.

`make check` doesn't catch this (only `next build` does). Verified with a full local `bun run build`: `/settings/dedicated-ips` is now correctly listed as a dynamic server-rendered route.

Fixes Deploy run [26339163734](https://github.com/namuh-eng/opensend/actions/runs/26339163734).

🤖 Generated with [Claude Code](https://claude.com/claude-code)