### PR TITLE
docs(webhooks): document emitted event catalog

### DIFF
--- a/agent_docs/learnings/active/2026-05-28-g004-webhook-signing-contract.md
+++ b/agent_docs/learnings/active/2026-05-28-g004-webhook-signing-contract.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-28
+issue: g004-webhook-event-catalog
+type: decision
+promoted_to: null
+---
+
+# Webhook docs must use actual Svix-compatible headers
+
+OpenSend dispatches webhook deliveries with `svix-id`, `svix-timestamp`, and `svix-signature`, signed over `<svix-id>.<svix-timestamp>.<raw-body>` with HMAC-SHA256. Do not document generic `webhook-id` style headers.
+
+The supported subscription catalog comes from `packages/core/src/webhook-events.ts`. `email.received` is a reserved inbound contract only and is not currently accepted by webhook create/update validation unless the product implementation changes.

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -132,24 +132,25 @@
 - [Template Variables](https://opensend.namuh.co/docs/dashboard/templates/template-variables.md): Use variables in templates.
 - [Template Version History](https://opensend.namuh.co/docs/dashboard/templates/version-history.md): Template lifecycle guidance.
 - [Topics](https://opensend.namuh.co/docs/dashboard/topics/introduction.md): Give recipients subscription preferences.
-- [Managing Webhooks](https://opensend.namuh.co/docs/webhooks/introduction.md): Receive real-time event notifications.
-- [Event Types](https://opensend.namuh.co/docs/webhooks/event-types.md): Supported webhook event names.
-- [Verify Webhook Requests](https://opensend.namuh.co/docs/webhooks/verify-webhooks-requests.md): Verify webhook signatures before trusting events.
-- [contact.created](https://opensend.namuh.co/docs/webhooks/contacts/created.md): Webhook event emitted when a contact is created.
-- [contact.deleted](https://opensend.namuh.co/docs/webhooks/contacts/deleted.md): Webhook event emitted when a contact is deleted.
-- [contact.updated](https://opensend.namuh.co/docs/webhooks/contacts/updated.md): Webhook event emitted when a contact is updated.
-- [domain.created](https://opensend.namuh.co/docs/webhooks/domains/created.md): Webhook event emitted when a domain is created.
-- [domain.deleted](https://opensend.namuh.co/docs/webhooks/domains/deleted.md): Webhook event emitted when a domain is deleted.
-- [domain.updated](https://opensend.namuh.co/docs/webhooks/domains/updated.md): Webhook event emitted when a domain changes.
-- [email.bounced](https://opensend.namuh.co/docs/webhooks/emails/bounced.md): Webhook event emitted when an email bounces.
-- [email.clicked](https://opensend.namuh.co/docs/webhooks/emails/clicked.md): Webhook event emitted when tracking records a click.
-- [email.complained](https://opensend.namuh.co/docs/webhooks/emails/complained.md): Webhook event emitted when a recipient reports spam.
-- [email.delivered](https://opensend.namuh.co/docs/webhooks/emails/delivered.md): Webhook event emitted when delivery is confirmed.
-- [email.failed](https://opensend.namuh.co/docs/webhooks/emails/failed.md): Webhook event emitted when sending fails.
-- [email.opened](https://opensend.namuh.co/docs/webhooks/emails/opened.md): Webhook event emitted when tracking records an open.
+- [Managing Webhooks](https://opensend.namuh.co/docs/webhooks/introduction.md): Use OpenSend webhooks to receive signed lifecycle events from your own OpenSend deployment.
+- [Event Types](https://opensend.namuh.co/docs/webhooks/event-types.md): OpenSend accepts the following webhook subscription event types.
+- [Verify Webhook Requests](https://opensend.namuh.co/docs/webhooks/verify-webhooks-requests.md): Verify every OpenSend webhook request before trusting the payload.
+- [contact.created](https://opensend.namuh.co/docs/webhooks/contacts/created.md): Contact was created.
+- [contact.deleted](https://opensend.namuh.co/docs/webhooks/contacts/deleted.md): Contact was deleted.
+- [contact.updated](https://opensend.namuh.co/docs/webhooks/contacts/updated.md): Contact changed.
+- [domain.created](https://opensend.namuh.co/docs/webhooks/domains/created.md): Domain was created.
+- [domain.deleted](https://opensend.namuh.co/docs/webhooks/domains/deleted.md): Domain was deleted.
+- [domain.updated](https://opensend.namuh.co/docs/webhooks/domains/updated.md): Domain changed or verification status changed.
+- [email.bounced](https://opensend.namuh.co/docs/webhooks/emails/bounced.md): Provider bounce notification received.
+- [email.clicked](https://opensend.namuh.co/docs/webhooks/emails/clicked.md): Tracked link redirect was requested.
+- [email.complained](https://opensend.namuh.co/docs/webhooks/emails/complained.md): Provider complaint notification received.
+- [email.delivered](https://opensend.namuh.co/docs/webhooks/emails/delivered.md): Provider delivery notification received.
+- [email.deliverydelayed](https://opensend.namuh.co/docs/webhooks/emails/delivery-delayed.md): Provider delivery delay notification received.
+- [email.failed](https://opensend.namuh.co/docs/webhooks/emails/failed.md): Provider reject, rendering failure, or retry exhaustion recorded.
+- [email.opened](https://opensend.namuh.co/docs/webhooks/emails/opened.md): Open tracking pixel was requested.
 - [email.received](https://opensend.namuh.co/docs/webhooks/emails/received.md): Inbound receiving is currently a deployment integration point: the repository includes read APIs and storage schema for received email rows, but it does not include a complete SES inbound MIME parser that emits this event automatically. If you build that parser for your self-hosted deployment, use the payload shape below so downstream agents and webhook consumers can rely on a stable contract.
-- [email.sent](https://opensend.namuh.co/docs/webhooks/emails/sent.md): Webhook event emitted when an email is sent.
-- [Retries and Replays](https://opensend.namuh.co/docs/webhooks/retries-and-replays.md): Handle webhook delivery failures.
+- [email.sent](https://opensend.namuh.co/docs/webhooks/emails/sent.md): Provider send notification received.
+- [Retries and Replays](https://opensend.namuh.co/docs/webhooks/retries-and-replays.md): OpenSend records webhook delivery attempts and retries failed deliveries.
 - [Cloudflare](https://opensend.namuh.co/docs/knowledge-base/cloudflare.md): Verify and configure domains with Cloudflare.
 - [GoDaddy](https://opensend.namuh.co/docs/knowledge-base/godaddy.md): Verify domains hosted on GoDaddy.
 - [How to Handle API Keys](https://opensend.namuh.co/docs/knowledge-base/how-to-handle-api-keys.md): API key storage guidance.

--- a/public/docs/webhooks/contacts/created.md
+++ b/public/docs/webhooks/contacts/created.md
@@ -1,5 +1,26 @@
 # contact.created
 
-Webhook event emitted when a contact is created.
+Contact was created.
 
-Contact events help sync audience records to external systems.
+## When it is emitted
+
+The contact create API emits `contact.created` after persistence succeeds.
+
+## Payload
+
+OpenSend sends this event in the standard webhook envelope:
+
+```json
+{
+  "id": "whd_delivery-id_1",
+  "type": "contact.created",
+  "created_at": "2026-05-10T00:00:00.000Z",
+  "data": {}
+}
+```
+
+The payload is the contact webhook DTO from the contact service, including the contact ID, email, profile fields, and preference data available to that service.
+
+## Handling guidance
+
+Verify `svix-id`, `svix-timestamp`, and `svix-signature` before processing. Store idempotency by delivery ID or by the domain/email/contact ID in `data` so retries and replays do not duplicate downstream side effects.

--- a/public/docs/webhooks/contacts/updated.md
+++ b/public/docs/webhooks/contacts/updated.md
@@ -1,5 +1,26 @@
 # contact.updated
 
-Webhook event emitted when a contact is updated.
+Contact changed.
 
-Use this event to sync preference or profile changes.
+## When it is emitted
+
+The contact update API emits `contact.updated` only when one or more fields changed.
+
+## Payload
+
+OpenSend sends this event in the standard webhook envelope:
+
+```json
+{
+  "id": "whd_delivery-id_1",
+  "type": "contact.updated",
+  "created_at": "2026-05-10T00:00:00.000Z",
+  "data": {}
+}
+```
+
+Payload includes `id`, `changed_fields`, and a `contact` object with the updated contact webhook DTO.
+
+## Handling guidance
+
+Verify `svix-id`, `svix-timestamp`, and `svix-signature` before processing. Store idempotency by delivery ID or by the domain/email/contact ID in `data` so retries and replays do not duplicate downstream side effects.

--- a/public/docs/webhooks/domains/created.md
+++ b/public/docs/webhooks/domains/created.md
@@ -1,5 +1,26 @@
 # domain.created
 
-Webhook event emitted when a domain is created.
+Domain was created.
 
-Domain events help operator workflows track setup.
+## When it is emitted
+
+The domain create API emits `domain.created` after persistence succeeds.
+
+## Payload
+
+OpenSend sends this event in the standard webhook envelope:
+
+```json
+{
+  "id": "whd_delivery-id_1",
+  "type": "domain.created",
+  "created_at": "2026-05-10T00:00:00.000Z",
+  "data": {}
+}
+```
+
+Payload includes domain identity fields such as `id`, `name`, `status`, `region`, DNS records, capabilities, and creation timestamp when available.
+
+## Handling guidance
+
+Verify `svix-id`, `svix-timestamp`, and `svix-signature` before processing. Store idempotency by delivery ID or by the domain/email/contact ID in `data` so retries and replays do not duplicate downstream side effects.

--- a/public/docs/webhooks/domains/deleted.md
+++ b/public/docs/webhooks/domains/deleted.md
@@ -1,5 +1,26 @@
 # domain.deleted
 
-Webhook event emitted when a domain is deleted.
+Domain was deleted.
 
-Use this event to clean up external DNS/ops records.
+## When it is emitted
+
+The domain delete API emits `domain.deleted` after OpenSend removes the domain row and attempts provider cleanup.
+
+## Payload
+
+OpenSend sends this event in the standard webhook envelope:
+
+```json
+{
+  "id": "whd_delivery-id_1",
+  "type": "domain.deleted",
+  "created_at": "2026-05-10T00:00:00.000Z",
+  "data": {}
+}
+```
+
+Payload includes the deleted domain identity and operational metadata returned by the domain detail service.
+
+## Handling guidance
+
+Verify `svix-id`, `svix-timestamp`, and `svix-signature` before processing. Store idempotency by delivery ID or by the domain/email/contact ID in `data` so retries and replays do not duplicate downstream side effects.

--- a/public/docs/webhooks/domains/updated.md
+++ b/public/docs/webhooks/domains/updated.md
@@ -1,5 +1,26 @@
 # domain.updated
 
-Webhook event emitted when a domain changes.
+Domain changed or verification status changed.
 
-Use this event to react to verification-state changes.
+## When it is emitted
+
+Domain update, verify, and background verification reconciliation paths can emit `domain.updated`.
+
+## Payload
+
+OpenSend sends this event in the standard webhook envelope:
+
+```json
+{
+  "id": "whd_delivery-id_1",
+  "type": "domain.updated",
+  "created_at": "2026-05-10T00:00:00.000Z",
+  "data": {}
+}
+```
+
+Payload includes domain identity fields and may include `previous_status` for verification reconciliation changes.
+
+## Handling guidance
+
+Verify `svix-id`, `svix-timestamp`, and `svix-signature` before processing. Store idempotency by delivery ID or by the domain/email/contact ID in `data` so retries and replays do not duplicate downstream side effects.

--- a/public/docs/webhooks/emails/bounced.md
+++ b/public/docs/webhooks/emails/bounced.md
@@ -1,5 +1,26 @@
 # email.bounced
 
-Webhook event emitted when an email bounces.
+Provider bounce notification received.
 
-Use this event to update suppression and support workflows.
+## When it is emitted
+
+SES/SNS lifecycle ingestion normalizes provider `Bounce` events to `email.bounced`.
+
+## Payload
+
+OpenSend sends this event in the standard webhook envelope:
+
+```json
+{
+  "id": "whd_delivery-id_1",
+  "type": "email.bounced",
+  "created_at": "2026-05-10T00:00:00.000Z",
+  "data": {}
+}
+```
+
+Use this event to update support views and suppress bounced recipients. The ingester can refresh suppressions from bounce recipients.
+
+## Handling guidance
+
+Verify `svix-id`, `svix-timestamp`, and `svix-signature` before processing. Store idempotency by delivery ID or by the domain/email/contact ID in `data` so retries and replays do not duplicate downstream side effects.

--- a/public/docs/webhooks/emails/clicked.md
+++ b/public/docs/webhooks/emails/clicked.md
@@ -1,5 +1,26 @@
 # email.clicked
 
-Webhook event emitted when tracking records a click.
+Tracked link redirect was requested.
 
-Click tracking depends on rewritten tracked links.
+## When it is emitted
+
+The click tracking route emits `email.clicked` after validating an OpenSend tracking token and target URL.
+
+## Payload
+
+OpenSend sends this event in the standard webhook envelope:
+
+```json
+{
+  "id": "whd_delivery-id_1",
+  "type": "email.clicked",
+  "created_at": "2026-05-10T00:00:00.000Z",
+  "data": {}
+}
+```
+
+Click tracking depends on rewritten links. Payload fields include `email_id`, `domain_id`, `recipient`, `url`, and request metadata.
+
+## Handling guidance
+
+Verify `svix-id`, `svix-timestamp`, and `svix-signature` before processing. Store idempotency by delivery ID or by the domain/email/contact ID in `data` so retries and replays do not duplicate downstream side effects.

--- a/public/docs/webhooks/emails/complained.md
+++ b/public/docs/webhooks/emails/complained.md
@@ -1,5 +1,26 @@
 # email.complained
 
-Webhook event emitted when a recipient reports spam.
+Provider complaint notification received.
 
-Use this event to stop further marketing sends to the recipient.
+## When it is emitted
+
+SES/SNS lifecycle ingestion normalizes provider `Complaint` events to `email.complained`.
+
+## Payload
+
+OpenSend sends this event in the standard webhook envelope:
+
+```json
+{
+  "id": "whd_delivery-id_1",
+  "type": "email.complained",
+  "created_at": "2026-05-10T00:00:00.000Z",
+  "data": {}
+}
+```
+
+Use this event to stop marketing sends and investigate complaint sources. The ingester can refresh suppressions from complaint recipients.
+
+## Handling guidance
+
+Verify `svix-id`, `svix-timestamp`, and `svix-signature` before processing. Store idempotency by delivery ID or by the domain/email/contact ID in `data` so retries and replays do not duplicate downstream side effects.

--- a/public/docs/webhooks/emails/delivered.md
+++ b/public/docs/webhooks/emails/delivered.md
@@ -1,5 +1,26 @@
 # email.delivered
 
-Webhook event emitted when delivery is confirmed.
+Provider delivery notification received.
 
-Use this event for delivered-state workflows.
+## When it is emitted
+
+SES/SNS lifecycle ingestion normalizes provider `Delivery` events to `email.delivered`.
+
+## Payload
+
+OpenSend sends this event in the standard webhook envelope:
+
+```json
+{
+  "id": "whd_delivery-id_1",
+  "type": "email.delivered",
+  "created_at": "2026-05-10T00:00:00.000Z",
+  "data": {}
+}
+```
+
+Use this event to move downstream workflows from sent to delivered. The payload is the provider delivery payload.
+
+## Handling guidance
+
+Verify `svix-id`, `svix-timestamp`, and `svix-signature` before processing. Store idempotency by delivery ID or by the domain/email/contact ID in `data` so retries and replays do not duplicate downstream side effects.

--- a/public/docs/webhooks/emails/delivery-delayed.md
+++ b/public/docs/webhooks/emails/delivery-delayed.md
@@ -1,10 +1,10 @@
-# contact.deleted
+# email.delivery_delayed
 
-Contact was deleted.
+Provider delivery delay notification received.
 
 ## When it is emitted
 
-The contact delete API emits `contact.deleted` after deletion succeeds.
+SES/SNS lifecycle ingestion normalizes provider `DeliveryDelay` events to `email.delivery_delayed`.
 
 ## Payload
 
@@ -13,13 +13,13 @@ OpenSend sends this event in the standard webhook envelope:
 ```json
 {
   "id": "whd_delivery-id_1",
-  "type": "contact.deleted",
+  "type": "email.delivery_delayed",
   "created_at": "2026-05-10T00:00:00.000Z",
   "data": {}
 }
 ```
 
-Payload includes the deleted contact `id` and `email`.
+Use this event for delayed-delivery visibility. It is not a final failure; wait for delivered, bounced, complained, or failed follow-up events.
 
 ## Handling guidance
 

--- a/public/docs/webhooks/emails/failed.md
+++ b/public/docs/webhooks/emails/failed.md
@@ -1,5 +1,26 @@
 # email.failed
 
-Webhook event emitted when sending fails.
+Provider reject, rendering failure, or retry exhaustion recorded.
 
-Use this event to alert operators or retry through your own workflow.
+## When it is emitted
+
+SES/SNS `Reject` and `RenderingFailure` events normalize to `email.failed`; the queue worker also records failure when provider retries are exhausted.
+
+## Payload
+
+OpenSend sends this event in the standard webhook envelope:
+
+```json
+{
+  "id": "whd_delivery-id_1",
+  "type": "email.failed",
+  "created_at": "2026-05-10T00:00:00.000Z",
+  "data": {}
+}
+```
+
+Use this event to alert operators, update support timelines, or dead-letter application workflows.
+
+## Handling guidance
+
+Verify `svix-id`, `svix-timestamp`, and `svix-signature` before processing. Store idempotency by delivery ID or by the domain/email/contact ID in `data` so retries and replays do not duplicate downstream side effects.

--- a/public/docs/webhooks/emails/opened.md
+++ b/public/docs/webhooks/emails/opened.md
@@ -1,5 +1,26 @@
 # email.opened
 
-Webhook event emitted when tracking records an open.
+Open tracking pixel was requested.
 
-Open tracking depends on recipient clients loading the tracking pixel.
+## When it is emitted
+
+The tracking pixel route emits `email.opened` after validating an OpenSend tracking token and tenant context.
+
+## Payload
+
+OpenSend sends this event in the standard webhook envelope:
+
+```json
+{
+  "id": "whd_delivery-id_1",
+  "type": "email.opened",
+  "created_at": "2026-05-10T00:00:00.000Z",
+  "data": {}
+}
+```
+
+Open tracking depends on image loading and can be blocked or prefetched by clients. Payload fields include `email_id`, `domain_id`, `recipient`, and request metadata.
+
+## Handling guidance
+
+Verify `svix-id`, `svix-timestamp`, and `svix-signature` before processing. Store idempotency by delivery ID or by the domain/email/contact ID in `data` so retries and replays do not duplicate downstream side effects.

--- a/public/docs/webhooks/emails/received.md
+++ b/public/docs/webhooks/emails/received.md
@@ -32,7 +32,7 @@ Keep the webhook payload metadata-only. Retrieve bodies with `GET /emails/receiv
 
 ## Delivery and verification
 
-OpenSend webhook deliveries use the same signing and retry guidance as other events. Verify the `webhook-id`, `webhook-timestamp`, and `webhook-signature` headers before acting on the inbound email. See [Verify webhook requests](../verify-webhooks-requests.md) and [Retries and replays](../retries-and-replays.md).
+OpenSend webhook deliveries use the same signing and retry guidance as other events. Verify the `svix-id`, `svix-timestamp`, and `svix-signature` headers before acting on the inbound email. See [Verify webhook requests](../verify-webhooks-requests.md) and [Retries and replays](../retries-and-replays.md).
 
 ## Operator status
 

--- a/public/docs/webhooks/emails/sent.md
+++ b/public/docs/webhooks/emails/sent.md
@@ -1,5 +1,26 @@
 # email.sent
 
-Webhook event emitted when an email is sent.
+Provider send notification received.
 
-Use this event to react after provider handoff.
+## When it is emitted
+
+SES/SNS lifecycle ingestion normalizes provider `Send` events to `email.sent`.
+
+## Payload
+
+OpenSend sends this event in the standard webhook envelope:
+
+```json
+{
+  "id": "whd_delivery-id_1",
+  "type": "email.sent",
+  "created_at": "2026-05-10T00:00:00.000Z",
+  "data": {}
+}
+```
+
+Use this event to mark messages as accepted by the sending provider. The payload is the provider send payload stored by the ingester.
+
+## Handling guidance
+
+Verify `svix-id`, `svix-timestamp`, and `svix-signature` before processing. Store idempotency by delivery ID or by the domain/email/contact ID in `data` so retries and replays do not duplicate downstream side effects.

--- a/public/docs/webhooks/event-types.md
+++ b/public/docs/webhooks/event-types.md
@@ -1,5 +1,39 @@
 # Event Types
 
-Supported webhook event names.
+OpenSend accepts the following webhook subscription event types.
 
-Events include email lifecycle, contact lifecycle, and domain lifecycle events where enabled.
+| Event | Emitted by | Notes |
+| --- | --- | --- |
+| `email.sent` | SES/SNS send lifecycle ingestion | Provider accepted or sent notification. |
+| `email.delivered` | SES/SNS delivery lifecycle ingestion | Final delivery confirmation from the provider. |
+| `email.bounced` | SES/SNS bounce lifecycle ingestion | Can also refresh suppressions for bounced recipients. |
+| `email.complained` | SES/SNS complaint lifecycle ingestion | Can also refresh suppressions for complained recipients. |
+| `email.delivery_delayed` | SES/SNS delivery-delay lifecycle ingestion | Indicates provider-side delay, not final failure. |
+| `email.opened` | Open tracking pixel route | Requires tracking token and image load. |
+| `email.clicked` | Click tracking redirect route | Requires rewritten tracked links. |
+| `email.failed` | SES reject/rendering failure or provider retry exhaustion | Use for operator alerts and support triage. |
+| `contact.created` | Contact create API | Emitted after contact persistence succeeds. |
+| `contact.updated` | Contact update API | Emitted only when at least one field changes. |
+| `contact.deleted` | Contact delete API | Emitted after contact deletion succeeds. |
+| `domain.created` | Domain create API | Emitted after domain persistence succeeds. |
+| `domain.updated` | Domain update, verify, or reconcile paths | Includes verification-state changes when available. |
+| `domain.deleted` | Domain delete API | Emitted after domain deletion succeeds. |
+
+## Reserved but not currently emitted by default
+
+`email.received` is documented as an inbound receiving contract for deployments that add their own MIME ingestion worker. It is not part of the default webhook subscription validation list in this repository today.
+
+## Payload shape
+
+All deliveries use the same outer envelope:
+
+```json
+{
+  "id": "whd_delivery-id_1",
+  "type": "contact.created",
+  "created_at": "2026-05-10T00:00:00.000Z",
+  "data": {}
+}
+```
+
+The `data` shape depends on the event source. Email lifecycle events usually carry provider or tracking payloads. Contact and domain events carry OpenSend-owned DTOs described in their event pages.

--- a/public/docs/webhooks/introduction.md
+++ b/public/docs/webhooks/introduction.md
@@ -1,5 +1,42 @@
 # Managing Webhooks
 
-Receive real-time event notifications.
+Use OpenSend webhooks to receive signed lifecycle events from your own OpenSend deployment.
 
-Webhooks deliver signed lifecycle events to your application.
+Webhooks are tenant-scoped. A webhook endpoint subscribes to one or more supported event types and receives deliveries only for events created by the same OpenSend user or API-key owner.
+
+## Delivery envelope
+
+OpenSend sends each delivery as an HTTP `POST` with JSON:
+
+```json
+{
+  "id": "whd_6f6f8b7e_1",
+  "type": "email.delivered",
+  "created_at": "2026-05-10T00:00:00.000Z",
+  "data": {
+    "email_id": "6f6f8b7e-534f-4b62-b0c1-64b79e45f3c2"
+  }
+}
+```
+
+The `id` is delivery-attempt scoped, `type` is the webhook event type, `created_at` is the dispatch attempt time, and `data` is the stored event payload.
+
+## Headers
+
+OpenSend signs deliveries with Svix-compatible header names:
+
+| Header | Description |
+| --- | --- |
+| `svix-id` | Delivery attempt identifier. |
+| `svix-timestamp` | Unix timestamp in seconds used in the signature input. |
+| `svix-signature` | `v1,<base64-hmac-sha256>` signature. |
+
+## Supported events
+
+See [Event Types](./event-types.md) for the exact event catalog. The catalog is generated from the event types accepted by the OpenSend API and dispatcher; unsupported events are rejected at webhook create/update time or marked terminal if an old stored event cannot be mapped.
+
+## Operational notes
+
+- Endpoint URLs are validated for outbound safety before create/update and again at dispatch time.
+- OpenSend stores delivery attempts with status, response status code, response body snippet, next retry time, and timestamps.
+- Replays create a new pending delivery for the original event and dispatch it through the same signing path.

--- a/public/docs/webhooks/retries-and-replays.md
+++ b/public/docs/webhooks/retries-and-replays.md
@@ -1,5 +1,36 @@
 # Retries and Replays
 
-Handle webhook delivery failures.
+OpenSend records webhook delivery attempts and retries failed deliveries.
 
-OpenSend records webhook deliveries and supports replay through `POST /api/webhooks/{id}/deliveries/{deliveryId}/replay` where enabled.
+A delivery succeeds when the endpoint returns any `2xx` response. Non-2xx responses, timeouts, network errors, unsafe URL rejections, disabled endpoints, or unsupported event types are recorded on the delivery row.
+
+## Retry schedule
+
+The dispatcher uses these retry delays after failed attempts:
+
+| Failed attempt | Next retry delay |
+| --- | --- |
+| 1 | 5 seconds |
+| 2 | 5 minutes |
+| 3 | 30 minutes |
+| 4 | 2 hours |
+| 5 | 5 hours |
+| 6 | 10 hours |
+| 7 | 10 hours |
+
+The eighth failed attempt is marked `dead_letter`. The dispatch timeout is 5 seconds.
+
+## Delivery fields
+
+Delivery records expose:
+
+- `status`: `pending`, `success`, `failed`, or `dead_letter`.
+- `attempt`: number of dispatch attempts already made.
+- `status_code`: HTTP status code from the last response, when available.
+- `response_body`: first 1,000 characters of the response body or error message.
+- `attempted_at`: timestamp of the last dispatch attempt.
+- `next_retry_at`: when the delivery is eligible for another scan.
+
+## Replays
+
+Use `POST /api/webhooks/{id}/deliveries/{deliveryId}/replay` to create a new delivery for the original event. Replays require a tenant-scoped API key or dashboard session, the endpoint must still be active, and the original delivery must belong to that endpoint.

--- a/public/docs/webhooks/verify-webhooks-requests.md
+++ b/public/docs/webhooks/verify-webhooks-requests.md
@@ -1,5 +1,63 @@
 # Verify Webhook Requests
 
-Verify webhook signatures before trusting events.
+Verify every OpenSend webhook request before trusting the payload.
 
-OpenSend signs webhook deliveries. Verify signatures with the configured webhook secret and reject invalid or replayed requests.
+OpenSend signs the exact JSON request body with the webhook signing secret returned when the endpoint is created. The secret is shown once; store it outside source control.
+
+## Headers
+
+| Header | Description |
+| --- | --- |
+| `svix-id` | Delivery attempt ID. |
+| `svix-timestamp` | Unix timestamp in seconds. Reject stale timestamps to reduce replay risk. |
+| `svix-signature` | One or more signatures in `v1,<signature>` form. |
+
+## Signature input
+
+OpenSend signs this string:
+
+```text
+<svix-id>.<svix-timestamp>.<raw-request-body>
+```
+
+The signature is HMAC-SHA256 with the webhook secret after removing the optional `whsec_` prefix, encoded as base64, then prefixed with `v1,`.
+
+## TypeScript example
+
+```ts
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+function verifyOpenSendWebhook(input: {
+  secret: string;
+  id: string;
+  timestamp: string;
+  body: string;
+  signatureHeader: string;
+}) {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (Math.abs(nowSeconds - Number(input.timestamp)) > 5 * 60) {
+    return false;
+  }
+
+  const secret = input.secret.replace(/^whsec_/, "");
+  const expected = createHmac("sha256", secret)
+    .update(`${input.id}.${input.timestamp}.${input.body}`)
+    .digest("base64");
+
+  return input.signatureHeader
+    .split(" ")
+    .flatMap((part) => part.split(","))
+    .some((part, index, parts) => {
+      if (part !== "v1") return false;
+      const candidate = parts[index + 1];
+      if (!candidate) return false;
+      const a = Buffer.from(candidate);
+      const b = Buffer.from(expected);
+      return a.length === b.length && timingSafeEqual(a, b);
+    });
+}
+```
+
+## Failure handling
+
+Return a non-2xx status when verification fails. OpenSend treats non-2xx responses as failed attempts and schedules retries until the delivery reaches the configured retry limit.

--- a/tests/docs-content.test.ts
+++ b/tests/docs-content.test.ts
@@ -137,3 +137,38 @@ function listMarkdownFiles(dir: string): string[] {
     return [];
   });
 }
+
+describe("webhook event docs", () => {
+  it("documents every supported webhook subscription event in public docs", async () => {
+    const { SUPPORTED_WEBHOOK_EVENT_TYPES } = await import(
+      "@opensend/core/src/webhook-events"
+    );
+    const docsRoot = path.join(process.cwd(), "public/docs/webhooks");
+
+    const eventDocPath = (eventType: string) => {
+      const [resource, action] = eventType.split(".") as [string, string];
+      const folder = `${resource}s`;
+      const file = `${action.replaceAll("_", "-")}.md`;
+      return path.join(docsRoot, folder, file);
+    };
+
+    for (const eventType of SUPPORTED_WEBHOOK_EVENT_TYPES) {
+      const markdown = readFileSync(eventDocPath(eventType), "utf8");
+      expect(markdown).toContain(`# ${eventType}`);
+      expect(markdown).toContain("## When it is emitted");
+      expect(markdown).toContain("svix-signature");
+    }
+
+    const eventTypes = readFileSync(
+      path.join(docsRoot, "event-types.md"),
+      "utf8",
+    );
+    for (const eventType of SUPPORTED_WEBHOOK_EVENT_TYPES) {
+      expect(eventTypes).toContain(`\`${eventType}\``);
+    }
+    expect(eventTypes).toContain("email.received");
+    expect(eventTypes).toContain(
+      "not part of the default webhook subscription",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- expands first-party webhook docs for delivery envelope, Svix-compatible signature headers, retries, replays, and event catalog
- adds `email.delivery_delayed` webhook event page and deepens all supported event pages with emitted-by/source guidance
- adds a docs-content test that every supported event in `SUPPORTED_WEBHOOK_EVENT_TYPES` has a public docs page

## Validation
- `bun run docs:generate`
- `bun run docs:check`
- `make check`
- `make test`
- `bunx vitest run tests/docs-content.test.ts tests/webhook-dispatcher.test.ts tests/webhook-lifecycle-queue.test.ts tests/webhook-service.test.ts`
- `git diff --check`
