### PR TITLE
chore(docs): tighten doc-standards wording and ignore local scrape dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ ralph_to_ralph_archive/
 # Local clawhip repo metadata (single-machine only)
 .clawhip/
 .scratch/
+
+# Scraped third-party docs and local scrape venv (never committed)
+resend-docs/
+.venv-scrape/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,11 +53,11 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
 
 
 ## Documentation Standards
-- Public docs must be OpenSend-owned first-party content. Do not route users to Resend docs or other competitor docs from OpenSend docs pages, `llms.txt`, examples, or public navigation. Use competitor docs only as private/internal parity inspiration.
+- Public docs must be OpenSend-owned first-party content. Do not route users to third-party docs from OpenSend docs pages, `llms.txt`, examples, or public navigation.
 - Canonical LLM documentation lives at `/docs/llms.txt`. Root `/llms.txt` may redirect there, but do not maintain a separate root LLM corpus.
 - Public markdown docs live under `public/docs/**/*.md` and must be indexed from `/docs/llms.txt` in the same style as a markdown documentation corpus. When adding a public API, SDK, dashboard feature, webhook event, automation feature, or operational guide, add/update the matching `.md` page and run `bun run docs:generate` in the same change.
 - `/docs` should present OpenSend as a complete first-party product surface: quickstart, OpenAPI, API groups, SDKs, MCP/LLM guidance, self-hosting, deliverability, webhooks, receiving, automations, logs, exports, suppressions, and troubleshooting. Do not leave implemented routes/features undocumented.
-- Keep docs truthful to the repo. If a feature is partial or operator-only, label it clearly instead of implying full hosted parity. Prefer route/file/OpenAPI evidence over aspirational copy.
+- Keep docs truthful to the repo. If a feature is partial or operator-only, label it clearly. Prefer route/file/OpenAPI evidence over aspirational copy.
 
 ## Quality Standards
 - TypeScript strict mode, no `any` types

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,11 +52,11 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
 
 
 ## Documentation Standards
-- Public docs must be OpenSend-owned first-party content. Do not route users to Resend docs or other competitor docs from OpenSend docs pages, `llms.txt`, examples, or public navigation. Use competitor docs only as private/internal parity inspiration.
+- Public docs must be OpenSend-owned first-party content. Do not route users to third-party docs from OpenSend docs pages, `llms.txt`, examples, or public navigation.
 - Canonical LLM documentation lives at `/docs/llms.txt`. Root `/llms.txt` may redirect there, but do not maintain a separate root LLM corpus.
 - Public markdown docs live under `public/docs/**/*.md` and must be indexed from `/docs/llms.txt` in the same style as a markdown documentation corpus. When adding a public API, SDK, dashboard feature, webhook event, automation feature, or operational guide, add/update the matching `.md` page and run `bun run docs:generate` in the same change.
 - `/docs` should present OpenSend as a complete first-party product surface: quickstart, OpenAPI, API groups, SDKs, MCP/LLM guidance, self-hosting, deliverability, webhooks, receiving, automations, logs, exports, suppressions, and troubleshooting. Do not leave implemented routes/features undocumented.
-- Keep docs truthful to the repo. If a feature is partial or operator-only, label it clearly instead of implying full hosted parity. Prefer route/file/OpenAPI evidence over aspirational copy.
+- Keep docs truthful to the repo. If a feature is partial or operator-only, label it clearly. Prefer route/file/OpenAPI evidence over aspirational copy.
 
 ## Quality Standards
 - TypeScript strict mode, no `any` types


### PR DESCRIPTION
## Summary
- Rephrase Documentation Standards in `CLAUDE.md` / `AGENTS.md` to drop third-party-product references; keep the no-link-to-third-party rule and the truthfulness rule.
- Ignore local scrape working dirs (`resend-docs/`, `.venv-scrape/`) so they never get committed.

## Test plan
- [x] `grep -i -E "parity|competitor" CLAUDE.md AGENTS.md` returns nothing
- [x] `git check-ignore resend-docs/ .venv-scrape/` resolves to the new rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)