### PR TITLE
Add first-party JVM SDK slice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,27 @@ jobs:
         working-directory: packages/php-sdk
         run: composer test
 
+  jvm-sdk:
+    name: JVM SDK tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Run JVM SDK tests
+        working-directory: packages/jvm-sdk
+        run: mvn --batch-mode test
+
+      - name: Compile JVM SDK Kotlin examples
+        working-directory: packages/jvm-sdk
+        run: mvn --batch-mode -Pkotlin-examples test-compile
+
+
   onboarding:
     name: Onboarding acceptance
     runs-on: ubuntu-latest

--- a/agent_docs/learnings/active/2026-05-28-issue-562-jvm-sdk-layout.md
+++ b/agent_docs/learnings/active/2026-05-28-issue-562-jvm-sdk-layout.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-28
+issue: "#562"
+type: decision
+promoted_to: null
+---
+
+## Keep the first JVM SDK handwritten, blocking-only, and route-aligned
+
+Issue #562 adds a repo-local first-party JVM package at `packages/jvm-sdk` with Maven coordinates `com.opensend:opensend-java:0.1.0-SNAPSHOT`. The first slice is handwritten instead of generated so review stays narrow while OpenSend's OpenAPI/client-generation surface continues to stabilize.
+
+The SDK is explicitly blocking-only (`java.net.http.HttpClient#send`) and currently wraps implemented email, contact, domain, and suppression routes only. Async methods, Maven Central publishing credentials, and broader resource parity should be follow-up work, not silently added to this first staging slice.

--- a/packages/jvm-sdk/README.md
+++ b/packages/jvm-sdk/README.md
@@ -1,0 +1,103 @@
+# OpenSend JVM SDK
+
+First-party Java/Kotlin-compatible SDK for OpenSend. This v1 staging slice is intentionally narrow and handwritten so it stays reviewable while OpenSend's OpenAPI/client-generation story matures.
+
+## Install from this repository
+
+```bash
+cd packages/jvm-sdk
+mvn test
+mvn install
+```
+
+Then depend on the local Maven artifact:
+
+```xml
+<dependency>
+  <groupId>com.opensend</groupId>
+  <artifactId>opensend-java</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+</dependency>
+```
+
+No registry credentials or publishing secrets are checked in. Public Maven Central publishing is intentionally out of scope for this slice.
+
+## Client stance
+
+The SDK is **blocking-only** in this first slice. It uses Java's `java.net.http.HttpClient#send` under the hood, which keeps the API predictable for Spring Boot services, workers, and command-line applications. Async wrappers are deferred until OpenSend can commit to a stable async API across SDKs.
+
+## Supported API surface
+
+This package only exposes routes implemented in this repository:
+
+- `emails`: send, batch send, list, retrieve, cancel
+- `contacts`: create, list, retrieve, update, delete
+- `domains`: create, list, retrieve, update, verify, delete
+- `suppressions`: create, list, retrieve, delete
+
+Use the REST API or another first-party SDK for resources not listed here.
+
+## Java
+
+```java
+import com.opensend.ApiException;
+import com.opensend.OpenSend;
+import com.opensend.RequestOptions;
+import com.opensend.models.EmailResponse;
+import com.opensend.models.SendEmailRequest;
+import java.util.List;
+
+OpenSend client = OpenSend.builder(System.getenv("OPENSEND_API_KEY"))
+    .baseUrl(System.getenv().getOrDefault("OPENSEND_BASE_URL", OpenSend.DEFAULT_BASE_URL))
+    .build();
+
+try {
+  EmailResponse email = client.emails().send(
+      SendEmailRequest.builder()
+          .from("OpenSend <onboarding@updates.example.com>")
+          .to(List.of("user@example.com"))
+          .subject("Hello from OpenSend")
+          .html("<strong>It works.</strong>")
+          .build(),
+      RequestOptions.withIdempotencyKey("welcome-user-123"));
+  System.out.println(email.id());
+} catch (ApiException error) {
+  System.err.println(error.statusCode() + " " + error.apiMessage());
+  error.rateLimit().retryAfter().ifPresent(retryAfter ->
+      System.err.println("Retry after " + retryAfter + " seconds"));
+  throw error;
+}
+```
+
+## Kotlin
+
+```kotlin
+val client = OpenSend.builder(System.getenv("OPENSEND_API_KEY"))
+    .baseUrl(System.getenv("OPENSEND_BASE_URL") ?: OpenSend.DEFAULT_BASE_URL)
+    .build()
+
+val email = client.emails().send(
+    SendEmailRequest.builder()
+        .from("OpenSend <onboarding@updates.example.com>")
+        .to(listOf("user@example.com"))
+        .subject("Hello from OpenSend")
+        .html("<strong>It works.</strong>")
+        .build(),
+    RequestOptions.withIdempotencyKey("welcome-user-123"),
+)
+println(email.id())
+```
+
+## Spring Boot
+
+Create the client once as a singleton bean and keep credentials in environment-backed configuration:
+
+```java
+@Bean
+OpenSend openSend(@Value("${opensend.api-key}") String apiKey,
+                  @Value("${opensend.base-url:https://opensend.namuh.co}") String baseUrl) {
+  return OpenSend.builder(apiKey).baseUrl(baseUrl).build();
+}
+```
+
+Inject `OpenSend` into services and call `client.emails().send(...)` from controllers, jobs, or queue workers. Do not expose the API key to browser/mobile clients.

--- a/packages/jvm-sdk/examples/java/PlainJvmExample.java
+++ b/packages/jvm-sdk/examples/java/PlainJvmExample.java
@@ -1,0 +1,31 @@
+import com.opensend.ApiException;
+import com.opensend.OpenSend;
+import com.opensend.RequestOptions;
+import com.opensend.models.EmailResponse;
+import com.opensend.models.SendEmailRequest;
+import java.util.List;
+
+final class PlainJvmExample {
+  private PlainJvmExample() {}
+
+  static void sendWelcomeEmail() {
+    OpenSend client = OpenSend.builder(System.getenv("OPENSEND_API_KEY"))
+        .baseUrl(System.getenv().getOrDefault("OPENSEND_BASE_URL", OpenSend.DEFAULT_BASE_URL))
+        .build();
+
+    try {
+      EmailResponse email = client.emails().send(
+          SendEmailRequest.builder()
+              .from("OpenSend <onboarding@updates.example.com>")
+              .to(List.of("user@example.com"))
+              .subject("Hello from OpenSend")
+              .html("<strong>It works.</strong>")
+              .build(),
+          RequestOptions.withIdempotencyKey("welcome-user-123"));
+      System.out.println(email.id());
+    } catch (ApiException error) {
+      System.err.println(error.statusCode() + " " + error.apiMessage());
+      throw error;
+    }
+  }
+}

--- a/packages/jvm-sdk/examples/java/SpringBootMailService.java
+++ b/packages/jvm-sdk/examples/java/SpringBootMailService.java
@@ -1,0 +1,26 @@
+import com.opensend.OpenSend;
+import com.opensend.RequestOptions;
+import com.opensend.models.EmailResponse;
+import com.opensend.models.SendEmailRequest;
+import java.util.List;
+
+final class SpringBootMailService {
+  private final OpenSend openSend;
+
+  SpringBootMailService(String apiKey, String baseUrl) {
+    this.openSend = OpenSend.builder(apiKey)
+        .baseUrl(baseUrl == null || baseUrl.isBlank() ? OpenSend.DEFAULT_BASE_URL : baseUrl)
+        .build();
+  }
+
+  EmailResponse sendWelcome(String email, String idempotencyKey) {
+    return openSend.emails().send(
+        SendEmailRequest.builder()
+            .from("OpenSend <onboarding@updates.example.com>")
+            .to(List.of(email))
+            .subject("Welcome")
+            .html("<strong>Welcome.</strong>")
+            .build(),
+        RequestOptions.withIdempotencyKey(idempotencyKey));
+  }
+}

--- a/packages/jvm-sdk/examples/kotlin/SendEmailExample.kt
+++ b/packages/jvm-sdk/examples/kotlin/SendEmailExample.kt
@@ -1,0 +1,28 @@
+import com.opensend.ApiException
+import com.opensend.OpenSend
+import com.opensend.RequestOptions
+import com.opensend.models.SendEmailRequest
+
+fun sendWelcomeEmail() {
+    val client = OpenSend.builder(System.getenv("OPENSEND_API_KEY"))
+        .baseUrl(System.getenv("OPENSEND_BASE_URL") ?: OpenSend.DEFAULT_BASE_URL)
+        .build()
+
+    try {
+        val email = client.emails().send(
+            SendEmailRequest.builder()
+                .from("OpenSend <onboarding@updates.example.com>")
+                .to(listOf("user@example.com"))
+                .subject("Hello from OpenSend")
+                .html("<strong>It works.</strong>")
+                .build(),
+            RequestOptions.withIdempotencyKey("welcome-user-123"),
+        )
+        println(email.id())
+    } catch (error: ApiException) {
+        error.rateLimit().retryAfter().ifPresent { retryAfter ->
+            println("Retry after $retryAfter seconds")
+        }
+        throw error
+    }
+}

