### PR TITLE
feat(editor): shared block editor + template/registry de-hardcoding

### DIFF
--- a/packages/core/src/services/template-renderer.ts
+++ b/packages/core/src/services/template-renderer.ts
@@ -30,7 +30,8 @@ export type TemplateRenderInput =
 
 export type TemplateRendererErrorCode =
   | "react_template_not_found"
-  | "react_render_failed";
+  | "react_render_failed"
+  | "react_required_variable_missing";
 
 export class TemplateRendererError extends Error {
   constructor(
@@ -110,17 +111,9 @@ function onboardingWelcomeTemplate(
   variables: TemplateRenderVariables,
 ): ReactElement {
   const recipientName = stringVariable(variables, "recipientName", "there");
-  const productName = stringVariable(variables, "productName", "Opensend");
-  const actionUrl = stringVariable(
-    variables,
-    "actionUrl",
-    "https://opensend.dev/docs",
-  );
-  const supportEmail = stringVariable(
-    variables,
-    "supportEmail",
-    "support@example.com",
-  );
+  const productName = stringVariable(variables, "productName", "");
+  const actionUrl = stringVariable(variables, "actionUrl", "");
+  const supportEmail = stringVariable(variables, "supportEmail", "");
 
   return React.createElement(
     "html",
@@ -349,12 +342,8 @@ function onboardingWelcomeTemplate(
 
 function demoWelcomeTemplate(variables: TemplateRenderVariables): ReactElement {
   const recipientName = stringVariable(variables, "recipientName", "there");
-  const productName = stringVariable(variables, "productName", "Opensend");
-  const actionUrl = stringVariable(
-    variables,
-    "actionUrl",
-    "https://opensend.dev",
-  );
+  const productName = stringVariable(variables, "productName", "your product");
+  const actionUrl = stringVariable(variables, "actionUrl", "#");
 
   return React.createElement(
     "html",
@@ -398,8 +387,8 @@ const REACT_EMAIL_TEMPLATES = {
         key: "productName",
         name: "Product name",
         type: "string",
-        required: false,
-        fallbackValue: "Opensend",
+        required: true,
+        fallbackValue: null,
         description: "Brand or workspace name shown in the hero.",
       },
       {
@@ -414,13 +403,13 @@ const REACT_EMAIL_TEMPLATES = {
         key: "supportEmail",
         name: "Support email",
         type: "string",
-        required: false,
-        fallbackValue: "support@example.com",
+        required: true,
+        fallbackValue: null,
         description: "Reply-to/support address shown in the footer.",
       },
     ],
     subject: (variables: TemplateRenderVariables) =>
-      `Welcome to ${stringVariable(variables, "productName", "Opensend")}`,
+      `Welcome to ${stringVariable(variables, "productName", "")}`,
     render: onboardingWelcomeTemplate,
   },
   "demo-welcome": {
@@ -441,7 +430,7 @@ const REACT_EMAIL_TEMPLATES = {
         name: "Product name",
         type: "string",
         required: false,
-        fallbackValue: "Opensend",
+        fallbackValue: "your product",
         description: "Product name used in the heading and subject.",
       },
       {
@@ -449,12 +438,12 @@ const REACT_EMAIL_TEMPLATES = {
         name: "Action URL",
         type: "string",
         required: false,
-        fallbackValue: "https://opensend.dev",
+        fallbackValue: "#",
         description: "CTA URL.",
       },
     ],
     subject: (variables: TemplateRenderVariables) =>
-      `Welcome to ${stringVariable(variables, "productName", "Opensend")}`,
+      `Welcome to ${stringVariable(variables, "productName", "your product")}`,
     render: demoWelcomeTemplate,
   },
 } satisfies Record<string, ReactEmailTemplateDefinition>;
@@ -535,6 +524,23 @@ export async function renderReactEmailTemplate(
 
   const definition = REACT_EMAIL_TEMPLATES[input.templateKey];
   const variables = input.variables ?? {};
+
+  const missingRequired = definition.variables
+    .filter((variable) => variable.required)
+    .filter((variable) => {
+      const value = variables[variable.key];
+      if (value === null || value === undefined) return true;
+      return typeof value === "string" && value.trim() === "";
+    })
+    .map((variable) => variable.key);
+
+  if (missingRequired.length > 0) {
+    throw new TemplateRendererError(
+      "react_required_variable_missing",
+      `Missing required variable(s) for template ${input.templateKey}: ${missingRequired.join(", ")}`,
+    );
+  }
+
   const element = definition.render(variables);
 
   try {

--- a/src/components/block-editor/block-editor-canvas.tsx
+++ b/src/components/block-editor/block-editor-canvas.tsx
@@ -1,0 +1,293 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { BlockRenderer } from "./block-renderer";
+import {
+  type BlockType,
+  COMPONENT_ITEMS,
+  type EditorBlock,
+  SLASH_MENU_ITEMS,
+  VARIABLES,
+} from "./types";
+
+type ToolbarTab = "text" | "image" | "components" | "variables";
+
+type BlockEditorCanvasProps = {
+  blocks: EditorBlock[];
+  onBlocksChange: (next: EditorBlock[]) => void;
+  ariaLabel?: string;
+  className?: string;
+};
+
+export function BlockEditorCanvas({
+  blocks,
+  onBlocksChange,
+  ariaLabel = "Content editor",
+  className,
+}: BlockEditorCanvasProps) {
+  const [slashMenuOpen, setSlashMenuOpen] = useState(false);
+  const [activeToolbarTab, setActiveToolbarTab] = useState<ToolbarTab>("text");
+  const slashMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (
+        slashMenuRef.current &&
+        !slashMenuRef.current.contains(e.target as Node)
+      ) {
+        setSlashMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  const insertBlock = useCallback(
+    (type: BlockType, content = "") => {
+      const newBlock: EditorBlock = {
+        id: crypto.randomUUID(),
+        type,
+        content,
+      };
+      onBlocksChange([...blocks, newBlock]);
+      setSlashMenuOpen(false);
+    },
+    [blocks, onBlocksChange],
+  );
+
+  const updateBlockContent = useCallback(
+    (id: string, content: string) => {
+      onBlocksChange(blocks.map((b) => (b.id === id ? { ...b, content } : b)));
+    },
+    [blocks, onBlocksChange],
+  );
+
+  const removeBlock = useCallback(
+    (id: string) => {
+      onBlocksChange(blocks.filter((b) => b.id !== id));
+    },
+    [blocks, onBlocksChange],
+  );
+
+  const handleEditorKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "/") setSlashMenuOpen(true);
+    if (e.key === "Escape") setSlashMenuOpen(false);
+  };
+
+  return (
+    <div className={className}>
+      <div className="relative">
+        <div
+          data-testid="block-editor"
+          className="min-h-[400px] border border-line rounded-lg p-4 relative"
+          onKeyDown={handleEditorKeyDown}
+          // biome-ignore lint/a11y/noNoninteractiveTabindex: editor needs keyboard focus for slash commands
+          tabIndex={0}
+          aria-label={ariaLabel}
+        >
+          {blocks.length === 0 && !slashMenuOpen && (
+            <p className="text-[14px] text-fg-4">
+              Press &apos;/&apos; for commands
+            </p>
+          )}
+
+          {blocks.map((block) => (
+            <div
+              key={block.id}
+              data-testid={`block-${block.type}`}
+              className="group relative mb-3"
+            >
+              <div className="absolute -left-8 top-1 opacity-0 group-hover:opacity-100 flex gap-0.5">
+                <button
+                  type="button"
+                  onClick={() => removeBlock(block.id)}
+                  className="p-0.5 text-fg-4 hover:text-red-400 text-xs"
+                  title="Remove block"
+                >
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    aria-hidden="true"
+                  >
+                    <path d="M18 6L6 18M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+              <BlockRenderer
+                block={block}
+                onUpdate={(content) => updateBlockContent(block.id, content)}
+              />
+            </div>
+          ))}
+
+          {slashMenuOpen && (
+            <div
+              ref={slashMenuRef}
+              className="absolute left-4 z-50 w-[280px] max-h-[360px] overflow-y-auto bg-bg-card border border-line rounded-lg shadow-xl"
+              style={{
+                top:
+                  blocks.length > 0 ? `${blocks.length * 48 + 16}px` : "16px",
+              }}
+            >
+              {SLASH_MENU_ITEMS.map((category) => (
+                <div key={category.category}>
+                  <div className="px-3 py-1.5 text-[11px] font-semibold text-fg-4 uppercase tracking-wider">
+                    {category.category}
+                  </div>
+                  {category.items.map((item) => (
+                    <button
+                      key={item.type}
+                      type="button"
+                      onClick={() => insertBlock(item.type)}
+                      className="w-full px-3 py-2 text-left text-[13px] text-fg-2 hover:bg-white/[0.08] hover:text-fg transition-colors flex items-center gap-2.5"
+                    >
+                      <span className="w-6 h-6 flex items-center justify-center rounded bg-white/[0.06] text-[11px] font-mono shrink-0">
+                        {item.icon}
+                      </span>
+                      {item.label}
+                    </button>
+                  ))}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="border-t border-line bg-bg-card mt-3">
+        <div className="flex items-center border-b border-line px-4">
+          {(
+            [
+              { key: "text", label: "Text" },
+              { key: "image", label: "Image" },
+              { key: "components", label: "Components" },
+              { key: "variables", label: "Variables" },
+            ] as const
+          ).map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setActiveToolbarTab(tab.key)}
+              className={`px-3 py-2.5 text-[13px] font-medium transition-colors relative ${
+                activeToolbarTab === tab.key
+                  ? "text-fg"
+                  : "text-fg-4 hover:text-fg-2"
+              }`}
+            >
+              {tab.label}
+              {activeToolbarTab === tab.key && (
+                <span className="absolute bottom-0 left-0 right-0 h-[2px] bg-white" />
+              )}
+            </button>
+          ))}
+        </div>
+
+        <div className="px-4 py-2 min-h-[44px]">
+          {activeToolbarTab === "text" && (
+            <div className="flex items-center gap-1">
+              {[
+                { title: "Bold", icon: "B", style: "font-bold" },
+                { title: "Italic", icon: "I", style: "italic" },
+                { title: "Underline", icon: "U", style: "underline" },
+                {
+                  title: "Strikethrough",
+                  icon: "S",
+                  style: "line-through",
+                },
+                { title: "Code", icon: "</>", style: "font-mono text-[11px]" },
+                { title: "Uppercase", icon: "AA", style: "text-[11px]" },
+              ].map((btn) => (
+                <button
+                  key={btn.title}
+                  type="button"
+                  title={btn.title}
+                  className="w-8 h-8 flex items-center justify-center rounded text-[13px] text-fg-2 hover:bg-white/[0.08] hover:text-fg transition-colors"
+                >
+                  <span className={btn.style}>{btn.icon}</span>
+                </button>
+              ))}
+
+              <span className="w-px h-5 bg-white/10 mx-1" />
+
+              {[
+                { title: "Align left", icon: "≡" },
+                { title: "Align center", icon: "≡" },
+                { title: "Align right", icon: "≡" },
+              ].map((btn) => (
+                <button
+                  key={btn.title}
+                  type="button"
+                  title={btn.title}
+                  className="w-8 h-8 flex items-center justify-center rounded text-[13px] text-fg-2 hover:bg-white/[0.08] hover:text-fg transition-colors"
+                >
+                  {btn.icon}
+                </button>
+              ))}
+
+              <span className="w-px h-5 bg-white/10 mx-1" />
+
+              {[
+                { title: "Bullet list", icon: "•" },
+                { title: "Numbered list", icon: "1." },
+              ].map((btn) => (
+                <button
+                  key={btn.title}
+                  type="button"
+                  title={btn.title}
+                  className="w-8 h-8 flex items-center justify-center rounded text-[13px] text-fg-2 hover:bg-white/[0.08] hover:text-fg transition-colors"
+                >
+                  {btn.icon}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {activeToolbarTab === "image" && (
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                className="h-8 px-3 text-[13px] text-fg-2 border border-line rounded-md hover:text-fg hover:border-line-3 transition-colors"
+              >
+                Upload image
+              </button>
+              <span className="text-[12px] text-fg-4">or drag and drop</span>
+            </div>
+          )}
+
+          {activeToolbarTab === "components" && (
+            <div className="flex items-center gap-1 flex-wrap">
+              {COMPONENT_ITEMS.map((item) => (
+                <button
+                  key={item.type}
+                  type="button"
+                  onClick={() => insertBlock(item.type)}
+                  className="h-8 px-3 text-[13px] text-fg-2 hover:bg-white/[0.08] hover:text-fg rounded transition-colors flex items-center gap-1.5"
+                >
+                  <span className="text-[11px] font-mono">{item.icon}</span>
+                  {item.label}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {activeToolbarTab === "variables" && (
+            <div className="flex items-center gap-1 flex-wrap">
+              {VARIABLES.map((v) => (
+                <button
+                  key={v.value}
+                  type="button"
+                  onClick={() => insertBlock("variable", v.value)}
+                  className="h-8 px-2.5 text-[12px] font-mono text-fg-2 hover:bg-white/[0.08] hover:text-fg rounded border border-line transition-colors"
+                >
+                  {v.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/block-editor/block-renderer.tsx
+++ b/src/components/block-editor/block-renderer.tsx
@@ -1,0 +1,188 @@
+import type { EditorBlock } from "./types";
+
+export function BlockRenderer({
+  block,
+  onUpdate,
+}: {
+  block: EditorBlock;
+  onUpdate: (content: string) => void;
+}) {
+  switch (block.type) {
+    case "title":
+      return (
+        <input
+          type="text"
+          value={block.content}
+          onChange={(e) => onUpdate(e.target.value)}
+          placeholder="Title"
+          className="w-full bg-transparent border-none outline-none text-[28px] font-bold text-fg placeholder-[#444]"
+        />
+      );
+    case "subtitle":
+      return (
+        <input
+          type="text"
+          value={block.content}
+          onChange={(e) => onUpdate(e.target.value)}
+          placeholder="Subtitle"
+          className="w-full bg-transparent border-none outline-none text-[20px] font-semibold text-fg-2 placeholder-[#444]"
+        />
+      );
+    case "heading":
+      return (
+        <input
+          type="text"
+          value={block.content}
+          onChange={(e) => onUpdate(e.target.value)}
+          placeholder="Heading"
+          className="w-full bg-transparent border-none outline-none text-[18px] font-semibold text-fg placeholder-[#444]"
+        />
+      );
+    case "quote":
+      return (
+        <div className="border-l-2 border-fg-2 pl-4">
+          <textarea
+            value={block.content}
+            onChange={(e) => onUpdate(e.target.value)}
+            placeholder="Quote"
+            rows={2}
+            className="w-full bg-transparent border-none outline-none text-[14px] italic text-fg-2 placeholder-[#444] resize-none"
+          />
+        </div>
+      );
+    case "code_block":
+      return (
+        <textarea
+          value={block.content}
+          onChange={(e) => onUpdate(e.target.value)}
+          placeholder="Code"
+          rows={4}
+          className="w-full bg-white/[0.03] border border-line rounded-md p-3 font-mono text-[13px] text-fg placeholder-[#444] resize-none outline-none"
+        />
+      );
+    case "bullet_list":
+      return (
+        <div className="flex items-start gap-2">
+          <span className="text-fg-2 mt-0.5">&#8226;</span>
+          <input
+            type="text"
+            value={block.content}
+            onChange={(e) => onUpdate(e.target.value)}
+            placeholder="List item"
+            className="flex-1 bg-transparent border-none outline-none text-[14px] text-fg placeholder-[#444]"
+          />
+        </div>
+      );
+    case "numbered_list":
+      return (
+        <div className="flex items-start gap-2">
+          <span className="text-fg-2 mt-0.5">1.</span>
+          <input
+            type="text"
+            value={block.content}
+            onChange={(e) => onUpdate(e.target.value)}
+            placeholder="List item"
+            className="flex-1 bg-transparent border-none outline-none text-[14px] text-fg placeholder-[#444]"
+          />
+        </div>
+      );
+    case "image":
+      return (
+        <div className="border border-dashed border-line-2 rounded-lg p-8 text-center">
+          <p className="text-[13px] text-fg-4">
+            Click to upload or drag and drop an image
+          </p>
+        </div>
+      );
+    case "youtube":
+      return (
+        <input
+          type="text"
+          value={block.content}
+          onChange={(e) => onUpdate(e.target.value)}
+          placeholder="Paste YouTube URL..."
+          className="w-full bg-white/[0.03] border border-line rounded-md px-3 py-2 text-[13px] text-fg placeholder-[#444] outline-none"
+        />
+      );
+    case "twitter":
+      return (
+        <input
+          type="text"
+          value={block.content}
+          onChange={(e) => onUpdate(e.target.value)}
+          placeholder="Paste X/Twitter URL..."
+          className="w-full bg-white/[0.03] border border-line rounded-md px-3 py-2 text-[13px] text-fg placeholder-[#444] outline-none"
+        />
+      );
+    case "button":
+      return (
+        <div className="flex justify-center">
+          <input
+            type="text"
+            value={block.content || "Button"}
+            onChange={(e) => onUpdate(e.target.value)}
+            className="btn btn-primary min-w-[120px] text-center"
+          />
+        </div>
+      );
+    case "divider":
+      return <hr className="border-t border-line-2 my-2" />;
+    case "section":
+      return (
+        <div className="border border-line rounded-lg p-4 min-h-[60px]">
+          <p className="text-[12px] text-fg-4">Section block</p>
+        </div>
+      );
+    case "columns":
+      return (
+        <div className="grid grid-cols-2 gap-3">
+          <div className="border border-line rounded-lg p-3 min-h-[60px]">
+            <p className="text-[12px] text-fg-4">Column 1</p>
+          </div>
+          <div className="border border-line rounded-lg p-3 min-h-[60px]">
+            <p className="text-[12px] text-fg-4">Column 2</p>
+          </div>
+        </div>
+      );
+    case "social_links":
+      return (
+        <div className="flex items-center justify-center gap-3 py-2">
+          <span className="text-[13px] text-fg-2">Social Links</span>
+        </div>
+      );
+    case "unsubscribe_footer":
+      return (
+        <div className="text-center py-3 text-[12px] text-fg-4">
+          <a href="{{{RESEND_UNSUBSCRIBE_URL}}}" className="underline">
+            Unsubscribe
+          </a>
+        </div>
+      );
+    case "html":
+      return (
+        <textarea
+          value={block.content}
+          onChange={(e) => onUpdate(e.target.value)}
+          placeholder="<html>...</html>"
+          rows={6}
+          className="w-full bg-white/[0.03] border border-line rounded-md p-3 font-mono text-[13px] text-fg placeholder-[#444] resize-none outline-none"
+        />
+      );
+    case "variable":
+      return (
+        <span className="inline-block px-2 py-1 bg-white/[0.08] rounded text-[13px] font-mono text-fg-2 border border-line">
+          {block.content}
+        </span>
+      );
+    default:
+      return (
+        <textarea
+          value={block.content}
+          onChange={(e) => onUpdate(e.target.value)}
+          placeholder="Type something..."
+          rows={2}
+          className="w-full bg-transparent border-none outline-none text-[14px] text-fg placeholder-[#444] resize-none"
+        />
+      );
+  }
+}

--- a/src/components/block-editor/index.ts
+++ b/src/components/block-editor/index.ts
@@ -1,0 +1,12 @@
+export { BlockEditorCanvas } from "./block-editor-canvas";
+export { BlockRenderer } from "./block-renderer";
+export { blocksToHtml } from "./serialize";
+export {
+  COMPONENT_ITEMS,
+  SLASH_MENU_ITEMS,
+  VARIABLES,
+  type BlockType,
+  type EditorBlock,
+  type SlashMenuCategory,
+  type SlashMenuItem,
+} from "./types";

--- a/src/components/block-editor/serialize.ts
+++ b/src/components/block-editor/serialize.ts
@@ -1,0 +1,73 @@
+import type { EditorBlock } from "./types";
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escapeAttr(value: string): string {
+  return value.replace(/"/g, "&quot;");
+}
+
+function renderBlock(block: EditorBlock): string | null {
+  const content = block.content ?? "";
+  switch (block.type) {
+    case "title":
+      return `<h1>${escapeHtml(content)}</h1>`;
+    case "subtitle":
+      return `<h2>${escapeHtml(content)}</h2>`;
+    case "heading":
+      return `<h3>${escapeHtml(content)}</h3>`;
+    case "text":
+      return `<p>${escapeHtml(content)}</p>`;
+    case "bullet_list":
+      return `<ul><li>${escapeHtml(content)}</li></ul>`;
+    case "numbered_list":
+      return `<ol><li>${escapeHtml(content)}</li></ol>`;
+    case "quote":
+      return `<blockquote>${escapeHtml(content)}</blockquote>`;
+    case "code_block":
+      return `<pre><code>${escapeHtml(content)}</code></pre>`;
+    case "image":
+      return content
+        ? `<img src="${escapeAttr(content)}" alt="" />`
+        : "<!-- image: not configured -->";
+    case "youtube":
+      return content
+        ? `<a href="${escapeAttr(content)}">${escapeHtml(content)}</a>`
+        : null;
+    case "twitter":
+      return content
+        ? `<a href="${escapeAttr(content)}">${escapeHtml(content)}</a>`
+        : null;
+    case "button":
+      return `<a href="#" class="button">${escapeHtml(content || "Button")}</a>`;
+    case "divider":
+      return "<hr />";
+    case "section":
+      return "<section></section>";
+    case "columns":
+      return `<table role="presentation" width="100%"><tr><td></td><td></td></tr></table>`;
+    case "social_links":
+      return "<!-- social links placeholder -->";
+    case "unsubscribe_footer":
+      return `<p style="text-align:center;font-size:12px;"><a href="{{{RESEND_UNSUBSCRIBE_URL}}}">Unsubscribe</a></p>`;
+    case "html":
+      return content;
+    case "variable":
+      return content;
+    default:
+      return content ? `<p>${escapeHtml(content)}</p>` : null;
+  }
+}
+
+export function blocksToHtml(blocks: EditorBlock[]): string {
+  return blocks
+    .map(renderBlock)
+    .filter((entry): entry is string => entry !== null)
+    .join("\n");
+}

--- a/src/components/block-editor/types.ts
+++ b/src/components/block-editor/types.ts
@@ -1,0 +1,105 @@
+export type BlockType =
+  | "text"
+  | "title"
+  | "subtitle"
+  | "heading"
+  | "bullet_list"
+  | "numbered_list"
+  | "quote"
+  | "code_block"
+  | "image"
+  | "youtube"
+  | "twitter"
+  | "button"
+  | "divider"
+  | "section"
+  | "columns"
+  | "social_links"
+  | "unsubscribe_footer"
+  | "html"
+  | "variable";
+
+export interface EditorBlock {
+  id: string;
+  type: BlockType;
+  content: string;
+}
+
+export type SlashMenuItem = {
+  type: BlockType;
+  label: string;
+  icon: string;
+};
+
+export type SlashMenuCategory = {
+  category: string;
+  items: SlashMenuItem[];
+};
+
+export const SLASH_MENU_ITEMS: SlashMenuCategory[] = [
+  {
+    category: "Text",
+    items: [
+      { type: "text", label: "Text", icon: "T" },
+      { type: "title", label: "Title", icon: "H1" },
+      { type: "subtitle", label: "Subtitle", icon: "H2" },
+      { type: "heading", label: "Heading", icon: "H3" },
+      { type: "bullet_list", label: "Bullet list", icon: "•" },
+      { type: "numbered_list", label: "Numbered list", icon: "1." },
+      { type: "quote", label: "Quote", icon: "❝" },
+      { type: "code_block", label: "Code block", icon: "</>" },
+    ],
+  },
+  {
+    category: "Media",
+    items: [
+      { type: "image", label: "Image", icon: "\u{1F5BC}" },
+      { type: "youtube", label: "YouTube", icon: "▶" },
+      { type: "twitter", label: "X/Twitter", icon: "\u{1D54F}" },
+    ],
+  },
+  {
+    category: "Layout",
+    items: [
+      { type: "button", label: "Button", icon: "▢" },
+      { type: "divider", label: "Divider", icon: "—" },
+      { type: "section", label: "Section", icon: "☐" },
+      { type: "columns", label: "Columns", icon: "▥" },
+      { type: "social_links", label: "Social Links", icon: "\u{1F517}" },
+      {
+        type: "unsubscribe_footer",
+        label: "Unsubscribe Footer",
+        icon: "✉",
+      },
+    ],
+  },
+  {
+    category: "Utility",
+    items: [
+      { type: "html", label: "HTML", icon: "<>" },
+      { type: "variable", label: "Variable", icon: "{}" },
+    ],
+  },
+];
+
+export const VARIABLES: { label: string; value: string }[] = [
+  { label: "{{{contact.first_name}}}", value: "{{{contact.first_name}}}" },
+  { label: "{{{contact.last_name}}}", value: "{{{contact.last_name}}}" },
+  { label: "{{{contact.email}}}", value: "{{{contact.email}}}" },
+  {
+    label: "{{{contact.company_name}}}",
+    value: "{{{contact.company_name}}}",
+  },
+  {
+    label: "{{{RESEND_UNSUBSCRIBE_URL}}}",
+    value: "{{{RESEND_UNSUBSCRIBE_URL}}}",
+  },
+];
+
+export const COMPONENT_ITEMS: SlashMenuItem[] = (
+  SLASH_MENU_ITEMS.find((c) => c.category === "Layout")?.items ?? []
+).concat(
+  (SLASH_MENU_ITEMS.find((c) => c.category === "Utility")?.items ?? []).filter(
+    (i) => i.type === "html" || i.type === "code_block",
+  ),
+);

--- a/src/components/broadcast-editor.tsx
+++ b/src/components/broadcast-editor.tsx
@@ -2,110 +2,12 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { BlockEditorCanvas, type EditorBlock } from "./block-editor";
 import {
   BroadcastEditorSidebar,
   type BroadcastStyle,
   DEFAULT_BROADCAST_STYLE,
 } from "./broadcast-editor-sidebar";
-
-// Block types for the editor
-type BlockType =
-  | "text"
-  | "title"
-  | "subtitle"
-  | "heading"
-  | "bullet_list"
-  | "numbered_list"
-  | "quote"
-  | "code_block"
-  | "image"
-  | "youtube"
-  | "twitter"
-  | "button"
-  | "divider"
-  | "section"
-  | "columns"
-  | "social_links"
-  | "unsubscribe_footer"
-  | "html"
-  | "variable";
-
-interface EditorBlock {
-  id: string;
-  type: BlockType;
-  content: string;
-}
-
-const SLASH_MENU_ITEMS: {
-  category: string;
-  items: { type: BlockType; label: string; icon: string }[];
-}[] = [
-  {
-    category: "Text",
-    items: [
-      { type: "text", label: "Text", icon: "T" },
-      { type: "title", label: "Title", icon: "H1" },
-      { type: "subtitle", label: "Subtitle", icon: "H2" },
-      { type: "heading", label: "Heading", icon: "H3" },
-      { type: "bullet_list", label: "Bullet list", icon: "•" },
-      { type: "numbered_list", label: "Numbered list", icon: "1." },
-      { type: "quote", label: "Quote", icon: "❝" },
-      { type: "code_block", label: "Code block", icon: "</>" },
-    ],
-  },
-  {
-    category: "Media",
-    items: [
-      { type: "image", label: "Image", icon: "🖼" },
-      { type: "youtube", label: "YouTube", icon: "▶" },
-      { type: "twitter", label: "X/Twitter", icon: "𝕏" },
-    ],
-  },
-  {
-    category: "Layout",
-    items: [
-      { type: "button", label: "Button", icon: "▢" },
-      { type: "divider", label: "Divider", icon: "—" },
-      { type: "section", label: "Section", icon: "☐" },
-      { type: "columns", label: "Columns", icon: "▥" },
-      { type: "social_links", label: "Social Links", icon: "🔗" },
-      {
-        type: "unsubscribe_footer",
-        label: "Unsubscribe Footer",
-        icon: "✉",
-      },
-    ],
-  },
-  {
-    category: "Utility",
-    items: [
-      { type: "html", label: "HTML", icon: "<>" },
-      { type: "variable", label: "Variable", icon: "{}" },
-    ],
-  },
-];
-
-const VARIABLES = [
-  { label: "{{{contact.first_name}}}", value: "{{{contact.first_name}}}" },
-  { label: "{{{contact.last_name}}}", value: "{{{contact.last_name}}}" },
-  { label: "{{{contact.email}}}", value: "{{{contact.email}}}" },
-  {
-    label: "{{{contact.company_name}}}",
-    value: "{{{contact.company_name}}}",
-  },
-  {
-    label: "{{{RESEND_UNSUBSCRIBE_URL}}}",
-    value: "{{{RESEND_UNSUBSCRIBE_URL}}}",
-  },
-];
-
-const COMPONENT_ITEMS = (
-  SLASH_MENU_ITEMS.find((c) => c.category === "Layout")?.items ?? []
-).concat(
-  (SLASH_MENU_ITEMS.find((c) => c.category === "Utility")?.items ?? []).filter(
-    (i) => i.type === "html" || i.type === "code_block",
-  ),
-);
 
 interface BroadcastData {
   id: string;
@@ -170,10 +72,6 @@ export function BroadcastEditor({
 
   // Block editor state
   const [blocks, setBlocks] = useState<EditorBlock[]>([]);
-  const [slashMenuOpen, setSlashMenuOpen] = useState(false);
-  const [activeToolbarTab, setActiveToolbarTab] = useState<
-    "text" | "image" | "components" | "variables"
-  >("text");
 
   // Right sidebar state
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -187,7 +85,6 @@ export function BroadcastEditor({
 
   const saveTimeout = useRef<ReturnType<typeof setTimeout>>(null);
   const topicDropdownRef = useRef<HTMLDivElement>(null);
-  const slashMenuRef = useRef<HTMLDivElement>(null);
 
   // Load broadcast data
   useEffect(() => {
@@ -252,7 +149,7 @@ export function BroadcastEditor({
     loadOptions();
   }, []);
 
-  // Close topic dropdown and slash menu on outside click
+  // Close topic dropdown on outside click
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
       if (
@@ -261,43 +158,10 @@ export function BroadcastEditor({
       ) {
         setTopicDropdownOpen(false);
       }
-      if (
-        slashMenuRef.current &&
-        !slashMenuRef.current.contains(e.target as Node)
-      ) {
-        setSlashMenuOpen(false);
-      }
     };
     document.addEventListener("mousedown", handleClick);
     return () => document.removeEventListener("mousedown", handleClick);
   }, []);
-
-  const insertBlock = (type: BlockType) => {
-    const newBlock: EditorBlock = {
-      id: crypto.randomUUID(),
-      type,
-      content: "",
-    };
-    setBlocks((prev) => [...prev, newBlock]);
-    setSlashMenuOpen(false);
-  };
-
-  const updateBlockContent = (id: string, content: string) => {
-    setBlocks((prev) => prev.map((b) => (b.id === id ? { ...b, content } : b)));
-  };
-
-  const removeBlock = (id: string) => {
-    setBlocks((prev) => prev.filter((b) => b.id !== id));
-  };
-
-  const handleEditorKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "/") {
-      setSlashMenuOpen(true);
-    }
-    if (e.key === "Escape") {
-      setSlashMenuOpen(false);
-    }
-  };
 
   // Auto-save
   const autoSave = useCallback(
@@ -723,94 +587,13 @@ export function BroadcastEditor({
               )}
             </div>
 
-            {/* Block Editor */}
-            <div className="mt-8 relative">
-              <div
-                data-testid="block-editor"
-                className="min-h-[400px] border border-line rounded-lg p-4 relative"
-                onKeyDown={handleEditorKeyDown}
-                // biome-ignore lint/a11y/noNoninteractiveTabindex: editor needs keyboard focus for slash commands
-                tabIndex={0}
-                aria-label="Content editor"
-              >
-                {blocks.length === 0 && !slashMenuOpen && (
-                  <p className="text-[14px] text-fg-4">
-                    Press &apos;/&apos; for commands
-                  </p>
-                )}
+            <BlockEditorCanvas
+              blocks={blocks}
+              onBlocksChange={setBlocks}
+              className="mt-8"
+            />
 
-                {/* Rendered blocks */}
-                {blocks.map((block) => (
-                  <div
-                    key={block.id}
-                    data-testid={`block-${block.type}`}
-                    className="group relative mb-3"
-                  >
-                    <div className="absolute -left-8 top-1 opacity-0 group-hover:opacity-100 flex gap-0.5">
-                      <button
-                        type="button"
-                        onClick={() => removeBlock(block.id)}
-                        className="p-0.5 text-fg-4 hover:text-red-400 text-xs"
-                        title="Remove block"
-                      >
-                        <svg
-                          width="14"
-                          height="14"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          aria-hidden="true"
-                        >
-                          <path d="M18 6L6 18M6 6l12 12" />
-                        </svg>
-                      </button>
-                    </div>
-                    <BlockRenderer
-                      block={block}
-                      onUpdate={(content) =>
-                        updateBlockContent(block.id, content)
-                      }
-                    />
-                  </div>
-                ))}
-
-                {/* Slash command menu */}
-                {slashMenuOpen && (
-                  <div
-                    ref={slashMenuRef}
-                    className="absolute left-4 z-50 w-[280px] max-h-[360px] overflow-y-auto bg-bg-card border border-line rounded-lg shadow-xl"
-                    style={{
-                      top:
-                        blocks.length > 0
-                          ? `${blocks.length * 48 + 16}px`
-                          : "16px",
-                    }}
-                  >
-                    {SLASH_MENU_ITEMS.map((category) => (
-                      <div key={category.category}>
-                        <div className="px-3 py-1.5 text-[11px] font-semibold text-fg-4 uppercase tracking-wider">
-                          {category.category}
-                        </div>
-                        {category.items.map((item) => (
-                          <button
-                            key={item.type}
-                            type="button"
-                            onClick={() => insertBlock(item.type)}
-                            className="w-full px-3 py-2 text-left text-[13px] text-fg-2 hover:bg-white/[0.08] hover:text-fg transition-colors flex items-center gap-2.5"
-                          >
-                            <span className="w-6 h-6 flex items-center justify-center rounded bg-white/[0.06] text-[11px] font-mono shrink-0">
-                              {item.icon}
-                            </span>
-                            {item.label}
-                          </button>
-                        ))}
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-
+            <div className="relative">
               {/* Pick a template / Upload HTML */}
               <div className="flex items-center gap-3 mt-3">
                 <button
@@ -1010,339 +793,6 @@ export function BroadcastEditor({
           </div>
         </div>
       )}
-
-      {/* Bottom Toolbar */}
-      <div className="border-t border-line bg-bg-card">
-        {/* Toolbar tabs */}
-        <div className="flex items-center border-b border-line px-4">
-          {(
-            [
-              { key: "text", label: "Text" },
-              { key: "image", label: "Image" },
-              { key: "components", label: "Components" },
-              { key: "variables", label: "Variables" },
-            ] as const
-          ).map((tab) => (
-            <button
-              key={tab.key}
-              type="button"
-              onClick={() => setActiveToolbarTab(tab.key)}
-              className={`px-3 py-2.5 text-[13px] font-medium transition-colors relative ${
-                activeToolbarTab === tab.key
-                  ? "text-fg"
-                  : "text-fg-4 hover:text-fg-2"
-              }`}
-            >
-              {tab.label}
-              {activeToolbarTab === tab.key && (
-                <span className="absolute bottom-0 left-0 right-0 h-[2px] bg-white" />
-              )}
-            </button>
-          ))}
-        </div>
-
-        {/* Toolbar content */}
-        <div className="px-4 py-2 min-h-[44px]">
-          {activeToolbarTab === "text" && (
-            <div className="flex items-center gap-1">
-              {[
-                { title: "Bold", icon: "B", style: "font-bold" },
-                { title: "Italic", icon: "I", style: "italic" },
-                { title: "Underline", icon: "U", style: "underline" },
-                {
-                  title: "Strikethrough",
-                  icon: "S",
-                  style: "line-through",
-                },
-                { title: "Code", icon: "</>", style: "font-mono text-[11px]" },
-                { title: "Uppercase", icon: "AA", style: "text-[11px]" },
-              ].map((btn) => (
-                <button
-                  key={btn.title}
-                  type="button"
-                  title={btn.title}
-                  className="w-8 h-8 flex items-center justify-center rounded text-[13px] text-fg-2 hover:bg-white/[0.08] hover:text-fg transition-colors"
-                >
-                  <span className={btn.style}>{btn.icon}</span>
-                </button>
-              ))}
-
-              <span className="w-px h-5 bg-white/10 mx-1" />
-
-              {/* Alignment */}
-              {[
-                { title: "Align left", icon: "≡" },
-                { title: "Align center", icon: "≡" },
-                { title: "Align right", icon: "≡" },
-              ].map((btn) => (
-                <button
-                  key={btn.title}
-                  type="button"
-                  title={btn.title}
-                  className="w-8 h-8 flex items-center justify-center rounded text-[13px] text-fg-2 hover:bg-white/[0.08] hover:text-fg transition-colors"
-                >
-                  {btn.icon}
-                </button>
-              ))}
-
-              <span className="w-px h-5 bg-white/10 mx-1" />
-
-              {/* Lists */}
-              {[
-                { title: "Bullet list", icon: "•" },
-                { title: "Numbered list", icon: "1." },
-              ].map((btn) => (
-                <button
-                  key={btn.title}
-                  type="button"
-                  title={btn.title}
-                  className="w-8 h-8 flex items-center justify-center rounded text-[13px] text-fg-2 hover:bg-white/[0.08] hover:text-fg transition-colors"
-                >
-                  {btn.icon}
-                </button>
-              ))}
-            </div>
-          )}
-
-          {activeToolbarTab === "image" && (
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                className="h-8 px-3 text-[13px] text-fg-2 border border-line rounded-md hover:text-fg hover:border-line-3 transition-colors"
-              >
-                Upload image
-              </button>
-              <span className="text-[12px] text-fg-4">or drag and drop</span>
-            </div>
-          )}
-
-          {activeToolbarTab === "components" && (
-            <div className="flex items-center gap-1 flex-wrap">
-              {COMPONENT_ITEMS.map((item) => (
-                <button
-                  key={item.type}
-                  type="button"
-                  onClick={() => insertBlock(item.type)}
-                  className="h-8 px-3 text-[13px] text-fg-2 hover:bg-white/[0.08] hover:text-fg rounded transition-colors flex items-center gap-1.5"
-                >
-                  <span className="text-[11px] font-mono">{item.icon}</span>
-                  {item.label}
-                </button>
-              ))}
-            </div>
-          )}
-
-          {activeToolbarTab === "variables" && (
-            <div className="flex items-center gap-1 flex-wrap">
-              {VARIABLES.map((v) => (
-                <button
-                  key={v.value}
-                  type="button"
-                  onClick={() => {
-                    const newBlock: EditorBlock = {
-                      id: crypto.randomUUID(),
-                      type: "variable",
-                      content: v.value,
-                    };
-                    setBlocks((prev) => [...prev, newBlock]);
-                  }}
-                  className="h-8 px-2.5 text-[12px] font-mono text-fg-2 hover:bg-white/[0.08] hover:text-fg rounded border border-line transition-colors"
-                >
-                  {v.label}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
     </div>
   );
-}
-
-/** Renders a single editor block by type */
-function BlockRenderer({
-  block,
-  onUpdate,
-}: {
-  block: EditorBlock;
-  onUpdate: (content: string) => void;
-}) {
-  switch (block.type) {
-    case "title":
-      return (
-        <input
-          type="text"
-          value={block.content}
-          onChange={(e) => onUpdate(e.target.value)}
-          placeholder="Title"
-          className="w-full bg-transparent border-none outline-none text-[28px] font-bold text-fg placeholder-[#444]"
-        />
-      );
-    case "subtitle":
-      return (
-        <input
-          type="text"
-          value={block.content}
-          onChange={(e) => onUpdate(e.target.value)}
-          placeholder="Subtitle"
-          className="w-full bg-transparent border-none outline-none text-[20px] font-semibold text-fg-2 placeholder-[#444]"
-        />
-      );
-    case "heading":
-      return (
-        <input
-          type="text"
-          value={block.content}
-          onChange={(e) => onUpdate(e.target.value)}
-          placeholder="Heading"
-          className="w-full bg-transparent border-none outline-none text-[18px] font-semibold text-fg placeholder-[#444]"
-        />
-      );
-    case "quote":
-      return (
-        <div className="border-l-2 border-fg-2 pl-4">
-          <textarea
-            value={block.content}
-            onChange={(e) => onUpdate(e.target.value)}
-            placeholder="Quote"
-            rows={2}
-            className="w-full bg-transparent border-none outline-none text-[14px] italic text-fg-2 placeholder-[#444] resize-none"
-          />
-        </div>
-      );
-    case "code_block":
-      return (
-        <textarea
-          value={block.content}
-          onChange={(e) => onUpdate(e.target.value)}
-          placeholder="Code"
-          rows={4}
-          className="w-full bg-white/[0.03] border border-line rounded-md p-3 font-mono text-[13px] text-fg placeholder-[#444] resize-none outline-none"
-        />
-      );
-    case "bullet_list":
-      return (
-        <div className="flex items-start gap-2">
-          <span className="text-fg-2 mt-0.5">&#8226;</span>
-          <input
-            type="text"
-            value={block.content}
-            onChange={(e) => onUpdate(e.target.value)}
-            placeholder="List item"
-            className="flex-1 bg-transparent border-none outline-none text-[14px] text-fg placeholder-[#444]"
-          />
-        </div>
-      );
-    case "numbered_list":
-      return (
-        <div className="flex items-start gap-2">
-          <span className="text-fg-2 mt-0.5">1.</span>
-          <input
-            type="text"
-            value={block.content}
-            onChange={(e) => onUpdate(e.target.value)}
-            placeholder="List item"
-            className="flex-1 bg-transparent border-none outline-none text-[14px] text-fg placeholder-[#444]"
-          />
-        </div>
-      );
-    case "image":
-      return (
-        <div className="border border-dashed border-line-2 rounded-lg p-8 text-center">
-          <p className="text-[13px] text-fg-4">
-            Click to upload or drag and drop an image
-          </p>
-        </div>
-      );
-    case "youtube":
-      return (
-        <input
-          type="text"
-          value={block.content}
-          onChange={(e) => onUpdate(e.target.value)}
-          placeholder="Paste YouTube URL..."
-          className="w-full bg-white/[0.03] border border-line rounded-md px-3 py-2 text-[13px] text-fg placeholder-[#444] outline-none"
-        />
-      );
-    case "twitter":
-      return (
-        <input
-          type="text"
-          value={block.content}
-          onChange={(e) => onUpdate(e.target.value)}
-          placeholder="Paste X/Twitter URL..."
-          className="w-full bg-white/[0.03] border border-line rounded-md px-3 py-2 text-[13px] text-fg placeholder-[#444] outline-none"
-        />
-      );
-    case "button":
-      return (
-        <div className="flex justify-center">
-          <input
-            type="text"
-            value={block.content || "Button"}
-            onChange={(e) => onUpdate(e.target.value)}
-            className="btn btn-primary min-w-[120px] text-center"
-          />
-        </div>
-      );
-    case "divider":
-      return <hr className="border-t border-line-2 my-2" />;
-    case "section":
-      return (
-        <div className="border border-line rounded-lg p-4 min-h-[60px]">
-          <p className="text-[12px] text-fg-4">Section block</p>
-        </div>
-      );
-    case "columns":
-      return (
-        <div className="grid grid-cols-2 gap-3">
-          <div className="border border-line rounded-lg p-3 min-h-[60px]">
-            <p className="text-[12px] text-fg-4">Column 1</p>
-          </div>
-          <div className="border border-line rounded-lg p-3 min-h-[60px]">
-            <p className="text-[12px] text-fg-4">Column 2</p>
-          </div>
-        </div>
-      );
-    case "social_links":
-      return (
-        <div className="flex items-center justify-center gap-3 py-2">
-          <span className="text-[13px] text-fg-2">Social Links</span>
-        </div>
-      );
-    case "unsubscribe_footer":
-      return (
-        <div className="text-center py-3 text-[12px] text-fg-4">
-          <a href="{{{RESEND_UNSUBSCRIBE_URL}}}" className="underline">
-            Unsubscribe
-          </a>
-        </div>
-      );
-    case "html":
-      return (
-        <textarea
-          value={block.content}
-          onChange={(e) => onUpdate(e.target.value)}
-          placeholder="<html>...</html>"
-          rows={6}
-          className="w-full bg-white/[0.03] border border-line rounded-md p-3 font-mono text-[13px] text-fg placeholder-[#444] resize-none outline-none"
-        />
-      );
-    case "variable":
-      return (
-        <span className="inline-block px-2 py-1 bg-white/[0.08] rounded text-[13px] font-mono text-fg-2 border border-line">
-          {block.content}
-        </span>
-      );
-    default:
-      return (
-        <textarea
-          value={block.content}
-          onChange={(e) => onUpdate(e.target.value)}
-          placeholder="Type something..."
-          rows={2}
-          className="w-full bg-transparent border-none outline-none text-[14px] text-fg placeholder-[#444] resize-none"
-        />
-      );
-  }
 }

--- a/src/components/template-editor.tsx
+++ b/src/components/template-editor.tsx
@@ -2,6 +2,11 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  BlockEditorCanvas,
+  type EditorBlock,
+  blocksToHtml,
+} from "./block-editor";
 
 type TemplateApiResponse = {
   id: string;
@@ -32,6 +37,7 @@ type TemplateFormState = {
 
 type SaveState = "idle" | "saving" | "saved" | "error";
 type LoadState = "loading" | "ready" | "error";
+type EditorMode = "visual" | "code";
 
 type TemplateEditorProps = {
   templateId: string;
@@ -59,6 +65,11 @@ function formFromTemplate(template: TemplateApiResponse): TemplateFormState {
     html: template.html ?? "",
     text: template.text ?? "",
   };
+}
+
+function blocksFromHtml(html: string): EditorBlock[] {
+  if (!html.trim()) return [];
+  return [{ id: crypto.randomUUID(), type: "html", content: html }];
 }
 
 function apiHeaders(): Record<string, string> {
@@ -114,6 +125,8 @@ export function TemplateEditor({ templateId }: TemplateEditorProps) {
   const [persistedForm, setPersistedForm] = useState<TemplateFormState | null>(
     null,
   );
+  const [blocks, setBlocks] = useState<EditorBlock[]>([]);
+  const [mode, setMode] = useState<EditorMode>("visual");
   const [loadState, setLoadState] = useState<LoadState>("loading");
   const [saveState, setSaveState] = useState<SaveState>("idle");
   const [message, setMessage] = useState<string | null>(null);
@@ -141,6 +154,7 @@ export function TemplateEditor({ templateId }: TemplateEditorProps) {
       setTemplate(payload);
       setForm(nextForm);
       setPersistedForm(nextForm);
+      setBlocks(blocksFromHtml(nextForm.html));
       setLoadState("ready");
     } catch (error) {
       setMessage(
@@ -160,6 +174,20 @@ export function TemplateEditor({ templateId }: TemplateEditorProps) {
   ) {
     setForm((current) => ({ ...current, [field]: value }));
     if (saveState === "saved") setSaveState("idle");
+  }
+
+  function handleBlocksChange(next: EditorBlock[]) {
+    setBlocks(next);
+    setForm((current) => ({ ...current, html: blocksToHtml(next) }));
+    if (saveState === "saved") setSaveState("idle");
+  }
+
+  function switchMode(next: EditorMode) {
+    if (next === mode) return;
+    if (next === "visual") {
+      setBlocks(blocksFromHtml(form.html));
+    }
+    setMode(next);
   }
 
   async function saveTemplate(): Promise<boolean> {
@@ -198,6 +226,7 @@ export function TemplateEditor({ templateId }: TemplateEditorProps) {
       setTemplate(payload);
       setForm(nextForm);
       setPersistedForm(nextForm);
+      setBlocks(blocksFromHtml(nextForm.html));
       setPreviewKey((key) => key + 1);
       setSaveState("saved");
       setMessage("Template saved.");
@@ -387,16 +416,59 @@ export function TemplateEditor({ templateId }: TemplateEditorProps) {
             />
           </label>
 
-          <label className="space-y-1.5 text-sm">
-            <span className="text-fg-2">HTML</span>
-            <textarea
-              value={form.html}
-              onChange={(event) => updateField("html", event.target.value)}
-              className="min-h-[360px] w-full resize-y rounded-md border border-line bg-bg px-3 py-2 font-mono text-sm outline-none focus:border-line-3"
-              aria-label="HTML"
-              spellCheck={false}
-            />
-          </label>
+          <div className="space-y-2">
+            <div
+              role="tablist"
+              aria-label="Editor mode"
+              className="inline-flex items-center gap-1 rounded-md border border-line p-0.5 text-xs"
+            >
+              <button
+                type="button"
+                role="tab"
+                aria-selected={mode === "visual"}
+                onClick={() => switchMode("visual")}
+                className={`rounded px-3 py-1.5 transition-colors ${
+                  mode === "visual"
+                    ? "bg-white/[0.08] text-fg"
+                    : "text-fg-3 hover:text-fg-2"
+                }`}
+              >
+                Visual
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={mode === "code"}
+                onClick={() => switchMode("code")}
+                className={`rounded px-3 py-1.5 transition-colors ${
+                  mode === "code"
+                    ? "bg-white/[0.08] text-fg"
+                    : "text-fg-3 hover:text-fg-2"
+                }`}
+              >
+                Code
+              </button>
+            </div>
+
+            {mode === "visual" ? (
+              <BlockEditorCanvas
+                blocks={blocks}
+                onBlocksChange={handleBlocksChange}
+                ariaLabel="Template content editor"
+              />
+            ) : (
+              <label className="block space-y-1.5 text-sm">
+                <span className="text-fg-2">HTML</span>
+                <textarea
+                  value={form.html}
+                  onChange={(event) => updateField("html", event.target.value)}
+                  className="min-h-[360px] w-full resize-y rounded-md border border-line bg-bg px-3 py-2 font-mono text-sm outline-none focus:border-line-3"
+                  aria-label="HTML"
+                  spellCheck={false}
+                />
+              </label>
+            )}
+          </div>
 
           <label className="space-y-1.5 text-sm">
             <span className="text-fg-2">Text/plain fallback</span>

--- a/tests/api-template-preview.test.ts
+++ b/tests/api-template-preview.test.ts
@@ -46,12 +46,19 @@ describe("GET /api/templates/:id/preview", () => {
           name: "productName",
           key: "productName",
           type: "string",
-          required: false,
-          fallbackValue: "Opensend",
+          required: true,
+          fallbackValue: null,
         },
         {
           name: "actionUrl",
           key: "actionUrl",
+          type: "string",
+          required: true,
+          fallbackValue: null,
+        },
+        {
+          name: "supportEmail",
+          key: "supportEmail",
           type: "string",
           required: true,
           fallbackValue: null,
@@ -81,7 +88,7 @@ describe("GET /api/templates/:id/preview", () => {
         kind: "react_email",
         template_key: "onboarding-welcome",
       },
-      subject: "Welcome to Opensend",
+      subject: "Welcome to Sample productName",
     });
     expect(body.html).toContain("Your email workspace is ready");
     expect(body.text).toContain("YOUR EMAIL WORKSPACE IS READY");
@@ -89,11 +96,16 @@ describe("GET /api/templates/:id/preview", () => {
       expect.arrayContaining([
         expect.objectContaining({
           key: "productName",
-          source: "fallback",
-          value: "Opensend",
+          source: "preview_sample",
+          sendRequired: true,
         }),
         expect.objectContaining({
           key: "actionUrl",
+          source: "preview_sample",
+          sendRequired: true,
+        }),
+        expect.objectContaining({
+          key: "supportEmail",
           source: "preview_sample",
           sendRequired: true,
         }),

--- a/tests/api-template-variables.test.ts
+++ b/tests/api-template-variables.test.ts
@@ -166,8 +166,13 @@ describe("template variable metadata service", () => {
         }),
         expect.objectContaining({
           key: "productName",
-          required: false,
-          fallbackValue: "Opensend",
+          required: true,
+          fallbackValue: null,
+        }),
+        expect.objectContaining({
+          key: "supportEmail",
+          required: true,
+          fallbackValue: null,
         }),
       ]),
     });

--- a/tests/template-editor.test.tsx
+++ b/tests/template-editor.test.tsx
@@ -66,6 +66,7 @@ describe("TemplateEditor", () => {
     expect(screen.getByDisplayValue("welcome-email")).toBeTruthy();
     expect(screen.getByDisplayValue("Welcome {{name}}")).toBeTruthy();
     expect(screen.getByTitle("Template editor live preview")).toBeTruthy();
+    expect(screen.getByLabelText("Template content editor")).toBeTruthy();
     expect(mockFetch).toHaveBeenCalledWith("/api/templates/tmpl-1", {
       headers: {},
     });
@@ -86,6 +87,7 @@ describe("TemplateEditor", () => {
 
     const name = await screen.findByLabelText("Template name");
     fireEvent.change(name, { target: { value: "Updated Welcome" } });
+    fireEvent.click(screen.getByRole("tab", { name: "Code" }));
     fireEvent.change(screen.getByLabelText("HTML"), {
       target: { value: "<h1>Updated</h1>" },
     });


### PR DESCRIPTION
## Summary

Three changes that together address (1) hardcoded platform branding in customer emails and (2) the template editor lagging far behind the broadcast editor's visual canvas.

- **Template registry de-hardcoding** (`e1a57e5`) — `productName`, `actionUrl`, and `supportEmail` on the React onboarding-welcome template are now `required: true` with `fallbackValue: null`. Missing values throw a new `react_required_variable_missing` error instead of silently rendering "Opensend"/"https://opensend.dev"/"support@example.com" into customer emails.
- **Shared block editor extraction** (`c66f645`) — The Notion-style block model in `broadcast-editor.tsx` (slash menu, block renderer, toolbar tabs, serializer) is now a reusable module at `src/components/block-editor/`. Broadcast editor imports it; 26 editor tests pass unchanged.
- **Template editor uses the shared canvas** (`af085a2`) — `/templates/[id]/editor` now mounts `<BlockEditorCanvas>` with a Visual/Code tab toggle. Visual gives the full canvas (slash menu, components, variables); Code keeps the HTML textarea for raw edits. Blocks serialize to HTML via `blocksToHtml` on every change so the PATCH body shape is unchanged.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bunx vitest run tests/template-editor.test.tsx tests/broadcast-editor.test.tsx tests/block-editor.test.tsx tests/broadcast-editor-sidebar.test.ts` — 29/29 pass
- [x] `bunx vitest run tests/template-renderer.test.ts tests/api-template-variables.test.ts tests/api-template-preview.test.ts` — registry validation tests pass with new required-variable error
- [ ] Manual: load existing template in `/templates/[id]/editor`, confirm HTML appears in Visual mode as one block, switch to Code, edit HTML, switch back, save
- [ ] Manual: send onboarding-welcome through API without productName — verify 422 with `react_required_variable_missing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)