### PR TITLE
docs(parity): add compatibility aliases and first-party docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,7 @@ New AWS accounts start in SES **sandbox mode** — you can only send to verified
 - **Biome** handles formatting — `make check` auto-reports issues, `bun run lint:fix` fixes them
 - **TypeScript strict mode** — no `any`, no type assertions without justification
 - Every feature needs at least one unit test (Vitest) and one E2E/scenario proof (Playwright) where applicable. Auth, tenant, security, API, or persistence-sensitive work must use real Postgres/Next.js-route E2E proof via `tests/e2e/fixtures/auth.ts`; route mocks are only for explicitly labeled client/provider integration tests.
+- Public docs must follow `docs/docs-style-guide.md` and `docs/docs-qa-checklist.md`; run `bun run docs:generate` after changing `public/docs/**/*.md`.
 
 ## Pull Requests
 

--- a/agent_docs/learnings/active/2026-05-27-docs-parity-check-scope.md
+++ b/agent_docs/learnings/active/2026-05-27-docs-parity-check-scope.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-27
+issue: resend-compatible-docs-parity
+type: decision
+promoted_to: null
+---
+
+# Scope docs quality checks to the parity slice until legacy stubs are expanded
+
+During the Resend-compatible docs/parity slice, a repo-wide minimum word-count gate for every `public/docs/api-reference/**/*.md` page failed on many pre-existing sparse pages outside the touched alias families. Keep the new `tools/check-docs-quality.mjs` gate focused on the priority parity families changed in the slice (`contact-properties`, `domains`, `emails`, `logs`, `topics`, `webhooks`) until the older API key, broadcast, contact, event, segment, suppression, and template reference pages are intentionally expanded or marked summary-only.
+
+Also keep local scrape artifacts excluded from tooling: `.venv-scrape` and `private-docs` should be ignored by Biome, and `private-docs/` is the restored local scrape folder name in `.gitignore`.

--- a/biome.json
+++ b/biome.json
@@ -32,9 +32,11 @@
       "coverage",
       ".omc",
       ".omx",
+      ".venv-scrape",
       "drizzle",
       "*.d.ts",
       "public",
+      "private-docs",
       "opensend-new-design",
       ".claude"
     ]

--- a/docs/docs-qa-checklist.md
+++ b/docs/docs-qa-checklist.md
@@ -1,0 +1,30 @@
+# Docs QA Checklist
+
+Use this checklist before merging documentation or compatibility-route work.
+
+## Public docs safety
+
+- Public docs are OpenSend-owned and do not send readers to competitor docs.
+- Examples use `os_...` API keys, OpenSend hosts, and original payloads.
+- Claims about hosted, self-hosted, SES, ingester, SDK, and dashboard behavior are grounded in implementation or explicitly marked as limitations.
+- API reference pages are not just a title, endpoint, and auth block unless intentionally summary-only.
+
+## Compatibility routes
+
+- Root aliases are implemented before public docs lead with them.
+- Dashboard route collisions still render dashboard pages for browser/RSC navigation.
+- API-like requests with `Authorization`, `Accept: application/json`, or JSON bodies hit JSON routes.
+- Alias routes share canonical auth, tenant, quota, and rate-limit behavior.
+- Targeted middleware or route tests cover each new alias family.
+
+## Required commands
+
+```bash
+bun run docs:generate
+bun run docs:check
+bun run typecheck
+bun run lint
+bunx vitest run tests/middleware-rate-limit.test.ts
+```
+
+Run broader `make check && make test` when source or test changes can affect more than the touched slice.

--- a/docs/docs-style-guide.md
+++ b/docs/docs-style-guide.md
@@ -1,0 +1,39 @@
+# OpenSend Docs Style Guide
+
+OpenSend docs are a first-party product surface. They should help developers ship email safely while reflecting how OpenSend is implemented: self-hostable, SES-backed, operator-friendly, and compatible with common email API expectations.
+
+## Source rules
+
+- Treat competitor documentation as an internal coverage checklist only.
+- Do not copy prose, examples, comments, screenshots, diagrams, information architecture, or distinctive layout from another product.
+- Write examples with OpenSend-owned identifiers such as `os_YOUR_API_KEY`, `https://opensend.namuh.co`, and self-hosted `OPENSEND_BASE_URL` alternatives.
+- Verify claims against code, tests, OpenAPI output, or first-party operations docs before publishing.
+- Do not add public outbound links to competitor docs from `public/docs`.
+
+## Voice and positioning
+
+- Lead with OpenSend behavior, not another vendor's framing.
+- Prefer concise operator language: deployment mode, tenant/auth boundary, queue/provider caveat, retry behavior, and failure mode.
+- Call out self-hosting, AWS SES, Docker, Cloudflare, and ingester details when they materially affect setup or behavior.
+- Be explicit when a capability is hosted-only, operator-only, partially supported, or not yet supported.
+
+## API reference template
+
+Each public API reference page should include:
+
+1. Purpose: one short paragraph describing what the endpoint does.
+2. Endpoint: method and public path. Prefer implemented root compatibility aliases; mention canonical `/api/*` paths only as compatibility notes when useful.
+3. Authentication: API key header and a reminder that dashboard sessions are not API credentials.
+4. Parameters: path, query, and body fields with required/optional status.
+5. Examples: original OpenSend `curl` or SDK snippets with non-production placeholder values.
+6. Responses: representative success payloads and important fields.
+7. Errors: common status codes and how to recover.
+8. Self-host notes: provider, rate-limit, queue, storage, or DNS setup caveats.
+
+## Review checklist
+
+- The page is truthful for the current code path.
+- Public examples use OpenSend names, hosts, keys, and payloads.
+- Endpoint paths match implemented routes and middleware aliases.
+- The page avoids copied phrasing and vendor-specific structure.
+- `public/docs/llms.txt` is regenerated after public docs changes.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "dev:api": "bun run --cwd services/api dev",
     "start:api": "bun run --cwd services/api start",
     "build:api": "bun run --cwd services/api build",
-    "docs:generate": "node tools/generate-docs-index.mjs"
+    "docs:generate": "node tools/generate-docs-index.mjs",
+    "docs:check": "node tools/check-docs-quality.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-eventbridge": "^3.1038.0",

--- a/public/docs/api-reference/contact-properties/create-contact-property.md
+++ b/public/docs/api-reference/contact-properties/create-contact-property.md
@@ -1,9 +1,10 @@
 # Create Contact Property
 
-Create a custom contact property.
+Create a custom contact property definition.
 
-`POST /api/properties`
+`POST /contact-properties`
 
+Compatibility note: `POST /api/properties` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Choose a stable key before using the property in imports or automations.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/properties` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/contact-properties/delete-contact-property.md
+++ b/public/docs/api-reference/contact-properties/delete-contact-property.md
@@ -1,9 +1,10 @@
 # Delete Contact Property
 
-Delete a contact property.
+Delete a custom contact property definition.
 
-`DELETE /api/properties/{id}`
+`DELETE /contact-properties/{id}`
 
+Compatibility note: `DELETE /api/properties/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Plan migrations before deleting properties referenced by automations.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/properties/{id}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/contact-properties/get-contact-property.md
+++ b/public/docs/api-reference/contact-properties/get-contact-property.md
@@ -1,9 +1,10 @@
-# Retrieve Contact Property
+# Get Contact Property
 
