### PR TITLE
Add first PHP SDK send-email slice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,26 @@ jobs:
       - name: bunx vitest run
         run: bunx vitest run
 
+
+  php-sdk:
+    name: PHP SDK tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          coverage: none
+
+      - name: Install PHP SDK dependencies
+        working-directory: packages/php-sdk
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHP SDK tests
+        working-directory: packages/php-sdk
+        run: composer test
+
   onboarding:
     name: Onboarding acceptance
     runs-on: ubuntu-latest

--- a/agent_docs/learnings/active/2026-05-28-issue-561-php-sdk-test-harness.md
+++ b/agent_docs/learnings/active/2026-05-28-issue-561-php-sdk-test-harness.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-28
+issue: "#561"
+type: pattern
+promoted_to: null
+---
+
+## Validate SDK request plumbing against a local HTTP fixture server
+
+**What:** The PHP SDK tests start PHP's built-in HTTP server with a tiny router fixture, record real HTTP requests, and serve configurable JSON/error responses.
+
+**Why:** SDK request construction, idempotency headers, response parsing, and error-envelope mapping can be verified without real OpenSend credentials while still exercising the actual stream HTTP transport instead of a mocked transport.
+
+**Pattern:** Keep Composer `vendor/`, `.phpunit.cache/`, and generated `composer.lock` ignored/removed before repo-wide Biome checks because the monorepo lint command scans files on disk, not just tracked files.

--- a/packages/php-sdk/.gitattributes
+++ b/packages/php-sdk/.gitattributes
@@ -1,0 +1,3 @@
+/tests export-ignore
+/examples export-ignore
+/phpunit.xml export-ignore

--- a/packages/php-sdk/.gitignore
+++ b/packages/php-sdk/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/.phpunit.cache/
+/composer.lock

--- a/packages/php-sdk/README.md
+++ b/packages/php-sdk/README.md
@@ -1,0 +1,80 @@
+# opensend-php
+
+First-party PHP SDK for OpenSend. This initial v1 slice focuses on the core send-email path and shared HTTP/error plumbing that future resource clients can reuse.
+
+## Install
+
+Install from this repository until Packagist publishing is enabled:
+
+```bash
+composer config repositories.opensend path ../../packages/php-sdk
+composer require opensend/opensend-php:dev-main
+```
+
+For local development inside this repo:
+
+```bash
+cd packages/php-sdk
+composer install
+composer test
+```
+
+## Send an email
+
+```php
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+use OpenSend\Client;
+use OpenSend\Errors\ApiException;
+use OpenSend\ValueObjects\RequestOptions;
+use OpenSend\ValueObjects\SendEmailRequest;
+
+$client = new Client(
+    apiKey: getenv('OPENSEND_API_KEY') ?: '',
+    baseUrl: getenv('OPENSEND_BASE_URL') ?: null,
+);
+
+try {
+    $email = $client->emails->send(
+        new SendEmailRequest(
+            from: 'OpenSend <hello@example.com>',
+            to: ['user@example.com'],
+            subject: 'Hello from OpenSend',
+            html: '<strong>It works.</strong>',
+        ),
+        RequestOptions::withIdempotencyKey('welcome-user-123'),
+    );
+
+    echo $email->id . PHP_EOL;
+} catch (ApiException $error) {
+    error_log($error->errorCode() . ': ' . $error->getMessage());
+    http_response_code($error->statusCode() ?: 500);
+}
+```
+
+The SDK targets `https://opensend.namuh.co` by default. Pass `baseUrl` for a self-hosted OpenSend deployment.
+
+## Payloads
+
+Use `OpenSend\ValueObjects\SendEmailRequest` for typed constructor validation, or pass an array with the same REST keys:
+
+```php
+$email = $client->emails->send([
+    'from' => 'hello@example.com',
+    'to' => 'user@example.com',
+    'subject' => 'Receipt',
+    'text' => 'Thanks for your purchase.',
+    'replyTo' => 'support@example.com', // normalized to reply_to
+]);
+```
+
+At least one of `html`, `text`, or `template` is required. The SDK validates required fields locally and maps OpenSend error envelopes to `OpenSend\Errors\ApiException` with `statusCode()`, `name()`, `errorCode()`, `details()`, and `rawBody()` accessors.
+
+## Publishing notes
+
+- Package name: `opensend/opensend-php`
+- Runtime requirement: PHP 8.1+
+- Dev/test dependency: PHPUnit 10
+- Do not commit API keys, Packagist tokens, or registry credentials. Configure publishing credentials in CI or your local Composer auth config when release automation is added.

--- a/packages/php-sdk/composer.json
+++ b/packages/php-sdk/composer.json
@@ -1,0 +1,27 @@
+{
+  "name": "opensend/opensend-php",
+  "description": "First-party PHP SDK for OpenSend email APIs.",
+  "type": "library",
+  "license": "Elastic-2.0",
+  "minimum-stability": "stable",
+  "prefer-stable": true,
+  "require": {
+    "php": ">=8.1"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^10.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "OpenSend\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "OpenSend\\Tests\\": "tests/"
+    }
+  },
+  "scripts": {
+    "test": "phpunit --configuration phpunit.xml"
+  }
+}

