### PR TITLE
docs(api): deepen remaining reference pages

### DIFF
--- a/public/docs/api-reference/api-keys/create-api-key.md
+++ b/public/docs/api-reference/api-keys/create-api-key.md
@@ -1,19 +1,50 @@
 # Create API Key
 
-Create a new API key.
+Create a new API key. This page documents the OpenSend-owned API contract for `POST /api-keys`.
 
 `POST /api-keys`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
 
+API key routes are account-management endpoints. Newly created tokens are only shown once, so store the `os_...` value in your secrets manager and rotate by creating a replacement key before deleting the old one. Create a new record using a JSON request body. Send only fields supported by the matching route; validation errors return a structured OpenSend error response.
 
-Requires a full-access key. Store the returned secret immediately; only a hash is persisted.
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "name": "Production worker"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "api_key_123",
+  "name": "Production worker",
+  "token": "os_...",
+  "createdAt": "2026-05-28T00:00:00.000Z"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/api-keys/delete-api-key.md
+++ b/public/docs/api-reference/api-keys/delete-api-key.md
@@ -1,16 +1,50 @@
 # Delete API Key
 
-Delete an API key.
+Delete an API key. This page documents the OpenSend-owned API contract for `DELETE /api-keys/{id}`.
 
 `DELETE /api-keys/{id}`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+API key routes are account-management endpoints. Newly created tokens are only shown once, so store the `os_...` value in your secrets manager and rotate by creating a replacement key before deleting the old one. Delete or detach the target record for the authenticated tenant. Treat deletes as irreversible unless the resource-specific docs state otherwise.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "name": "Production worker"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "api_key_123",
+  "name": "Production worker",
+  "token": "os_...",
+  "createdAt": "2026-05-28T00:00:00.000Z"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/api-keys/list-api-keys.md
+++ b/public/docs/api-reference/api-keys/list-api-keys.md
@@ -1,16 +1,42 @@
 # List API Keys
 
-List API keys for the authenticated tenant.
+List API keys for the authenticated tenant. This page documents the OpenSend-owned API contract for `GET /api-keys`.
 
 `GET /api-keys`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+API key routes are account-management endpoints. Newly created tokens are only shown once, so store the `os_...` value in your secrets manager and rotate by creating a replacement key before deleting the old one. Return a tenant-scoped collection. Use pagination parameters when available instead of assuming a fixed result size.
+
+## Parameters
+
+`limit` and `after` may be used on collection routes when the route supports cursor pagination.
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "api_key_123",
+  "name": "Production worker",
+  "token": "os_...",
+  "createdAt": "2026-05-28T00:00:00.000Z"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/broadcasts/create-broadcast.md
+++ b/public/docs/api-reference/broadcasts/create-broadcast.md
@@ -1,16 +1,51 @@
 # Create Broadcast
 
-Create a broadcast draft.
+Create a broadcast draft. This page documents the OpenSend-owned API contract for `POST /broadcasts`.
 
 `POST /broadcasts`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Broadcast routes manage newsletter-style sends for an audience. They operate on the authenticated tenant and use the same contact, segment, topic, and suppression data as the dashboard. Create a new record using a JSON request body. Send only fields supported by the matching route; validation errors return a structured OpenSend error response.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "name": "Product update",
+  "subject": "What is new",
+  "from": "updates@example.com"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "broadcast_123",
+  "name": "Product update",
+  "status": "draft"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/broadcasts/delete-broadcast.md
+++ b/public/docs/api-reference/broadcasts/delete-broadcast.md
@@ -1,16 +1,51 @@
 # Delete Broadcast
 
-Delete a broadcast.
+Delete a broadcast. This page documents the OpenSend-owned API contract for `DELETE /broadcasts/{id}`.
 
 `DELETE /broadcasts/{id}`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Broadcast routes manage newsletter-style sends for an audience. They operate on the authenticated tenant and use the same contact, segment, topic, and suppression data as the dashboard. Delete or detach the target record for the authenticated tenant. Treat deletes as irreversible unless the resource-specific docs state otherwise.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "name": "Product update",
+  "subject": "What is new",
+  "from": "updates@example.com"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "broadcast_123",
+  "name": "Product update",
+  "status": "draft"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/broadcasts/get-broadcast.md
+++ b/public/docs/api-reference/broadcasts/get-broadcast.md
@@ -1,16 +1,41 @@
 # Retrieve Broadcast
 
-Retrieve a broadcast.
+Retrieve a broadcast. This page documents the OpenSend-owned API contract for `GET /broadcasts/{id}`.
 
 `GET /broadcasts/{id}`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Broadcast routes manage newsletter-style sends for an audience. They operate on the authenticated tenant and use the same contact, segment, topic, and suppression data as the dashboard. Retrieve one tenant-scoped record by ID. A missing or cross-tenant ID returns not found instead of leaking ownership details.
+
+## Parameters
+
+Path and query parameters follow the endpoint shape above. IDs are tenant-scoped and should be treated as opaque strings.
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "broadcast_123",
+  "name": "Product update",
+  "status": "draft"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/broadcasts/list-broadcasts.md
+++ b/public/docs/api-reference/broadcasts/list-broadcasts.md
@@ -1,16 +1,41 @@
 # List Broadcasts
 
-List broadcasts.
+List broadcasts. This page documents the OpenSend-owned API contract for `GET /broadcasts`.
 
 `GET /broadcasts`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Broadcast routes manage newsletter-style sends for an audience. They operate on the authenticated tenant and use the same contact, segment, topic, and suppression data as the dashboard. Return a tenant-scoped collection. Use pagination parameters when available instead of assuming a fixed result size.