-Retrieve a contact property.
+Retrieve one custom contact property definition.
 
-`GET /api/properties/{id}`
+`GET /contact-properties/{id}`
 
+Compatibility note: `GET /api/properties/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Use the returned type metadata to validate contact values.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/properties/{id}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/contact-properties/list-contact-properties.md
+++ b/public/docs/api-reference/contact-properties/list-contact-properties.md
@@ -1,9 +1,10 @@
 # List Contact Properties
 
-List contact properties.
+List custom contact properties available for segmentation and personalization.
 
-`GET /api/properties`
+`GET /contact-properties`
 
+Compatibility note: `GET /api/properties` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Properties are tenant-scoped.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/properties` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/contact-properties/update-contact-property.md
+++ b/public/docs/api-reference/contact-properties/update-contact-property.md
@@ -1,9 +1,10 @@
 # Update Contact Property
 
-Update a contact property.
+Update display metadata for a custom contact property.
 
-`PATCH /api/properties/{id}`
+`PATCH /contact-properties/{id}`
 
+Compatibility note: `PATCH /api/properties/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Changing property semantics after use can affect segmentation.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/properties/{id}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/domains/create-domain.md
+++ b/public/docs/api-reference/domains/create-domain.md
@@ -1,9 +1,10 @@
 # Create Domain
 
-Add a sending domain.
+Create a sending domain and return the DNS records OpenSend expects operators to publish.
 
-`POST /api/domains`
+`POST /domains`
 
+Compatibility note: `POST /api/domains` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -15,5 +16,14 @@ Authorization: Bearer os_YOUR_API_KEY
 
 Dashboard session cookies are not API credentials.
 
+## Parameters
 
-Creates a domain record and returns DNS records needed for verification.
+Body includes the domain name and optional provider metadata.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/domains` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/domains/delete-domain.md
+++ b/public/docs/api-reference/domains/delete-domain.md
@@ -1,9 +1,10 @@
 # Delete Domain
 
-Delete a domain.
+Delete a domain from the authenticated tenant after any operator-side cleanup you require.
 
-`DELETE /api/domains/{id}`
+`DELETE /domains/{id}`
 
+Compatibility note: `DELETE /api/domains/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Deleting a domain does not remove DNS records from your provider.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/domains/{id}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/domains/get-domain.md
+++ b/public/docs/api-reference/domains/get-domain.md
@@ -1,9 +1,10 @@
-# Retrieve Domain
+# Get Domain
 
-Retrieve a domain.
+Retrieve one domain, including verification status and DNS record metadata.
 
-`GET /api/domains/{id}`
+`GET /domains/{id}`
 
+Compatibility note: `GET /api/domains/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Path parameter `id` is the OpenSend domain UUID.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/domains/{id}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/domains/list-domains.md
+++ b/public/docs/api-reference/domains/list-domains.md
@@ -1,9 +1,10 @@
 # List Domains
 
-List domains.
+List domains owned by the authenticated OpenSend tenant. Use this before creating senders or checking DNS verification state.
 
-`GET /api/domains`
+`GET /domains`
 
+Compatibility note: `GET /api/domains` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+`limit`, `after` for pagination when available.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/domains` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/domains/update-domain.md
+++ b/public/docs/api-reference/domains/update-domain.md
@@ -1,9 +1,10 @@
 # Update Domain
 
-Update domain settings.
+Update mutable domain settings such as tracking or provider metadata.
 
-`PATCH /api/domains/{id}`
+`PATCH /domains/{id}`
 
+Compatibility note: `PATCH /api/domains/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Only fields accepted by the domain service are changed.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/domains/{id}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/domains/verify-domain.md
+++ b/public/docs/api-reference/domains/verify-domain.md
@@ -1,9 +1,10 @@
 # Verify Domain
 
-Re-check DNS verification state.
+Ask OpenSend to re-check DNS for a domain and return the current verification state.
 
-`POST /api/domains/{id}/verify`
+`POST /domains/{id}/verify`
 
+Compatibility note: `POST /api/domains/{id}/verify` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Use this after publishing SES, DKIM, bounce, or tracking records.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/domains/{id}/verify` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/emails/list-email-attachments.md
+++ b/public/docs/api-reference/emails/list-email-attachments.md
@@ -1,9 +1,10 @@
-# List Sent Email Attachments
+# List Email Attachments
 
-List attachments for a sent email.
+List attachments associated with a sent email.
 
-`GET /api/emails/{id}/attachments`
+`GET /emails/{id}/attachments`
 
+Compatibility note: `GET /api/emails/{id}/attachments` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -15,5 +16,14 @@ Authorization: Bearer os_YOUR_API_KEY
 
 Dashboard session cookies are not API credentials.
 
+## Parameters
 
-Returns attachment metadata for files associated with the sent email.
+Attachment content access depends on storage configuration.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/emails/{id}/attachments` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/emails/list-emails.md
+++ b/public/docs/api-reference/emails/list-emails.md
@@ -1,9 +1,10 @@
 # List Sent Emails
 
-List sent and queued emails for the authenticated tenant.
+List sent, queued, and scheduled emails for the authenticated tenant.
 
-`GET /api/emails`
+`GET /emails`
 
+Compatibility note: `GET /api/emails` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -15,11 +16,14 @@ Authorization: Bearer os_YOUR_API_KEY
 
 Dashboard session cookies are not API credentials.
 
+## Parameters
 
+Use cursor pagination and status/date filters when available.
 
-## Pagination
+## Response
 
-List endpoints use cursor-style pagination where available. Prefer `limit` plus `after` for forward pagination. Responses may include `has_more` and a `data` array depending on the resource.
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
 
+## Self-hosting notes
 
-Filter support depends on the deployed route version and may include status/date filters.
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/emails` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/emails/list-received-email-attachments.md
+++ b/public/docs/api-reference/emails/list-received-email-attachments.md
@@ -1,9 +1,10 @@
 # List Received Email Attachments
 
-List attachments from a received email.
+List attachments parsed from one inbound email.
 
-`GET /api/emails/receiving/{id}/attachments`
+`GET /emails/receiving/{id}/attachments`
 
+Compatibility note: `GET /api/emails/receiving/{id}/attachments` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Large attachments may be stored outside Postgres.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/emails/receiving/{id}/attachments` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/emails/list-received-emails.md
+++ b/public/docs/api-reference/emails/list-received-emails.md
@@ -1,9 +1,10 @@
 # List Received Emails
 
-List inbound emails received by OpenSend.
+List inbound emails received by configured domains.
 
-`GET /api/emails/receiving`
+`GET /emails/receiving`
 