--- a/packages/php-sdk/examples/send-email.php
+++ b/packages/php-sdk/examples/send-email.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use OpenSend\Client;
+use OpenSend\Errors\ApiException;
+use OpenSend\ValueObjects\RequestOptions;
+
+$apiKey = getenv('OPENSEND_API_KEY');
+if (!is_string($apiKey) || trim($apiKey) === '') {
+    fwrite(STDERR, "Set OPENSEND_API_KEY before running this example.\n");
+    exit(1);
+}
+
+$client = new Client(
+    apiKey: $apiKey,
+    baseUrl: getenv('OPENSEND_BASE_URL') ?: null,
+);
+
+try {
+    $email = $client->emails->send([
+        'from' => 'OpenSend <hello@example.com>',
+        'to' => 'recipient@example.com',
+        'subject' => 'Hello from OpenSend PHP',
+        'html' => '<h1>It works!</h1>',
+    ], RequestOptions::withIdempotencyKey('php-example-' . date('YmdHis')));
+
+    echo "Queued email {$email->id}\n";
+} catch (ApiException $error) {
+    fwrite(STDERR, "OpenSend API error {$error->statusCode()}: {$error->getMessage()}\n");
+    if ($error->details() !== null) {
+        fwrite(STDERR, json_encode($error->details(), JSON_PRETTY_PRINT) . "\n");
+    }
+    exit(1);
+}

--- a/packages/php-sdk/phpunit.xml
+++ b/packages/php-sdk/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         failOnRisky="true"
+         failOnWarning="true">
+  <testsuites>
+    <testsuite name="OpenSend PHP SDK">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/packages/php-sdk/src/Client.php
+++ b/packages/php-sdk/src/Client.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSend;
+
+use InvalidArgumentException;
+use OpenSend\Contracts\HttpTransport;
+use OpenSend\Http\HttpClient;
+use OpenSend\Http\StreamHttpTransport;
+use OpenSend\Resources\Emails;
+
+class Client
+{
+    public readonly Emails $emails;
+
+    public function __construct(
+        string $apiKey,
+        ?string $baseUrl = null,
+        ?HttpTransport $transport = null,
+    ) {
+        $normalizedApiKey = $this->normalizeApiKey($apiKey);
+        $normalizedBaseUrl = $this->normalizeBaseUrl($baseUrl ?? Constants::DEFAULT_BASE_URL);
+        $http = new HttpClient($normalizedApiKey, $normalizedBaseUrl, $transport ?? new StreamHttpTransport());
+        $this->emails = new Emails($http);
+    }
+
+    private function normalizeApiKey(string $apiKey): string
+    {
+        $apiKey = trim($apiKey);
+        if ($apiKey === '') {
+            throw new InvalidArgumentException('API key is required.');
+        }
+
+        return $apiKey;
+    }
+
+    private function normalizeBaseUrl(string $baseUrl): string
+    {
+        $baseUrl = trim($baseUrl);
+        if ($baseUrl === '' || filter_var($baseUrl, FILTER_VALIDATE_URL) === false) {
+            throw new InvalidArgumentException('baseUrl must be a valid absolute http or https URL.');
+        }
+
+        $scheme = strtolower((string) parse_url($baseUrl, PHP_URL_SCHEME));
+        if (!in_array($scheme, ['http', 'https'], true)) {
+            throw new InvalidArgumentException('baseUrl must use http or https.');
+        }
+
+        return rtrim($baseUrl, '/');
+    }
+}

--- a/packages/php-sdk/src/Constants.php
+++ b/packages/php-sdk/src/Constants.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSend;
+
+final class Constants
+{
+    public const DEFAULT_BASE_URL = 'https://opensend.namuh.co';
+    public const VERSION = '0.1.0';
+    public const USER_AGENT = 'opensend-php/' . self::VERSION;
+}

--- a/packages/php-sdk/src/Contracts/HttpTransport.php
+++ b/packages/php-sdk/src/Contracts/HttpTransport.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSend\Contracts;
+
+use OpenSend\Http\HttpResponse;
+
+interface HttpTransport
+{
+    /**
+     * @param array<string, string> $headers
+     */
+    public function send(string $method, string $url, array $headers, ?string $body): HttpResponse;
+}

--- a/packages/php-sdk/src/Errors/ApiException.php
+++ b/packages/php-sdk/src/Errors/ApiException.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSend\Errors;
+
+use RuntimeException;
+use Throwable;
+
+final class ApiException extends RuntimeException
+{
+    /**
+     * @param array<string, mixed>|null $details
+     */
+    public function __construct(
+        string $message,
+        private readonly int $statusCode,
+        private readonly ?string $name = null,
+        private readonly ?string $errorCode = null,
+        private readonly ?array $details = null,
+        private readonly ?string $rawBody = null,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, $statusCode, $previous);
+    }
+
+    public function statusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    public function name(): ?string
+    {
+        return $this->name;
+    }
+
+    public function errorCode(): ?string
+    {
+        return $this->errorCode;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function details(): ?array
+    {
+        return $this->details;
+    }
+
+    public function rawBody(): ?string
+    {
+        return $this->rawBody;
+    }
+}