+
+## Parameters
+
+`limit` and `after` may be used on collection routes when the route supports cursor pagination.
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "broadcast_123",
+  "name": "Product update",
+  "status": "draft"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/broadcasts/send-broadcast.md
+++ b/public/docs/api-reference/broadcasts/send-broadcast.md
@@ -1,16 +1,51 @@
 # Send Broadcast
 
-Send or schedule a broadcast.
+Send or schedule a broadcast. This page documents the OpenSend-owned API contract for `POST /broadcasts/{id}/send`.
 
 `POST /broadcasts/{id}/send`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Broadcast routes manage newsletter-style sends for an audience. They operate on the authenticated tenant and use the same contact, segment, topic, and suppression data as the dashboard. Trigger delivery for an already-created resource. The route validates ownership and current state before queueing work.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "name": "Product update",
+  "subject": "What is new",
+  "from": "updates@example.com"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "broadcast_123",
+  "name": "Product update",
+  "status": "draft"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/broadcasts/update-broadcast.md
+++ b/public/docs/api-reference/broadcasts/update-broadcast.md
@@ -1,16 +1,51 @@
 # Update Broadcast
 
-Update a broadcast.
+Update a broadcast. This page documents the OpenSend-owned API contract for `PATCH /broadcasts/{id}`.
 
 `PATCH /broadcasts/{id}`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Broadcast routes manage newsletter-style sends for an audience. They operate on the authenticated tenant and use the same contact, segment, topic, and suppression data as the dashboard. Update the mutable fields for the target record. Fields not accepted by the API are ignored or rejected by route validation.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "name": "Product update",
+  "subject": "What is new",
+  "from": "updates@example.com"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "broadcast_123",
+  "name": "Product update",
+  "status": "draft"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/contacts/add-contact-to-segment.md
+++ b/public/docs/api-reference/contacts/add-contact-to-segment.md
@@ -1,16 +1,51 @@
 # Add Contact to Segment
 
-Add a contact to a segment.
+Add a contact to a segment. This page documents the OpenSend-owned API contract for `POST /api/contacts/{id}/segments`.
 
 `POST /api/contacts/{id}/segments`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Contact routes manage audience records for the authenticated tenant. Segment and topic relationship endpoints only affect the target contact and never expose another tenant's audience data. Attach the related resource to the target contact after validating both records belong to the caller.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "email": "ada@example.com",
+  "firstName": "Ada",
+  "lastName": "Lovelace"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "contact_123",
+  "email": "ada@example.com",
+  "subscribed": true
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/contacts/create-contact.md
+++ b/public/docs/api-reference/contacts/create-contact.md
@@ -1,16 +1,51 @@
 # Create Contact
 
-Create an audience contact.
+Create an audience contact. This page documents the OpenSend-owned API contract for `POST /contacts`.
 
 `POST /contacts`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Contact routes manage audience records for the authenticated tenant. Segment and topic relationship endpoints only affect the target contact and never expose another tenant's audience data. Create a new record using a JSON request body. Send only fields supported by the matching route; validation errors return a structured OpenSend error response.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "email": "ada@example.com",
+  "firstName": "Ada",
+  "lastName": "Lovelace"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "contact_123",
+  "email": "ada@example.com",
+  "subscribed": true
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/contacts/delete-contact-segment.md
+++ b/public/docs/api-reference/contacts/delete-contact-segment.md
@@ -1,16 +1,51 @@
 # Delete Contact Segment
 
-Remove a contact from a segment.
+Remove a contact from a segment. This page documents the OpenSend-owned API contract for `DELETE /api/contacts/{id}/segments/{segment_id}`.
 
 `DELETE /api/contacts/{id}/segments/{segment_id}`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Contact routes manage audience records for the authenticated tenant. Segment and topic relationship endpoints only affect the target contact and never expose another tenant's audience data. Delete or detach the target record for the authenticated tenant. Treat deletes as irreversible unless the resource-specific docs state otherwise.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "email": "ada@example.com",
+  "firstName": "Ada",
+  "lastName": "Lovelace"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "contact_123",
+  "email": "ada@example.com",
+  "subscribed": true
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/contacts/delete-contact.md
+++ b/public/docs/api-reference/contacts/delete-contact.md
@@ -1,16 +1,51 @@
 # Delete Contact
 
-Delete a contact.
+Delete a contact. This page documents the OpenSend-owned API contract for `DELETE /contacts/{contact_id}`.
 
 `DELETE /contacts/{contact_id}`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Contact routes manage audience records for the authenticated tenant. Segment and topic relationship endpoints only affect the target contact and never expose another tenant's audience data. Delete or detach the target record for the authenticated tenant. Treat deletes as irreversible unless the resource-specific docs state otherwise.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "email": "ada@example.com",
+  "firstName": "Ada",
+  "lastName": "Lovelace"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "contact_123",
+  "email": "ada@example.com",
+  "subscribed": true
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/contacts/get-contact-topics.md
+++ b/public/docs/api-reference/contacts/get-contact-topics.md
@@ -1,16 +1,41 @@
 # Retrieve Contact Topics
 
-Get topic subscriptions for a contact.
+Get topic subscriptions for a contact. This page documents the OpenSend-owned API contract for `GET /api/contacts/{id}/topics`.
 
 `GET /api/contacts/{id}/topics`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Contact routes manage audience records for the authenticated tenant. Segment and topic relationship endpoints only affect the target contact and never expose another tenant's audience data. Retrieve one tenant-scoped record by ID. A missing or cross-tenant ID returns not found instead of leaking ownership details.