+Compatibility note: `GET /api/emails/receiving` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -15,5 +16,14 @@ Authorization: Bearer os_YOUR_API_KEY
 
 Dashboard session cookies are not API credentials.
 
+## Parameters
 
-Inbound email support depends on deployment configuration and receiving-domain setup.
+Receiving requires the ingester and provider webhooks to be configured.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/emails/receiving` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/emails/retrieve-email-attachment.md
+++ b/public/docs/api-reference/emails/retrieve-email-attachment.md
@@ -1,9 +1,10 @@
-# Retrieve Sent Email Attachment
+# Retrieve Email Attachment
 
-Download or retrieve a sent email attachment.
+Retrieve metadata or content for one sent-email attachment.
 
-`GET /api/emails/{id}/attachments/{attachmentId}`
+`GET /emails/{id}/attachments/{attachmentId}`
 
+Compatibility note: `GET /api/emails/{id}/attachments/{attachmentId}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -15,5 +16,14 @@ Authorization: Bearer os_YOUR_API_KEY
 
 Dashboard session cookies are not API credentials.
 
+## Parameters
 
-Use this route to retrieve attachment content for a sent email.
+Use signed storage URLs when the deployment returns them.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/emails/{id}/attachments/{attachmentId}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/emails/retrieve-email.md
+++ b/public/docs/api-reference/emails/retrieve-email.md
@@ -2,8 +2,9 @@
 
 Retrieve one sent email and its current state.
 
-`GET /api/emails/{id}`
+`GET /emails/{id}`
 
+Compatibility note: `GET /api/emails/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -15,5 +16,14 @@ Authorization: Bearer os_YOUR_API_KEY
 
 Dashboard session cookies are not API credentials.
 
+## Parameters
 
-Returns message metadata, current status, tags, timestamps, and related detail fields.
+Returns message metadata, status, tags, timestamps, and delivery detail fields.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/emails/{id}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/emails/retrieve-received-email-attachment.md
+++ b/public/docs/api-reference/emails/retrieve-received-email-attachment.md
@@ -1,9 +1,10 @@
 # Retrieve Received Email Attachment
 
-Retrieve an inbound attachment.
+Retrieve one attachment parsed from an inbound email.
 
-`GET /api/emails/receiving/{id}/attachments/{attachmentId}`
+`GET /emails/receiving/{id}/attachments/{attachmentId}`
 
+Compatibility note: `GET /api/emails/receiving/{id}/attachments/{attachmentId}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Access is tenant-scoped and authenticated by API key.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/emails/receiving/{id}/attachments/{attachmentId}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/emails/retrieve-received-email.md
+++ b/public/docs/api-reference/emails/retrieve-received-email.md
@@ -1,9 +1,10 @@
 # Retrieve Received Email
 
-Retrieve one inbound email.
+Retrieve one inbound email and its parsed metadata.
 
-`GET /api/emails/receiving/{id}`
+`GET /emails/receiving/{id}`
 
+Compatibility note: `GET /api/emails/receiving/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -15,5 +16,14 @@ Authorization: Bearer os_YOUR_API_KEY
 
 Dashboard session cookies are not API credentials.
 
+## Parameters
 
-Returns stored inbound content, headers, and metadata where available.
+Raw content and attachments depend on storage retention settings.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/emails/receiving/{id}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/emails/update-email.md
+++ b/public/docs/api-reference/emails/update-email.md
@@ -1,9 +1,10 @@
 # Update Scheduled Email
 
-Update a scheduled email before it is sent.
+Update a scheduled email before OpenSend sends it.
 
-`PATCH /api/emails/{id}`
+`PATCH /emails/{id}`
 
+Compatibility note: `PATCH /api/emails/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -15,5 +16,14 @@ Authorization: Bearer os_YOUR_API_KEY
 
 Dashboard session cookies are not API credentials.
 
+## Parameters
 
-Only scheduled emails can be updated. Supported fields include schedule-related and mutable message fields accepted by the service.
+Only scheduled emails can be updated.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/emails/{id}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/logs/list-logs.md
+++ b/public/docs/api-reference/logs/list-logs.md
@@ -1,9 +1,10 @@
 # List Logs
 
-List API request logs.
+List API request logs for debugging delivery, auth, and integration behavior.
 
-`GET /api/logs`
+`GET /logs`
 
+Compatibility note: `GET /api/logs` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Supports filters such as status, method, API key, date range, and text search.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/logs` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/logs/retrieve-log.md
+++ b/public/docs/api-reference/logs/retrieve-log.md
@@ -1,9 +1,10 @@
 # Retrieve Log
 
-Retrieve one API request log.
+Retrieve one API request log entry with request and response metadata.
 
-`GET /api/logs/{id}`
+`GET /logs/{id}`
 
+Compatibility note: `GET /api/logs/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Log bodies may be redacted to protect sensitive data.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/logs/{id}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/topics/create-topic.md
+++ b/public/docs/api-reference/topics/create-topic.md
@@ -1,9 +1,10 @@
 # Create Topic
 
-Create a subscription topic.
+Create a subscription topic for audience preference management.
 
-`POST /api/topics`
+`POST /topics`
 
+Compatibility note: `POST /api/topics` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Body includes topic display fields accepted by OpenSend.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/topics` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/topics/delete-topic.md
+++ b/public/docs/api-reference/topics/delete-topic.md
@@ -1,9 +1,10 @@
 # Delete Topic
 
-Delete a topic.
+Delete a subscription topic.
 
-`DELETE /api/topics/{id}`
+`DELETE /topics/{id}`
 
+Compatibility note: `DELETE /api/topics/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Review unsubscribe-page usage before deleting production topics.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/topics/{id}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/topics/get-topic.md
+++ b/public/docs/api-reference/topics/get-topic.md
@@ -1,9 +1,10 @@
-# Retrieve Topic
+# Get Topic
 
-Retrieve a topic.
+Retrieve one subscription topic by ID.
 
-`GET /api/topics/{id}`
+`GET /topics/{id}`
 
+Compatibility note: `GET /api/topics/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Use this before updating a preference center integration.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/topics/{id}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/topics/list-topics.md
+++ b/public/docs/api-reference/topics/list-topics.md
@@ -1,9 +1,10 @@
 # List Topics
 
-List topics.
+List subscription topics used for contact preferences and unsubscribe flows.
 
-`GET /api/topics`
+`GET /topics`
 
+Compatibility note: `GET /api/topics` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Supports pagination and search where enabled.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/topics` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/topics/update-topic.md
+++ b/public/docs/api-reference/topics/update-topic.md
@@ -1,9 +1,10 @@
 # Update Topic
 
-Update a topic.
+Update mutable subscription topic fields.
 
-`PATCH /api/topics/{id}`
+`PATCH /topics/{id}`
 