--- a/packages/php-sdk/src/Http/HttpClient.php
+++ b/packages/php-sdk/src/Http/HttpClient.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSend\Http;
+
+use JsonException;
+use OpenSend\Constants;
+use OpenSend\Contracts\HttpTransport;
+use OpenSend\Errors\ApiException;
+use OpenSend\ValueObjects\RequestOptions;
+
+final class HttpClient
+{
+    public function __construct(
+        private readonly string $apiKey,
+        private readonly string $baseUrl,
+        private readonly HttpTransport $transport = new StreamHttpTransport(),
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed>|null $payload
+     * @return array<string, mixed>
+     */
+    public function request(string $method, string $path, ?array $payload = null, ?RequestOptions $options = null): array
+    {
+        $body = null;
+        if ($payload !== null) {
+            try {
+                $body = json_encode($payload, JSON_THROW_ON_ERROR);
+            } catch (JsonException $exception) {
+                throw new ApiException('Failed to encode OpenSend request JSON.', 0, 'request_error', 'request_error', previous: $exception);
+            }
+        }
+
+        $headers = [
+            'Accept' => 'application/json',
+            'Authorization' => 'Bearer ' . $this->apiKey,
+            'Content-Type' => 'application/json',
+            'User-Agent' => Constants::USER_AGENT,
+        ];
+
+        if ($options?->idempotencyKey !== null) {
+            $headers['Idempotency-Key'] = $options->idempotencyKey;
+        }
+
+        $response = $this->transport->send(
+            strtoupper($method),
+            $this->endpoint($path),
+            $headers,
+            $body,
+        );
+
+        $decoded = $this->decodeJson($response->body, $response->statusCode);
+        if ($response->statusCode < 200 || $response->statusCode >= 300) {
+            throw $this->apiException($response, $decoded);
+        }
+
+        return $decoded;
+    }
+
+    private function endpoint(string $path): string
+    {
+        return rtrim($this->baseUrl, '/') . '/' . ltrim($path, '/');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(string $body, int $statusCode): array
+    {
+        if (trim($body) === '') {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new ApiException(
+                'Invalid JSON response from OpenSend.',
+                $statusCode,
+                'parse_error',
+                'parse_error',
+                rawBody: $body,
+                previous: $exception,
+            );
+        }
+
+        if (!is_array($decoded)) {
+            throw new ApiException(
+                'OpenSend returned a JSON response that was not an object.',
+                $statusCode,
+                'parse_error',
+                'parse_error',
+                rawBody: $body,
+            );
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * @param array<string, mixed> $decoded
+     */
+    private function apiException(HttpResponse $response, array $decoded): ApiException
+    {
+        $message = $this->stringValue($decoded['message'] ?? null)
+            ?? $this->stringValue($decoded['error'] ?? null)
+            ?? 'OpenSend API request failed.';
+        $name = $this->stringValue($decoded['name'] ?? null);
+        $code = $this->stringValue($decoded['code'] ?? null);
+        $details = isset($decoded['details']) && is_array($decoded['details']) ? $decoded['details'] : null;
+
+        return new ApiException($message, $response->statusCode, $name, $code, $details, $response->body);
+    }
+
+    private function stringValue(mixed $value): ?string
+    {
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/packages/php-sdk/src/Http/HttpResponse.php
+++ b/packages/php-sdk/src/Http/HttpResponse.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSend\Http;
+
+final class HttpResponse
+{
+    /**
+     * @param array<string, string> $headers
+     */
+    public function __construct(
+        public readonly int $statusCode,
+        public readonly string $body,
+        public readonly array $headers = [],
+    ) {
+    }
+}

--- a/packages/php-sdk/src/Http/StreamHttpTransport.php
+++ b/packages/php-sdk/src/Http/StreamHttpTransport.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSend\Http;
+
+use OpenSend\Contracts\HttpTransport;
+use OpenSend\Errors\ApiException;
+
+final class StreamHttpTransport implements HttpTransport
+{
+    /**
+     * @param array<string, string> $headers
+     */
+    public function send(string $method, string $url, array $headers, ?string $body): HttpResponse
+    {
+        $headerLines = [];
+        foreach ($headers as $name => $value) {
+            $headerLines[] = $name . ': ' . $value;
+        }
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => $method,
+                'header' => implode("\r\n", $headerLines),
+                'content' => $body ?? '',
+                'ignore_errors' => true,
+                'timeout' => 30,
+            ],
+        ]);
+
+        $rawBody = @file_get_contents($url, false, $context);
+        if ($rawBody === false) {
+            $lastError = error_get_last();
+            throw new ApiException(
+                $lastError['message'] ?? 'OpenSend request failed before a response was received.',
+                0,
+                'request_error',
+                'request_error',
+            );
+        }
+
+        /** @var list<string> $responseHeaders */
+        $responseHeaders = $http_response_header ?? [];
+
+        return new HttpResponse(
+            $this->statusCode($responseHeaders),
+            $rawBody,
+            $this->headers($responseHeaders),
+        );
+    }
+
+    /**
+     * @param list<string> $headers
+     */
+    private function statusCode(array $headers): int
+    {
+        foreach ($headers as $line) {
+            if (preg_match('/^HTTP\/\S+\s+(\d{3})\b/', $line, $matches) === 1) {
+                return (int) $matches[1];
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param list<string> $headers
+     * @return array<string, string>
+     */
+    private function headers(array $headers): array
+    {
+        $parsed = [];
+        foreach ($headers as $line) {
+            if (!str_contains($line, ':')) {
+                continue;
+            }
+
+            [$name, $value] = explode(':', $line, 2);
+            $parsed[strtolower(trim($name))] = trim($value);
+        }
+
+        return $parsed;
+    }
+}

--- a/packages/php-sdk/src/Resend.php
+++ b/packages/php-sdk/src/Resend.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSend;
+
+use OpenSend\Contracts\HttpTransport;
+
+final class Resend extends Client
+{
+    public function __construct(string $apiKey, ?string $baseUrl = null, ?HttpTransport $transport = null)
+    {
+        parent::__construct($apiKey, $baseUrl, $transport);
+    }
+}

--- a/packages/php-sdk/src/Resources/Emails.php
+++ b/packages/php-sdk/src/Resources/Emails.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSend\Resources;
+
+use OpenSend\Http\HttpClient;
+use OpenSend\ValueObjects\EmailResponse;
+use OpenSend\ValueObjects\RequestOptions;
+use OpenSend\ValueObjects\SendEmailRequest;
+
+final class Emails
+{
+    public function __construct(private readonly HttpClient $http)
+    {
+    }
+
+    /**
+     * @param SendEmailRequest|array<string, mixed> $request
+     */
+    public function send(SendEmailRequest|array $request, ?RequestOptions $options = null): EmailResponse
+    {
+        $payload = $request instanceof SendEmailRequest
+            ? $request->toArray()
+            : SendEmailRequest::fromArray($request)->toArray();
+
+        return EmailResponse::fromArray($this->http->request('POST', '/emails', $payload, $options));
+    }
+}

--- a/packages/php-sdk/src/ValueObjects/EmailResponse.php
+++ b/packages/php-sdk/src/ValueObjects/EmailResponse.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSend\ValueObjects;
+
+use UnexpectedValueException;
+
+final class EmailResponse
+{
+    /**
+     * @param array<string, mixed> $raw
+     */
+    public function __construct(
+        public readonly string $id,
+        private readonly array $raw = [],
+    ) {
+        if (trim($id) === '') {
+            throw new UnexpectedValueException('OpenSend email response did not include a non-empty id.');
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        $id = $payload['id'] ?? null;
+        if (!is_string($id)) {
+            throw new UnexpectedValueException('OpenSend email response did not include a string id.');
+        }
+
+        return new self($id, $payload);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->raw === [] ? ['id' => $this->id] : $this->raw;
+    }
+}

--- a/packages/php-sdk/src/ValueObjects/RequestOptions.php
+++ b/packages/php-sdk/src/ValueObjects/RequestOptions.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSend\ValueObjects;
+
+use InvalidArgumentException;
+
+final class RequestOptions
+{
+    public function __construct(
+        public readonly ?string $idempotencyKey = null,
+    ) {
+        if ($idempotencyKey !== null) {
+            $length = strlen($idempotencyKey);
+            if ($length < 1 || $length > 256) {
+                throw new InvalidArgumentException('idempotencyKey must be between 1 and 256 characters.');
+            }
+        }
+    }
+
+    public static function withIdempotencyKey(string $idempotencyKey): self
+    {
+        return new self($idempotencyKey);
+    }
+}

--- a/packages/php-sdk/src/ValueObjects/SendEmailRequest.php
+++ b/packages/php-sdk/src/ValueObjects/SendEmailRequest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSend\ValueObjects;
+
+use InvalidArgumentException;
+
+final class SendEmailRequest
+{
+    /**
+     * @param string|list<string> $to
+     * @param string|list<string>|null $cc
+     * @param string|list<string>|null $bcc
+     * @param string|list<string>|null $replyTo
+     * @param array<string, string>|null $headers
+     * @param list<array<string, mixed>>|null $attachments
+     * @param list<array{name: string, value: string}>|null $tags
+     * @param array{id: string, variables?: array<string, mixed>}|null $template
+     */
+    public function __construct(
+        public readonly string $from,
+        public readonly string|array $to,
+        public readonly string $subject,
+        public readonly ?string $html = null,
+        public readonly ?string $text = null,
+        public readonly string|array|null $cc = null,
+        public readonly string|array|null $bcc = null,
+        public readonly string|array|null $replyTo = null,
+        public readonly ?array $headers = null,
+        public readonly ?array $attachments = null,
+        public readonly ?array $tags = null,
+        public readonly ?string $scheduledAt = null,
+        public readonly ?string $topicId = null,
+        public readonly ?array $template = null,
+    ) {
+        self::assertNonEmptyString($from, 'from');
+        self::assertRecipient($to, 'to');
+        self::assertNonEmptyString($subject, 'subject');
+
+        if (($html === null || $html === '') && ($text === null || $text === '') && $template === null) {
+            throw new InvalidArgumentException('html, text, or template is required.');
+        }
+
+        if ($cc !== null) {
+            self::assertRecipient($cc, 'cc');
+        }
+        if ($bcc !== null) {
+            self::assertRecipient($bcc, 'bcc');
+        }
+        if ($replyTo !== null) {
+            self::assertRecipient($replyTo, 'replyTo');
+        }
+        if ($headers !== null) {
+            foreach ($headers as $name => $value) {
+                self::assertNonEmptyString((string) $name, 'headers key');
+                self::assertStringValue($value, 'headers.' . $name);
+            }
+        }
+        if ($tags !== null && count($tags) > 75) {
+            throw new InvalidArgumentException('tags may contain at most 75 entries.');
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        $replyTo = $payload['reply_to'] ?? $payload['replyTo'] ?? null;
+        $scheduledAt = $payload['scheduled_at'] ?? $payload['scheduledAt'] ?? null;
+        $topicId = $payload['topic_id'] ?? $payload['topicId'] ?? null;
+
+        return new self(
+            from: self::stringField($payload, 'from'),
+            to: self::requiredRecipientField($payload, 'to'),
+            subject: self::stringField($payload, 'subject'),
+            html: self::optionalString($payload['html'] ?? null, 'html'),
+            text: self::optionalString($payload['text'] ?? null, 'text'),
+            cc: self::optionalRecipient($payload['cc'] ?? null, 'cc'),
+            bcc: self::optionalRecipient($payload['bcc'] ?? null, 'bcc'),
+            replyTo: self::optionalRecipient($replyTo, 'replyTo'),
+            headers: self::optionalArray($payload['headers'] ?? null, 'headers'),
+            attachments: self::optionalArray($payload['attachments'] ?? null, 'attachments'),
+            tags: self::optionalArray($payload['tags'] ?? null, 'tags'),
+            scheduledAt: self::optionalString($scheduledAt, 'scheduledAt'),
+            topicId: self::optionalString($topicId, 'topicId'),
+            template: self::optionalArray($payload['template'] ?? null, 'template'),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $payload = [
+            'from' => $this->from,
+            'to' => $this->to,
+            'subject' => $this->subject,
+        ];
+
+        $this->putIfNotNull($payload, 'html', $this->html);
+        $this->putIfNotNull($payload, 'text', $this->text);
+        $this->putIfNotNull($payload, 'cc', $this->cc);
+        $this->putIfNotNull($payload, 'bcc', $this->bcc);
+        $this->putIfNotNull($payload, 'reply_to', $this->replyTo);
+        $this->putIfNotNull($payload, 'headers', $this->headers);
+        $this->putIfNotNull($payload, 'attachments', $this->attachments);
+        $this->putIfNotNull($payload, 'tags', $this->tags);
+        $this->putIfNotNull($payload, 'scheduled_at', $this->scheduledAt);
+        $this->putIfNotNull($payload, 'topic_id', $this->topicId);
+        $this->putIfNotNull($payload, 'template', $this->template);
+
+        return $payload;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function putIfNotNull(array &$payload, string $key, mixed $value): void
+    {
+        if ($value !== null) {
+            $payload[$key] = $value;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function stringField(array $payload, string $key): string
+    {
+        if (!array_key_exists($key, $payload)) {
+            throw new InvalidArgumentException($key . ' is required.');
+        }
+
+        return self::optionalString($payload[$key], $key) ?? '';
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @return string|list<string>
+     */
+    private static function requiredRecipientField(array $payload, string $key): string|array
+    {
+        if (!array_key_exists($key, $payload)) {
+            throw new InvalidArgumentException($key . ' is required.');
+        }
+
+        return self::optionalRecipient($payload[$key], $key) ?? '';
+    }
+
+    private static function optionalString(mixed $value, string $field): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+        self::assertStringValue($value, $field);
+
+        return $value;
+    }
+
+    /**
+     * @return string|list<string>|null
+     */
+    private static function optionalRecipient(mixed $value, string $field): string|array|null
+    {
+        if ($value === null) {
+            return null;
+        }
+        if (is_string($value)) {
+            self::assertNonEmptyString($value, $field);
+
+            return $value;
+        }
+        if (is_array($value)) {
+            if ($value === []) {
+                throw new InvalidArgumentException($field . ' must not be empty.');
+            }
+            foreach ($value as $recipient) {
+                self::assertNonEmptyString($recipient, $field);
+            }
+
+            return array_values($value);
+        }
+
+        throw new InvalidArgumentException($field . ' must be a string or a list of strings.');
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    private static function optionalArray(mixed $value, string $field): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+        if (!is_array($value)) {
+            throw new InvalidArgumentException($field . ' must be an array.');
+        }
+
+        return $value;
+    }
+
+    private static function assertRecipient(string|array $value, string $field): void
+    {
+        self::optionalRecipient($value, $field);
+    }
+
+    private static function assertStringValue(mixed $value, string $field): void
+    {
+        if (!is_string($value)) {
+            throw new InvalidArgumentException($field . ' must be a string.');
+        }
+    }
+
+    private static function assertNonEmptyString(mixed $value, string $field): void
+    {
+        self::assertStringValue($value, $field);
+        if (trim($value) === '') {
+            throw new InvalidArgumentException($field . ' must be a non-empty string.');
+        }
+    }
+}

--- a/packages/php-sdk/tests/EmailsTest.php
+++ b/packages/php-sdk/tests/EmailsTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSend\Tests;
+
+use InvalidArgumentException;
+use OpenSend\Client;
+use OpenSend\Errors\ApiException;
+use OpenSend\ValueObjects\RequestOptions;
+use OpenSend\ValueObjects\SendEmailRequest;
+
+final class EmailsTest extends IntegrationTestCase
+{
+    public function testSendPostsEmailRequestWithAuthAndIdempotencyHeaders(): void
+    {
+        $this->setServerResponse(200, ['id' => 'email_123']);
+        $client = new Client('os_test_key', $this->baseUrl);
+
+        $response = $client->emails->send(
+            new SendEmailRequest(
+                from: 'OpenSend <hello@example.com>',
+                to: ['user@example.com'],
+                subject: 'Welcome',
+                html: '<p>Hello</p>',
+                replyTo: 'support@example.com',
+                tags: [['name' => 'flow', 'value' => 'signup']],
+            ),
+            RequestOptions::withIdempotencyKey('welcome-user-123'),
+        );
+
+        self::assertSame('email_123', $response->id);
+        $request = $this->lastRequest();
+        self::assertSame('POST', $request['method']);
+        self::assertSame('/emails', $request['path']);
+        self::assertSame('Bearer os_test_key', $request['headers']['authorization']);
+        self::assertSame('application/json', $request['headers']['content-type']);
+        self::assertSame('welcome-user-123', $request['headers']['idempotency-key']);
+        self::assertSame('OpenSend <hello@example.com>', $request['jsonBody']['from']);
+        self::assertSame(['user@example.com'], $request['jsonBody']['to']);
+        self::assertSame('support@example.com', $request['jsonBody']['reply_to']);
+        self::assertArrayNotHasKey('replyTo', $request['jsonBody']);
+    }
+
+    public function testSendAcceptsArrayPayloadAliases(): void
+    {
+        $this->setServerResponse(200, ['id' => 'email_alias']);
+        $client = new Client('os_test_key', $this->baseUrl);
+
+        $response = $client->emails->send([
+            'from' => 'hello@example.com',
+            'to' => 'user@example.com',
+            'subject' => 'Alias',
+            'text' => 'Hello',
+            'replyTo' => ['reply@example.com'],
+            'scheduledAt' => '2026-06-01T00:00:00.000Z',
+        ]);
+
+        self::assertSame('email_alias', $response->id);
+        $request = $this->lastRequest();
+        self::assertSame(['reply@example.com'], $request['jsonBody']['reply_to']);
+        self::assertSame('2026-06-01T00:00:00.000Z', $request['jsonBody']['scheduled_at']);
+    }
+
+    public function testErrorEnvelopeThrowsTypedApiException(): void
+    {
+        $this->setServerResponse(422, [
+            'name' => 'validation_error',
+            'code' => 'validation_error',
+            'message' => 'html, text, or template is required',
+            'statusCode' => 422,
+            'details' => [
+                'formErrors' => [],
+                'fieldErrors' => ['html' => ['html, text, or template is required']],
+            ],
+        ]);
+        $client = new Client('os_test_key', $this->baseUrl);
+
+        try {
+            $client->emails->send([
+                'from' => 'hello@example.com',
+                'to' => 'user@example.com',
+                'subject' => 'Server validation',
+                'html' => '<p>Client allows this so the server response is exercised.</p>',
+            ]);
+            self::fail('Expected ApiException to be thrown.');
+        } catch (ApiException $exception) {
+            self::assertSame(422, $exception->statusCode());
+            self::assertSame('validation_error', $exception->name());
+            self::assertSame('validation_error', $exception->errorCode());
+            self::assertSame('html, text, or template is required', $exception->getMessage());
+            self::assertSame(['html' => ['html, text, or template is required']], $exception->details()['fieldErrors']);
+        }
+    }
+
+    public function testLocalValidationRejectsIncompleteSendPayloadBeforeNetwork(): void
+    {
+        $client = new Client('os_test_key', $this->baseUrl);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('html, text, or template is required.');
+
+        $client->emails->send([
+            'from' => 'hello@example.com',
+            'to' => 'user@example.com',
+            'subject' => 'No body',
+        ]);
+    }
+
+    public function testInvalidJsonResponseMapsToParseError(): void
+    {
+        $this->setRawServerResponse(200, '{not-json', 'application/json');
+        $client = new Client('os_test_key', $this->baseUrl);
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('Invalid JSON response from OpenSend.');
+
+        $client->emails->send([
+            'from' => 'hello@example.com',
+            'to' => 'user@example.com',
+            'subject' => 'Bad JSON',
+            'text' => 'Hello',
+        ]);
+    }
+
+}

--- a/packages/php-sdk/tests/Fixtures/router.php
+++ b/packages/php-sdk/tests/Fixtures/router.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+$responsePath = getenv('OPENSEND_TEST_RESPONSE_PATH');
+$recordPath = getenv('OPENSEND_TEST_RECORD_PATH');
+
+if (!is_string($responsePath) || !is_string($recordPath)) {
+    http_response_code(500);
+    echo json_encode(['error' => 'test server not configured']);
+    return;
+}
+
+$body = file_get_contents('php://input') ?: '';
+$decodedBody = null;
+if ($body !== '') {
+    $decodedBody = json_decode($body, true);
+}
+
+$headers = function_exists('getallheaders') ? getallheaders() : [];
+$normalizedHeaders = [];
+foreach ($headers as $name => $value) {
+    $normalizedHeaders[strtolower((string) $name)] = (string) $value;
+}
+
+$record = [
+    'method' => $_SERVER['REQUEST_METHOD'] ?? '',
+    'path' => parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH),
+    'query' => $_GET,
+    'headers' => $normalizedHeaders,
+    'rawBody' => $body,
+    'jsonBody' => $decodedBody,
+];
+file_put_contents($recordPath, json_encode($record, JSON_THROW_ON_ERROR) . PHP_EOL, FILE_APPEND | LOCK_EX);
+
+$response = json_decode((string) file_get_contents($responsePath), true);
+if (!is_array($response)) {
+    $response = ['status' => 200, 'body' => []];
+}
+
+http_response_code((int) ($response['status'] ?? 200));
+foreach (($response['headers'] ?? []) as $name => $value) {
+    header((string) $name . ': ' . (string) $value);
+}
+header('Content-Type: ' . (string) ($response['contentType'] ?? 'application/json'));
+if (array_key_exists('rawBody', $response)) {
+    echo (string) $response['rawBody'];
+    return;
+}
+echo json_encode($response['body'] ?? [], JSON_THROW_ON_ERROR);

--- a/packages/php-sdk/tests/IntegrationTestCase.php
+++ b/packages/php-sdk/tests/IntegrationTestCase.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSend\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class IntegrationTestCase extends TestCase
+{
+    protected string $baseUrl;
+    private string $tempDir;
+    private string $responsePath;
+    private string $recordPath;
+
+    /** @var resource|null */
+    private $process = null;
+
+    /** @var array<int, resource> */
+    private array $pipes = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tempDir = sys_get_temp_dir() . '/opensend-php-sdk-' . bin2hex(random_bytes(6));
+        mkdir($this->tempDir, 0700, true);
+        $this->responsePath = $this->tempDir . '/response.json';
+        $this->recordPath = $this->tempDir . '/requests.jsonl';
+        $this->setServerResponse(200, ['id' => 'email_default']);
+        file_put_contents($this->recordPath, '');
+
+        $port = $this->reservePort();
+        $this->baseUrl = 'http://127.0.0.1:' . $port;
+
+        $router = __DIR__ . '/Fixtures/router.php';
+        $command = escapeshellarg(PHP_BINARY) . ' -S 127.0.0.1:' . $port . ' ' . escapeshellarg($router);
+        $this->process = proc_open(
+            $command,
+            [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $this->pipes,
+            dirname(__DIR__),
+            [
+                'OPENSEND_TEST_RESPONSE_PATH' => $this->responsePath,
+                'OPENSEND_TEST_RECORD_PATH' => $this->recordPath,
+            ],
+        );
+
+        if (!is_resource($this->process)) {
+            self::fail('Failed to start PHP test server.');
+        }
+
+        $this->waitForServer($port);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->process)) {
+            proc_terminate($this->process);
+            proc_close($this->process);
+        }
+        foreach ($this->pipes as $pipe) {
+            if (is_resource($pipe)) {
+                fclose($pipe);
+            }
+        }
+        $this->removeDirectory($this->tempDir);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     * @param array<string, string> $headers
+     */
+    protected function setServerResponse(int $status, array $body, array $headers = []): void
+    {
+        file_put_contents($this->responsePath, json_encode([
+            'status' => $status,
+            'body' => $body,
+            'headers' => $headers,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+
+    /**
+     * @param array<string, string> $headers
+     */
+    protected function setRawServerResponse(int $status, string $rawBody, string $contentType = 'application/json', array $headers = []): void
+    {
+        file_put_contents($this->responsePath, json_encode([
+            'status' => $status,
+            'rawBody' => $rawBody,
+            'contentType' => $contentType,
+            'headers' => $headers,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    protected function recordedRequests(): array
+    {
+        $contents = trim((string) file_get_contents($this->recordPath));
+        if ($contents === '') {
+            return [];
+        }
+
+        return array_map(
+            static fn (string $line): array => json_decode($line, true, 512, JSON_THROW_ON_ERROR),
+            explode(PHP_EOL, $contents),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function lastRequest(): array
+    {
+        $requests = $this->recordedRequests();
+        self::assertNotEmpty($requests);
+
+        return $requests[array_key_last($requests)];
+    }
+
+    private function reservePort(): int
+    {
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        if ($socket === false) {
+            self::fail('Failed to reserve a test server port: ' . $errstr);
+        }
+
+        $name = stream_socket_get_name($socket, false);
+        fclose($socket);
+        if (!is_string($name) || !str_contains($name, ':')) {
+            self::fail('Failed to discover reserved test server port.');
+        }
+
+        return (int) substr(strrchr($name, ':'), 1);
+    }
+
+    private function waitForServer(int $port): void
+    {
+        $deadline = microtime(true) + 5;
+        do {
+            $socket = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.1);
+            if (is_resource($socket)) {
+                fclose($socket);
+                return;
+            }
+            usleep(50_000);
+        } while (microtime(true) < $deadline);
+
+        self::fail('PHP test server did not start on port ' . $port . '.');
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $file = $path . DIRECTORY_SEPARATOR . $entry;
+            is_dir($file) ? $this->removeDirectory($file) : unlink($file);
+        }
+        rmdir($path);
+    }
+}

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -30,6 +30,7 @@
 - [React Email Skill](https://opensend.namuh.co/docs/react-email-skill.md): Build HTML email with React components.
 - [Email Best Practices Skill](https://opensend.namuh.co/docs/email-best-practices-skill.md): Guardrails for production email systems.
 - [Custom Event Schemas](https://opensend.namuh.co/docs/custom-event-schemas.md): Define and validate custom event payloads.
+- [Send emails with PHP](https://opensend.namuh.co/docs/send-with-php.md): Send email from PHP with the first-party OpenSend PHP SDK. This first SDK slice supports the core single-email send path, idempotency keys, typed request/response objects, and typed OpenSend API errors.
 - [Introduction](https://opensend.namuh.co/docs/api-reference/introduction.md): Core concepts for the OpenSend API.
 - [Authentication](https://opensend.namuh.co/docs/api-reference/authentication.md): How API key authentication works in OpenSend.
 - [Pagination](https://opensend.namuh.co/docs/api-reference/pagination.md): OpenSend collection endpoints use cursor-style pagination where the route supports it. The API keeps pagination deliberately simple so self-hosted deployments and generated clients can share the same contract.

--- a/public/docs/sdks.md
+++ b/public/docs/sdks.md
@@ -12,6 +12,7 @@ Use an OpenSend API key that starts with `os_`. Keep keys in server-side environ
 | Python | `packages/python-sdk` / future `opensend` PyPI package | Django, Flask, FastAPI, scripts, workers | First-party package; install from the repo until PyPI publishing is enabled |
 | Go | `github.com/namuh-eng/opensend/packages/go-sdk` | API services, workers, CLIs | First-party module |
 | Ruby | `packages/ruby-sdk` / future `opensend` gem | Rails, Sinatra, Ruby jobs | First-party package; install from the repo until RubyGems publishing is enabled |
+| PHP | `packages/php-sdk` / future `opensend/opensend-php` Composer package | PHP services, Laravel/Symfony apps, workers | First-party send-email slice; install from the repo until Packagist publishing is enabled |
 | SMTP relay | `@opensend/smtp-relay` service | Apps that only speak SMTP | Self-hosted relay service |
 | Other languages | `/openapi.json` | Generated clients | Generate from the OpenAPI contract |
 
@@ -170,6 +171,50 @@ puts email.fetch("id")
 ```
 
 The Ruby package also exports `Resend` as a compatibility alias for migration-oriented code.
+
+
+## PHP
+
+Install from this repository until Packagist publishing is complete:
+
+```bash
+composer config repositories.opensend path ../../packages/php-sdk
+composer require opensend/opensend-php:dev-main
+```
+
+Send one email:
+
+```php
+<?php
+
+use OpenSend\Client;
+use OpenSend\Errors\ApiException;
+use OpenSend\ValueObjects\RequestOptions;
+use OpenSend\ValueObjects\SendEmailRequest;
+
+$client = new Client(
+    apiKey: getenv('OPENSEND_API_KEY') ?: '',
+    baseUrl: getenv('OPENSEND_BASE_URL') ?: null,
+);
+
+try {
+    $email = $client->emails->send(
+        new SendEmailRequest(
+            from: 'OpenSend <onboarding@updates.example.com>',
+            to: ['user@example.com'],
+            subject: 'Hello from OpenSend',
+            html: '<strong>It works.</strong>',
+        ),
+        RequestOptions::withIdempotencyKey('welcome-user-123'),
+    );
+
+    echo $email->id;
+} catch (ApiException $error) {
+    throw $error;
+}
+```
+
+The PHP SDK currently supports single-email sends plus shared request, response, idempotency, and error-envelope plumbing. Use the REST API for other resources until more PHP clients are added.
 
 ## SMTP relay
 

--- a/public/docs/send-with-php.md
+++ b/public/docs/send-with-php.md
@@ -1,0 +1,98 @@
+# Send emails with PHP
+
+Send email from PHP with the first-party OpenSend PHP SDK. This first SDK slice supports the core single-email send path, idempotency keys, typed request/response objects, and typed OpenSend API errors.
+
+## Install
+
+Install from this repository until Packagist publishing is enabled:
+
+```bash
+composer config repositories.opensend path ../../packages/php-sdk
+composer require opensend/opensend-php:dev-main
+```
+
+For development inside the OpenSend repository:
+
+```bash
+cd packages/php-sdk
+composer install
+composer test
+```
+
+## Configure
+
+Keep the API key on the server. If `OPENSEND_BASE_URL` is unset, the SDK targets OpenSend Cloud at `https://opensend.namuh.co`.
+
+```bash
+export OPENSEND_API_KEY="os_your_api_key"
+export OPENSEND_BASE_URL="http://localhost:3015" # optional for self-hosting
+```
+
+## Send one email
+
+```php
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+use OpenSend\Client;
+use OpenSend\Errors\ApiException;
+use OpenSend\ValueObjects\RequestOptions;
+use OpenSend\ValueObjects\SendEmailRequest;
+
+$client = new Client(
+    apiKey: getenv('OPENSEND_API_KEY') ?: '',
+    baseUrl: getenv('OPENSEND_BASE_URL') ?: null,
+);
+
+try {
+    $email = $client->emails->send(
+        new SendEmailRequest(
+            from: 'hello@yourdomain.com',
+            to: ['recipient@example.com'],
+            subject: 'Hello from OpenSend',
+            html: '<h1>It works!</h1>',
+        ),
+        RequestOptions::withIdempotencyKey('receipt-123'),
+    );
+
+    echo $email->id . PHP_EOL;
+} catch (ApiException $error) {
+    error_log($error->errorCode() . ': ' . $error->getMessage());
+    http_response_code($error->statusCode() ?: 500);
+}
+```
+
+## Array payloads
+
+You can also pass arrays shaped like the REST API. `replyTo`, `scheduledAt`, and `topicId` aliases are normalized to `reply_to`, `scheduled_at`, and `topic_id` before the request is sent.
+
+```php
+$email = $client->emails->send([
+    'from' => 'hello@yourdomain.com',
+    'to' => 'recipient@example.com',
+    'subject' => 'Receipt',
+    'text' => 'Thanks for your purchase.',
+    'replyTo' => 'support@yourdomain.com',
+]);
+```
+
+## Error handling
+
+OpenSend API error envelopes are raised as `OpenSend\Errors\ApiException`.
+
+```php
+try {
+    $client->emails->send($payload);
+} catch (ApiException $error) {
+    $status = $error->statusCode();
+    $code = $error->errorCode();
+    $details = $error->details();
+}
+```
+
+The exception preserves `statusCode`, `name`, `code`, sanitized `details`, and the raw response body for logging or debugging. Do not log API keys or message content in production logs.
+
+## Supported resources
+
+The PHP SDK currently supports `client->emails->send(...)` only. Use the REST API for reads, batch sends, contacts, domains, webhooks, suppressions, broadcasts, and API keys until those PHP resource clients are added.

--- a/tests/docs-content.test.ts
+++ b/tests/docs-content.test.ts
@@ -160,6 +160,7 @@ describe("docs content shell", () => {
       "send-with-django.md",
       "send-with-rails.md",
       "send-with-sinatra.md",
+      "send-with-php.md",
     ];
 
     for (const guide of requiredGuides) {
@@ -172,7 +173,8 @@ describe("docs content shell", () => {
     expect(sdks).toContain("v0.2.0");
     expect(sdks).toContain("install from the repo until PyPI");
     expect(sdks).toContain("install from the repo until RubyGems");
-    expect(sdks).not.toMatch(/PHP SDK|Java SDK|\\.NET SDK|Rust SDK/);
+    expect(sdks).toContain("opensend/opensend-php");
+    expect(sdks).not.toMatch(/Java SDK|\\.NET SDK|Rust SDK/);
   });
 
   it("documents implemented dashboard product areas with caveats", () => {


### PR DESCRIPTION
## Summary
- Adds a Composer-ready `opensend/opensend-php` package for the first PHP SDK slice.
- Implements single-email sends with typed-ish request/response objects, idempotency key support, stream-based HTTP transport, and typed API error envelope mapping.
- Adds fixture-backed PHPUnit coverage, CI execution, examples, and public docs for the supported PHP surface.

Refs #561

## Changes
- **PHP SDK**: `OpenSend\Client`, `Resend` alias, `emails->send(...)`, `SendEmailRequest`, `EmailResponse`, `RequestOptions`, `ApiException`, and reusable HTTP transport abstractions.
- **Tests/CI**: PHPUnit tests use a local PHP HTTP fixture server to validate request construction, response parsing, idempotency headers, local validation, and API error envelopes without real credentials.
- **Docs**: Adds PHP send guide, updates SDK overview, refreshes `public/docs/llms.txt`, and documents Packagist publishing notes without secrets.

## How to Test
- [ ] `cd packages/php-sdk && composer install && composer test`
- [ ] `make check`
- [ ] `make test`
- [ ] `bun run docs:generate`

## Notes
- Scope is intentionally send-email only for this staging slice; other PHP resource clients should reuse the new HTTP/error/request foundation.
- No Packagist credentials or publishing tokens are included.