+
+## Parameters
+
+`limit` and `after` may be used on collection routes when the route supports cursor pagination.
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "contact_123",
+  "email": "ada@example.com",
+  "subscribed": true
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/contacts/get-contact.md
+++ b/public/docs/api-reference/contacts/get-contact.md
@@ -1,16 +1,41 @@
 # Retrieve Contact
 
-Retrieve a contact by id or email where supported.
+Retrieve a contact by id or email where supported. This page documents the OpenSend-owned API contract for `GET /contacts/{contact_id}`.
 
 `GET /contacts/{contact_id}`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Contact routes manage audience records for the authenticated tenant. Segment and topic relationship endpoints only affect the target contact and never expose another tenant's audience data. Retrieve one tenant-scoped record by ID. A missing or cross-tenant ID returns not found instead of leaking ownership details.
+
+## Parameters
+
+Path and query parameters follow the endpoint shape above. IDs are tenant-scoped and should be treated as opaque strings.
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "contact_123",
+  "email": "ada@example.com",
+  "subscribed": true
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/contacts/list-contact-segments.md
+++ b/public/docs/api-reference/contacts/list-contact-segments.md
@@ -1,16 +1,41 @@
 # List Contact Segments
 
-List segments for a contact.
+List segments for a contact. This page documents the OpenSend-owned API contract for `GET /api/contacts/{id}/segments`.
 
 `GET /api/contacts/{id}/segments`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Contact routes manage audience records for the authenticated tenant. Segment and topic relationship endpoints only affect the target contact and never expose another tenant's audience data. Return a tenant-scoped collection. Use pagination parameters when available instead of assuming a fixed result size.
+
+## Parameters
+
+`limit` and `after` may be used on collection routes when the route supports cursor pagination.
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "contact_123",
+  "email": "ada@example.com",
+  "subscribed": true
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/contacts/list-contacts.md
+++ b/public/docs/api-reference/contacts/list-contacts.md
@@ -1,22 +1,41 @@
 # List Contacts
 
-List contacts.
+List contacts. This page documents the OpenSend-owned API contract for `GET /contacts`.
 
 `GET /contacts`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
 
+Contact routes manage audience records for the authenticated tenant. Segment and topic relationship endpoints only affect the target contact and never expose another tenant's audience data. Return a tenant-scoped collection. Use pagination parameters when available instead of assuming a fixed result size.
 
+## Parameters
 
-## Pagination
+`limit` and `after` may be used on collection routes when the route supports cursor pagination.
 
-List endpoints use cursor-style pagination where available. Prefer `limit` plus `after` for forward pagination. Responses may include `has_more` and a `data` array depending on the resource.
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "contact_123",
+  "email": "ada@example.com",
+  "subscribed": true
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/contacts/update-contact-topics.md
+++ b/public/docs/api-reference/contacts/update-contact-topics.md
@@ -1,16 +1,51 @@
 # Update Contact Topics
 
-Update topic subscriptions for a contact.
+Update topic subscriptions for a contact. This page documents the OpenSend-owned API contract for `PATCH /api/contacts/{id}/topics`.
 
 `PATCH /api/contacts/{id}/topics`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Contact routes manage audience records for the authenticated tenant. Segment and topic relationship endpoints only affect the target contact and never expose another tenant's audience data. Update the mutable fields for the target record. Fields not accepted by the API are ignored or rejected by route validation.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "email": "ada@example.com",
+  "firstName": "Ada",
+  "lastName": "Lovelace"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "contact_123",
+  "email": "ada@example.com",
+  "subscribed": true
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/contacts/update-contact.md
+++ b/public/docs/api-reference/contacts/update-contact.md
@@ -1,16 +1,51 @@
 # Update Contact
 
-Update contact fields.
+Update contact fields. This page documents the OpenSend-owned API contract for `PATCH /contacts/{contact_id}`.
 
 `PATCH /contacts/{contact_id}`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Contact routes manage audience records for the authenticated tenant. Segment and topic relationship endpoints only affect the target contact and never expose another tenant's audience data. Update the mutable fields for the target record. Fields not accepted by the API are ignored or rejected by route validation.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "email": "ada@example.com",
+  "firstName": "Ada",
+  "lastName": "Lovelace"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "contact_123",
+  "email": "ada@example.com",
+  "subscribed": true
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/events/list-events.md
+++ b/public/docs/api-reference/events/list-events.md
@@ -1,16 +1,42 @@
 # List Events
 
-List custom events.
+List custom events. This page documents the OpenSend-owned API contract for `GET /api/events`.
 
 `GET /api/events`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Event routes expose OpenSend automation events. Use them to inspect or send custom events that can trigger automations when your workspace has matching triggers configured. Return a tenant-scoped collection. Use pagination parameters when available instead of assuming a fixed result size.
+
+## Parameters
+
+`limit` and `after` may be used on collection routes when the route supports cursor pagination.
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "data": [
+    { "id": "event_123", "type": "user.signed_up" }
+  ],
+  "hasMore": false
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/events/send.md
+++ b/public/docs/api-reference/events/send.md
@@ -1,19 +1,52 @@
 # Send Custom Event
 
-Send a custom event into OpenSend.
+Send a custom event into OpenSend. This page documents the OpenSend-owned API contract for `POST /api/events/send`.
 
 `POST /api/events/send`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
 
+Event routes expose OpenSend automation events. Use them to inspect or send custom events that can trigger automations when your workspace has matching triggers configured. Trigger delivery for an already-created resource. The route validates ownership and current state before queueing work.
 