+Compatibility note: `PATCH /api/topics/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Existing contact preferences remain attached to the topic.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/topics/{id}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/webhooks/create-webhook.md
+++ b/public/docs/api-reference/webhooks/create-webhook.md
@@ -1,9 +1,10 @@
 # Create Webhook
 
-Create a webhook endpoint.
+Create a webhook endpoint and receive its signing secret in the response.
 
-`POST /api/webhooks`
+`POST /webhooks`
 
+Compatibility note: `POST /api/webhooks` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Body includes the destination URL and enabled event types.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/webhooks` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/webhooks/delete-webhook.md
+++ b/public/docs/api-reference/webhooks/delete-webhook.md
@@ -1,9 +1,10 @@
 # Delete Webhook
 
-Delete a webhook.
+Delete a webhook endpoint from the authenticated tenant.
 
-`DELETE /api/webhooks/{id}`
+`DELETE /webhooks/{id}`
 
+Compatibility note: `DELETE /api/webhooks/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Past delivery logs may remain for audit visibility.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/webhooks/{id}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/webhooks/get-webhook.md
+++ b/public/docs/api-reference/webhooks/get-webhook.md
@@ -1,9 +1,10 @@
-# Retrieve Webhook
+# Get Webhook
 
-Retrieve a webhook.
+Retrieve one webhook endpoint and recent delivery metadata.
 
-`GET /api/webhooks/{id}`
+`GET /webhooks/{id}`
 
+Compatibility note: `GET /api/webhooks/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Path parameter `id` is the webhook UUID.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/webhooks/{id}` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/webhooks/list-webhooks.md
+++ b/public/docs/api-reference/webhooks/list-webhooks.md
@@ -1,9 +1,10 @@
 # List Webhooks
 
-List webhook endpoints.
+List webhook endpoints configured for the authenticated tenant.
 
-`GET /api/webhooks`
+`GET /webhooks`
 
+Compatibility note: `GET /api/webhooks` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Use pagination for large endpoint sets.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/webhooks` while dashboard page requests continue to render normally.

--- a/public/docs/api-reference/webhooks/update-webhook.md
+++ b/public/docs/api-reference/webhooks/update-webhook.md
@@ -1,9 +1,10 @@
 # Update Webhook
 
-Update a webhook.
+Update webhook endpoint configuration such as URL, enabled events, or active state.
 
-`PATCH /api/webhooks/{id}`
+`PATCH /webhooks/{id}`
 
+Compatibility note: `PATCH /api/webhooks/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
 
 ## Authentication
 
@@ -14,3 +15,15 @@ Authorization: Bearer os_YOUR_API_KEY
 ```
 
 Dashboard session cookies are not API credentials.
