### PR TITLE
fix(ui): broken mailto links and clipped template card popover

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -48,13 +48,17 @@ export default async function DashboardLayout({
           <div className="flex-1 px-6 py-6">{children}</div>
           <footer className="flex items-center justify-end gap-4 border-t border-line px-6 py-3">
             <a
-              href="mailto:feedback@example.com?subject=Opensend%20Feedback"
+              href="https://github.com/namuh-eng/opensend/issues/new?labels=feedback"
+              target="_blank"
+              rel="noreferrer noopener"
               className="text-[13px] text-fg-3 transition-colors hover:text-fg"
             >
               Feedback
             </a>
             <a
-              href="mailto:help@example.com?subject=Opensend%20Help"
+              href="https://github.com/namuh-eng/opensend/issues"
+              target="_blank"
+              rel="noreferrer noopener"
               className="text-[13px] text-fg-3 transition-colors hover:text-fg"
             >
               Help

--- a/src/components/templates-list.tsx
+++ b/src/components/templates-list.tsx
@@ -427,11 +427,11 @@ export function TemplatesList() {
             <div
               key={t.id}
               data-testid="template-card"
-              className="group border border-line rounded-lg overflow-hidden hover:border-line-3 transition-colors"
+              className="group border border-line rounded-lg hover:border-line-3 transition-colors"
             >
               {/* Preview thumbnail */}
               <Link href={`/templates/${t.id}/editor`}>
-                <div className="aspect-[4/3] bg-white flex items-start justify-start p-4 cursor-pointer">
+                <div className="aspect-[4/3] bg-white flex items-start justify-start p-4 cursor-pointer rounded-t-lg">
                   <div className="w-3/4 space-y-2 pt-2">
                     <div className="h-1.5 bg-white/[0.12] rounded w-full" />
                     <div className="h-1.5 bg-white/[0.12] rounded w-3/4" />


### PR DESCRIPTION
## Summary

- Dashboard footer mailto links pointed at `feedback@example.com` / `help@example.com` — placeholder addresses that bounce. Replaced with the opensend GitHub issues URL (open-source repo, contributors handle both feedback and help via GitHub).
- Template card had `overflow-hidden` on the outer card div, which clipped the three-dot actions popover. Dropped it and moved `rounded-t-lg` onto the white preview thumbnail so the rounded look is preserved.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bunx vitest run tests/templates-list.test.tsx` — 11/11 pass
- [ ] Manual: open `/templates`, click the three-dot button on a card — confirm full menu visible (View details / Edit template / Rename / etc.)
- [ ] Manual: open any dashboard page, click Feedback/Help in footer — confirm opens GitHub issues in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)