-Custom events can trigger automations and analytics workflows.
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "event": "user.signed_up",
+  "email": "ada@example.com",
+  "properties": { "plan": "pro" }
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "data": [
+    { "id": "event_123", "type": "user.signed_up" }
+  ],
+  "hasMore": false
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/pagination.md
+++ b/public/docs/api-reference/pagination.md
@@ -1,7 +1,25 @@
 # Pagination
 
-Pagination behavior for list endpoints.
+OpenSend collection endpoints use cursor-style pagination where the route supports it. The API keeps pagination deliberately simple so self-hosted deployments and generated clients can share the same contract.
 
-## Pagination
+## Query parameters
 
-List endpoints use cursor-style pagination where available. Prefer `limit` plus `after` for forward pagination. Responses may include `has_more` and a `data` array depending on the resource.
+- `limit`: maximum number of records to return. Use a modest value for dashboard or worker jobs instead of assuming every tenant has a small dataset.
+- `after`: cursor returned from a previous page. Pass it back unchanged to retrieve the next page.
+
+## Response shape
+
+Collection responses generally include an array of records and a continuation indicator or cursor when more records are available. Exact field names are documented per endpoint and in `/openapi.json`.
+
+```json
+{
+  "data": [
+    { "id": "resource_123" }
+  ],
+  "hasMore": false
+}
+```
+
+## Operational notes
+
+Pagination is tenant-scoped. A cursor from one tenant or environment should never be reused for another tenant. If your worker exports large datasets, process one page at a time and persist progress between runs.

--- a/public/docs/api-reference/segments/create-segment.md
+++ b/public/docs/api-reference/segments/create-segment.md
@@ -1,16 +1,48 @@
 # Create Segment
 
-Create a segment.
+Create a segment. This page documents the OpenSend-owned API contract for `POST /segments`.
 
 `POST /segments`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Segment routes manage audience groupings. Segment membership is tenant-scoped and can be used by broadcasts, automations, and dashboard audience filters. Create a new record using a JSON request body. Send only fields supported by the matching route; validation errors return a structured OpenSend error response.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "name": "Product qualified leads"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "segment_123",
+  "name": "Product qualified leads"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/segments/delete-segment.md
+++ b/public/docs/api-reference/segments/delete-segment.md
@@ -1,16 +1,48 @@
 # Delete Segment
 
-Delete a segment.
+Delete a segment. This page documents the OpenSend-owned API contract for `DELETE /segments/{id}`.
 
 `DELETE /segments/{id}`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Segment routes manage audience groupings. Segment membership is tenant-scoped and can be used by broadcasts, automations, and dashboard audience filters. Delete or detach the target record for the authenticated tenant. Treat deletes as irreversible unless the resource-specific docs state otherwise.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "name": "Product qualified leads"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "segment_123",
+  "name": "Product qualified leads"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/segments/get-segment.md
+++ b/public/docs/api-reference/segments/get-segment.md
@@ -1,16 +1,40 @@
 # Retrieve Segment
 
-Retrieve a segment.
+Retrieve a segment. This page documents the OpenSend-owned API contract for `GET /segments/{id}`.
 
 `GET /segments/{id}`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Segment routes manage audience groupings. Segment membership is tenant-scoped and can be used by broadcasts, automations, and dashboard audience filters. Retrieve one tenant-scoped record by ID. A missing or cross-tenant ID returns not found instead of leaking ownership details.
+
+## Parameters
+
+Path and query parameters follow the endpoint shape above. IDs are tenant-scoped and should be treated as opaque strings.
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "segment_123",
+  "name": "Product qualified leads"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/segments/list-segment-contacts.md
+++ b/public/docs/api-reference/segments/list-segment-contacts.md
@@ -1,16 +1,40 @@
 # List Segment Contacts
 
-List contacts in a segment.
+List contacts in a segment. This page documents the OpenSend-owned API contract for `GET /segments/{id}/contacts`.
 
 `GET /segments/{id}/contacts`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Segment routes manage audience groupings. Segment membership is tenant-scoped and can be used by broadcasts, automations, and dashboard audience filters. Return a tenant-scoped collection. Use pagination parameters when available instead of assuming a fixed result size.
+
+## Parameters
+
+`limit` and `after` may be used on collection routes when the route supports cursor pagination.
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "segment_123",
+  "name": "Product qualified leads"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/segments/list-segments.md
+++ b/public/docs/api-reference/segments/list-segments.md
@@ -1,16 +1,40 @@
 # List Segments
 
-List segments.
+List segments. This page documents the OpenSend-owned API contract for `GET /segments`.
 
 `GET /segments`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Segment routes manage audience groupings. Segment membership is tenant-scoped and can be used by broadcasts, automations, and dashboard audience filters. Return a tenant-scoped collection. Use pagination parameters when available instead of assuming a fixed result size.
+
+## Parameters
+
+`limit` and `after` may be used on collection routes when the route supports cursor pagination.
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "segment_123",
+  "name": "Product qualified leads"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/suppressions/delete-suppression.md
+++ b/public/docs/api-reference/suppressions/delete-suppression.md
@@ -1,16 +1,46 @@
 # Delete Suppression
 
-Remove a recipient from suppressions.
+Remove a recipient from suppressions. This page documents the OpenSend-owned API contract for `DELETE /api/suppressions/{email}`.
 
 `DELETE /api/suppressions/{email}`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Suppressions are an OpenSend extension for managing addresses that should not receive mail. Removing an address permits future sends only if your own consent and compliance rules allow it. Delete or detach the target record for the authenticated tenant. Treat deletes as irreversible unless the resource-specific docs state otherwise.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+This operation does not require a large JSON body. Send only the path parameters and any route-supported fields documented by `/openapi.json`.
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "data": [
+    { "email": "bounced@example.com", "reason": "bounce" }
+  ],
+  "hasMore": false
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/suppressions/list-suppressions.md
+++ b/public/docs/api-reference/suppressions/list-suppressions.md
@@ -1,16 +1,42 @@
 # List Suppressions
 
