### PR TITLE
[codex] Add dashboard template editor

### DIFF
--- a/agent_docs/learnings/active/2026-05-23-template-editor-dashboard-auth.md
+++ b/agent_docs/learnings/active/2026-05-23-template-editor-dashboard-auth.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-23
+issue: "template-editor"
+type: decision
+promoted_to: null
+---
+
+## Template editor dashboard auth and React Email starter conversion
+
+The dashboard template editor uses `/api/templates/:id` and `/api/templates/:id/publish`, so those app API routes must accept the same dashboard-session auth as `/api/templates` and `/api/templates/:id/preview`; API-key-only auth leaves authenticated dashboard users with a blank or unusable editor unless they also have `localStorage.api_key`.
+
+When a React Email registry starter template is edited as custom HTML, clear the stored React Email renderer document on save. Otherwise the database `html` changes but preview/send continues rendering the registry template, making the editor appear to save while production output ignores the edited content.

--- a/packages/core/src/services/template.ts
+++ b/packages/core/src/services/template.ts
@@ -376,6 +376,17 @@ function toReactEmailStarterVariables(
   );
 }
 
+function isReactEmailDocument(document: unknown): boolean {
+  if (!isRecord(document)) return false;
+  if (document.kind === "react_email") return true;
+
+  const rendering = document.rendering;
+  if (isRecord(rendering) && rendering.kind === "react_email") return true;
+
+  const renderer = document.renderer;
+  return isRecord(renderer) && renderer.kind === "react_email";
+}
+
 function getReactEmailTemplateKey(input: Record<string, unknown>): string {
   const rawKey = input.react_email_template_key;
   return typeof rawKey === "string" ? rawKey.trim() : "";
@@ -598,6 +609,14 @@ export function createTemplateService({
 
       if (body.html !== undefined || body.subject !== undefined) {
         updateData.variables = buildAutomaticVariables(existing, body);
+      }
+
+      if (
+        typeof body.html === "string" &&
+        body.html !== existing.html &&
+        isReactEmailDocument(existing.document)
+      ) {
+        updateData.document = null;
       }
 
       if (body.variables !== undefined) {

--- a/src/app/(dashboard)/templates/[id]/editor/page.tsx
+++ b/src/app/(dashboard)/templates/[id]/editor/page.tsx
@@ -1,3 +1,5 @@
+import { TemplateEditor } from "@/components/template-editor";
+
 export default async function TemplateEditorPage({
   params,
 }: {
@@ -5,10 +7,5 @@ export default async function TemplateEditorPage({
 }) {
   const { id } = await params;
 
-  return (
-    <div>
-      <h1 className="text-2xl font-semibold text-fg">Template Editor</h1>
-      <p className="text-[14px] text-fg-2 mt-2">Editing template {id}</p>
-    </div>
-  );
+  return <TemplateEditor templateId={id} />;
 }

--- a/src/app/(dashboard)/templates/[id]/page.tsx
+++ b/src/app/(dashboard)/templates/[id]/page.tsx
@@ -1,43 +1,44 @@
 import { TemplateDetail } from "@/components/template-detail";
+import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { templates } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
-import { notFound } from "next/navigation";
+import { and, eq } from "drizzle-orm";
+import { notFound, redirect } from "next/navigation";
 
 export default async function TemplateDetailPage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
+  const session = await getServerSession();
+  if (!session) redirect("/auth");
+
   const { id } = await params;
+  const userId = session.user.id;
 
-  try {
-    const [template] = await db
-      .select()
-      .from(templates)
-      .where(eq(templates.id, id))
-      .limit(1);
+  const [template] = await db
+    .select()
+    .from(templates)
+    .where(and(eq(templates.id, id), eq(templates.userId, userId)))
+    .limit(1);
 
-    if (!template) {
-      notFound();
-    }
-
-    const templateData = {
-      id: template.id,
-      name: template.name,
-      alias: template.alias,
-      from: template.from,
-      subject: template.subject,
-      html: template.html,
-      text: template.text,
-      published: template.status === "published",
-      variables: template.variables ?? [],
-      createdAt: template.createdAt.toISOString(),
-      updatedAt: template.createdAt.toISOString(),
-    };
-
-    return <TemplateDetail template={templateData} />;
-  } catch {
+  if (!template) {
     notFound();
   }
+
+  const templateData = {
+    id: template.id,
+    name: template.name,
+    alias: template.alias,
+    from: template.from,
+    subject: template.subject,
+    html: template.html,
+    text: template.text,
+    published: template.status === "published",
+    variables: template.variables ?? [],
+    createdAt: template.createdAt.toISOString(),
+    updatedAt: template.createdAt.toISOString(),
+  };
+
+  return <TemplateDetail template={templateData} />;
 }

--- a/src/app/api/templates/[id]/duplicate/route.ts
+++ b/src/app/api/templates/[id]/duplicate/route.ts
@@ -1,7 +1,6 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { TemplateServiceError, createTemplateService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
+import { authorizeTemplateRoute } from "../../auth";
 
 function mapTemplateError(error: unknown, fallback: string) {
   if (error instanceof TemplateServiceError) {
@@ -21,14 +20,13 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
+  const auth = await authorizeTemplateRoute(
+    request.headers.get("authorization"),
+  );
+  if (!auth.ok) return auth.response;
 
   try {
     const { id } = await params;
-    if (!auth.userId) return unauthorizedResponse();
     const duplicated = await templateService().duplicateTemplate(id, {
       userId: auth.userId,
     });

--- a/src/app/api/templates/[id]/publish/route.ts
+++ b/src/app/api/templates/[id]/publish/route.ts
@@ -1,7 +1,6 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import { TemplateServiceError, createTemplateService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
+import { authorizeTemplateRoute } from "../../auth";
 
 function mapTemplateError(error: unknown, fallback: string) {
   if (error instanceof TemplateServiceError) {
@@ -22,14 +21,13 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
+  const auth = await authorizeTemplateRoute(
+    request.headers.get("authorization"),
+  );
+  if (!auth.ok) return auth.response;
 
   try {
     const { id } = await params;
-    if (!auth.userId) return unauthorizedResponse();
     const published = await templateService().publishTemplate(id, {
       userId: auth.userId,
     });

--- a/src/app/api/templates/[id]/route.ts
+++ b/src/app/api/templates/[id]/route.ts
@@ -1,11 +1,10 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
 import {
   type TemplateDetail,
   TemplateServiceError,
   createTemplateService,
 } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
+import { authorizeTemplateRoute } from "../auth";
 
 function mapTemplateError(error: unknown, fallback: string) {
   if (error instanceof TemplateServiceError) {
@@ -44,14 +43,13 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
+  const auth = await authorizeTemplateRoute(
+    request.headers.get("authorization"),
+  );
+  if (!auth.ok) return auth.response;
 
   try {
     const { id } = await params;
-    if (!auth.userId) return unauthorizedResponse();
     const template = await templateService().getTemplate(id, {
       userId: auth.userId,
     });
@@ -65,14 +63,13 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
+  const auth = await authorizeTemplateRoute(
+    request.headers.get("authorization"),
+  );
+  if (!auth.ok) return auth.response;
 
   try {
     const { id } = await params;
-    if (!auth.userId) return unauthorizedResponse();
     const updated = await templateService().updateTemplate(
       id,
       await request.json(),
@@ -89,14 +86,13 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
-  if (permissionError) return permissionError;
+  const auth = await authorizeTemplateRoute(
+    request.headers.get("authorization"),
+  );
+  if (!auth.ok) return auth.response;
 
   try {
     const { id } = await params;
-    if (!auth.userId) return unauthorizedResponse();
     await templateService().deleteTemplate(id, { userId: auth.userId });
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/templates/auth.ts
+++ b/src/app/api/templates/auth.ts
@@ -10,7 +10,7 @@ type TemplateRouteAuth = NonNullable<
 >;
 
 type TemplateRouteAuthResult =
-  | { ok: true; userId?: string }
+  | { ok: true; userId: string }
   | { ok: false; response: Response };
 
 async function getRouteUserId(auth: TemplateRouteAuth): Promise<string | null> {
@@ -38,5 +38,7 @@ export async function authorizeTemplateRoute(
   }
 
   const userId = await getRouteUserId(auth);
-  return userId ? { ok: true, userId } : { ok: true };
+  return userId
+    ? { ok: true, userId }
+    : { ok: false, response: unauthorizedResponse() };
 }

--- a/src/components/template-editor.tsx
+++ b/src/components/template-editor.tsx
@@ -1,0 +1,478 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type TemplateApiResponse = {
+  id: string;
+  name: string;
+  alias: string | null;
+  status: string;
+  subject: string | null;
+  from: string | null;
+  reply_to: string | null;
+  preview_text: string | null;
+  html: string | null;
+  text: string | null;
+  variables: unknown[] | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type TemplateFormState = {
+  name: string;
+  alias: string;
+  from: string;
+  replyTo: string;
+  subject: string;
+  previewText: string;
+  html: string;
+  text: string;
+};
+
+type SaveState = "idle" | "saving" | "saved" | "error";
+type LoadState = "loading" | "ready" | "error";
+
+type TemplateEditorProps = {
+  templateId: string;
+};
+
+const EMPTY_FORM: TemplateFormState = {
+  name: "",
+  alias: "",
+  from: "",
+  replyTo: "",
+  subject: "",
+  previewText: "",
+  html: "",
+  text: "",
+};
+
+function formFromTemplate(template: TemplateApiResponse): TemplateFormState {
+  return {
+    name: template.name,
+    alias: template.alias ?? "",
+    from: template.from ?? "",
+    replyTo: template.reply_to ?? "",
+    subject: template.subject ?? "",
+    previewText: template.preview_text ?? "",
+    html: template.html ?? "",
+    text: template.text ?? "",
+  };
+}
+
+function apiHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const apiKey =
+    typeof window !== "undefined"
+      ? (window.localStorage?.getItem?.("api_key") ?? null)
+      : null;
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+  return headers;
+}
+
+async function readError(
+  response: Response,
+  fallback: string,
+): Promise<string> {
+  const payload: unknown = await response.json().catch(() => null);
+  if (
+    payload &&
+    typeof payload === "object" &&
+    "error" in payload &&
+    typeof payload.error === "string" &&
+    payload.error.trim()
+  ) {
+    return payload.error;
+  }
+  return fallback;
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+function isDirty(
+  current: TemplateFormState,
+  persisted: TemplateFormState | null,
+): boolean {
+  if (!persisted) return false;
+  return Object.keys(current).some((key) => {
+    const formKey = key as keyof TemplateFormState;
+    return current[formKey] !== persisted[formKey];
+  });
+}
+
+function textOrPlaceholder(value: string, placeholder: string): string {
+  return value.trim() ? value : placeholder;
+}
+
+export function TemplateEditor({ templateId }: TemplateEditorProps) {
+  const [template, setTemplate] = useState<TemplateApiResponse | null>(null);
+  const [form, setForm] = useState<TemplateFormState>(EMPTY_FORM);
+  const [persistedForm, setPersistedForm] = useState<TemplateFormState | null>(
+    null,
+  );
+  const [loadState, setLoadState] = useState<LoadState>("loading");
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+  const [message, setMessage] = useState<string | null>(null);
+  const [previewKey, setPreviewKey] = useState(0);
+
+  const dirty = useMemo(
+    () => isDirty(form, persistedForm),
+    [form, persistedForm],
+  );
+  const canSave = form.name.trim().length > 0 && form.html.trim().length > 0;
+  const isDraft = template?.status !== "published";
+
+  const loadTemplate = useCallback(async () => {
+    setLoadState("loading");
+    setMessage(null);
+    try {
+      const response = await fetch(`/api/templates/${templateId}`, {
+        headers: apiHeaders(),
+      });
+      if (!response.ok) {
+        throw new Error(await readError(response, "Could not load template."));
+      }
+      const payload = (await response.json()) as TemplateApiResponse;
+      const nextForm = formFromTemplate(payload);
+      setTemplate(payload);
+      setForm(nextForm);
+      setPersistedForm(nextForm);
+      setLoadState("ready");
+    } catch (error) {
+      setMessage(
+        error instanceof Error ? error.message : "Could not load template.",
+      );
+      setLoadState("error");
+    }
+  }, [templateId]);
+
+  useEffect(() => {
+    loadTemplate();
+  }, [loadTemplate]);
+
+  function updateField<K extends keyof TemplateFormState>(
+    field: K,
+    value: TemplateFormState[K],
+  ) {
+    setForm((current) => ({ ...current, [field]: value }));
+    if (saveState === "saved") setSaveState("idle");
+  }
+
+  async function saveTemplate(): Promise<boolean> {
+    if (!canSave) {
+      setSaveState("error");
+      setMessage("Template name and HTML are required.");
+      return false;
+    }
+
+    setSaveState("saving");
+    setMessage(null);
+    try {
+      const response = await fetch(`/api/templates/${templateId}`, {
+        method: "PATCH",
+        headers: {
+          ...apiHeaders(),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: form.name.trim(),
+          alias: form.alias.trim() || null,
+          from: form.from.trim() || null,
+          reply_to: form.replyTo.trim() || null,
+          subject: form.subject,
+          preview_text: form.previewText,
+          html: form.html,
+          text: form.text,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(await readError(response, "Could not save template."));
+      }
+
+      const payload = (await response.json()) as TemplateApiResponse;
+      const nextForm = formFromTemplate(payload);
+      setTemplate(payload);
+      setForm(nextForm);
+      setPersistedForm(nextForm);
+      setPreviewKey((key) => key + 1);
+      setSaveState("saved");
+      setMessage("Template saved.");
+      return true;
+    } catch (error) {
+      setSaveState("error");
+      setMessage(
+        error instanceof Error ? error.message : "Could not save template.",
+      );
+      return false;
+    }
+  }
+
+  async function publishTemplate() {
+    setSaveState("saving");
+    setMessage(null);
+    try {
+      if (dirty) {
+        const saved = await saveTemplate();
+        if (!saved) return;
+      }
+      const response = await fetch(`/api/templates/${templateId}/publish`, {
+        method: "POST",
+        headers: apiHeaders(),
+      });
+      if (!response.ok) {
+        throw new Error(
+          await readError(response, "Could not publish template."),
+        );
+      }
+      const payload = (await response.json()) as {
+        status?: string;
+        published_at?: string | null;
+        has_unpublished_versions?: boolean;
+      };
+      setTemplate((current) =>
+        current
+          ? {
+              ...current,
+              status: payload.status ?? "published",
+              updated_at: new Date().toISOString(),
+            }
+          : current,
+      );
+      setSaveState("saved");
+      setMessage("Template published.");
+    } catch (error) {
+      setSaveState("error");
+      setMessage(
+        error instanceof Error ? error.message : "Could not publish template.",
+      );
+    }
+  }
+
+  if (loadState === "loading") {
+    return (
+      <div className="flex min-h-[480px] items-center justify-center text-sm text-fg-2">
+        Loading template editor...
+      </div>
+    );
+  }
+
+  if (loadState === "error") {
+    return (
+      <div className="mx-auto max-w-xl rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-300">
+        {message ?? "Could not load template."}
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-bg text-fg">
+      <header className="sticky top-0 z-20 border-b border-line bg-bg/95 backdrop-blur">
+        <div className="flex h-16 items-center justify-between gap-4 px-6">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 text-xs text-fg-3">
+              <Link href="/templates" className="hover:text-fg">
+                Templates
+              </Link>
+              <span>/</span>
+              <span className="truncate">
+                {textOrPlaceholder(form.name, "Untitled Template")}
+              </span>
+              <span
+                className={`rounded-full px-2 py-0.5 text-[11px] ${isDraft ? "bg-yellow-900/30 text-yellow-300" : "bg-green-900/30 text-green-300"}`}
+              >
+                {isDraft ? "Draft" : "Published"}
+              </span>
+              {dirty ? <span className="text-yellow-300">Unsaved</span> : null}
+            </div>
+            <h1 className="mt-1 truncate text-lg font-semibold">
+              Template editor
+            </h1>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <Link
+              href={`/templates/${templateId}`}
+              className="rounded-md border border-line px-3 py-2 text-sm text-fg-2 transition-colors hover:border-line-3 hover:text-fg"
+            >
+              View details
+            </Link>
+            <button
+              type="button"
+              onClick={saveTemplate}
+              disabled={saveState === "saving" || !canSave}
+              className="rounded-md border border-line px-3 py-2 text-sm font-medium text-fg transition-colors hover:border-line-3 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {saveState === "saving" ? "Saving..." : "Save"}
+            </button>
+            <button
+              type="button"
+              onClick={publishTemplate}
+              disabled={saveState === "saving" || !canSave || !isDraft}
+              className="rounded-md bg-fg px-3 py-2 text-sm font-medium text-bg transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isDraft ? "Publish" : "Published"}
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main className="grid gap-6 p-6 xl:grid-cols-[minmax(0,1fr)_420px]">
+        <section className="space-y-5 rounded-xl border border-line bg-bg-card p-5">
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="space-y-1.5 text-sm">
+              <span className="text-fg-2">Template name</span>
+              <input
+                value={form.name}
+                onChange={(event) => updateField("name", event.target.value)}
+                className="h-10 w-full rounded-md border border-line bg-transparent px-3 text-sm outline-none focus:border-line-3"
+                aria-label="Template name"
+              />
+            </label>
+            <label className="space-y-1.5 text-sm">
+              <span className="text-fg-2">Alias</span>
+              <input
+                value={form.alias}
+                onChange={(event) => updateField("alias", event.target.value)}
+                className="h-10 w-full rounded-md border border-line bg-transparent px-3 text-sm outline-none focus:border-line-3"
+                aria-label="Alias"
+                placeholder="welcome-email"
+              />
+            </label>
+            <label className="space-y-1.5 text-sm">
+              <span className="text-fg-2">From</span>
+              <input
+                value={form.from}
+                onChange={(event) => updateField("from", event.target.value)}
+                className="h-10 w-full rounded-md border border-line bg-transparent px-3 text-sm outline-none focus:border-line-3"
+                aria-label="From"
+                placeholder="Acme <hello@example.com>"
+              />
+            </label>
+            <label className="space-y-1.5 text-sm">
+              <span className="text-fg-2">Reply-To</span>
+              <input
+                value={form.replyTo}
+                onChange={(event) => updateField("replyTo", event.target.value)}
+                className="h-10 w-full rounded-md border border-line bg-transparent px-3 text-sm outline-none focus:border-line-3"
+                aria-label="Reply-To"
+                placeholder="support@example.com"
+              />
+            </label>
+          </div>
+
+          <label className="space-y-1.5 text-sm">
+            <span className="text-fg-2">Subject</span>
+            <input
+              value={form.subject}
+              onChange={(event) => updateField("subject", event.target.value)}
+              className="h-10 w-full rounded-md border border-line bg-transparent px-3 text-sm outline-none focus:border-line-3"
+              aria-label="Subject"
+              placeholder="Welcome, {{name}}"
+            />
+          </label>
+
+          <label className="space-y-1.5 text-sm">
+            <span className="text-fg-2">Preview text</span>
+            <input
+              value={form.previewText}
+              onChange={(event) =>
+                updateField("previewText", event.target.value)
+              }
+              className="h-10 w-full rounded-md border border-line bg-transparent px-3 text-sm outline-none focus:border-line-3"
+              aria-label="Preview text"
+              placeholder="A short inbox preview"
+            />
+          </label>
+
+          <label className="space-y-1.5 text-sm">
+            <span className="text-fg-2">HTML</span>
+            <textarea
+              value={form.html}
+              onChange={(event) => updateField("html", event.target.value)}
+              className="min-h-[360px] w-full resize-y rounded-md border border-line bg-bg px-3 py-2 font-mono text-sm outline-none focus:border-line-3"
+              aria-label="HTML"
+              spellCheck={false}
+            />
+          </label>
+
+          <label className="space-y-1.5 text-sm">
+            <span className="text-fg-2">Text/plain fallback</span>
+            <textarea
+              value={form.text}
+              onChange={(event) => updateField("text", event.target.value)}
+              className="min-h-[140px] w-full resize-y rounded-md border border-line bg-bg px-3 py-2 font-mono text-sm outline-none focus:border-line-3"
+              aria-label="Text/plain fallback"
+              spellCheck={false}
+            />
+          </label>
+        </section>
+
+        <aside className="space-y-5">
+          {message ? (
+            <output
+              aria-live="polite"
+              className={`block rounded-lg border p-3 text-sm ${saveState === "error" ? "border-red-500/30 bg-red-500/10 text-red-300" : "border-line bg-bg-card text-fg-2"}`}
+            >
+              {message}
+            </output>
+          ) : null}
+
+          <section className="overflow-hidden rounded-xl border border-line bg-bg-card">
+            <div className="flex items-center justify-between border-b border-line px-4 py-3">
+              <div>
+                <h2 className="text-sm font-medium">Live HTML preview</h2>
+                <p className="mt-1 text-xs text-fg-3">
+                  Updates as you type. Save to refresh production rendering.
+                </p>
+              </div>
+            </div>
+            <div className="bg-white p-3">
+              {form.html.trim() ? (
+                <iframe
+                  key={previewKey}
+                  srcDoc={form.html}
+                  title="Template editor live preview"
+                  sandbox="allow-same-origin"
+                  className="h-[420px] w-full rounded-md border border-gray-200 bg-white"
+                />
+              ) : (
+                <div className="flex h-[420px] items-center justify-center rounded-md border border-dashed border-gray-300 text-sm text-gray-500">
+                  Add HTML to preview this template.
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section className="rounded-xl border border-line bg-bg-card p-4 text-sm text-fg-2">
+            <h2 className="text-sm font-medium text-fg">Template metadata</h2>
+            <dl className="mt-3 space-y-2">
+              <div className="flex justify-between gap-3">
+                <dt>Status</dt>
+                <dd className="text-fg">{template?.status ?? "draft"}</dd>
+              </div>
+              <div className="flex justify-between gap-3">
+                <dt>Created</dt>
+                <dd className="text-right text-fg">
+                  {template ? formatDate(template.created_at) : "—"}
+                </dd>
+              </div>
+              <div className="flex justify-between gap-3">
+                <dt>Updated</dt>
+                <dd className="text-right text-fg">
+                  {template ? formatDate(template.updated_at) : "—"}
+                </dd>
+              </div>
+              <div className="flex justify-between gap-3">
+                <dt>Variables</dt>
+                <dd className="text-fg">{template?.variables?.length ?? 0}</dd>
+              </div>
+            </dl>
+          </section>
+        </aside>
+      </main>
+    </div>
+  );
+}

--- a/tests/api-template-variables.test.ts
+++ b/tests/api-template-variables.test.ts
@@ -308,6 +308,36 @@ describe("template variable metadata service", () => {
     ]);
   });
 
+  it("converts React Email starters to editable HTML when custom HTML is saved", async () => {
+    const updates: Array<{ id: string; data: Partial<TemplateInsert> }> = [];
+    const repository = createRepository({
+      async findByIdOrAlias() {
+        return templateRow({
+          html: "<!-- React Email registry template: onboarding-welcome -->",
+          document: {
+            rendering: {
+              kind: "react_email",
+              templateKey: "onboarding-welcome",
+            },
+          },
+        });
+      },
+      async update(id, data) {
+        updates.push({ id, data });
+        return [templateRow({ id, ...data })];
+      },
+    });
+
+    await createTemplateService({ repository }).updateTemplate("tmpl-1", {
+      html: "<h1>Custom welcome</h1>",
+    });
+
+    expect(updates[0]?.data).toMatchObject({
+      html: "<h1>Custom welcome</h1>",
+      document: null,
+    });
+  });
+
   it("preserves existing variable metadata during automatic extraction", async () => {
     const updates: Array<{ id: string; data: Partial<TemplateInsert> }> = [];
     const repository = createRepository({

--- a/tests/dashboard-pages-tenant-scope.test.tsx
+++ b/tests/dashboard-pages-tenant-scope.test.tsx
@@ -99,6 +99,12 @@ vi.mock("@/components/log-detail", () => ({
   ),
 }));
 
+vi.mock("@/components/template-detail", () => ({
+  TemplateDetail: (props: { template: { id: string } }) => (
+    <div data-testid="template-detail" data-props={JSON.stringify(props)} />
+  ),
+}));
+
 function makeQuery<T>(rows: T[]) {
   const chain = {
     from: vi.fn(() => chain),
@@ -153,6 +159,7 @@ function parsedProps<T>(element: TestElement): T {
           "webhooks",
           "logs",
           "log",
+          "template",
           "apiKey",
           "email",
         ].some((key) => item.props[key] !== undefined),
@@ -270,8 +277,16 @@ describe("dashboard pages tenant scoping", () => {
       LogDetailPage({ params: Promise.resolve({ id: "log-a" }) }),
     ).rejects.toThrow("NEXT_NOT_FOUND");
 
+    queueRows([]);
+    const TemplateDetailPage = (
+      await import("@/app/(dashboard)/templates/[id]/page")
+    ).default;
+    await expect(
+      TemplateDetailPage({ params: Promise.resolve({ id: "template-a" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
     expect(
       mockEq.mock.calls.filter(([, right]) => right === "user-b").length,
-    ).toBeGreaterThanOrEqual(3);
+    ).toBeGreaterThanOrEqual(4);
   });
 });

--- a/tests/e2e/templates-list.spec.ts
+++ b/tests/e2e/templates-list.spec.ts
@@ -63,6 +63,75 @@ test.describe("Templates List Page", () => {
     ]);
   });
 
+  test("edits and publishes a template through the dashboard editor", async ({
+    authenticatedPage: page,
+    e2eDb,
+    e2eUser,
+  }) => {
+    const templateId = randomUUID();
+    await e2eDb.query(
+      `insert into templates
+        (id, name, alias, status, subject, html, text, user_id, created_at)
+       values
+        ($1, 'Editable Template', 'editable-template', 'draft', 'Old subject', '<p>Old body</p>', 'Old body', $2, now())`,
+      [templateId, e2eUser.id],
+    );
+
+    await page.goto(`/templates/${templateId}/editor`);
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.getByRole("heading", { name: "Template editor" }),
+    ).toBeVisible();
+    await expect(page.getByLabel("Template name")).toHaveValue(
+      "Editable Template",
+    );
+
+    await page.getByLabel("Template name").fill("Edited Template");
+    await page.getByLabel("Subject").fill("New subject {{firstName}}");
+    await page.getByLabel("HTML").fill("<h1>Hello {{firstName}}</h1>");
+    await page.getByLabel("Text/plain fallback").fill("Hello {{firstName}}");
+    await page.getByRole("button", { name: "Save" }).click();
+
+    await expect(page.getByText("Template saved.")).toBeVisible();
+
+    const saved = await e2eDb.query<{
+      name: string;
+      subject: string | null;
+      html: string | null;
+      text: string | null;
+      variables: Array<{ key: string }> | null;
+      status: string;
+    }>(
+      "select name, subject, html, text, variables, status from templates where id = $1 and user_id = $2",
+      [templateId, e2eUser.id],
+    );
+    expect(saved.rows[0]).toMatchObject({
+      name: "Edited Template",
+      subject: "New subject {{firstName}}",
+      html: "<h1>Hello {{firstName}}</h1>",
+      text: "Hello {{firstName}}",
+      status: "draft",
+    });
+    expect(saved.rows[0]?.variables?.map((variable) => variable.key)).toContain(
+      "firstName",
+    );
+
+    await page.getByRole("button", { name: "Publish" }).click();
+    await expect(page.getByText("Template published.")).toBeVisible();
+
+    const published = await e2eDb.query<{ status: string }>(
+      "select status from templates where id = $1 and user_id = $2",
+      [templateId, e2eUser.id],
+    );
+    expect(published.rows[0]?.status).toBe("published");
+
+    await e2eDb.query("delete from templates where id = $1 and user_id = $2", [
+      templateId,
+      e2eUser.id,
+    ]);
+  });
+
   test("renders React Email-backed template preview with text and variable diagnostics", async ({
     authenticatedPage: page,
     e2eDb,

--- a/tests/template-editor.test.tsx
+++ b/tests/template-editor.test.tsx
@@ -1,0 +1,141 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+import { TemplateEditor } from "@/components/template-editor";
+
+const templateResponse = {
+  object: "template",
+  id: "tmpl-1",
+  name: "Welcome Email",
+  alias: "welcome-email",
+  status: "draft",
+  subject: "Welcome {{name}}",
+  from: "Acme <hello@example.com>",
+  reply_to: "support@example.com",
+  preview_text: "Start here",
+  html: "<h1>Hello {{name}}</h1>",
+  text: "Hello {{name}}",
+  variables: [],
+  created_at: "2026-05-23T00:00:00.000Z",
+  updated_at: "2026-05-23T00:00:00.000Z",
+};
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe("TemplateEditor", () => {
+  beforeEach(() => {
+    mockFetch.mockResolvedValue(jsonResponse(templateResponse));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("loads an existing template into editable fields", async () => {
+    render(<TemplateEditor templateId="tmpl-1" />);
+
+    expect(await screen.findByDisplayValue("Welcome Email")).toBeTruthy();
+    expect(screen.getByDisplayValue("welcome-email")).toBeTruthy();
+    expect(screen.getByDisplayValue("Welcome {{name}}")).toBeTruthy();
+    expect(screen.getByTitle("Template editor live preview")).toBeTruthy();
+    expect(mockFetch).toHaveBeenCalledWith("/api/templates/tmpl-1", {
+      headers: {},
+    });
+  });
+
+  it("saves edited template fields through the template API", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(templateResponse))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          ...templateResponse,
+          name: "Updated Welcome",
+          html: "<h1>Updated</h1>",
+        }),
+      );
+
+    render(<TemplateEditor templateId="tmpl-1" />);
+
+    const name = await screen.findByLabelText("Template name");
+    fireEvent.change(name, { target: { value: "Updated Welcome" } });
+    fireEvent.change(screen.getByLabelText("HTML"), {
+      target: { value: "<h1>Updated</h1>" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        "/api/templates/tmpl-1",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({
+            name: "Updated Welcome",
+            alias: "welcome-email",
+            from: "Acme <hello@example.com>",
+            reply_to: "support@example.com",
+            subject: "Welcome {{name}}",
+            preview_text: "Start here",
+            html: "<h1>Updated</h1>",
+            text: "Hello {{name}}",
+          }),
+        }),
+      );
+    });
+    expect(await screen.findByText("Template saved.")).toBeTruthy();
+  });
+
+  it("publishes saved draft templates", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(templateResponse))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          object: "template",
+          id: "tmpl-1",
+          status: "published",
+          published_at: "2026-05-23T00:01:00.000Z",
+          has_unpublished_versions: false,
+        }),
+      );
+
+    render(<TemplateEditor templateId="tmpl-1" />);
+
+    await screen.findByDisplayValue("Welcome Email");
+    fireEvent.click(screen.getByRole("button", { name: "Publish" }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        "/api/templates/tmpl-1/publish",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    expect(await screen.findByText("Template published.")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the blank dashboard template editor stub with a functional editor for template metadata, HTML, text fallback, live preview, save, and publish.
- Allow dashboard-session auth on template detail/update/publish/duplicate app API routes and require a tenant user id.
- Tenant-scope the template detail page and convert React Email starter templates to editable HTML when custom HTML is saved so production rendering reflects edits.

## Validation
- `make check`
- `bunx vitest run tests/template-editor.test.tsx tests/api-template-variables.test.ts tests/dashboard-pages-tenant-scope.test.tsx`
- `bunx playwright test tests/e2e/templates-list.spec.ts`
- push guardrails: typecheck + changed-file Biome