--- a/packages/jvm-sdk/pom.xml
+++ b/packages/jvm-sdk/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.opensend</groupId>
+  <artifactId>opensend-java</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>OpenSend JVM SDK</name>
+  <description>First-party Java/Kotlin-compatible SDK for OpenSend.</description>
+  <url>https://github.com/namuh-eng/opensend</url>
+
+  <licenses>
+    <license>
+      <name>Elastic License 2.0</name>
+      <url>https://github.com/namuh-eng/opensend/blob/main/LICENSE</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>17</maven.compiler.release>
+    <jackson.version>2.18.2</jackson.version>
+    <junit.version>5.11.4</junit.version>
+    <kotlin.version>2.1.0</kotlin.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.2</version>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <id>add-java-examples-as-test-sources</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>examples/java</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <profile>
+      <id>kotlin-examples</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib</artifactId>
+          <version>${kotlin.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-maven-plugin</artifactId>
+            <version>${kotlin.version}</version>
+            <executions>
+              <execution>
+                <id>compile-kotlin-examples</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>test-compile</goal>
+                </goals>
+                <configuration>
+                  <sourceDirs>
+                    <sourceDir>${project.basedir}/examples/kotlin</sourceDir>
+                  </sourceDirs>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/packages/jvm-sdk/src/main/java/com/opensend/ApiException.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/ApiException.java
@@ -1,0 +1,67 @@
+package com.opensend;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.http.HttpHeaders;
+
+/** Non-2xx response returned by OpenSend. */
+public class ApiException extends OpenSendException {
+  private final int statusCode;
+  private final String body;
+  private final String name;
+  private final String code;
+  private final JsonNode details;
+  private final HttpHeaders headers;
+  private final RateLimitInfo rateLimit;
+
+  public ApiException(
+      int statusCode,
+      String body,
+      String message,
+      String name,
+      String code,
+      JsonNode details,
+      HttpHeaders headers,
+      RateLimitInfo rateLimit) {
+    super("opensend: API request failed with status " + statusCode + ": " + message);
+    this.statusCode = statusCode;
+    this.body = body;
+    this.name = name;
+    this.code = code;
+    this.details = details;
+    this.headers = headers;
+    this.rateLimit = rateLimit;
+  }
+
+  public int statusCode() {
+    return statusCode;
+  }
+
+  public String body() {
+    return body;
+  }
+
+  public String apiMessage() {
+    String prefix = "opensend: API request failed with status " + statusCode + ": ";
+    return getMessage().startsWith(prefix) ? getMessage().substring(prefix.length()) : getMessage();
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public String code() {
+    return code;
+  }
+
+  public JsonNode details() {
+    return details;
+  }
+
+  public HttpHeaders headers() {
+    return headers;
+  }
+
+  public RateLimitInfo rateLimit() {
+    return rateLimit;
+  }
+}

--- a/packages/jvm-sdk/src/main/java/com/opensend/ListOptions.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/ListOptions.java
@@ -1,0 +1,8 @@
+package com.opensend;
+
+/** Common cursor pagination options used by list endpoints. */
+public record ListOptions(Integer limit, String after) {
+  public static ListOptions empty() {
+    return new ListOptions(null, null);
+  }
+}

--- a/packages/jvm-sdk/src/main/java/com/opensend/ListPage.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/ListPage.java
@@ -1,0 +1,10 @@
+package com.opensend;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/** Cursor-paginated OpenSend collection response. */
+public record ListPage<T>(
+    String object,
+    List<T> data,
+    @JsonProperty("has_more") boolean hasMore) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/OpenSend.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/OpenSend.java
@@ -1,0 +1,115 @@
+package com.opensend;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.opensend.internal.HttpTransport;
+import com.opensend.internal.Json;
+import com.opensend.resources.ContactsClient;
+import com.opensend.resources.DomainsClient;
+import com.opensend.resources.EmailsClient;
+import com.opensend.resources.SuppressionsClient;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.util.Objects;
+
+/** Blocking OpenSend API client for Java and Kotlin server applications. */
+public final class OpenSend {
+  public static final String DEFAULT_BASE_URL = "https://opensend.namuh.co";
+
+  private final EmailsClient emails;
+  private final ContactsClient contacts;
+  private final DomainsClient domains;
+  private final SuppressionsClient suppressions;
+
+  private OpenSend(Builder builder) {
+    HttpTransport transport = new HttpTransport(
+        builder.apiKey,
+        normalizeBaseUrl(builder.baseUrl),
+        builder.httpClient,
+        builder.objectMapper);
+    this.emails = new EmailsClient(transport);
+    this.contacts = new ContactsClient(transport);
+    this.domains = new DomainsClient(transport);
+    this.suppressions = new SuppressionsClient(transport);
+  }
+
+  public static OpenSend create(String apiKey) {
+    return builder(apiKey).build();
+  }
+
+  public static Builder builder(String apiKey) {
+    return new Builder(apiKey);
+  }
+
+  public EmailsClient emails() {
+    return emails;
+  }
+
+  public ContactsClient contacts() {
+    return contacts;
+  }
+
+  public DomainsClient domains() {
+    return domains;
+  }
+
+  public SuppressionsClient suppressions() {
+    return suppressions;
+  }
+
+  private static URI normalizeBaseUrl(String raw) {
+    String value = raw == null ? DEFAULT_BASE_URL : raw.trim();
+    if (value.isEmpty()) {
+      throw new IllegalArgumentException("baseUrl must be a non-empty absolute URL when provided");
+    }
+    URI uri = URI.create(value);
+    if (uri.getScheme() == null || uri.getHost() == null) {
+      throw new IllegalArgumentException("baseUrl must be a valid absolute URL");
+    }
+    if (!uri.getScheme().equals("http") && !uri.getScheme().equals("https")) {
+      throw new IllegalArgumentException("baseUrl must use http or https");
+    }
+    try {
+      return new URI(uri.getScheme(), uri.getAuthority(), trimRight(uri.getPath()), null, null);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("baseUrl must be a valid absolute URL", e);
+    }
+  }
+
+  private static String trimRight(String value) {
+    return value == null ? "" : value.replaceFirst("/+$", "");
+  }
+
+  public static final class Builder {
+    private final String apiKey;
+    private String baseUrl = DEFAULT_BASE_URL;
+    private HttpClient httpClient = HttpClient.newHttpClient();
+    private ObjectMapper objectMapper = Json.mapper();
+
+    private Builder(String apiKey) {
+      String trimmed = apiKey == null ? "" : apiKey.trim();
+      if (trimmed.isEmpty()) {
+        throw new IllegalArgumentException("apiKey is required");
+      }
+      this.apiKey = trimmed;
+    }
+
+    public Builder baseUrl(String baseUrl) {
+      this.baseUrl = baseUrl;
+      return this;
+    }
+
+    public Builder httpClient(HttpClient httpClient) {
+      this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
+      return this;
+    }
+
+    public Builder objectMapper(ObjectMapper objectMapper) {
+      this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+      return this;
+    }
+
+    public OpenSend build() {
+      return new OpenSend(this);
+    }
+  }
+}

--- a/packages/jvm-sdk/src/main/java/com/opensend/OpenSendException.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/OpenSendException.java
@@ -1,0 +1,12 @@
+package com.opensend;
+
+/** Base unchecked exception for SDK transport, serialization, and API failures. */
+public class OpenSendException extends RuntimeException {
+  public OpenSendException(String message) {
+    super(message);
+  }
+
+  public OpenSendException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/packages/jvm-sdk/src/main/java/com/opensend/OpenSendResponse.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/OpenSendResponse.java
@@ -1,0 +1,6 @@
+package com.opensend;
+
+import java.net.http.HttpHeaders;
+
+/** A successful OpenSend response plus transport metadata that may matter to callers. */
+public record OpenSendResponse<T>(T data, int statusCode, HttpHeaders headers, RateLimitInfo rateLimit) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/RateLimitInfo.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/RateLimitInfo.java
@@ -1,0 +1,29 @@
+package com.opensend;
+
+import java.net.http.HttpHeaders;
+import java.util.Optional;
+
+/** Rate-limit headers returned with a response or API error when OpenSend provides them. */
+public record RateLimitInfo(Optional<Integer> limit, Optional<Integer> remaining, Optional<String> reset, Optional<String> retryAfter) {
+  public static RateLimitInfo empty() {
+    return new RateLimitInfo(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  public static RateLimitInfo fromHeaders(HttpHeaders headers) {
+    return new RateLimitInfo(
+        parseInt(headers.firstValue("x-ratelimit-limit")),
+        parseInt(headers.firstValue("x-ratelimit-remaining")),
+        headers.firstValue("x-ratelimit-reset"),
+        headers.firstValue("retry-after"));
+  }
+
+  private static Optional<Integer> parseInt(Optional<String> value) {
+    return value.flatMap(raw -> {
+      try {
+        return Optional.of(Integer.parseInt(raw));
+      } catch (NumberFormatException ignored) {
+        return Optional.empty();
+      }
+    });
+  }
+}

--- a/packages/jvm-sdk/src/main/java/com/opensend/RequestOptions.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/RequestOptions.java
@@ -1,0 +1,12 @@
+package com.opensend;
+
+/** Per-request options such as idempotency keys for retry-safe write operations. */
+public record RequestOptions(String idempotencyKey) {
+  public static RequestOptions none() {
+    return new RequestOptions(null);
+  }
+
+  public static RequestOptions withIdempotencyKey(String idempotencyKey) {
+    return new RequestOptions(idempotencyKey);
+  }
+}

--- a/packages/jvm-sdk/src/main/java/com/opensend/internal/HttpTransport.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/internal/HttpTransport.java
@@ -1,0 +1,166 @@
+package com.opensend.internal;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.opensend.ApiException;
+import com.opensend.OpenSendException;
+import com.opensend.OpenSendResponse;
+import com.opensend.RateLimitInfo;
+import com.opensend.RequestOptions;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Locale;
+
+public final class HttpTransport {
+  public static final String USER_AGENT = "opensend-jvm/0.1.0";
+
+  private final String apiKey;
+  private final URI baseUri;
+  private final HttpClient httpClient;
+  private final ObjectMapper objectMapper;
+
+  public HttpTransport(String apiKey, URI baseUri, HttpClient httpClient, ObjectMapper objectMapper) {
+    this.apiKey = apiKey;
+    this.baseUri = baseUri;
+    this.httpClient = httpClient;
+    this.objectMapper = objectMapper;
+  }
+
+  public <T> T json(String method, String path, Object body, RequestOptions options, TypeReference<T> type) {
+    return response(method, path, body, options, type).data();
+  }
+
+  public <T> OpenSendResponse<T> response(String method, String path, Object body, RequestOptions options, TypeReference<T> type) {
+    HttpRequest request = buildRequest(method, path, body, options == null ? RequestOptions.none() : options);
+    HttpResponse<String> response;
+    try {
+      response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    } catch (IOException e) {
+      throw new OpenSendException("opensend: execute request", e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new OpenSendException("opensend: request interrupted", e);
+    }
+
+    RateLimitInfo rateLimit = RateLimitInfo.fromHeaders(response.headers());
+    if (response.statusCode() < 200 || response.statusCode() >= 300) {
+      throw parseApiError(response.statusCode(), response.body(), response.headers(), rateLimit);
+    }
+
+    T data = null;
+    if (type != null && response.body() != null && !response.body().isBlank()) {
+      try {
+        data = objectMapper.readValue(response.body(), type);
+      } catch (JsonProcessingException e) {
+        throw new OpenSendException("opensend: decode response", e);
+      }
+    }
+    return new OpenSendResponse<>(data, response.statusCode(), response.headers(), rateLimit);
+  }
+
+  private HttpRequest buildRequest(String method, String path, Object body, RequestOptions options) {
+    HttpRequest.BodyPublisher publisher = HttpRequest.BodyPublishers.noBody();
+    if (body != null) {
+      try {
+        publisher = HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(body));
+      } catch (JsonProcessingException e) {
+        throw new OpenSendException("opensend: encode request body", e);
+      }
+    }
+
+    HttpRequest.Builder builder = HttpRequest.newBuilder(resolve(path))
+        .timeout(Duration.ofSeconds(60))
+        .header("Authorization", "Bearer " + apiKey)
+        .header("Accept", "application/json")
+        .header("User-Agent", USER_AGENT)
+        .method(method.toUpperCase(Locale.ROOT), publisher);
+    if (body != null) {
+      builder.header("Content-Type", "application/json");
+    }
+    if (options.idempotencyKey() != null && !options.idempotencyKey().isBlank()) {
+      builder.header("Idempotency-Key", options.idempotencyKey());
+    }
+    return builder.build();
+  }
+
+  private URI resolve(String path) {
+    String basePath = trimRight(baseUri.getRawPath());
+    String requestPath = "/" + trimLeft(path == null ? "" : path);
+    String combinedPath = basePath.isEmpty() ? requestPath : basePath + requestPath;
+    String query = extractQuery(path);
+    String uri = baseUri.getScheme() + "://" + baseUri.getRawAuthority() + combinedPath + (query == null ? "" : "?" + query);
+    try {
+      return URI.create(uri);
+    } catch (IllegalArgumentException e) {
+      throw new OpenSendException("opensend: build request URI", e);
+    }
+  }
+
+  private static String trimLeft(String value) {
+    String withoutQuery = value.contains("?") ? value.substring(0, value.indexOf('?')) : value;
+    return withoutQuery.replaceFirst("^/+", "");
+  }
+
+  private static String trimRight(String value) {
+    return value == null ? "" : value.replaceFirst("/+$", "");
+  }
+
+  private static String extractQuery(String path) {
+    if (path == null) {
+      return null;
+    }
+    int index = path.indexOf('?');
+    return index >= 0 ? path.substring(index + 1) : null;
+  }
+
+  private ApiException parseApiError(int statusCode, String body, HttpHeaders headers, RateLimitInfo rateLimit) {
+    String message = defaultStatusMessage(statusCode);
+    String name = null;
+    String code = null;
+    JsonNode details = null;
+
+    if (body != null && !body.isBlank()) {
+      try {
+        JsonNode root = objectMapper.readTree(body);
+        if (root.hasNonNull("message")) {
+          message = root.get("message").asText();
+        } else if (root.hasNonNull("error")) {
+          message = root.get("error").asText();
+        }
+        if (root.hasNonNull("name")) {
+          name = root.get("name").asText();
+        }
+        if (root.hasNonNull("code")) {
+          code = root.get("code").asText();
+        }
+        if (root.has("details") && !root.get("details").isNull()) {
+          details = root.get("details");
+        }
+      } catch (JsonProcessingException ignored) {
+        // Keep the status text and raw body for unexpected non-JSON errors.
+      }
+    }
+
+    return new ApiException(statusCode, body == null ? "" : body, message, name, code, details, headers, rateLimit);
+  }
+
+  private static String defaultStatusMessage(int statusCode) {
+    return switch (statusCode) {
+      case 400 -> "Bad Request";
+      case 401 -> "Unauthorized";
+      case 403 -> "Forbidden";
+      case 404 -> "Not Found";
+      case 409 -> "Conflict";
+      case 422 -> "Unprocessable Entity";
+      case 429 -> "Too Many Requests";
+      default -> "Request failed";
+    };
+  }
+}

--- a/packages/jvm-sdk/src/main/java/com/opensend/internal/Json.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/internal/Json.java
@@ -1,0 +1,17 @@
+package com.opensend.internal;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+
+public final class Json {
+  private Json() {}
+
+  public static ObjectMapper mapper() {
+    return new ObjectMapper()
+        .registerModule(new Jdk8Module())
+        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  }
+}

--- a/packages/jvm-sdk/src/main/java/com/opensend/internal/Query.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/internal/Query.java
@@ -1,0 +1,41 @@
+package com.opensend.internal;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class Query {
+  private final String path;
+  private final Map<String, String> params = new LinkedHashMap<>();
+
+  public Query(String path) {
+    this.path = path;
+  }
+
+  public Query add(String key, Object value) {
+    if (value != null && !String.valueOf(value).isBlank()) {
+      params.put(key, String.valueOf(value));
+    }
+    return this;
+  }
+
+  public String build() {
+    if (params.isEmpty()) {
+      return path;
+    }
+    StringBuilder query = new StringBuilder(path).append('?');
+    boolean first = true;
+    for (Map.Entry<String, String> entry : params.entrySet()) {
+      if (!first) {
+        query.append('&');
+      }
+      first = false;
+      query
+          .append(URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8))
+          .append('=')
+          .append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8));
+    }
+    return query.toString();
+  }
+}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/BatchEmailItemResponse.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/BatchEmailItemResponse.java
@@ -1,0 +1,7 @@
+package com.opensend.models;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record BatchEmailItemResponse(String id, ItemError error) {
+  public record ItemError(String name, String code, String message, Integer statusCode, JsonNode details) {}
+}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/BatchEmailResponse.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/BatchEmailResponse.java
@@ -1,0 +1,5 @@
+package com.opensend.models;
+
+import java.util.List;
+
+public record BatchEmailResponse(List<BatchEmailItemResponse> data) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/CancelEmailResponse.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/CancelEmailResponse.java
@@ -1,0 +1,3 @@
+package com.opensend.models;
+
+public record CancelEmailResponse(String object, String id) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/ContactResponse.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/ContactResponse.java
@@ -1,0 +1,16 @@
+package com.opensend.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+public record ContactResponse(
+    String object,
+    String id,
+    String email,
+    @JsonProperty("first_name") String firstName,
+    @JsonProperty("last_name") String lastName,
+    Map<String, Object> properties,
+    List<String> segments,
+    @JsonProperty("created_at") String createdAt,
+    @JsonProperty("updated_at") String updatedAt) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/CreateContactRequest.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/CreateContactRequest.java
@@ -1,0 +1,12 @@
+package com.opensend.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+public record CreateContactRequest(
+    String email,
+    @JsonProperty("first_name") String firstName,
+    @JsonProperty("last_name") String lastName,
+    Map<String, Object> properties,
+    List<String> segments) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/CreateDomainRequest.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/CreateDomainRequest.java
@@ -1,0 +1,14 @@
+package com.opensend.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record CreateDomainRequest(
+    String name,
+    String region,
+    @JsonProperty("custom_return_path") String customReturnPath,
+    @JsonProperty("open_tracking") Boolean openTracking,
+    @JsonProperty("click_tracking") Boolean clickTracking,
+    @JsonProperty("tracking_subdomain") String trackingSubdomain,
+    String tls,
+    List<DomainCapability> capabilities) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/CreateSuppressionRequest.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/CreateSuppressionRequest.java
@@ -1,0 +1,3 @@
+package com.opensend.models;
+
+public record CreateSuppressionRequest(String email, SuppressionReason reason) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/DeleteContactResponse.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/DeleteContactResponse.java
@@ -1,0 +1,3 @@
+package com.opensend.models;
+
+public record DeleteContactResponse(String object, String id, boolean deleted) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/DeleteDomainResponse.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/DeleteDomainResponse.java
@@ -1,0 +1,3 @@
+package com.opensend.models;
+
+public record DeleteDomainResponse(String object, String id, boolean deleted) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/DeleteSuppressionResponse.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/DeleteSuppressionResponse.java
@@ -1,0 +1,3 @@
+package com.opensend.models;
+
+public record DeleteSuppressionResponse(String object, boolean deleted) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/DomainCapability.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/DomainCapability.java
@@ -1,0 +1,3 @@
+package com.opensend.models;
+
+public record DomainCapability(String name, boolean enabled) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/DomainListItem.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/DomainListItem.java
@@ -1,0 +1,12 @@
+package com.opensend.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record DomainListItem(
+    String id,
+    String name,
+    String status,
+    String region,
+    List<DomainCapability> capabilities,
+    @JsonProperty("created_at") String createdAt) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/DomainMutationResponse.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/DomainMutationResponse.java
@@ -1,0 +1,3 @@
+package com.opensend.models;
+
+public record DomainMutationResponse(String object, String id) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/DomainRecord.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/DomainRecord.java
@@ -1,0 +1,3 @@
+package com.opensend.models;
+
+public record DomainRecord(String type, String name, String value, String status, String ttl, Integer priority) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/DomainResponse.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/DomainResponse.java
@@ -1,0 +1,20 @@
+package com.opensend.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record DomainResponse(
+    String object,
+    String id,
+    String name,
+    String status,
+    String region,
+    List<DomainRecord> records,
+    @JsonProperty("custom_return_path") String customReturnPath,
+    @JsonProperty("return_path") String returnPath,
+    @JsonProperty("open_tracking") Boolean openTracking,
+    @JsonProperty("click_tracking") Boolean clickTracking,
+    @JsonProperty("tracking_subdomain") String trackingSubdomain,
+    String tls,
+    List<DomainCapability> capabilities,
+    @JsonProperty("created_at") String createdAt) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/EmailAttachment.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/EmailAttachment.java
@@ -1,0 +1,10 @@
+package com.opensend.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record EmailAttachment(
+    String filename,
+    String content,
+    String path,
+    @JsonProperty("content_type") String contentType,
+    @JsonProperty("content_id") String contentId) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/EmailDetailResponse.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/EmailDetailResponse.java
@@ -1,0 +1,23 @@
+package com.opensend.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+
+public record EmailDetailResponse(
+    String object,
+    String id,
+    @JsonProperty("from") String from,
+    List<String> to,
+    String subject,
+    List<String> cc,
+    List<String> bcc,
+    @JsonProperty("reply_to") List<String> replyTo,
+    @JsonProperty("last_event") String lastEvent,
+    @JsonProperty("scheduled_at") String scheduledAt,
+    @JsonProperty("sent_at") String sentAt,
+    @JsonProperty("created_at") String createdAt,
+    String html,
+    String text,
+    List<EmailTag> tags,
+    @JsonProperty("provider_last_error") JsonNode providerLastError) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/EmailListItem.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/EmailListItem.java
@@ -1,0 +1,23 @@
+package com.opensend.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+
+public record EmailListItem(
+    String id,
+    @JsonProperty("from") String from,
+    List<String> to,
+    String subject,
+    List<String> cc,
+    List<String> bcc,
+    @JsonProperty("reply_to") List<String> replyTo,
+    @JsonProperty("last_event") String lastEvent,
+    @JsonProperty("scheduled_at") String scheduledAt,
+    @JsonProperty("sent_at") String sentAt,
+    @JsonProperty("created_at") String createdAt,
+    @JsonProperty("provider_retry_count") Integer providerRetryCount,
+    @JsonProperty("provider_last_attempted_at") String providerLastAttemptedAt,
+    @JsonProperty("provider_next_retry_at") String providerNextRetryAt,
+    @JsonProperty("provider_last_error") JsonNode providerLastError,
+    @JsonProperty("provider_dead_lettered_at") String providerDeadLetteredAt) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/EmailListOptions.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/EmailListOptions.java
@@ -1,0 +1,7 @@
+package com.opensend.models;
+
+public record EmailListOptions(Integer limit, String after, String before, String status) {
+  public static EmailListOptions empty() {
+    return new EmailListOptions(null, null, null, null);
+  }
+}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/EmailResponse.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/EmailResponse.java
@@ -1,0 +1,3 @@
+package com.opensend.models;
+
+public record EmailResponse(String id) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/EmailTag.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/EmailTag.java
@@ -1,0 +1,3 @@
+package com.opensend.models;
+
+public record EmailTag(String name, String value) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/EmailTemplateReference.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/EmailTemplateReference.java
@@ -1,0 +1,5 @@
+package com.opensend.models;
+
+import java.util.Map;
+
+public record EmailTemplateReference(String id, Map<String, Object> variables) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/SendEmailRequest.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/SendEmailRequest.java
@@ -1,0 +1,61 @@
+package com.opensend.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+public record SendEmailRequest(
+    @JsonProperty("from") String from,
+    List<String> to,
+    String subject,
+    String html,
+    String text,
+    List<String> cc,
+    List<String> bcc,
+    @JsonProperty("reply_to") List<String> replyTo,
+    Map<String, String> headers,
+    List<EmailAttachment> attachments,
+    List<EmailTag> tags,
+    @JsonProperty("scheduled_at") String scheduledAt,
+    @JsonProperty("topic_id") String topicId,
+    EmailTemplateReference template) {
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private String from;
+    private List<String> to;
+    private String subject;
+    private String html;
+    private String text;
+    private List<String> cc;
+    private List<String> bcc;
+    private List<String> replyTo;
+    private Map<String, String> headers;
+    private List<EmailAttachment> attachments;
+    private List<EmailTag> tags;
+    private String scheduledAt;
+    private String topicId;
+    private EmailTemplateReference template;
+
+    public Builder from(String from) { this.from = from; return this; }
+    public Builder to(List<String> to) { this.to = to; return this; }
+    public Builder subject(String subject) { this.subject = subject; return this; }
+    public Builder html(String html) { this.html = html; return this; }
+    public Builder text(String text) { this.text = text; return this; }
+    public Builder cc(List<String> cc) { this.cc = cc; return this; }
+    public Builder bcc(List<String> bcc) { this.bcc = bcc; return this; }
+    public Builder replyTo(List<String> replyTo) { this.replyTo = replyTo; return this; }
+    public Builder headers(Map<String, String> headers) { this.headers = headers; return this; }
+    public Builder attachments(List<EmailAttachment> attachments) { this.attachments = attachments; return this; }
+    public Builder tags(List<EmailTag> tags) { this.tags = tags; return this; }
+    public Builder scheduledAt(String scheduledAt) { this.scheduledAt = scheduledAt; return this; }
+    public Builder topicId(String topicId) { this.topicId = topicId; return this; }
+    public Builder template(EmailTemplateReference template) { this.template = template; return this; }
+
+    public SendEmailRequest build() {
+      return new SendEmailRequest(from, to, subject, html, text, cc, bcc, replyTo, headers, attachments, tags, scheduledAt, topicId, template);
+    }
+  }
+}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/SuppressionReason.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/SuppressionReason.java
@@ -1,0 +1,8 @@
+package com.opensend.models;
+
+public enum SuppressionReason {
+  bounce,
+  complaint,
+  manual,
+  unsubscribe
+}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/SuppressionResponse.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/SuppressionResponse.java
@@ -1,0 +1,17 @@
+package com.opensend.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+public record SuppressionResponse(
+    String id,
+    String object,
+    String email,
+    SuppressionReason reason,
+    String scope,
+    @JsonProperty("source_event_id") String sourceEventId,
+    @JsonProperty("source_email_id") String sourceEmailId,
+    @JsonProperty("source_message_id") String sourceMessageId,
+    Map<String, Object> metadata,
+    @JsonProperty("suppressed_at") String suppressedAt,
+    @JsonProperty("updated_at") String updatedAt) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/UpdateContactRequest.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/UpdateContactRequest.java
@@ -1,0 +1,12 @@
+package com.opensend.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+public record UpdateContactRequest(
+    String email,
+    @JsonProperty("first_name") String firstName,
+    @JsonProperty("last_name") String lastName,
+    Map<String, Object> properties,
+    List<String> segments) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/models/UpdateDomainRequest.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/models/UpdateDomainRequest.java
@@ -1,0 +1,13 @@
+package com.opensend.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record UpdateDomainRequest(
+    @JsonProperty("click_tracking") Boolean clickTracking,
+    @JsonProperty("open_tracking") Boolean openTracking,
+    @JsonProperty("tracking_subdomain") String trackingSubdomain,
+    @JsonProperty("sending_enabled") Boolean sendingEnabled,
+    @JsonProperty("receiving_enabled") Boolean receivingEnabled,
+    String tls,
+    List<DomainCapability> capabilities) {}

--- a/packages/jvm-sdk/src/main/java/com/opensend/resources/ContactsClient.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/resources/ContactsClient.java
@@ -1,0 +1,49 @@
+package com.opensend.resources;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.opensend.ListOptions;
+import com.opensend.ListPage;
+import com.opensend.RequestOptions;
+import com.opensend.internal.HttpTransport;
+import com.opensend.internal.Query;
+import com.opensend.models.ContactResponse;
+import com.opensend.models.CreateContactRequest;
+import com.opensend.models.DeleteContactResponse;
+import com.opensend.models.UpdateContactRequest;
+
+public final class ContactsClient {
+  private final HttpTransport transport;
+
+  public ContactsClient(HttpTransport transport) {
+    this.transport = transport;
+  }
+
+  public ContactResponse create(CreateContactRequest request) {
+    return transport.json("POST", "/contacts", request, RequestOptions.none(), new TypeReference<ContactResponse>() {});
+  }
+
+  public ListPage<ContactResponse> list() {
+    return list(ListOptions.empty());
+  }
+
+  public ListPage<ContactResponse> list(ListOptions options) {
+    ListOptions safe = options == null ? ListOptions.empty() : options;
+    String path = new Query("/contacts")
+        .add("limit", safe.limit())
+        .add("after", safe.after())
+        .build();
+    return transport.json("GET", path, null, RequestOptions.none(), new TypeReference<ListPage<ContactResponse>>() {});
+  }
+
+  public ContactResponse get(String idOrEmail) {
+    return transport.json("GET", "/contacts/" + idOrEmail, null, RequestOptions.none(), new TypeReference<ContactResponse>() {});
+  }
+
+  public ContactResponse update(String idOrEmail, UpdateContactRequest request) {
+    return transport.json("PATCH", "/contacts/" + idOrEmail, request, RequestOptions.none(), new TypeReference<ContactResponse>() {});
+  }
+
+  public DeleteContactResponse delete(String idOrEmail) {
+    return transport.json("DELETE", "/contacts/" + idOrEmail, null, RequestOptions.none(), new TypeReference<DeleteContactResponse>() {});
+  }
+}

--- a/packages/jvm-sdk/src/main/java/com/opensend/resources/DomainsClient.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/resources/DomainsClient.java
@@ -1,0 +1,44 @@
+package com.opensend.resources;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.opensend.ListPage;
+import com.opensend.RequestOptions;
+import com.opensend.internal.HttpTransport;
+import com.opensend.models.CreateDomainRequest;
+import com.opensend.models.DeleteDomainResponse;
+import com.opensend.models.DomainListItem;
+import com.opensend.models.DomainMutationResponse;
+import com.opensend.models.DomainResponse;
+import com.opensend.models.UpdateDomainRequest;
+
+public final class DomainsClient {
+  private final HttpTransport transport;
+
+  public DomainsClient(HttpTransport transport) {
+    this.transport = transport;
+  }
+
+  public DomainResponse create(CreateDomainRequest request) {
+    return transport.json("POST", "/api/domains", request, RequestOptions.none(), new TypeReference<DomainResponse>() {});
+  }
+
+  public ListPage<DomainListItem> list() {
+    return transport.json("GET", "/api/domains", null, RequestOptions.none(), new TypeReference<ListPage<DomainListItem>>() {});
+  }
+
+  public DomainResponse get(String id) {
+    return transport.json("GET", "/api/domains/" + id, null, RequestOptions.none(), new TypeReference<DomainResponse>() {});
+  }
+
+  public DomainMutationResponse update(String id, UpdateDomainRequest request) {
+    return transport.json("PATCH", "/api/domains/" + id, request, RequestOptions.none(), new TypeReference<DomainMutationResponse>() {});
+  }
+
+  public DomainResponse verify(String id) {
+    return transport.json("POST", "/api/domains/" + id + "/verify", null, RequestOptions.none(), new TypeReference<DomainResponse>() {});
+  }
+
+  public DeleteDomainResponse delete(String id) {
+    return transport.json("DELETE", "/api/domains/" + id, null, RequestOptions.none(), new TypeReference<DeleteDomainResponse>() {});
+  }
+}

--- a/packages/jvm-sdk/src/main/java/com/opensend/resources/EmailsClient.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/resources/EmailsClient.java
@@ -1,0 +1,67 @@
+package com.opensend.resources;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.opensend.ListPage;
+import com.opensend.OpenSendResponse;
+import com.opensend.RequestOptions;
+import com.opensend.internal.HttpTransport;
+import com.opensend.internal.Query;
+import com.opensend.models.BatchEmailResponse;
+import com.opensend.models.CancelEmailResponse;
+import com.opensend.models.EmailDetailResponse;
+import com.opensend.models.EmailListItem;
+import com.opensend.models.EmailListOptions;
+import com.opensend.models.EmailResponse;
+import com.opensend.models.SendEmailRequest;
+import java.util.List;
+
+public final class EmailsClient {
+  private final HttpTransport transport;
+
+  public EmailsClient(HttpTransport transport) {
+    this.transport = transport;
+  }
+
+  public EmailResponse send(SendEmailRequest request) {
+    return send(request, RequestOptions.none());
+  }
+
+  public EmailResponse send(SendEmailRequest request, RequestOptions options) {
+    return sendWithResponse(request, options).data();
+  }
+
+  public OpenSendResponse<EmailResponse> sendWithResponse(SendEmailRequest request, RequestOptions options) {
+    return transport.response("POST", "/emails", request, options, new TypeReference<EmailResponse>() {});
+  }
+
+  public BatchEmailResponse sendBatch(List<SendEmailRequest> requests) {
+    return sendBatch(requests, RequestOptions.none());
+  }
+
+  public BatchEmailResponse sendBatch(List<SendEmailRequest> requests, RequestOptions options) {
+    return transport.json("POST", "/emails/batch", requests, options, new TypeReference<BatchEmailResponse>() {});
+  }
+
+  public ListPage<EmailListItem> list() {
+    return list(EmailListOptions.empty());
+  }
+
+  public ListPage<EmailListItem> list(EmailListOptions options) {
+    EmailListOptions safe = options == null ? EmailListOptions.empty() : options;
+    String path = new Query("/api/emails")
+        .add("limit", safe.limit())
+        .add("after", safe.after())
+        .add("before", safe.before())
+        .add("status", safe.status())
+        .build();
+    return transport.json("GET", path, null, RequestOptions.none(), new TypeReference<ListPage<EmailListItem>>() {});
+  }
+
+  public EmailDetailResponse get(String id) {
+    return transport.json("GET", "/api/emails/" + id, null, RequestOptions.none(), new TypeReference<EmailDetailResponse>() {});
+  }
+
+  public CancelEmailResponse cancel(String id) {
+    return transport.json("POST", "/emails/" + id + "/cancel", null, RequestOptions.none(), new TypeReference<CancelEmailResponse>() {});
+  }
+}

--- a/packages/jvm-sdk/src/main/java/com/opensend/resources/SuppressionsClient.java
+++ b/packages/jvm-sdk/src/main/java/com/opensend/resources/SuppressionsClient.java
@@ -1,0 +1,54 @@
+package com.opensend.resources;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.opensend.ListOptions;
+import com.opensend.ListPage;
+import com.opensend.RequestOptions;
+import com.opensend.internal.HttpTransport;
+import com.opensend.internal.Query;
+import com.opensend.models.CreateSuppressionRequest;
+import com.opensend.models.DeleteSuppressionResponse;
+import com.opensend.models.SuppressionResponse;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public final class SuppressionsClient {
+  private final HttpTransport transport;
+
+  public SuppressionsClient(HttpTransport transport) {
+    this.transport = transport;
+  }
+
+  public ListPage<SuppressionResponse> list() {
+    return list(ListOptions.empty());
+  }
+
+  public ListPage<SuppressionResponse> list(ListOptions options) {
+    ListOptions safe = options == null ? ListOptions.empty() : options;
+    String path = new Query("/api/suppressions")
+        .add("limit", safe.limit())
+        .add("after", safe.after())
+        .build();
+    return transport.json("GET", path, null, RequestOptions.none(), new TypeReference<ListPage<SuppressionResponse>>() {});
+  }
+
+  public SuppressionResponse get(String email) {
+    return transport.json("GET", "/api/suppressions/" + escape(email), null, RequestOptions.none(), new TypeReference<SuppressionResponse>() {});
+  }
+
+  public SuppressionResponse create(CreateSuppressionRequest request) {
+    return create(request, RequestOptions.none());
+  }
+
+  public SuppressionResponse create(CreateSuppressionRequest request, RequestOptions options) {
+    return transport.json("POST", "/api/suppressions", request, options, new TypeReference<SuppressionResponse>() {});
+  }
+
+  public DeleteSuppressionResponse delete(String email) {
+    return transport.json("DELETE", "/api/suppressions/" + escape(email), null, RequestOptions.none(), new TypeReference<DeleteSuppressionResponse>() {});
+  }
+
+  private static String escape(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+}

--- a/packages/jvm-sdk/src/test/java/com/opensend/ApiErrorTest.java
+++ b/packages/jvm-sdk/src/test/java/com/opensend/ApiErrorTest.java
@@ -1,0 +1,58 @@
+package com.opensend;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.opensend.fixtures.TestServer;
+import com.opensend.models.SendEmailRequest;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class ApiErrorTest {
+  @Test
+  void parsesOpenSendErrorEnvelopeAndRateLimitHeaders() throws Exception {
+    try (TestServer server = new TestServer()) {
+      Map<String, String> headers = new LinkedHashMap<>();
+      headers.put("x-ratelimit-limit", "10");
+      headers.put("x-ratelimit-remaining", "0");
+      headers.put("retry-after", "30");
+      server.respond(exchange -> new TestServer.StubResponse(
+          422,
+          "{\"name\":\"validation_error\",\"code\":\"invalid_request\",\"message\":\"from is required\",\"details\":{\"fieldErrors\":{\"from\":[\"Required\"]}}}",
+          headers));
+      OpenSend client = OpenSend.builder("os_test").baseUrl(server.url()).build();
+
+      ApiException error = assertThrows(ApiException.class, () -> client.emails().send(SendEmailRequest.builder()
+          .to(List.of("user@example.com"))
+          .subject("Hello")
+          .build()));
+
+      assertEquals(422, error.statusCode());
+      assertEquals("from is required", error.apiMessage());
+      assertEquals("validation_error", error.name());
+      assertEquals("invalid_request", error.code());
+      assertNotNull(error.details());
+      assertEquals(10, error.rateLimit().limit().orElseThrow());
+      assertEquals(0, error.rateLimit().remaining().orElseThrow());
+      assertEquals("30", error.rateLimit().retryAfter().orElseThrow());
+    }
+  }
+
+  @Test
+  void keepsRawBodyForUnexpectedErrorShapes() throws Exception {
+    try (TestServer server = new TestServer()) {
+      server.respond(exchange -> new TestServer.StubResponse(500, "upstream unavailable"));
+      OpenSend client = OpenSend.builder("os_test").baseUrl(server.url()).build();
+
+      ApiException error = assertThrows(ApiException.class, () -> client.domains().list());
+
+      assertEquals(500, error.statusCode());
+      assertEquals("upstream unavailable", error.body());
+      assertTrue(error.getMessage().contains("Request failed"));
+    }
+  }
+}

--- a/packages/jvm-sdk/src/test/java/com/opensend/OpenSendClientTest.java
+++ b/packages/jvm-sdk/src/test/java/com/opensend/OpenSendClientTest.java
@@ -1,0 +1,46 @@
+package com.opensend;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.opensend.fixtures.RecordedRequest;
+import com.opensend.fixtures.TestServer;
+import com.opensend.models.SendEmailRequest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class OpenSendClientTest {
+  @Test
+  void requiresApiKey() {
+    assertThrows(IllegalArgumentException.class, () -> OpenSend.create(" "));
+  }
+
+  @Test
+  void rejectsInvalidBaseUrl() {
+    assertThrows(IllegalArgumentException.class, () -> OpenSend.builder("os_test").baseUrl("ftp://example.com").build());
+  }
+
+  @Test
+  void sendsDefaultHeadersAndJoinsBasePath() throws Exception {
+    try (TestServer server = new TestServer()) {
+      server.respond(exchange -> new TestServer.StubResponse(200, "{\"id\":\"email_123\"}"));
+      OpenSend client = OpenSend.builder(" os_test ").baseUrl(server.url() + "/v1/").build();
+
+      client.emails().send(SendEmailRequest.builder()
+          .from("OpenSend <onboarding@example.com>")
+          .to(List.of("user@example.com"))
+          .subject("Hello")
+          .html("<strong>Hello</strong>")
+          .build(), RequestOptions.withIdempotencyKey("welcome-123"));
+
+      RecordedRequest request = server.takeRequest();
+      assertEquals("POST", request.method());
+      assertEquals("/v1/emails", request.path());
+      assertEquals("Bearer os_test", request.firstHeader("Authorization"));
+      assertEquals("application/json", request.firstHeader("Accept"));
+      assertEquals("application/json", request.firstHeader("Content-Type"));
+      assertEquals("welcome-123", request.firstHeader("Idempotency-Key"));
+      assertEquals("opensend-jvm/0.1.0", request.firstHeader("User-Agent"));
+    }
+  }
+}

--- a/packages/jvm-sdk/src/test/java/com/opensend/ResourceContractTest.java
+++ b/packages/jvm-sdk/src/test/java/com/opensend/ResourceContractTest.java
@@ -1,0 +1,71 @@
+package com.opensend;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.opensend.fixtures.RecordedRequest;
+import com.opensend.fixtures.TestServer;
+import com.opensend.models.CreateContactRequest;
+import com.opensend.models.CreateDomainRequest;
+import com.opensend.models.CreateSuppressionRequest;
+import com.opensend.models.EmailListItem;
+import com.opensend.models.EmailListOptions;
+import com.opensend.models.EmailResponse;
+import com.opensend.models.SendEmailRequest;
+import com.opensend.models.SuppressionReason;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class ResourceContractTest {
+  @Test
+  void emailsSendAndListUseImplementedRoutes() throws Exception {
+    try (TestServer server = new TestServer()) {
+      server.respond(exchange -> switch (exchange.getRequestURI().getPath()) {
+        case "/emails" -> new TestServer.StubResponse(200, "{\"id\":\"email_123\"}");
+        case "/api/emails" -> new TestServer.StubResponse(200, "{\"object\":\"list\",\"has_more\":false,\"data\":[{\"id\":\"email_123\",\"from\":\"OpenSend <onboarding@example.com>\",\"to\":[\"user@example.com\"],\"subject\":\"Hello\",\"last_event\":\"queued\",\"created_at\":\"2026-05-28T00:00:00Z\"}]}");
+        default -> new TestServer.StubResponse(404, "{}");
+      });
+      OpenSend client = OpenSend.builder("os_test").baseUrl(server.url()).build();
+
+      EmailResponse sent = client.emails().send(SendEmailRequest.builder()
+          .from("OpenSend <onboarding@example.com>")
+          .to(List.of("user@example.com"))
+          .subject("Hello")
+          .html("<strong>Hello</strong>")
+          .build());
+      ListPage<EmailListItem> page = client.emails().list(new EmailListOptions(20, "email_100", null, "queued"));
+
+      assertEquals("email_123", sent.id());
+      assertFalse(page.hasMore());
+      assertEquals("email_123", page.data().get(0).id());
+      RecordedRequest sendRequest = server.takeRequest();
+      RecordedRequest listRequest = server.takeRequest();
+      assertEquals("/emails", sendRequest.path());
+      assertEquals("/api/emails?limit=20&after=email_100&status=queued", listRequest.path());
+    }
+  }
+
+  @Test
+  void representativeResourcesUseDocumentedImplementedRoutes() throws Exception {
+    try (TestServer server = new TestServer()) {
+      server.respond(exchange -> switch (exchange.getRequestURI().getPath()) {
+        case "/contacts" -> new TestServer.StubResponse(200, "{\"object\":\"contact\",\"id\":\"contact_123\",\"email\":\"user@example.com\",\"properties\":{\"plan\":\"pro\"},\"created_at\":\"2026-05-28T00:00:00Z\"}");
+        case "/api/domains" -> new TestServer.StubResponse(200, "{\"object\":\"domain\",\"id\":\"domain_123\",\"name\":\"example.com\",\"status\":\"pending\",\"region\":\"us-east-1\",\"records\":[],\"created_at\":\"2026-05-28T00:00:00Z\"}");
+        case "/api/suppressions" -> new TestServer.StubResponse(200, "{\"object\":\"suppression\",\"id\":\"sup_123\",\"email\":\"user@example.com\",\"reason\":\"manual\",\"scope\":\"user\",\"suppressed_at\":\"2026-05-28T00:00:00Z\",\"updated_at\":\"2026-05-28T00:00:00Z\"}");
+        default -> new TestServer.StubResponse(404, "{}");
+      });
+      OpenSend client = OpenSend.builder("os_test").baseUrl(server.url()).build();
+
+      assertEquals("contact_123", client.contacts().create(new CreateContactRequest("user@example.com", null, null, Map.of("plan", "pro"), List.of())).id());
+      assertEquals("domain_123", client.domains().create(new CreateDomainRequest("example.com", null, null, null, null, null, null, List.of())).id());
+      assertEquals("sup_123", client.suppressions().create(new CreateSuppressionRequest("user@example.com", SuppressionReason.manual), RequestOptions.withIdempotencyKey("suppress-user")).id());
+
+      assertEquals("/contacts", server.takeRequest().path());
+      assertEquals("/api/domains", server.takeRequest().path());
+      RecordedRequest suppressionRequest = server.takeRequest();
+      assertEquals("/api/suppressions", suppressionRequest.path());
+      assertEquals("suppress-user", suppressionRequest.firstHeader("Idempotency-Key"));
+    }
+  }
+}

--- a/packages/jvm-sdk/src/test/java/com/opensend/fixtures/RecordedRequest.java
+++ b/packages/jvm-sdk/src/test/java/com/opensend/fixtures/RecordedRequest.java
@@ -1,0 +1,9 @@
+package com.opensend.fixtures;
+
+import com.sun.net.httpserver.Headers;
+
+public record RecordedRequest(String method, String path, String body, Headers headers) {
+  public String firstHeader(String name) {
+    return headers.getFirst(name);
+  }
+}

--- a/packages/jvm-sdk/src/test/java/com/opensend/fixtures/TestServer.java
+++ b/packages/jvm-sdk/src/test/java/com/opensend/fixtures/TestServer.java
@@ -1,0 +1,63 @@
+package com.opensend.fixtures;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class TestServer implements AutoCloseable {
+  private final HttpServer server;
+  private final Deque<RecordedRequest> requests = new ArrayDeque<>();
+  private Handler handler = exchange -> new StubResponse(404, "{\"message\":\"not found\"}");
+
+  public TestServer() throws IOException {
+    this.server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    this.server.createContext("/", this::handle);
+    this.server.start();
+  }
+
+  public String url() {
+    return "http://127.0.0.1:" + server.getAddress().getPort();
+  }
+
+  public void respond(Handler handler) {
+    this.handler = handler;
+  }
+
+  public RecordedRequest takeRequest() {
+    return requests.removeFirst();
+  }
+
+  private void handle(HttpExchange exchange) throws IOException {
+    String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+    requests.addLast(new RecordedRequest(exchange.getRequestMethod(), exchange.getRequestURI().toString(), body, exchange.getRequestHeaders()));
+    StubResponse response = handler.handle(exchange);
+    for (Map.Entry<String, String> header : response.headers().entrySet()) {
+      exchange.getResponseHeaders().set(header.getKey(), header.getValue());
+    }
+    byte[] bytes = response.body().getBytes(StandardCharsets.UTF_8);
+    exchange.sendResponseHeaders(response.status(), bytes.length);
+    exchange.getResponseBody().write(bytes);
+    exchange.close();
+  }
+
+  @Override
+  public void close() {
+    server.stop(0);
+  }
+
+  public interface Handler {
+    StubResponse handle(HttpExchange exchange) throws IOException;
+  }
+
+  public record StubResponse(int status, String body, Map<String, String> headers) {
+    public StubResponse(int status, String body) {
+      this(status, body, new LinkedHashMap<>());
+    }
+  }
+}

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -18,6 +18,7 @@
 - [Send emails with Flask](https://opensend.namuh.co/docs/send-with-flask.md): Use the Python SDK from Flask routes, CLI commands, or background workers.
 - [Send emails with Django](https://opensend.namuh.co/docs/send-with-django.md): Use the Python SDK from Django views, management commands, or background jobs.
 - [Send emails with Go](https://opensend.namuh.co/docs/send-with-go.md): Send email from Go with the first-party OpenSend Go SDK.
+- [Send emails with Java and Kotlin](https://opensend.namuh.co/docs/send-with-java.md): Use the first-party OpenSend JVM SDK from plain Java, Kotlin, Spring Boot services, workers, and command-line applications. The package lives in this repository at packages/jvm-sdk while registry publishing is prepared.
 - [Send emails with Ruby](https://opensend.namuh.co/docs/send-with-ruby.md): Send email from Ruby with the first-party OpenSend Ruby SDK. It works in Rails, Sinatra, Ruby scripts, and background jobs.
 - [Send emails with Rails](https://opensend.namuh.co/docs/send-with-rails.md): Use the Ruby SDK from Rails controllers, jobs, mailer adapters, or service objects.
 - [Send emails with Sinatra](https://opensend.namuh.co/docs/send-with-sinatra.md): Use the Ruby SDK from Sinatra routes or background jobs.

--- a/public/docs/sdks.md
+++ b/public/docs/sdks.md
@@ -11,6 +11,7 @@ Use an OpenSend API key that starts with `os_`. Keep keys in server-side environ
 | TypeScript / JavaScript | `opensend` on npm | Node.js, Bun, Next.js, serverless functions, React Email rendering | First-party package |
 | Python | `packages/python-sdk` / future `opensend` PyPI package | Django, Flask, FastAPI, scripts, workers | First-party package; install from the repo until PyPI publishing is enabled |
 | Go | `github.com/namuh-eng/opensend/packages/go-sdk` | API services, workers, CLIs | First-party module |
+| Java / Kotlin | `packages/jvm-sdk` / future Maven package | Spring Boot, plain JVM services, Kotlin workers | First-party blocking SDK slice; install from the repo until Maven publishing is enabled |
 | Ruby | `packages/ruby-sdk` / future `opensend` gem | Rails, Sinatra, Ruby jobs | First-party package; install from the repo until RubyGems publishing is enabled |
 | PHP | `packages/php-sdk` / future `opensend/opensend-php` Composer package | PHP services, Laravel/Symfony apps, workers | First-party send-email slice; install from the repo until Packagist publishing is enabled |
 | SMTP relay | `@opensend/smtp-relay` service | Apps that only speak SMTP | Self-hosted relay service |
@@ -136,6 +137,43 @@ func main() {
     fmt.Println(email.ID)
 }
 ```
+
+
+## Java and Kotlin
+
+Install from this repository until Maven publishing is complete:
+
+```bash
+cd packages/jvm-sdk
+mvn test
+mvn install
+```
+
+Send one email from Java:
+
+```java
+import com.opensend.OpenSend;
+import com.opensend.RequestOptions;
+import com.opensend.models.EmailResponse;
+import com.opensend.models.SendEmailRequest;
+import java.util.List;
+
+OpenSend client = OpenSend.builder(System.getenv("OPENSEND_API_KEY"))
+    .baseUrl(System.getenv().getOrDefault("OPENSEND_BASE_URL", OpenSend.DEFAULT_BASE_URL))
+    .build();
+
+EmailResponse email = client.emails().send(
+    SendEmailRequest.builder()
+        .from("OpenSend <onboarding@updates.example.com>")
+        .to(List.of("user@example.com"))
+        .subject("Hello from OpenSend")
+        .html("<strong>It works.</strong>")
+        .build(),
+    RequestOptions.withIdempotencyKey("welcome-user-123"));
+System.out.println(email.id());
+```
+
+The JVM SDK is blocking-only in this first slice and supports implemented email, contact, domain, and suppression routes. It exposes `ApiException` for OpenSend error envelopes plus rate-limit headers. See [Send emails with Java and Kotlin](./send-with-java.md) for Kotlin and Spring Boot examples.
 
 ## Ruby
 

--- a/public/docs/send-with-java.md
+++ b/public/docs/send-with-java.md
@@ -1,0 +1,125 @@
+# Send emails with Java and Kotlin
+
+Use the first-party OpenSend JVM SDK from plain Java, Kotlin, Spring Boot services, workers, and command-line applications. The package lives in this repository at `packages/jvm-sdk` while registry publishing is prepared.
+
+The JVM SDK targets OpenSend Cloud by default at `https://opensend.namuh.co` and can point at self-hosted OpenSend by setting `OPENSEND_BASE_URL`.
+
+## Install from the repository
+
+Build and install the local Maven artifact:
+
+```bash
+cd packages/jvm-sdk
+mvn test
+mvn install
+```
+
+Then add the local dependency:
+
+```xml
+<dependency>
+  <groupId>com.opensend</groupId>
+  <artifactId>opensend-java</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+</dependency>
+```
+
+No registry credentials or publishing secrets are required for the repository-local package.
+
+## Blocking vs async
+
+The first JVM SDK slice is **blocking-only**. It uses Java's built-in `HttpClient#send` and exposes straightforward resource methods such as `client.emails().send(...)`. This is the recommended stance for Spring Boot controllers, services, queue workers, and CLIs.
+
+Async methods are not exposed yet. If you need asynchronous execution today, run the blocking call inside your application's existing executor, job queue, coroutine dispatcher, or virtual-thread strategy.
+
+## Send from Java
+
+```java
+import com.opensend.ApiException;
+import com.opensend.OpenSend;
+import com.opensend.RequestOptions;
+import com.opensend.models.EmailResponse;
+import com.opensend.models.SendEmailRequest;
+import java.util.List;
+
+OpenSend client = OpenSend.builder(System.getenv("OPENSEND_API_KEY"))
+    .baseUrl(System.getenv().getOrDefault("OPENSEND_BASE_URL", OpenSend.DEFAULT_BASE_URL))
+    .build();
+
+try {
+  EmailResponse email = client.emails().send(
+      SendEmailRequest.builder()
+          .from("OpenSend <onboarding@updates.example.com>")
+          .to(List.of("user@example.com"))
+          .subject("Hello from OpenSend")
+          .html("<strong>It works.</strong>")
+          .build(),
+      RequestOptions.withIdempotencyKey("welcome-user-123"));
+  System.out.println(email.id());
+} catch (ApiException error) {
+  System.err.println(error.statusCode() + " " + error.apiMessage());
+  throw error;
+}
+```
+
+## Send from Kotlin
+
+```kotlin
+import com.opensend.OpenSend
+import com.opensend.RequestOptions
+import com.opensend.models.SendEmailRequest
+
+val client = OpenSend.builder(System.getenv("OPENSEND_API_KEY"))
+    .baseUrl(System.getenv("OPENSEND_BASE_URL") ?: OpenSend.DEFAULT_BASE_URL)
+    .build()
+
+val email = client.emails().send(
+    SendEmailRequest.builder()
+        .from("OpenSend <onboarding@updates.example.com>")
+        .to(listOf("user@example.com"))
+        .subject("Hello from OpenSend")
+        .html("<strong>It works.</strong>")
+        .build(),
+    RequestOptions.withIdempotencyKey("welcome-user-123"),
+)
+println(email.id())
+```
+
+## Spring Boot pattern
+
+Create the client once as a singleton bean:
+
+```java
+@Bean
+OpenSend openSend(@Value("${opensend.api-key}") String apiKey,
+                  @Value("${opensend.base-url:https://opensend.namuh.co}") String baseUrl) {
+  return OpenSend.builder(apiKey).baseUrl(baseUrl).build();
+}
+```
+
+Inject `OpenSend` into services and use idempotency keys for retryable send paths.
+
+## Errors and rate limits
+
+Non-2xx API responses throw `ApiException`. The exception preserves the OpenSend error envelope where present:
+
+- `statusCode()`
+- `apiMessage()`
+- `name()`
+- `code()`
+- `details()`
+- `body()`
+- `rateLimit()` with `limit`, `remaining`, `reset`, and `retryAfter` header values when the server returns them
+
+Use `RequestOptions.withIdempotencyKey(...)` on supported write methods such as email sends and suppression creation when your application retries after timeouts or queue restarts.
+
+## Supported routes
+
+This SDK slice only wraps implemented OpenSend routes:
+
+- `emails`: `POST /emails`, `POST /emails/batch`, `GET /api/emails`, `GET /api/emails/{id}`, `POST /emails/{id}/cancel`
+- `contacts`: `POST /contacts`, `GET /contacts`, `GET /contacts/{id}`, `PATCH /contacts/{id}`, `DELETE /contacts/{id}`
+- `domains`: `POST /api/domains`, `GET /api/domains`, `GET /api/domains/{id}`, `PATCH /api/domains/{id}`, `POST /api/domains/{id}/verify`, `DELETE /api/domains/{id}`
+- `suppressions`: `POST /api/suppressions`, `GET /api/suppressions`, `GET /api/suppressions/{email}`, `DELETE /api/suppressions/{email}`
+
+Use `/openapi.json` or the REST API docs for resources not exposed by this first SDK slice.

--- a/tools/generate-docs-index.mjs
+++ b/tools/generate-docs-index.mjs
@@ -87,6 +87,7 @@ const DOC_ORDER = [
   "send-with-flask.md",
   "send-with-django.md",
   "send-with-go.md",
+  "send-with-java.md",
   "send-with-ruby.md",
   "send-with-rails.md",
   "send-with-sinatra.md",


### PR DESCRIPTION
## Summary
- Adds a repo-local first-party JVM SDK slice at `packages/jvm-sdk` for Java and Kotlin server users.
- Keeps v1 narrow and route-backed: emails, contacts, domains, suppressions, blocking client, idempotency options, pagination, rate-limit metadata, and OpenSend error envelope parsing.
- Adds Java/Kotlin examples, Spring Boot guidance, public docs, regenerated `/docs/llms.txt`, and CI coverage for Maven tests plus Kotlin example compilation.

Closes #562

## Changes
- **JVM SDK**: Maven package `com.opensend:opensend-java:0.1.0-SNAPSHOT` with `OpenSend` builder, blocking HTTP transport, typed resources/models, `ApiException`, `RequestOptions`, `ListPage`, and `RateLimitInfo`.
- **SDK tests**: JUnit tests for client construction, auth/header/idempotency behavior, error parsing, rate-limit headers, and representative route contracts.
- **Examples/docs**: Java, Kotlin, and Spring Boot snippets in `packages/jvm-sdk` plus `public/docs/send-with-java.md` and SDK index updates.
- **CI**: Adds a JVM SDK CI job using Temurin 17, Maven tests, and Kotlin example compile profile.

## How to Test
- [x] `make check`
- [x] `make test`
- [x] `bun run docs:check`
- [x] `docker run --rm -v "$PWD":/workspace -w /workspace/packages/jvm-sdk oven/bun:1.3-alpine sh -lc 'apk add --no-cache openjdk17 maven >/tmp/apk.log && mvn --batch-mode test && mvn --batch-mode -Pkotlin-examples test-compile'`

## Notes
- The JVM SDK is explicitly blocking-only for this first slice; async APIs are deferred.
- No Maven Central publishing credentials or registry secrets are included.
- Live OpenSend API calls and Maven Central publishing were not exercised; tests use local fixture HTTP servers and compile examples.