-List suppressed recipients.
+List suppressed recipients. This page documents the OpenSend-owned API contract for `GET /api/suppressions`.
 
 `GET /api/suppressions`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Suppressions are an OpenSend extension for managing addresses that should not receive mail. Removing an address permits future sends only if your own consent and compliance rules allow it. Return a tenant-scoped collection. Use pagination parameters when available instead of assuming a fixed result size.
+
+## Parameters
+
+`limit` and `after` may be used on collection routes when the route supports cursor pagination.
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "data": [
+    { "email": "bounced@example.com", "reason": "bounce" }
+  ],
+  "hasMore": false
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/templates/create-template.md
+++ b/public/docs/api-reference/templates/create-template.md
@@ -1,16 +1,51 @@
 # Create Template
 
-Create a reusable template.
+Create a reusable template. This page documents the OpenSend-owned API contract for `POST /templates`.
 
 `POST /templates`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Template routes manage stored email templates. Published templates can be used by sends and broadcasts; draft and preview behavior depends on the renderer metadata stored with the template. Create a new record using a JSON request body. Send only fields supported by the matching route; validation errors return a structured OpenSend error response.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "name": "Welcome",
+  "subject": "Welcome to OpenSend",
+  "html": "<p>Hello {{name}}</p>"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "template_123",
+  "name": "Welcome",
+  "status": "draft"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/templates/delete-template.md
+++ b/public/docs/api-reference/templates/delete-template.md
@@ -1,16 +1,51 @@
 # Delete Template
 
-Delete a template.
+Delete a template. This page documents the OpenSend-owned API contract for `DELETE /templates/{id}`.
 
 `DELETE /templates/{id}`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Template routes manage stored email templates. Published templates can be used by sends and broadcasts; draft and preview behavior depends on the renderer metadata stored with the template. Delete or detach the target record for the authenticated tenant. Treat deletes as irreversible unless the resource-specific docs state otherwise.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "name": "Welcome",
+  "subject": "Welcome to OpenSend",
+  "html": "<p>Hello {{name}}</p>"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "template_123",
+  "name": "Welcome",
+  "status": "draft"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/templates/duplicate-template.md
+++ b/public/docs/api-reference/templates/duplicate-template.md
@@ -1,16 +1,51 @@
 # Duplicate Template
 
-Duplicate a template.
+Duplicate a template. This page documents the OpenSend-owned API contract for `POST /templates/{id}/duplicate`.
 
 `POST /templates/{id}/duplicate`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Template routes manage stored email templates. Published templates can be used by sends and broadcasts; draft and preview behavior depends on the renderer metadata stored with the template. Create a copy that can be edited independently from the source template.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "name": "Welcome",
+  "subject": "Welcome to OpenSend",
+  "html": "<p>Hello {{name}}</p>"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "template_123",
+  "name": "Welcome",
+  "status": "draft"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/templates/get-template.md
+++ b/public/docs/api-reference/templates/get-template.md
@@ -1,16 +1,41 @@
 # Get Template
 
-Retrieve a template by id or alias.
+Retrieve a template by id or alias. This page documents the OpenSend-owned API contract for `GET /templates/{id}`.
 
 `GET /templates/{id}`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Template routes manage stored email templates. Published templates can be used by sends and broadcasts; draft and preview behavior depends on the renderer metadata stored with the template. Retrieve one tenant-scoped record by ID. A missing or cross-tenant ID returns not found instead of leaking ownership details.
+
+## Parameters
+
+Path and query parameters follow the endpoint shape above. IDs are tenant-scoped and should be treated as opaque strings.
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "template_123",
+  "name": "Welcome",
+  "status": "draft"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/templates/list-templates.md
+++ b/public/docs/api-reference/templates/list-templates.md
@@ -1,16 +1,41 @@
 # List Templates
 
-List templates.
+List templates. This page documents the OpenSend-owned API contract for `GET /templates`.
 
 `GET /templates`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Template routes manage stored email templates. Published templates can be used by sends and broadcasts; draft and preview behavior depends on the renderer metadata stored with the template. Return a tenant-scoped collection. Use pagination parameters when available instead of assuming a fixed result size.
+
+## Parameters
+
+`limit` and `after` may be used on collection routes when the route supports cursor pagination.
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "template_123",
+  "name": "Welcome",
+  "status": "draft"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/templates/publish-template.md
+++ b/public/docs/api-reference/templates/publish-template.md
@@ -1,16 +1,51 @@
 # Publish Template
 
-Publish a draft template.
+Publish a draft template. This page documents the OpenSend-owned API contract for `POST /templates/{id}/publish`.
 
 `POST /templates/{id}/publish`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Template routes manage stored email templates. Published templates can be used by sends and broadcasts; draft and preview behavior depends on the renderer metadata stored with the template. Publish the current draft state so application sends can use the template intentionally.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "name": "Welcome",
+  "subject": "Welcome to OpenSend",
+  "html": "<p>Hello {{name}}</p>"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "template_123",
+  "name": "Welcome",
+  "status": "draft"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/api-reference/templates/update-template.md
+++ b/public/docs/api-reference/templates/update-template.md
@@ -1,16 +1,51 @@
 # Update Template
 
-Update a template.
+Update a template. This page documents the OpenSend-owned API contract for `PATCH /templates/{id}`.
 
 `PATCH /templates/{id}`
 