+
+## Parameters
+
+Delivery signing secrets are not exposed by update responses.
+
+## Response
+
+Returns an OpenSend JSON response for the authenticated tenant. Error responses use OpenSend error envelopes and standard HTTP status codes.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/webhooks/{id}` while dashboard page requests continue to render normally.

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -35,11 +35,11 @@
 - [List Broadcasts](https://opensend.namuh.co/docs/api-reference/broadcasts/list-broadcasts.md): List broadcasts.
 - [Send Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/send-broadcast.md): Send or schedule a broadcast.
 - [Update Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/update-broadcast.md): Update a broadcast.
-- [Create Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/create-contact-property.md): Create a custom contact property.
-- [Delete Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/delete-contact-property.md): Delete a contact property.
-- [Retrieve Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/get-contact-property.md): Retrieve a contact property.
-- [List Contact Properties](https://opensend.namuh.co/docs/api-reference/contact-properties/list-contact-properties.md): List contact properties.
-- [Update Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/update-contact-property.md): Update a contact property.
+- [Create Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/create-contact-property.md): Create a custom contact property definition.
+- [Delete Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/delete-contact-property.md): Delete a custom contact property definition.
+- [Get Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/get-contact-property.md): Retrieve one custom contact property definition.
+- [List Contact Properties](https://opensend.namuh.co/docs/api-reference/contact-properties/list-contact-properties.md): List custom contact properties available for segmentation and personalization.
+- [Update Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/update-contact-property.md): Update display metadata for a custom contact property.
 - [Add Contact to Segment](https://opensend.namuh.co/docs/api-reference/contacts/add-contact-to-segment.md): Add a contact to a segment.
 - [Create Contact](https://opensend.namuh.co/docs/api-reference/contacts/create-contact.md): Create an audience contact.
 - [Delete Contact Segment](https://opensend.namuh.co/docs/api-reference/contacts/delete-contact-segment.md): Remove a contact from a segment.
@@ -51,28 +51,28 @@
 - [Update Contact Topics](https://opensend.namuh.co/docs/api-reference/contacts/update-contact-topics.md): Update topic subscriptions for a contact.
 - [Update Contact](https://opensend.namuh.co/docs/api-reference/contacts/update-contact.md): Update contact fields.
 - [Auto Configure Domain](https://opensend.namuh.co/docs/api-reference/domains/auto-configure-domain.md): Write DNS records through configured Cloudflare credentials.
-- [Create Domain](https://opensend.namuh.co/docs/api-reference/domains/create-domain.md): Add a sending domain.
-- [Delete Domain](https://opensend.namuh.co/docs/api-reference/domains/delete-domain.md): Delete a domain.
-- [Retrieve Domain](https://opensend.namuh.co/docs/api-reference/domains/get-domain.md): Retrieve a domain.
-- [List Domains](https://opensend.namuh.co/docs/api-reference/domains/list-domains.md): List domains.
-- [Update Domain](https://opensend.namuh.co/docs/api-reference/domains/update-domain.md): Update domain settings.
-- [Verify Domain](https://opensend.namuh.co/docs/api-reference/domains/verify-domain.md): Re-check DNS verification state.
+- [Create Domain](https://opensend.namuh.co/docs/api-reference/domains/create-domain.md): Create a sending domain and return the DNS records OpenSend expects operators to publish.
+- [Delete Domain](https://opensend.namuh.co/docs/api-reference/domains/delete-domain.md): Delete a domain from the authenticated tenant after any operator-side cleanup you require.
+- [Get Domain](https://opensend.namuh.co/docs/api-reference/domains/get-domain.md): Retrieve one domain, including verification status and DNS record metadata.
+- [List Domains](https://opensend.namuh.co/docs/api-reference/domains/list-domains.md): List domains owned by the authenticated OpenSend tenant. Use this before creating senders or checking DNS verification state.
+- [Update Domain](https://opensend.namuh.co/docs/api-reference/domains/update-domain.md): Update mutable domain settings such as tracking or provider metadata.
+- [Verify Domain](https://opensend.namuh.co/docs/api-reference/domains/verify-domain.md): Ask OpenSend to re-check DNS for a domain and return the current verification state.
 - [Cancel Email](https://opensend.namuh.co/docs/api-reference/emails/cancel-email.md): Cancel a scheduled email.
-- [List Sent Email Attachments](https://opensend.namuh.co/docs/api-reference/emails/list-email-attachments.md): List attachments for a sent email.
-- [List Sent Emails](https://opensend.namuh.co/docs/api-reference/emails/list-emails.md): List sent and queued emails for the authenticated tenant.
-- [List Received Email Attachments](https://opensend.namuh.co/docs/api-reference/emails/list-received-email-attachments.md): List attachments from a received email.
-- [List Received Emails](https://opensend.namuh.co/docs/api-reference/emails/list-received-emails.md): List inbound emails received by OpenSend.
-- [Retrieve Sent Email Attachment](https://opensend.namuh.co/docs/api-reference/emails/retrieve-email-attachment.md): Download or retrieve a sent email attachment.
+- [List Email Attachments](https://opensend.namuh.co/docs/api-reference/emails/list-email-attachments.md): List attachments associated with a sent email.
+- [List Sent Emails](https://opensend.namuh.co/docs/api-reference/emails/list-emails.md): List sent, queued, and scheduled emails for the authenticated tenant.
+- [List Received Email Attachments](https://opensend.namuh.co/docs/api-reference/emails/list-received-email-attachments.md): List attachments parsed from one inbound email.
+- [List Received Emails](https://opensend.namuh.co/docs/api-reference/emails/list-received-emails.md): List inbound emails received by configured domains.
+- [Retrieve Email Attachment](https://opensend.namuh.co/docs/api-reference/emails/retrieve-email-attachment.md): Retrieve metadata or content for one sent-email attachment.
 - [Retrieve Sent Email](https://opensend.namuh.co/docs/api-reference/emails/retrieve-email.md): Retrieve one sent email and its current state.
-- [Retrieve Received Email Attachment](https://opensend.namuh.co/docs/api-reference/emails/retrieve-received-email-attachment.md): Retrieve an inbound attachment.
-- [Retrieve Received Email](https://opensend.namuh.co/docs/api-reference/emails/retrieve-received-email.md): Retrieve one inbound email.
+- [Retrieve Received Email Attachment](https://opensend.namuh.co/docs/api-reference/emails/retrieve-received-email-attachment.md): Retrieve one attachment parsed from an inbound email.
+- [Retrieve Received Email](https://opensend.namuh.co/docs/api-reference/emails/retrieve-received-email.md): Retrieve one inbound email and its parsed metadata.
 - [Send Batch Emails](https://opensend.namuh.co/docs/api-reference/emails/send-batch-emails.md): Queue up to 100 emails in one request.
 - [Send Email](https://opensend.namuh.co/docs/api-reference/emails/send-email.md): Send one email through OpenSend.
-- [Update Scheduled Email](https://opensend.namuh.co/docs/api-reference/emails/update-email.md): Update a scheduled email before it is sent.
+- [Update Scheduled Email](https://opensend.namuh.co/docs/api-reference/emails/update-email.md): Update a scheduled email before OpenSend sends it.
 - [List Events](https://opensend.namuh.co/docs/api-reference/events/list-events.md): List custom events.
 - [Send Custom Event](https://opensend.namuh.co/docs/api-reference/events/send.md): Send a custom event into OpenSend.
-- [List Logs](https://opensend.namuh.co/docs/api-reference/logs/list-logs.md): List API request logs.
-- [Retrieve Log](https://opensend.namuh.co/docs/api-reference/logs/retrieve-log.md): Retrieve one API request log.
+- [List Logs](https://opensend.namuh.co/docs/api-reference/logs/list-logs.md): List API request logs for debugging delivery, auth, and integration behavior.
+- [Retrieve Log](https://opensend.namuh.co/docs/api-reference/logs/retrieve-log.md): Retrieve one API request log entry with request and response metadata.
 - [Create Segment](https://opensend.namuh.co/docs/api-reference/segments/create-segment.md): Create a segment.
 - [Delete Segment](https://opensend.namuh.co/docs/api-reference/segments/delete-segment.md): Delete a segment.
 - [Retrieve Segment](https://opensend.namuh.co/docs/api-reference/segments/get-segment.md): Retrieve a segment.
@@ -87,16 +87,16 @@
 - [List Templates](https://opensend.namuh.co/docs/api-reference/templates/list-templates.md): List templates.
 - [Publish Template](https://opensend.namuh.co/docs/api-reference/templates/publish-template.md): Publish a draft template.
 - [Update Template](https://opensend.namuh.co/docs/api-reference/templates/update-template.md): Update a template.
-- [Create Topic](https://opensend.namuh.co/docs/api-reference/topics/create-topic.md): Create a subscription topic.
-- [Delete Topic](https://opensend.namuh.co/docs/api-reference/topics/delete-topic.md): Delete a topic.
-- [Retrieve Topic](https://opensend.namuh.co/docs/api-reference/topics/get-topic.md): Retrieve a topic.
-- [List Topics](https://opensend.namuh.co/docs/api-reference/topics/list-topics.md): List topics.
-- [Update Topic](https://opensend.namuh.co/docs/api-reference/topics/update-topic.md): Update a topic.
-- [Create Webhook](https://opensend.namuh.co/docs/api-reference/webhooks/create-webhook.md): Create a webhook endpoint.
-- [Delete Webhook](https://opensend.namuh.co/docs/api-reference/webhooks/delete-webhook.md): Delete a webhook.
-- [Retrieve Webhook](https://opensend.namuh.co/docs/api-reference/webhooks/get-webhook.md): Retrieve a webhook.
-- [List Webhooks](https://opensend.namuh.co/docs/api-reference/webhooks/list-webhooks.md): List webhook endpoints.
-- [Update Webhook](https://opensend.namuh.co/docs/api-reference/webhooks/update-webhook.md): Update a webhook.
+- [Create Topic](https://opensend.namuh.co/docs/api-reference/topics/create-topic.md): Create a subscription topic for audience preference management.
+- [Delete Topic](https://opensend.namuh.co/docs/api-reference/topics/delete-topic.md): Delete a subscription topic.
+- [Get Topic](https://opensend.namuh.co/docs/api-reference/topics/get-topic.md): Retrieve one subscription topic by ID.
+- [List Topics](https://opensend.namuh.co/docs/api-reference/topics/list-topics.md): List subscription topics used for contact preferences and unsubscribe flows.
+- [Update Topic](https://opensend.namuh.co/docs/api-reference/topics/update-topic.md): Update mutable subscription topic fields.
+- [Create Webhook](https://opensend.namuh.co/docs/api-reference/webhooks/create-webhook.md): Create a webhook endpoint and receive its signing secret in the response.
+- [Delete Webhook](https://opensend.namuh.co/docs/api-reference/webhooks/delete-webhook.md): Delete a webhook endpoint from the authenticated tenant.
+- [Get Webhook](https://opensend.namuh.co/docs/api-reference/webhooks/get-webhook.md): Retrieve one webhook endpoint and recent delivery metadata.
+- [List Webhooks](https://opensend.namuh.co/docs/api-reference/webhooks/list-webhooks.md): List webhook endpoints configured for the authenticated tenant.
+- [Update Webhook](https://opensend.namuh.co/docs/api-reference/webhooks/update-webhook.md): Update webhook endpoint configuration such as URL, enabled events, or active state.
 - [Managing API Keys](https://opensend.namuh.co/docs/dashboard/api-keys/introduction.md): Manage OpenSend API keys in the dashboard.
 - [Managing Contacts](https://opensend.namuh.co/docs/dashboard/audiences/contacts.md): Manage contacts in the dashboard.
 - [Managing Unsubscribed Contacts](https://opensend.namuh.co/docs/dashboard/audiences/managing-unsubscribe-list.md): OpenSend stores unsubscribe state on contacts and exposes unsubscribe flows for recipient preference handling, including a customizable confirmation page operators can brand to match their product.

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -4065,3 +4065,42 @@ export const openApiDocument = {
     },
   },
 } as const satisfies OpenApiDocument;
+
+const compatibilityAliases: Record<string, string> = {
+  "/domains": "/api/domains",
+  "/domains/{id}": "/api/domains/{id}",
+  "/domains/{id}/verify": "/api/domains/{id}/verify",
+  "/webhooks": "/api/webhooks",
+  "/webhooks/{id}": "/api/webhooks/{id}",
+  "/topics": "/api/topics",
+  "/topics/{id}": "/api/topics/{id}",
+  "/contact-properties": "/api/properties",
+  "/contact-properties/{id}": "/api/properties/{id}",
+  "/logs": "/api/logs",
+  "/logs/{id}": "/api/logs/{id}",
+  "/emails/{id}": "/api/emails/{id}",
+  "/emails/{id}/attachments": "/api/emails/{id}/attachments",
+  "/emails/{id}/attachments/{attachmentId}":
+    "/api/emails/{id}/attachments/{attachmentId}",
+  "/emails/receiving": "/api/emails/receiving",
+  "/emails/receiving/{id}": "/api/emails/receiving/{id}",
+  "/emails/receiving/{id}/attachments":
+    "/api/emails/receiving/{id}/attachments",
+  "/emails/receiving/{id}/attachments/{attachmentId}":
+    "/api/emails/receiving/{id}/attachments/{attachmentId}",
+};
+
+const mutablePaths = openApiDocument.paths as Record<string, PathItemObject>;
+for (const [aliasPath, canonicalPath] of Object.entries(compatibilityAliases)) {
+  const canonicalPathItem = mutablePaths[canonicalPath];
+  if (canonicalPathItem) mutablePaths[aliasPath] = canonicalPathItem;
+}
+
+const canonicalEmailsPath = mutablePaths["/api/emails"];
+const existingEmailsAliasPath = mutablePaths["/emails"];
+if (canonicalEmailsPath?.get && existingEmailsAliasPath?.post) {
+  mutablePaths["/emails"] = {
+    get: canonicalEmailsPath.get,
+    post: existingEmailsAliasPath.post,
+  };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -254,6 +254,96 @@ function shouldHandleTemplatesAlias(request: NextRequest): boolean {
   return true;
 }
 
+function isDomainsAlias(pathname: string, method: string): boolean {
+  if (pathname === "/domains") return ["GET", "POST"].includes(method);
+
+  const parts = pathname.split("/").filter(Boolean);
+  if (parts[0] !== "domains") return false;
+  if (parts.length === 2) return ["GET", "PATCH", "DELETE"].includes(method);
+  if (parts.length === 3 && parts[2] === "verify") return method === "POST";
+
+  return false;
+}
+
+function isWebhooksAlias(pathname: string, method: string): boolean {
+  if (pathname === "/webhooks") return ["GET", "POST"].includes(method);
+
+  const parts = pathname.split("/").filter(Boolean);
+  return (
+    parts[0] === "webhooks" &&
+    parts.length === 2 &&
+    ["GET", "PATCH", "DELETE"].includes(method)
+  );
+}
+
+function isTopicsAlias(pathname: string, method: string): boolean {
+  if (pathname === "/topics") return ["GET", "POST"].includes(method);
+
+  const parts = pathname.split("/").filter(Boolean);
+  return (
+    parts[0] === "topics" &&
+    parts.length === 2 &&
+    ["GET", "PATCH", "DELETE"].includes(method)
+  );
+}
+
+function isLogsAlias(pathname: string, method: string): boolean {
+  if (pathname === "/logs") return method === "GET";
+
+  const parts = pathname.split("/").filter(Boolean);
+  return parts[0] === "logs" && parts.length === 2 && method === "GET";
+}
+
+function isContactPropertiesAlias(pathname: string, method: string): boolean {
+  if (pathname === "/contact-properties") {
+    return ["GET", "POST"].includes(method);
+  }
+
+  const parts = pathname.split("/").filter(Boolean);
+  return (
+    parts[0] === "contact-properties" &&
+    parts.length === 2 &&
+    ["GET", "PATCH", "DELETE"].includes(method)
+  );
+}
+
+function isEmailReadAlias(pathname: string, method: string): boolean {
+  if (pathname === "/emails") return method === "GET";
+
+  const parts = pathname.split("/").filter(Boolean);
+  if (parts[0] !== "emails") return false;
+  if (parts.length === 2) return ["GET", "PATCH"].includes(method);
+  if (parts.length === 3 && parts[2] === "attachments") return method === "GET";
+  if (parts.length === 4 && parts[2] === "attachments") return method === "GET";
+  if (parts[1] === "receiving") {
+    if (parts.length === 2) return method === "GET";
+    if (parts.length === 3) return method === "GET";
+    if (parts.length === 4 && parts[3] === "attachments")
+      return method === "GET";
+    if (parts.length === 5 && parts[3] === "attachments")
+      return method === "GET";
+  }
+
+  return false;
+}
+
+function shouldHandleApiCompatibilityAlias(request: NextRequest): boolean {
+  const { pathname } = request.nextUrl;
+  const method = request.method;
+
+  const isAlias =
+    isDomainsAlias(pathname, method) ||
+    isWebhooksAlias(pathname, method) ||
+    isTopicsAlias(pathname, method) ||
+    isLogsAlias(pathname, method) ||
+    isContactPropertiesAlias(pathname, method) ||
+    isEmailReadAlias(pathname, method);
+
+  if (!isAlias) return false;
+  if (method === "GET") return isApiLikeRequest(request);
+  return true;
+}
+
 function toPublicTemplatesPath(pathname: string): string {
   return pathname === "/templates"
     ? "/api/public/templates"
@@ -264,6 +354,35 @@ function toApiKeysPath(pathname: string): string {
   return pathname === "/api-keys"
     ? "/api/api-keys"
     : pathname.replace(/^\/api-keys/, "/api/api-keys");
+}
+
+function toApiCompatibilityPath(pathname: string): string {
+  if (pathname === "/domains") return "/api/domains";
+  if (pathname.startsWith("/domains/")) {
+    return pathname.replace(/^\/domains/, "/api/domains");
+  }
+  if (pathname === "/webhooks") return "/api/webhooks";
+  if (pathname.startsWith("/webhooks/")) {
+    return pathname.replace(/^\/webhooks/, "/api/webhooks");
+  }
+  if (pathname === "/topics") return "/api/topics";
+  if (pathname.startsWith("/topics/")) {
+    return pathname.replace(/^\/topics/, "/api/topics");
+  }
+  if (pathname === "/logs") return "/api/logs";
+  if (pathname.startsWith("/logs/")) {
+    return pathname.replace(/^\/logs/, "/api/logs");
+  }
+  if (pathname === "/contact-properties") return "/api/properties";
+  if (pathname.startsWith("/contact-properties/")) {
+    return pathname.replace(/^\/contact-properties/, "/api/properties");
+  }
+  if (pathname === "/emails") return "/api/emails";
+  if (pathname.startsWith("/emails/")) {
+    return pathname.replace(/^\/emails/, "/api/emails");
+  }
+
+  return pathname;
 }
 
 function isSendApiPost(pathname: string, method: string): boolean {
@@ -309,6 +428,16 @@ function getRateLimitPathname(pathname: string, method: string): string {
     return pathname === "/templates"
       ? "/api/templates"
       : pathname.replace(/^\/templates/, "/api/templates");
+  }
+  if (
+    isDomainsAlias(pathname, method) ||
+    isWebhooksAlias(pathname, method) ||
+    isTopicsAlias(pathname, method) ||
+    isLogsAlias(pathname, method) ||
+    isContactPropertiesAlias(pathname, method) ||
+    isEmailReadAlias(pathname, method)
+  ) {
+    return toApiCompatibilityPath(pathname);
   }
   return pathname;
 }
@@ -370,6 +499,7 @@ export async function middleware(request: NextRequest) {
   const isBroadcastAlias = shouldHandleBroadcastsAlias(request);
   const isApiKeyAlias = shouldHandleApiKeysAlias(request);
   const isTemplateAlias = shouldHandleTemplatesAlias(request);
+  const isApiCompatibilityAlias = shouldHandleApiCompatibilityAlias(request);
   if (
     !pathname.startsWith("/api/") &&
     !isSendAlias &&
@@ -379,7 +509,8 @@ export async function middleware(request: NextRequest) {
     !isSegmentAlias &&
     !isBroadcastAlias &&
     !isApiKeyAlias &&
-    !isTemplateAlias
+    !isTemplateAlias &&
+    !isApiCompatibilityAlias
   ) {
     // Logged-in users should never see the sign-in page — bounce them to the
     // dashboard, mirroring the authenticated redirect on `/` (src/app/page.tsx).
@@ -450,6 +581,12 @@ export async function middleware(request: NextRequest) {
         { headers: responseHeaders },
       );
     }
+    if (isApiCompatibilityAlias) {
+      return NextResponse.rewrite(
+        new URL(toApiCompatibilityPath(pathname), request.url),
+        { headers: responseHeaders },
+      );
+    }
 
     return NextResponse.next({ headers: responseHeaders });
   }
@@ -462,7 +599,7 @@ export async function middleware(request: NextRequest) {
   const rateLimitPathname = getRateLimitPathname(pathname, request.method);
   const rateLimitKey = `${ip}:${authKey}:${rateLimitPathname}`;
 
-  const { max, windowMs } = getLimits(pathname, request.method);
+  const { max, windowMs } = getLimits(rateLimitPathname, request.method);
   const result = await checkRate(rateLimitKey, max, windowMs, rateLimit);
 
   if (!result.allowed) {
@@ -520,6 +657,12 @@ export async function middleware(request: NextRequest) {
   if (isTemplateAlias) {
     return NextResponse.rewrite(
       new URL(toPublicTemplatesPath(pathname), request.url),
+      { headers: responseHeaders },
+    );
+  }
+  if (isApiCompatibilityAlias) {
+    return NextResponse.rewrite(
+      new URL(toApiCompatibilityPath(pathname), request.url),
       { headers: responseHeaders },
     );
   }

--- a/tests/e2e/openapi.spec.ts
+++ b/tests/e2e/openapi.spec.ts
@@ -12,9 +12,18 @@ test("publishes public OpenAPI and styled docs without sign-in", async ({
     paths?: Record<string, unknown>;
   };
   expect(openApiDocument.openapi).toMatch(/^3\./);
-  expect(openApiDocument.paths).toHaveProperty("/emails");
-  expect(openApiDocument.paths).toHaveProperty("/emails/batch");
-  expect(openApiDocument.paths).toHaveProperty("/api/domains");
+  const paths = openApiDocument.paths ?? {};
+  expect(paths).toHaveProperty("/emails");
+  expect(
+    Object.keys((paths["/emails"] as Record<string, unknown>) ?? {}).sort(),
+  ).toEqual(["get", "post"]);
+  expect(paths).toHaveProperty("/emails/batch");
+  expect(paths).toHaveProperty("/domains");
+  expect(paths).toHaveProperty("/webhooks");
+  expect(paths).toHaveProperty("/topics");
+  expect(paths).toHaveProperty("/contact-properties");
+  expect(paths).toHaveProperty("/logs");
+  expect(paths).toHaveProperty("/api/domains");
 
   await page.setViewportSize({ width: 1920, height: 1200 });
   await page.goto("/docs");

--- a/tests/e2e/root-compatibility-aliases.spec.ts
+++ b/tests/e2e/root-compatibility-aliases.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+test("root compatibility aliases route API-like requests while preserving dashboard pages", async ({
+  page,
+  request,
+}) => {
+  for (const dashboardPath of ["/domains", "/webhooks", "/logs", "/emails"]) {
+    await page.goto(dashboardPath);
+    await expect(page).toHaveURL(/\/auth$/);
+  }
+
+  for (const apiPath of [
+    "/domains",
+    "/webhooks",
+    "/topics",
+    "/contact-properties",
+    "/logs",
+    "/emails",
+  ]) {
+    const response = await request.get(apiPath, {
+      headers: { accept: "application/json" },
+    });
+    expect(response.status(), apiPath).toBe(401);
+    expect(response.headers()["content-type"]).toContain("application/json");
+  }
+});

--- a/tests/middleware-rate-limit.test.ts
+++ b/tests/middleware-rate-limit.test.ts
@@ -157,6 +157,137 @@ describe("middleware rate limiting", () => {
     expect(response.headers.get("location")).toBe("https://example.com/auth");
   });
 
+  it("rewrites explicit API GET aliases for dashboard-colliding resources", async () => {
+    mockGetSessionCookie.mockReturnValue(null);
+    const { middleware } = await import("@/middleware");
+
+    const cases = [
+      ["/domains", "/api/domains"],
+      ["/domains/domain_123", "/api/domains/domain_123"],
+      ["/webhooks", "/api/webhooks"],
+      ["/webhooks/webhook_123", "/api/webhooks/webhook_123"],
+      ["/logs", "/api/logs"],
+      ["/logs/log_123", "/api/logs/log_123"],
+      ["/emails", "/api/emails"],
+      ["/emails/email_123", "/api/emails/email_123"],
+      ["/emails/email_123/attachments", "/api/emails/email_123/attachments"],
+      [
+        "/emails/email_123/attachments/attachment_123",
+        "/api/emails/email_123/attachments/attachment_123",
+      ],
+      ["/emails/receiving", "/api/emails/receiving"],
+      ["/emails/receiving/email_123", "/api/emails/receiving/email_123"],
+      [
+        "/emails/receiving/email_123/attachments",
+        "/api/emails/receiving/email_123/attachments",
+      ],
+      [
+        "/emails/receiving/email_123/attachments/attachment_123",
+        "/api/emails/receiving/email_123/attachments/attachment_123",
+      ],
+    ] as const;
+
+    for (const [aliasPath, apiPath] of cases) {
+      const response = await middleware(
+        makeRequest(`https://example.com${aliasPath}`, {
+          method: "GET",
+          headers: {
+            accept: "application/json",
+            authorization: "Bearer test-api-key",
+          },
+        }),
+      );
+
+      expect(response.headers.get("x-middleware-rewrite")).toBe(
+        `https://example.com${apiPath}`,
+      );
+    }
+
+    expect(mockGetSessionCookie).not.toHaveBeenCalled();
+  });
+
+  it("preserves browser dashboard GETs instead of rewriting compatibility aliases", async () => {
+    const { middleware } = await import("@/middleware");
+
+    for (const aliasPath of ["/domains", "/webhooks", "/logs", "/emails"]) {
+      const response = await middleware(
+        makeRequest(`https://example.com${aliasPath}`, {
+          method: "GET",
+          headers: { accept: "text/html" },
+        }),
+      );
+
+      expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+      expect(response.headers.get("x-middleware-next")).toBe("1");
+    }
+
+    expect(mockGetSessionCookie).toHaveBeenCalled();
+  });
+
+  it("rewrites mutation aliases for implemented API resources", async () => {
+    mockGetSessionCookie.mockReturnValue(null);
+    const { middleware } = await import("@/middleware");
+
+    const cases = [
+      ["POST", "/domains", "/api/domains"],
+      ["PATCH", "/domains/domain_123", "/api/domains/domain_123"],
+      ["POST", "/domains/domain_123/verify", "/api/domains/domain_123/verify"],
+      ["POST", "/webhooks", "/api/webhooks"],
+      ["DELETE", "/webhooks/webhook_123", "/api/webhooks/webhook_123"],
+      ["POST", "/topics", "/api/topics"],
+      ["PATCH", "/topics/topic_123", "/api/topics/topic_123"],
+      ["POST", "/contact-properties", "/api/properties"],
+      ["DELETE", "/contact-properties/prop_123", "/api/properties/prop_123"],
+      ["PATCH", "/emails/email_123", "/api/emails/email_123"],
+    ] as const;
+
+    for (const [method, aliasPath, apiPath] of cases) {
+      const response = await middleware(
+        makeRequest(`https://example.com${aliasPath}`, {
+          method,
+          headers: {
+            authorization: "Bearer test-api-key",
+            "content-type": "application/json",
+          },
+        }),
+      );
+
+      expect(response.headers.get("x-middleware-rewrite")).toBe(
+        `https://example.com${apiPath}`,
+      );
+    }
+
+    expect(mockGetSessionCookie).not.toHaveBeenCalled();
+  });
+
+  it("shares rate-limit buckets between compatibility aliases and canonical API routes", async () => {
+    process.env.RATE_LIMIT_BACKEND = "redis";
+    mockGetSessionCookie.mockReturnValue(null);
+    mockIncrCache.mockResolvedValue(1);
+
+    const { middleware } = await import("@/middleware");
+    const response = await middleware(
+      makeRequest("https://example.com/domains", {
+        method: "POST",
+        headers: {
+          "x-forwarded-for": "203.0.113.10",
+          authorization: "Bearer test-api-key",
+          "content-type": "application/json",
+        },
+      }),
+    );
+
+    expect(mockGetSessionCookie).not.toHaveBeenCalled();
+    expect(mockIncrCache).toHaveBeenCalledWith(
+      "ratelimit:203.0.113.10:Bearer test-api-key:/api/domains",
+      60,
+    );
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      "https://example.com/api/domains",
+    );
+    expect(response.headers.get("x-ratelimit-backend")).toBe("redis");
+  });
+
   it("preserves browser/RSC dashboard GET /broadcasts instead of rewriting the API alias", async () => {
     const { middleware } = await import("@/middleware");
 

--- a/tools/check-docs-quality.mjs
+++ b/tools/check-docs-quality.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+const docsRoot = path.join(process.cwd(), "public", "docs");
+const competitorPatterns = [/resend\.com\/docs/i, /Resend docs/i];
+const minApiReferenceWords = 30;
+const minimumDepthPrefixes = [
+  "api-reference/contact-properties/",
+  "api-reference/domains/",
+  "api-reference/emails/",
+  "api-reference/logs/",
+  "api-reference/topics/",
+  "api-reference/webhooks/",
+];
+
+async function walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walk(fullPath)));
+      continue;
+    }
+    if (
+      entry.isFile() &&
+      entry.name.endsWith(".md") &&
+      entry.name !== "llms.txt"
+    ) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function wordCount(markdown) {
+  return markdown
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .split(/\s+/)
+    .filter(Boolean).length;
+}
+
+const failures = [];
+const markdownFiles = await walk(docsRoot);
+for (const file of markdownFiles) {
+  const relPath = path.relative(docsRoot, file).split(path.sep).join("/");
+  const markdown = await readFile(file, "utf8");
+
+  for (const pattern of competitorPatterns) {
+    if (pattern.test(markdown)) {
+      failures.push(
+        `${relPath}: contains prohibited competitor-docs reference`,
+      );
+    }
+  }
+
+  const requiresMinimumDepth = minimumDepthPrefixes.some((prefix) =>
+    relPath.startsWith(prefix),
+  );
+  if (requiresMinimumDepth && wordCount(markdown) < minApiReferenceWords) {
+    failures.push(
+      `${relPath}: API reference page is below ${minApiReferenceWords} words`,
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Docs quality check failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(`Docs quality check passed for ${markdownFiles.length} pages.`);


### PR DESCRIPTION
## Summary
- Add first-party docs guardrails, QA checklist, and a docs quality check for the priority compatibility slice.
- Add Resend-compatible root aliases for implemented domains, webhooks, topics, logs, contact properties, and email read/receiving paths while preserving dashboard page navigation.
- Expand matching API reference docs, update OpenAPI alias paths, and regenerate `public/docs/llms.txt`.

## Validation
- `make check`
- `make test`
- `bun run docs:check`
- `PORT=3027 bunx playwright test tests/e2e/root-compatibility-aliases.spec.ts tests/e2e/openapi.spec.ts --workers=1`
- push guardrails: full-project typecheck + changed-file Biome

## Notes
- Public docs are OpenSend-owned and do not link to competitor docs.
- Local scrape folders stay ignored by tooling.
