### PR TITLE
fix(settings): replace MOCK_MEMBERS with real session user

### DIFF
--- a/src/components/settings-team.tsx
+++ b/src/components/settings-team.tsx
@@ -1,35 +1,11 @@
 "use client";
 
 import { StatusBadge } from "@/components/status-badge";
-import { useState } from "react";
-
-interface TeamMember {
-  id: string;
-  name: string;
-  email: string;
-  role: "admin" | "member";
-  status: "active" | "pending";
-}
-
-const MOCK_MEMBERS: TeamMember[] = [
-  {
-    id: "1",
-    name: "Ashley",
-    email: "ashley@example.com",
-    role: "admin",
-    status: "active",
-  },
-  {
-    id: "2",
-    name: "Jaeyun",
-    email: "jaeyun@example.com",
-    role: "admin",
-    status: "active",
-  },
-];
+import { authClient } from "@/lib/auth-client";
 
 export function TeamTab() {
-  const [members] = useState<TeamMember[]>(MOCK_MEMBERS);
+  const { data: session, isPending } = authClient.useSession();
+  const user = session?.user;
 
   return (
     <div className="space-y-6">
@@ -74,31 +50,30 @@ export function TeamTab() {
             </tr>
           </thead>
           <tbody>
-            {members.map((member) => (
-              <tr
-                key={member.id}
-                className="border-b border-line last:border-0 hover:bg-bg-2 transition-colors"
-              >
+            {isPending ? (
+              <tr>
+                <td
+                  colSpan={4}
+                  className="px-4 py-6 text-center text-[13px] text-fg-2"
+                >
+                  Loading…
+                </td>
+              </tr>
+            ) : user ? (
+              <tr className="border-b border-line last:border-0 hover:bg-bg-2 transition-colors">
                 <td className="px-4 py-4">
                   <div className="flex flex-col">
                     <span className="text-[14px] text-fg font-medium">
-                      {member.name}
+                      {user.name || user.email}
                     </span>
-                    <span className="text-[12px] text-fg-2">
-                      {member.email}
-                    </span>
+                    <span className="text-[12px] text-fg-2">{user.email}</span>
                   </div>
                 </td>
                 <td className="px-4 py-4">
-                  <span className="text-[13px] text-fg capitalize">
-                    {member.role}
-                  </span>
+                  <span className="text-[13px] text-fg capitalize">Owner</span>
                 </td>
                 <td className="px-4 py-4">
-                  <StatusBadge
-                    status={member.status === "active" ? "Active" : "Pending"}
-                    variant={member.status === "active" ? "success" : "warning"}
-                  />
+                  <StatusBadge status="Active" variant="success" />
                 </td>
                 <td className="px-4 py-4 text-right">
                   <button
@@ -106,14 +81,23 @@ export function TeamTab() {
                     className="cursor-not-allowed text-[12px] text-fg-3 opacity-70"
                     disabled
                     aria-describedby="team-actions-unavailable"
-                    aria-label={`Edit ${member.name} unavailable`}
+                    aria-label="Edit member unavailable"
                     title="Team role editing is not available yet."
                   >
                     Edit
                   </button>
                 </td>
               </tr>
-            ))}
+            ) : (
+              <tr>
+                <td
+                  colSpan={4}
+                  className="px-4 py-6 text-center text-[13px] text-fg-2"
+                >
+                  Sign in to view team members.
+                </td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>

--- a/tests/settings-team.test.tsx
+++ b/tests/settings-team.test.tsx
@@ -1,8 +1,24 @@
 // ABOUTME: Unit tests for the Settings Team tab — member action availability and explanatory copy
 
-import { TeamTab } from "@/components/settings-team";
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    useSession: () => ({
+      data: {
+        user: {
+          id: "user-1",
+          name: "Ada Lovelace",
+          email: "ada@example.com",
+        },
+      },
+      isPending: false,
+    }),
+  },
+}));
+
+import { TeamTab } from "@/components/settings-team";
 
 afterEach(cleanup);
 
@@ -38,5 +54,14 @@ describe("TeamTab", () => {
         "team-actions-unavailable",
       );
     }
+  });
+
+  it("renders the signed-in user as the sole member row instead of mock seeds", () => {
+    render(<TeamTab />);
+
+    expect(screen.getByText("Ada Lovelace")).toBeDefined();
+    expect(screen.getByText("ada@example.com")).toBeDefined();
+    expect(screen.queryByText(/ashley@example\.com/i)).toBeNull();
+    expect(screen.queryByText(/jaeyun@example\.com/i)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

`src/components/settings-team.tsx` rendered two hardcoded fake team members ("Ashley", "Jaeyun") in the dashboard's Team tab. Replaced with the signed-in user from `authClient.useSession()`, role "Owner", with loading and signed-out empty states.

## Test plan

- [x] `bunx vitest run tests/settings-team.test.tsx` — 3/3 pass, including a regression test that asserts `ashley@example.com` / `jaeyun@example.com` no longer appear
- [ ] Manual: load `/settings/team` signed in — confirm own email/name shown with Owner badge
- [ ] Manual: load while signed out — confirm empty state, not a fake row

🤖 Generated with [Claude Code](https://claude.com/claude-code)