-
 ## Authentication
 
-Use an OpenSend API key in the Authorization header.
+Use an OpenSend API key in the Authorization header. Dashboard session cookies are not API credentials for public API clients.
 
 ```http
 Authorization: Bearer os_YOUR_API_KEY
 ```
 
-Dashboard session cookies are not API credentials.
+## When to use it
+
+Template routes manage stored email templates. Published templates can be used by sends and broadcasts; draft and preview behavior depends on the renderer metadata stored with the template. Update the mutable fields for the target record. Fields not accepted by the API are ignored or rejected by route validation.
+
+## Parameters
+
+Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+
+## Request example
+
+```json
+{
+  "name": "Welcome",
+  "subject": "Welcome to OpenSend",
+  "html": "<p>Hello {{name}}</p>"
+}
+```
+
+## Response
+
+Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+
+```json
+{
+  "id": "template_123",
+  "name": "Welcome",
+  "status": "draft"
+}
+```
+
+## Errors
+
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+
+## Self-hosting notes
+
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Run migrations before deploying code that expects new fields, and keep API keys in a secrets manager instead of committing them to source control.

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -23,33 +23,33 @@
 - [Custom Event Schemas](https://opensend.namuh.co/docs/custom-event-schemas.md): Define and validate custom event payloads.
 - [Introduction](https://opensend.namuh.co/docs/api-reference/introduction.md): Core concepts for the OpenSend API.
 - [Authentication](https://opensend.namuh.co/docs/api-reference/authentication.md): How API key authentication works in OpenSend.
-- [Pagination](https://opensend.namuh.co/docs/api-reference/pagination.md): Pagination behavior for list endpoints.
+- [Pagination](https://opensend.namuh.co/docs/api-reference/pagination.md): OpenSend collection endpoints use cursor-style pagination where the route supports it. The API keeps pagination deliberately simple so self-hosted deployments and generated clients can share the same contract.
 - [Errors](https://opensend.namuh.co/docs/api-reference/errors.md): Common OpenSend API error shapes and status codes.
 - [Usage Limits](https://opensend.namuh.co/docs/api-reference/rate-limit.md): Rate limits, quotas, and operational limits.
-- [Create API Key](https://opensend.namuh.co/docs/api-reference/api-keys/create-api-key.md): Create a new API key.
-- [Delete API Key](https://opensend.namuh.co/docs/api-reference/api-keys/delete-api-key.md): Delete an API key.
-- [List API Keys](https://opensend.namuh.co/docs/api-reference/api-keys/list-api-keys.md): List API keys for the authenticated tenant.
-- [Create Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/create-broadcast.md): Create a broadcast draft.
-- [Delete Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/delete-broadcast.md): Delete a broadcast.
-- [Retrieve Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/get-broadcast.md): Retrieve a broadcast.
-- [List Broadcasts](https://opensend.namuh.co/docs/api-reference/broadcasts/list-broadcasts.md): List broadcasts.
-- [Send Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/send-broadcast.md): Send or schedule a broadcast.
-- [Update Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/update-broadcast.md): Update a broadcast.
+- [Create API Key](https://opensend.namuh.co/docs/api-reference/api-keys/create-api-key.md): Create a new API key. This page documents the OpenSend-owned API contract for POST /api-keys.
+- [Delete API Key](https://opensend.namuh.co/docs/api-reference/api-keys/delete-api-key.md): Delete an API key. This page documents the OpenSend-owned API contract for DELETE /api-keys/{id}.
+- [List API Keys](https://opensend.namuh.co/docs/api-reference/api-keys/list-api-keys.md): List API keys for the authenticated tenant. This page documents the OpenSend-owned API contract for GET /api-keys.
+- [Create Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/create-broadcast.md): Create a broadcast draft. This page documents the OpenSend-owned API contract for POST /broadcasts.
+- [Delete Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/delete-broadcast.md): Delete a broadcast. This page documents the OpenSend-owned API contract for DELETE /broadcasts/{id}.
+- [Retrieve Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/get-broadcast.md): Retrieve a broadcast. This page documents the OpenSend-owned API contract for GET /broadcasts/{id}.
+- [List Broadcasts](https://opensend.namuh.co/docs/api-reference/broadcasts/list-broadcasts.md): List broadcasts. This page documents the OpenSend-owned API contract for GET /broadcasts.
+- [Send Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/send-broadcast.md): Send or schedule a broadcast. This page documents the OpenSend-owned API contract for POST /broadcasts/{id}/send.
+- [Update Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/update-broadcast.md): Update a broadcast. This page documents the OpenSend-owned API contract for PATCH /broadcasts/{id}.
 - [Create Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/create-contact-property.md): Create a custom contact property definition.
 - [Delete Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/delete-contact-property.md): Delete a custom contact property definition.
 - [Get Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/get-contact-property.md): Retrieve one custom contact property definition.
 - [List Contact Properties](https://opensend.namuh.co/docs/api-reference/contact-properties/list-contact-properties.md): List custom contact properties available for segmentation and personalization.
 - [Update Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/update-contact-property.md): Update display metadata for a custom contact property.
-- [Add Contact to Segment](https://opensend.namuh.co/docs/api-reference/contacts/add-contact-to-segment.md): Add a contact to a segment.
-- [Create Contact](https://opensend.namuh.co/docs/api-reference/contacts/create-contact.md): Create an audience contact.
-- [Delete Contact Segment](https://opensend.namuh.co/docs/api-reference/contacts/delete-contact-segment.md): Remove a contact from a segment.
-- [Delete Contact](https://opensend.namuh.co/docs/api-reference/contacts/delete-contact.md): Delete a contact.
-- [Retrieve Contact Topics](https://opensend.namuh.co/docs/api-reference/contacts/get-contact-topics.md): Get topic subscriptions for a contact.
-- [Retrieve Contact](https://opensend.namuh.co/docs/api-reference/contacts/get-contact.md): Retrieve a contact by id or email where supported.
-- [List Contact Segments](https://opensend.namuh.co/docs/api-reference/contacts/list-contact-segments.md): List segments for a contact.
-- [List Contacts](https://opensend.namuh.co/docs/api-reference/contacts/list-contacts.md): List contacts.
-- [Update Contact Topics](https://opensend.namuh.co/docs/api-reference/contacts/update-contact-topics.md): Update topic subscriptions for a contact.
-- [Update Contact](https://opensend.namuh.co/docs/api-reference/contacts/update-contact.md): Update contact fields.
+- [Add Contact to Segment](https://opensend.namuh.co/docs/api-reference/contacts/add-contact-to-segment.md): Add a contact to a segment. This page documents the OpenSend-owned API contract for POST /api/contacts/{id}/segments.
+- [Create Contact](https://opensend.namuh.co/docs/api-reference/contacts/create-contact.md): Create an audience contact. This page documents the OpenSend-owned API contract for POST /contacts.
+- [Delete Contact Segment](https://opensend.namuh.co/docs/api-reference/contacts/delete-contact-segment.md): Remove a contact from a segment. This page documents the OpenSend-owned API contract for DELETE /api/contacts/{id}/segments/{segmentid}.
+- [Delete Contact](https://opensend.namuh.co/docs/api-reference/contacts/delete-contact.md): Delete a contact. This page documents the OpenSend-owned API contract for DELETE /contacts/{contactid}.
+- [Retrieve Contact Topics](https://opensend.namuh.co/docs/api-reference/contacts/get-contact-topics.md): Get topic subscriptions for a contact. This page documents the OpenSend-owned API contract for GET /api/contacts/{id}/topics.
+- [Retrieve Contact](https://opensend.namuh.co/docs/api-reference/contacts/get-contact.md): Retrieve a contact by id or email where supported. This page documents the OpenSend-owned API contract for GET /contacts/{contactid}.
+- [List Contact Segments](https://opensend.namuh.co/docs/api-reference/contacts/list-contact-segments.md): List segments for a contact. This page documents the OpenSend-owned API contract for GET /api/contacts/{id}/segments.
+- [List Contacts](https://opensend.namuh.co/docs/api-reference/contacts/list-contacts.md): List contacts. This page documents the OpenSend-owned API contract for GET /contacts.
+- [Update Contact Topics](https://opensend.namuh.co/docs/api-reference/contacts/update-contact-topics.md): Update topic subscriptions for a contact. This page documents the OpenSend-owned API contract for PATCH /api/contacts/{id}/topics.
+- [Update Contact](https://opensend.namuh.co/docs/api-reference/contacts/update-contact.md): Update contact fields. This page documents the OpenSend-owned API contract for PATCH /contacts/{contactid}.
 - [Auto Configure Domain](https://opensend.namuh.co/docs/api-reference/domains/auto-configure-domain.md): Write DNS records through configured Cloudflare credentials.
 - [Create Domain](https://opensend.namuh.co/docs/api-reference/domains/create-domain.md): Create a sending domain and return the DNS records OpenSend expects operators to publish.
 - [Delete Domain](https://opensend.namuh.co/docs/api-reference/domains/delete-domain.md): Delete a domain from the authenticated tenant after any operator-side cleanup you require.
@@ -69,24 +69,24 @@
 - [Send Batch Emails](https://opensend.namuh.co/docs/api-reference/emails/send-batch-emails.md): Queue up to 100 emails in one request.
 - [Send Email](https://opensend.namuh.co/docs/api-reference/emails/send-email.md): Send one email through OpenSend.
 - [Update Scheduled Email](https://opensend.namuh.co/docs/api-reference/emails/update-email.md): Update a scheduled email before OpenSend sends it.
-- [List Events](https://opensend.namuh.co/docs/api-reference/events/list-events.md): List custom events.
-- [Send Custom Event](https://opensend.namuh.co/docs/api-reference/events/send.md): Send a custom event into OpenSend.
+- [List Events](https://opensend.namuh.co/docs/api-reference/events/list-events.md): List custom events. This page documents the OpenSend-owned API contract for GET /api/events.
+- [Send Custom Event](https://opensend.namuh.co/docs/api-reference/events/send.md): Send a custom event into OpenSend. This page documents the OpenSend-owned API contract for POST /api/events/send.
 - [List Logs](https://opensend.namuh.co/docs/api-reference/logs/list-logs.md): List API request logs for debugging delivery, auth, and integration behavior.
 - [Retrieve Log](https://opensend.namuh.co/docs/api-reference/logs/retrieve-log.md): Retrieve one API request log entry with request and response metadata.
-- [Create Segment](https://opensend.namuh.co/docs/api-reference/segments/create-segment.md): Create a segment.
-- [Delete Segment](https://opensend.namuh.co/docs/api-reference/segments/delete-segment.md): Delete a segment.
-- [Retrieve Segment](https://opensend.namuh.co/docs/api-reference/segments/get-segment.md): Retrieve a segment.
-- [List Segment Contacts](https://opensend.namuh.co/docs/api-reference/segments/list-segment-contacts.md): List contacts in a segment.
-- [List Segments](https://opensend.namuh.co/docs/api-reference/segments/list-segments.md): List segments.
-- [Delete Suppression](https://opensend.namuh.co/docs/api-reference/suppressions/delete-suppression.md): Remove a recipient from suppressions.
-- [List Suppressions](https://opensend.namuh.co/docs/api-reference/suppressions/list-suppressions.md): List suppressed recipients.
-- [Create Template](https://opensend.namuh.co/docs/api-reference/templates/create-template.md): Create a reusable template.
-- [Delete Template](https://opensend.namuh.co/docs/api-reference/templates/delete-template.md): Delete a template.
-- [Duplicate Template](https://opensend.namuh.co/docs/api-reference/templates/duplicate-template.md): Duplicate a template.
-- [Get Template](https://opensend.namuh.co/docs/api-reference/templates/get-template.md): Retrieve a template by id or alias.
-- [List Templates](https://opensend.namuh.co/docs/api-reference/templates/list-templates.md): List templates.
-- [Publish Template](https://opensend.namuh.co/docs/api-reference/templates/publish-template.md): Publish a draft template.
-- [Update Template](https://opensend.namuh.co/docs/api-reference/templates/update-template.md): Update a template.
+- [Create Segment](https://opensend.namuh.co/docs/api-reference/segments/create-segment.md): Create a segment. This page documents the OpenSend-owned API contract for POST /segments.
+- [Delete Segment](https://opensend.namuh.co/docs/api-reference/segments/delete-segment.md): Delete a segment. This page documents the OpenSend-owned API contract for DELETE /segments/{id}.
+- [Retrieve Segment](https://opensend.namuh.co/docs/api-reference/segments/get-segment.md): Retrieve a segment. This page documents the OpenSend-owned API contract for GET /segments/{id}.
+- [List Segment Contacts](https://opensend.namuh.co/docs/api-reference/segments/list-segment-contacts.md): List contacts in a segment. This page documents the OpenSend-owned API contract for GET /segments/{id}/contacts.
+- [List Segments](https://opensend.namuh.co/docs/api-reference/segments/list-segments.md): List segments. This page documents the OpenSend-owned API contract for GET /segments.
+- [Delete Suppression](https://opensend.namuh.co/docs/api-reference/suppressions/delete-suppression.md): Remove a recipient from suppressions. This page documents the OpenSend-owned API contract for DELETE /api/suppressions/{email}.
+- [List Suppressions](https://opensend.namuh.co/docs/api-reference/suppressions/list-suppressions.md): List suppressed recipients. This page documents the OpenSend-owned API contract for GET /api/suppressions.
+- [Create Template](https://opensend.namuh.co/docs/api-reference/templates/create-template.md): Create a reusable template. This page documents the OpenSend-owned API contract for POST /templates.
+- [Delete Template](https://opensend.namuh.co/docs/api-reference/templates/delete-template.md): Delete a template. This page documents the OpenSend-owned API contract for DELETE /templates/{id}.
+- [Duplicate Template](https://opensend.namuh.co/docs/api-reference/templates/duplicate-template.md): Duplicate a template. This page documents the OpenSend-owned API contract for POST /templates/{id}/duplicate.
+- [Get Template](https://opensend.namuh.co/docs/api-reference/templates/get-template.md): Retrieve a template by id or alias. This page documents the OpenSend-owned API contract for GET /templates/{id}.
+- [List Templates](https://opensend.namuh.co/docs/api-reference/templates/list-templates.md): List templates. This page documents the OpenSend-owned API contract for GET /templates.
+- [Publish Template](https://opensend.namuh.co/docs/api-reference/templates/publish-template.md): Publish a draft template. This page documents the OpenSend-owned API contract for POST /templates/{id}/publish.
+- [Update Template](https://opensend.namuh.co/docs/api-reference/templates/update-template.md): Update a template. This page documents the OpenSend-owned API contract for PATCH /templates/{id}.
 - [Create Topic](https://opensend.namuh.co/docs/api-reference/topics/create-topic.md): Create a subscription topic for audience preference management.
 - [Delete Topic](https://opensend.namuh.co/docs/api-reference/topics/delete-topic.md): Delete a subscription topic.
 - [Get Topic](https://opensend.namuh.co/docs/api-reference/topics/get-topic.md): Retrieve one subscription topic by ID.

--- a/tools/check-docs-quality.mjs
+++ b/tools/check-docs-quality.mjs
@@ -6,10 +6,17 @@ const docsRoot = path.join(process.cwd(), "public", "docs");
 const competitorPatterns = [/resend\.com\/docs/i, /Resend docs/i];
 const minApiReferenceWords = 30;
 const minimumDepthPrefixes = [
+  "api-reference/api-keys/",
+  "api-reference/broadcasts/",
   "api-reference/contact-properties/",
+  "api-reference/contacts/",
   "api-reference/domains/",
   "api-reference/emails/",
+  "api-reference/events/",
   "api-reference/logs/",
+  "api-reference/segments/",
+  "api-reference/suppressions/",
+  "api-reference/templates/",
   "api-reference/topics/",
   "api-reference/webhooks/",
 ];


### PR DESCRIPTION
## Summary
- Expand first-party API reference pages for broadcasts, templates, contacts, segments, suppressions, events, API keys, and pagination.
- Add usage guidance, authentication notes, examples, errors, and self-hosting notes without copying competitor docs or implying unsupported behavior.
- Extend `docs:check` to cover the newly expanded API reference groups and regenerate `public/docs/llms.txt`.

## Validation
- `bun run docs:generate`
- `bun run docs:check`
- `make check`
- `bunx vitest run tests/docs-content.test.ts`
- `git diff --check`
- push guardrails: full-project typecheck + changed-file Biome
