### PR TITLE
Add per-message trace and tag-filtered metrics

### DIFF
--- a/agent_docs/learnings/active/2026-05-28-issue-558-trace-tag-metrics-bounds.md
+++ b/agent_docs/learnings/active/2026-05-28-issue-558-trace-tag-metrics-bounds.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-28
+issue: "#558"
+type: decision
+promoted_to: null
+---
+
+## Bound tag metrics to safe dashboard windows
+
+**What:** Tag-filtered metrics and tag breakdowns stay inside the existing dashboard date presets and cap tag option/breakdown source rows instead of scanning a tenant's full email history.
+
+**Why:** Email tags are JSONB compatibility metadata, not a warehouse dimension table. The safe staging slice should use tenant/date predicates plus GIN indexes and explicit row/entry limits before considering a dedicated aggregate table.
+
+**Fix:** Keep tag predicates centralized with send-tag validation semantics, require tenant predicates on every tag query, and add relational/tag indexes before widening metrics surfaces.

--- a/drizzle/0028_sweet_blue_blade.sql
+++ b/drizzle/0028_sweet_blue_blade.sql
@@ -1,0 +1,3 @@
+CREATE INDEX "emails_tags_gin_idx" ON "emails" USING gin ("tags");--> statement-breakpoint
+CREATE INDEX "logs_user_created_at_idx" ON "logs" USING btree ("user_id","created_at");--> statement-breakpoint
+CREATE INDEX "logs_document_gin_idx" ON "logs" USING gin ("document");

--- a/drizzle/meta/0028_snapshot.json
+++ b/drizzle/meta/0028_snapshot.json
@@ -1,0 +1,4022 @@
+{
+  "id": "4ccf7321-dbd1-4ea8-bcf3-ae3444f20a17",
+  "prevId": "1ead0794-609d-455f-9b0d-890eaa532e16",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_preview": {
+          "name": "token_preview",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_access'"
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_token_hash_idx": {
+          "name": "api_keys_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_api_key_id": {
+          "name": "source_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_user_created_at_idx": {
+          "name": "audit_events_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_user_action_idx": {
+          "name": "audit_events_user_action_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_source_api_key_idx": {
+          "name": "audit_events_source_api_key_idx",
+          "columns": [
+            {
+              "expression": "source_api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_runs": {
+      "name": "automation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_event_id": {
+          "name": "trigger_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "current_step_key": {
+          "name": "current_step_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_states": {
+          "name": "step_states",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_step_at": {
+          "name": "next_step_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "automation_runs_status_next_step_at_idx": {
+          "name": "automation_runs_status_next_step_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_step_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_automation_id_created_at_idx": {
+          "name": "automation_runs_automation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_runs_automation_id_automations_id_fk": {
+          "name": "automation_runs_automation_id_automations_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_steps": {
+      "name": "automation_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_steps_automation_id_key_idx": {
+          "name": "automation_steps_automation_id_key_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_steps_automation_id_position_idx": {
+          "name": "automation_steps_automation_id_position_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_steps_automation_id_automations_id_fk": {
+          "name": "automation_steps_automation_id_automations_id_fk",
+          "tableFrom": "automation_steps",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automations": {
+      "name": "automations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "trigger_event_name": {
+          "name": "trigger_event_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connections": {
+          "name": "connections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "automations_status_trigger_idx": {
+          "name": "automations_status_trigger_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automations_user_id_idx": {
+          "name": "automations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.broadcasts": {
+      "name": "broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_id": {
+          "name": "audience_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_properties": {
+      "name": "contact_properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'string'"
+        },
+        "fallback_value": {
+          "name": "fallback_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_properties_key_idx": {
+          "name": "contact_properties_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed": {
+          "name": "unsubscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "custom_properties": {
+          "name": "custom_properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segments": {
+          "name": "segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_subscriptions": {
+          "name": "topic_subscriptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contacts_email_idx": {
+          "name": "contacts_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_unsubscribed_idx": {
+          "name": "contacts_unsubscribed_idx",
+          "columns": [
+            {
+              "expression": "unsubscribed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_created_at_idx": {
+          "name": "contacts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts_to_segments": {
+      "name": "contacts_to_segments",
+      "schema": "",
+      "columns": {
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contacts_to_segments_idx": {
+          "name": "contacts_to_segments_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "segment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_to_segments_segment_id_idx": {
+          "name": "contacts_to_segments_segment_id_idx",
+          "columns": [
+            {
+              "expression": "segment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contacts_to_segments_contact_id_contacts_id_fk": {
+          "name": "contacts_to_segments_contact_id_contacts_id_fk",
+          "tableFrom": "contacts_to_segments",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contacts_to_segments_segment_id_segments_id_fk": {
+          "name": "contacts_to_segments_segment_id_segments_id_fk",
+          "tableFrom": "contacts_to_segments",
+          "tableTo": "segments",
+          "columnsFrom": [
+            "segment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_event_deliveries": {
+      "name": "custom_event_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "custom_event_deliveries_event_name_idx": {
+          "name": "custom_event_deliveries_event_name_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_event_deliveries_received_at_idx": {
+          "name": "custom_event_deliveries_received_at_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_events": {
+      "name": "custom_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "custom_events_user_name_idx": {
+          "name": "custom_events_user_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_export_jobs": {
+      "name": "dashboard_export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_email": {
+          "name": "created_by_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'csv'"
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloaded_at": {
+          "name": "downloaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "dashboard_export_jobs_user_created_at_idx": {
+          "name": "dashboard_export_jobs_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_export_jobs_user_status_idx": {
+          "name": "dashboard_export_jobs_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_export_jobs_expires_at_idx": {
+          "name": "dashboard_export_jobs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dedicated_ip_pools": {
+      "name": "dedicated_ip_pools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ses_pool_name": {
+          "name": "ses_pool_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scaling_mode": {
+          "name": "scaling_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MANAGED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dedicated_ip_pools_ses_pool_name_idx": {
+          "name": "dedicated_ip_pools_ses_pool_name_idx",
+          "columns": [
+            {
+              "expression": "ses_pool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dedicated_ip_pools_user_id_idx": {
+          "name": "dedicated_ip_pools_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domains": {
+      "name": "domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'us-east-1'"
+        },
+        "dkim_tokens": {
+          "name": "dkim_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "records": {
+          "name": "records",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_clicks": {
+          "name": "track_clicks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "track_opens": {
+          "name": "track_opens",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tls": {
+          "name": "tls",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opportunistic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_return_path": {
+          "name": "custom_return_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_subdomain": {
+          "name": "tracking_subdomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_origin": {
+          "name": "dkim_origin",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AWS_SES'"
+        },
+        "dkim_selector": {
+          "name": "dkim_selector",
+          "type": "varchar(63)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_public_key": {
+          "name": "dkim_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_private_key_ct": {
+          "name": "dkim_private_key_ct",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_private_key_iv": {
+          "name": "dkim_private_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedicated_ip_pool_id": {
+          "name": "dedicated_ip_pool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ses_configuration_set_name": {
+          "name": "ses_configuration_set_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_events": {
+      "name": "email_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_events_email_id_idx": {
+          "name": "email_events_email_id_idx",
+          "columns": [
+            {
+              "expression": "email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_events_user_id_idx": {
+          "name": "email_events_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_events_source_id_idx": {
+          "name": "email_events_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_events_email_id_emails_id_fk": {
+          "name": "email_events_email_id_emails_id_fk",
+          "tableFrom": "email_events",
+          "tableTo": "emails",
+          "columnsFrom": [
+            "email_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_email_id": {
+          "name": "source_email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed_at": {
+          "name": "suppressed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_suppressions_user_email_idx": {
+          "name": "email_suppressions_user_email_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_user_idx": {
+          "name": "email_suppressions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_email_idx": {
+          "name": "email_suppressions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.emails": {
+      "name": "emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc": {
+          "name": "cc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider_retry_count": {
+          "name": "provider_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "provider_last_attempted_at": {
+          "name": "provider_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_next_retry_at": {
+          "name": "provider_next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_last_error_code": {
+          "name": "provider_last_error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_last_error_message": {
+          "name": "provider_last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_dead_lettered_at": {
+          "name": "provider_dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "emails_status_idx": {
+          "name": "emails_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_created_at_idx": {
+          "name": "emails_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_status_created_at_idx": {
+          "name": "emails_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_user_created_at_idx": {
+          "name": "emails_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_tags_gin_idx": {
+          "name": "emails_tags_gin_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "emails_user_id_idempotency_key_idx": {
+          "name": "emails_user_id_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_provider_events": {
+      "name": "inbound_provider_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "terminal_reason": {
+          "name": "terminal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_metadata": {
+          "name": "raw_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_email_id": {
+          "name": "received_email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_of_event_id": {
+          "name": "duplicate_of_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inbound_provider_events_provider_event_idx": {
+          "name": "inbound_provider_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbound_provider_events_status_idx": {
+          "name": "inbound_provider_events_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbound_provider_events_user_created_at_idx": {
+          "name": "inbound_provider_events_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "logs_user_created_at_idx": {
+          "name": "logs_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_document_gin_idx": {
+          "name": "logs_document_gin_idx",
+          "columns": [
+            {
+              "expression": "document",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_price_cents": {
+          "name": "monthly_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthly_email_quota": {
+          "name": "monthly_email_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "daily_email_quota": {
+          "name": "daily_email_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_domains": {
+          "name": "max_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_api_keys": {
+          "name": "max_api_keys",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_contacts": {
+          "name": "max_contacts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_segments": {
+          "name": "max_segments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_broadcasts": {
+          "name": "max_broadcasts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_per_second": {
+          "name": "rate_per_second",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dedicated_ips_enabled": {
+          "name": "dedicated_ips_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_dedicated_ips": {
+          "name": "max_dedicated_ips",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plans_slug_idx": {
+          "name": "plans_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.received_emails": {
+      "name": "received_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "route_decisions": {
+          "name": "route_decisions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "received_emails_created_at_idx": {
+          "name": "received_emails_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receiving_routes": {
+      "name": "receiving_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_part": {
+          "name": "local_part",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_local_part": {
+          "name": "target_local_part",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "receiving_routes_user_id_idx": {
+          "name": "receiving_routes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receiving_routes_domain_id_idx": {
+          "name": "receiving_routes_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receiving_routes_domain_type_local_idx": {
+          "name": "receiving_routes_domain_type_local_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_part",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "receiving_routes_domain_id_domains_id_fk": {
+          "name": "receiving_routes_domain_id_domains_id_fk",
+          "tableFrom": "receiving_routes",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segments": {
+      "name": "segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contacts_count": {
+          "name": "contacts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unsubscribed_count": {
+          "name": "unsubscribed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_customers": {
+      "name": "stripe_customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_customers_user_id_idx": {
+          "name": "stripe_customers_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_customers_stripe_customer_id_idx": {
+          "name": "stripe_customers_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events_processed": {
+      "name": "stripe_events_processed",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_processed_processed_at_idx": {
+          "name": "stripe_events_processed_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_subscription_id_idx": {
+          "name": "subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_status_idx": {
+          "name": "subscriptions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_plan_id_plans_id_fk": {
+          "name": "subscriptions_plan_id_plans_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled Template'"
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_unpublished_versions": {
+          "name": "has_unpublished_versions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_subscription": {
+          "name": "default_subscription",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opt_out'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.unsubscribe_page_settings": {
+      "name": "unsubscribe_page_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_color": {
+          "name": "brand_color",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#10b981'"
+        },
+        "headline": {
+          "name": "headline",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unsubscribed successfully'"
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'You have been removed from this mailing list. You will no longer receive marketing emails from this sender.'"
+        },
+        "footer_text": {
+          "name": "footer_text",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Powered by OpenSend'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unsubscribe_page_settings_user_id_idx": {
+          "name": "unsubscribe_page_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_periods": {
+      "name": "usage_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emails_sent": {
+          "name": "emails_sent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_increment_at": {
+          "name": "last_increment_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_periods_user_period_idx": {
+          "name": "usage_periods_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_periods_user_id_idx": {
+          "name": "usage_periods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_webhook_id_idx": {
+          "name": "webhook_deliveries_webhook_id_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_status_idx": {
+          "name": "webhook_deliveries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_deliveries_event_id_email_events_id_fk": {
+          "name": "webhook_deliveries_event_id_email_events_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "email_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "signing_secret_enc": {
+          "name": "signing_secret_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1779948010126,
       "tag": "0027_ambitious_lucky_pierre",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1779949904271,
+      "tag": "0028_sweet_blue_blade",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/repositories/logRepo.ts
+++ b/packages/core/src/db/repositories/logRepo.ts
@@ -12,7 +12,7 @@ import {
   sql,
 } from "drizzle-orm";
 import { db } from "../client";
-import { logs } from "../schema";
+import { emails, logs } from "../schema";
 
 export const logRepo = {
   async findById(id: string) {
@@ -71,6 +71,8 @@ export const logRepo = {
     dateTo?: Date;
     userAgent?: string;
     search?: string;
+    tagName?: string;
+    tagValue?: string;
   }) {
     const conditions: SQL[] = [eq(logs.userId, options.userId)];
 
@@ -109,6 +111,25 @@ export const logRepo = {
           sql`${logs.responseBody}::text ILIKE ${`%${options.search}%`}`,
           sql`${logs.document}::text ILIKE ${`%${options.search}%`}`,
         ) as SQL,
+      );
+    }
+    if (options.tagName) {
+      const tagPredicate = JSON.stringify(
+        options.tagValue === undefined
+          ? [{ name: options.tagName }]
+          : [{ name: options.tagName, value: options.tagValue }],
+      );
+      conditions.push(
+        sql`exists (
+          select 1 from ${emails}
+          where ${emails.userId} = ${options.userId}
+            and ${emails.userId} = ${logs.userId}
+            and (
+              ${emails.id}::text = ${logs.document}->>'emailId'
+              or coalesce(${logs.document}->'emailIds', '[]'::jsonb) ? ${emails.id}::text
+            )
+            and ${emails.tags} @> ${tagPredicate}::jsonb
+        )`,
       );
     }
 

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -243,6 +243,7 @@ export const emails = pgTable(
     index("emails_created_at_idx").on(table.createdAt),
     index("emails_status_created_at_idx").on(table.status, table.createdAt),
     index("emails_user_created_at_idx").on(table.userId, table.createdAt),
+    index("emails_tags_gin_idx").using("gin", table.tags),
     uniqueIndex("emails_user_id_idempotency_key_idx").on(
       table.userId,
       table.idempotencyKey,
@@ -418,21 +419,28 @@ export const templates = pgTable("templates", {
   userId: text("user_id"),
 });
 
-export const logs = pgTable("logs", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  endpoint: text("endpoint"),
-  status: integer("status"),
-  method: varchar("method", { length: 10 }),
-  userAgent: text("user_agent"),
-  requestBody: jsonb("request_body"),
-  responseBody: jsonb("response_body"),
-  createdAt: timestamp("created_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-  document: jsonb("document"),
-  userId: text("user_id"),
-  apiKeyId: uuid("api_key_id"),
-});
+export const logs = pgTable(
+  "logs",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    endpoint: text("endpoint"),
+    status: integer("status"),
+    method: varchar("method", { length: 10 }),
+    userAgent: text("user_agent"),
+    requestBody: jsonb("request_body"),
+    responseBody: jsonb("response_body"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    document: jsonb("document"),
+    userId: text("user_id"),
+    apiKeyId: uuid("api_key_id"),
+  },
+  (table) => [
+    index("logs_user_created_at_idx").on(table.userId, table.createdAt),
+    index("logs_document_gin_idx").using("gin", table.document),
+  ],
+);
 
 export const auditEvents = pgTable(
   "audit_events",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,7 @@ export * from "./services/email";
 export * from "./services/email-webhook-events";
 export * from "./services/deliveryFailureExport";
 export * from "./services/emailEventTrace";
+export * from "./services/emailTrace";
 export * from "./services/emailLifecycle";
 export * from "./services/emailRead";
 export * from "./services/emailDetail";

--- a/packages/core/src/services/dashboardAggregates.ts
+++ b/packages/core/src/services/dashboardAggregates.ts
@@ -108,6 +108,13 @@ export type DashboardTagOption = {
   values: string[];
 };
 
+export type DashboardTagBreakdownRow = {
+  name: string;
+  value: string;
+  total: number;
+  delivered: number;
+};
+
 export type DashboardStoredEmailTag = {
   name: string;
   value: string;
@@ -155,7 +162,12 @@ export type DashboardAggregateRepository = {
   listDomainBreakdown(
     input: DashboardMetricsBaseInput,
   ): Promise<DashboardDomainBreakdownRow[]>;
-  listTagOptions(userId: string): Promise<DashboardTagOption[]>;
+  listTagBreakdown(
+    input: DashboardMetricsBaseInput,
+  ): Promise<DashboardTagBreakdownRow[]>;
+  listTagOptions(
+    input: DashboardMetricsBaseInput,
+  ): Promise<DashboardTagOption[]>;
   countUsage(input: DashboardUsageCountInput): Promise<DashboardUsageCounts>;
 };
 
@@ -179,6 +191,12 @@ export type DashboardMetricsPayload = {
   dailyData: DashboardDailyCountRow[];
   domainBreakdown: Array<{
     domain: string;
+    count: number;
+    rate: number;
+  }>;
+  tagBreakdown: Array<{
+    name: string;
+    value: string;
     count: number;
     rate: number;
   }>;
@@ -281,6 +299,9 @@ function collectTagOptions(
     }));
 }
 
+const DASHBOARD_TAG_OPTIONS_EMAIL_LIMIT = 5000;
+const DASHBOARD_TAG_BREAKDOWN_LIMIT = 50;
+
 const emptyMetricsStats: DashboardMetricsStats = {
   total: 0,
   delivered: 0,
@@ -365,11 +386,59 @@ const defaultDashboardAggregateRepository: DashboardAggregateRepository = {
       .orderBy(sql`count(*) desc`);
   },
 
-  async listTagOptions(userId) {
+  async listTagBreakdown(input) {
+    const rows = await db
+      .select({ tags: emails.tags, status: emails.status })
+      .from(emails)
+      .where(and(...metricConditions(input)))
+      .orderBy(sql`${emails.createdAt} desc`)
+      .limit(DASHBOARD_TAG_OPTIONS_EMAIL_LIMIT);
+
+    const statsByTag = new Map<string, DashboardTagBreakdownRow>();
+    for (const row of rows) {
+      if (!Array.isArray(row.tags)) continue;
+      for (const tag of row.tags) {
+        if (!isStoredEmailTag(tag) || tag.name === "") continue;
+        const key = JSON.stringify([tag.name, tag.value]);
+        const existing = statsByTag.get(key) ?? {
+          name: tag.name,
+          value: tag.value,
+          total: 0,
+          delivered: 0,
+        };
+        existing.total += 1;
+        if (row.status === "delivered") existing.delivered += 1;
+        statsByTag.set(key, existing);
+      }
+    }
+
+    return Array.from(statsByTag.values())
+      .sort((left, right) => {
+        const totalDiff = right.total - left.total;
+        if (totalDiff !== 0) return totalDiff;
+        const nameDiff = left.name.localeCompare(right.name);
+        return nameDiff !== 0
+          ? nameDiff
+          : left.value.localeCompare(right.value);
+      })
+      .slice(0, DASHBOARD_TAG_BREAKDOWN_LIMIT);
+  },
+
+  async listTagOptions(input) {
     const rows = await db
       .select({ tags: emails.tags })
       .from(emails)
-      .where(eq(emails.userId, userId));
+      .where(
+        and(
+          ...metricConditions({
+            ...input,
+            tagName: null,
+            tagValue: null,
+          }),
+        ),
+      )
+      .orderBy(sql`${emails.createdAt} desc`)
+      .limit(DASHBOARD_TAG_OPTIONS_EMAIL_LIMIT);
 
     return collectTagOptions(rows);
   },
@@ -439,6 +508,7 @@ export function createDashboardAggregateService({
         dailyBounceRows,
         dailyComplainRows,
         domainRows,
+        tagRows,
         tagOptions,
       ] = await Promise.all([
         repository.aggregateMetrics(baseInput),
@@ -449,7 +519,8 @@ export function createDashboardAggregateService({
         repository.listDailyBounceRates(baseInput),
         repository.listDailyComplainRates(baseInput),
         repository.listDomainBreakdown(baseInput),
-        repository.listTagOptions(input.userId),
+        repository.listTagBreakdown(baseInput),
+        repository.listTagOptions(baseInput),
       ]);
 
       const totalEmails = stats.total;
@@ -476,6 +547,12 @@ export function createDashboardAggregateService({
           count: row.count,
         })),
         domainBreakdown,
+        tagBreakdown: tagRows.map((row) => ({
+          name: row.name,
+          value: row.value,
+          count: row.total,
+          rate: roundRate(row.delivered, row.total),
+        })),
         bounceBreakdown: {
           permanent: stats.hard_bounced,
           transient: stats.soft_bounced,

--- a/packages/core/src/services/emailTrace.ts
+++ b/packages/core/src/services/emailTrace.ts
@@ -1,0 +1,484 @@
+import { and, asc, desc, eq, sql } from "drizzle-orm";
+import { db } from "../db/client";
+import {
+  emailEvents,
+  emailSuppressions,
+  emails,
+  logs,
+  webhookDeliveries,
+  webhooks,
+} from "../db/schema";
+import {
+  type EmailEventTraceDetailValue,
+  type EmailEventTraceDetails,
+  toEmailEventTraceItem,
+} from "./emailEventTrace";
+
+type EmailRow = typeof emails.$inferSelect;
+type EmailEventRow = typeof emailEvents.$inferSelect;
+type LogRow = typeof logs.$inferSelect;
+type SuppressionRow = typeof emailSuppressions.$inferSelect;
+
+type EmailTraceEmailRow = Pick<
+  EmailRow,
+  | "id"
+  | "to"
+  | "subject"
+  | "status"
+  | "scheduledAt"
+  | "sentAt"
+  | "createdAt"
+  | "providerRetryCount"
+  | "providerLastAttemptedAt"
+  | "providerNextRetryAt"
+  | "providerLastErrorCode"
+  | "providerLastErrorMessage"
+  | "providerDeadLetteredAt"
+  | "tags"
+>;
+
+type EmailTraceLogRow = Pick<
+  LogRow,
+  "id" | "method" | "endpoint" | "status" | "apiKeyId" | "createdAt"
+>;
+
+type EmailTraceSuppressionRow = Pick<
+  SuppressionRow,
+  | "id"
+  | "email"
+  | "reason"
+  | "sourceEmailId"
+  | "sourceMessageId"
+  | "metadata"
+  | "suppressedAt"
+>;
+
+export type EmailTraceWebhookDeliveryRow = {
+  id: string;
+  webhookId: string;
+  webhookUrl: string | null;
+  eventId: string;
+  eventType: string;
+  attempt: number;
+  status: string;
+  statusCode: number | null;
+  attemptedAt: Date | null;
+  nextRetryAt: Date | null;
+  createdAt: Date;
+};
+
+export type EmailTraceSource =
+  | "request"
+  | "queue"
+  | "provider"
+  | "webhook"
+  | "suppression";
+
+export type EmailTraceItem = {
+  object: "email_trace_event";
+  id: string;
+  source: EmailTraceSource;
+  type: string;
+  created_at: Date;
+  summary: string;
+  details: EmailEventTraceDetails;
+  related_id: string | null;
+  related_url: string | null;
+};
+
+export type EmailTraceResponse = {
+  object: "email_trace";
+  email_id: string;
+  data: EmailTraceItem[];
+};
+
+export type EmailTraceRepository = {
+  findEmailForUser(
+    id: string,
+    userId: string,
+  ): Promise<EmailTraceEmailRow | undefined>;
+  listEventsByEmailIdAsc(emailId: string): Promise<EmailEventRow[]>;
+  listLogsForEmail(
+    userId: string,
+    emailId: string,
+  ): Promise<EmailTraceLogRow[]>;
+  listWebhookDeliveriesForEmail(
+    userId: string,
+    emailId: string,
+  ): Promise<EmailTraceWebhookDeliveryRow[]>;
+  findSuppressionForEmail(
+    userId: string,
+    emailId: string,
+    recipient: string | null,
+  ): Promise<EmailTraceSuppressionRow | undefined>;
+};
+
+export type EmailTraceServiceErrorCode = "email_not_found";
+
+export class EmailTraceServiceError extends Error {
+  constructor(
+    readonly code: EmailTraceServiceErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "EmailTraceServiceError";
+  }
+}
+
+export type EmailTraceServiceDependencies = {
+  repository?: EmailTraceRepository;
+};
+
+const defaultRepository: EmailTraceRepository = {
+  async findEmailForUser(id, userId) {
+    return await db.query.emails.findFirst({
+      where: and(eq(emails.id, id), eq(emails.userId, userId)),
+    });
+  },
+
+  async listEventsByEmailIdAsc(emailId) {
+    return await db
+      .select()
+      .from(emailEvents)
+      .where(eq(emailEvents.emailId, emailId))
+      .orderBy(asc(emailEvents.receivedAt));
+  },
+
+  async listLogsForEmail(userId, emailId) {
+    return await db
+      .select({
+        id: logs.id,
+        method: logs.method,
+        endpoint: logs.endpoint,
+        status: logs.status,
+        apiKeyId: logs.apiKeyId,
+        createdAt: logs.createdAt,
+      })
+      .from(logs)
+      .where(
+        and(
+          eq(logs.userId, userId),
+          sql`(${logs.document}->>'emailId' = ${emailId} OR coalesce(${logs.document}->'emailIds', '[]'::jsonb) ? ${emailId})`,
+        ),
+      )
+      .orderBy(asc(logs.createdAt))
+      .limit(20);
+  },
+
+  async listWebhookDeliveriesForEmail(userId, emailId) {
+    return await db
+      .select({
+        id: webhookDeliveries.id,
+        webhookId: webhookDeliveries.webhookId,
+        webhookUrl: webhooks.url,
+        eventId: webhookDeliveries.eventId,
+        eventType: emailEvents.type,
+        attempt: webhookDeliveries.attempt,
+        status: webhookDeliveries.status,
+        statusCode: webhookDeliveries.statusCode,
+        attemptedAt: webhookDeliveries.attemptedAt,
+        nextRetryAt: webhookDeliveries.nextRetryAt,
+        createdAt: webhookDeliveries.createdAt,
+      })
+      .from(webhookDeliveries)
+      .innerJoin(emailEvents, eq(webhookDeliveries.eventId, emailEvents.id))
+      .innerJoin(webhooks, eq(webhookDeliveries.webhookId, webhooks.id))
+      .where(
+        and(
+          eq(emailEvents.emailId, emailId),
+          eq(emailEvents.userId, userId),
+          eq(webhooks.userId, userId),
+        ),
+      )
+      .orderBy(asc(webhookDeliveries.createdAt))
+      .limit(50);
+  },
+
+  async findSuppressionForEmail(userId, emailId, recipient) {
+    const recipientFilter = recipient
+      ? eq(emailSuppressions.email, recipient.toLowerCase())
+      : undefined;
+    return await db.query.emailSuppressions.findFirst({
+      where: and(
+        eq(emailSuppressions.userId, userId),
+        sql`(${emailSuppressions.sourceEmailId} = ${emailId}::uuid OR ${recipientFilter ?? sql`false`})`,
+      ),
+      orderBy: desc(emailSuppressions.suppressedAt),
+    });
+  },
+};
+
+function item(input: Omit<EmailTraceItem, "object">): EmailTraceItem {
+  return { object: "email_trace_event", ...input };
+}
+
+function detailString(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function addDetail(
+  details: EmailEventTraceDetails,
+  key: string,
+  value: EmailEventTraceDetailValue | null | undefined,
+): void {
+  if (value === null || value === undefined) return;
+  if (typeof value === "string" && value.trim() === "") return;
+  if (Array.isArray(value) && value.length === 0) return;
+  details[key] = value;
+}
+
+function tagDetails(tags: EmailTraceEmailRow["tags"]): string[] {
+  if (!Array.isArray(tags)) return [];
+  return tags
+    .filter(
+      (tag): tag is { name: string; value: string } =>
+        typeof tag?.name === "string" && typeof tag?.value === "string",
+    )
+    .map((tag) => `${tag.name}=${tag.value}`);
+}
+
+function queueItems(email: EmailTraceEmailRow): EmailTraceItem[] {
+  const details: EmailEventTraceDetails = { status: email.status };
+  addDetail(details, "tags", tagDetails(email.tags));
+
+  const rows = [
+    item({
+      id: `email:${email.id}:created`,
+      source: "queue",
+      type: "created",
+      created_at: email.createdAt,
+      summary: `Email record created in ${email.status} state`,
+      details,
+      related_id: email.id,
+      related_url: `/emails/${email.id}`,
+    }),
+  ];
+
+  if (email.scheduledAt) {
+    rows.push(
+      item({
+        id: `email:${email.id}:scheduled`,
+        source: "queue",
+        type: "scheduled",
+        created_at: email.scheduledAt,
+        summary: "Email scheduled for delivery",
+        details: { scheduled_at: email.scheduledAt.toISOString() },
+        related_id: email.id,
+        related_url: `/emails/${email.id}`,
+      }),
+    );
+  }
+
+  if (email.sentAt) {
+    rows.push(
+      item({
+        id: `email:${email.id}:sent`,
+        source: "queue",
+        type: "sent",
+        created_at: email.sentAt,
+        summary: "Email handed to provider worker",
+        details: { sent_at: email.sentAt.toISOString() },
+        related_id: email.id,
+        related_url: `/emails/${email.id}`,
+      }),
+    );
+  }
+
+  if (email.providerLastAttemptedAt) {
+    const retryDetails: EmailEventTraceDetails = {
+      provider_retry_count: email.providerRetryCount,
+    };
+    addDetail(
+      retryDetails,
+      "next_retry_at",
+      email.providerNextRetryAt?.toISOString(),
+    );
+    addDetail(
+      retryDetails,
+      "error_code",
+      detailString(email.providerLastErrorCode),
+    );
+    addDetail(
+      retryDetails,
+      "error_message",
+      detailString(email.providerLastErrorMessage),
+    );
+    rows.push(
+      item({
+        id: `email:${email.id}:provider-attempt`,
+        source: "provider",
+        type: email.providerLastErrorCode
+          ? "provider_retry"
+          : "provider_attempt",
+        created_at: email.providerLastAttemptedAt,
+        summary: email.providerLastErrorCode
+          ? "Provider send attempt failed"
+          : "Provider send attempt recorded",
+        details: retryDetails,
+        related_id: email.id,
+        related_url: `/emails/${email.id}`,
+      }),
+    );
+  }
+
+  if (email.providerDeadLetteredAt) {
+    rows.push(
+      item({
+        id: `email:${email.id}:dead-lettered`,
+        source: "provider",
+        type: "provider_dead_lettered",
+        created_at: email.providerDeadLetteredAt,
+        summary: "Provider retries exhausted",
+        details: { provider_retry_count: email.providerRetryCount },
+        related_id: email.id,
+        related_url: `/emails/${email.id}`,
+      }),
+    );
+  }
+
+  return rows;
+}
+
+function logItems(rows: EmailTraceLogRow[]): EmailTraceItem[] {
+  return rows.map((row) => {
+    const method = row.method ?? "GET";
+    const endpoint = row.endpoint ?? "";
+    const status = row.status ?? 0;
+    return item({
+      id: `log:${row.id}`,
+      source: "request",
+      type: "api_request",
+      created_at: row.createdAt,
+      summary: `${method} ${endpoint || "request"} returned ${status}`,
+      details: {
+        method,
+        endpoint,
+        status_code: status,
+        ...(row.apiKeyId ? { api_key_id: row.apiKeyId } : {}),
+      },
+      related_id: row.id,
+      related_url: `/logs/${row.id}`,
+    });
+  });
+}
+
+function eventItems(rows: EmailEventRow[]): EmailTraceItem[] {
+  return rows.map((row) => {
+    const trace = toEmailEventTraceItem(row);
+    return item({
+      id: `event:${trace.id}`,
+      source: "provider",
+      type: trace.type,
+      created_at: trace.created_at,
+      summary: trace.summary,
+      details: trace.details,
+      related_id: trace.id,
+      related_url: null,
+    });
+  });
+}
+
+function webhookItems(rows: EmailTraceWebhookDeliveryRow[]): EmailTraceItem[] {
+  return rows.map((row) => {
+    const details: EmailEventTraceDetails = {
+      webhook_id: row.webhookId,
+      event_id: row.eventId,
+      event_type: row.eventType,
+      attempt: row.attempt,
+      status: row.status,
+    };
+    addDetail(details, "status_code", row.statusCode ?? undefined);
+    addDetail(details, "next_retry_at", row.nextRetryAt?.toISOString());
+    return item({
+      id: `webhook:${row.id}`,
+      source: "webhook",
+      type: "webhook_delivery",
+      created_at: row.attemptedAt ?? row.createdAt,
+      summary: `Webhook delivery ${row.status}`,
+      details,
+      related_id: row.id,
+      related_url: row.webhookUrl ? `/webhooks/${row.webhookId}` : null,
+    });
+  });
+}
+
+function suppressionItem(row: EmailTraceSuppressionRow): EmailTraceItem {
+  const details: EmailEventTraceDetails = {
+    email: row.email,
+    reason: row.reason,
+  };
+  addDetail(details, "source", row.metadata?.source);
+  addDetail(details, "source_email_id", row.sourceEmailId ?? undefined);
+  addDetail(details, "source_message_id", row.sourceMessageId ?? undefined);
+
+  return item({
+    id: `suppression:${row.id}`,
+    source: "suppression",
+    type: "suppressed",
+    created_at: row.suppressedAt,
+    summary: `${row.email} suppressed (${row.reason})`,
+    details,
+    related_id: row.id,
+    related_url: `/suppressions?search=${encodeURIComponent(row.email)}`,
+  });
+}
+
+function sortTraceItems(items: EmailTraceItem[]): EmailTraceItem[] {
+  const sourceOrder: Record<EmailTraceSource, number> = {
+    request: 0,
+    queue: 1,
+    provider: 2,
+    webhook: 3,
+    suppression: 4,
+  };
+
+  return [...items].sort((left, right) => {
+    const timeDiff = left.created_at.getTime() - right.created_at.getTime();
+    if (timeDiff !== 0) return timeDiff;
+    const sourceDiff = sourceOrder[left.source] - sourceOrder[right.source];
+    return sourceDiff !== 0 ? sourceDiff : left.id.localeCompare(right.id);
+  });
+}
+
+export function createEmailTraceService({
+  repository = defaultRepository,
+}: EmailTraceServiceDependencies = {}) {
+  return {
+    async getTrace(
+      userId: string,
+      emailId: string,
+    ): Promise<EmailTraceResponse> {
+      const email = await repository.findEmailForUser(emailId, userId);
+      if (!email) {
+        throw new EmailTraceServiceError("email_not_found", "Email not found");
+      }
+
+      const primaryRecipient = email.to[0]?.toLowerCase() ?? null;
+      const [events, requestLogs, webhookRows, suppression] = await Promise.all(
+        [
+          repository.listEventsByEmailIdAsc(emailId),
+          repository.listLogsForEmail(userId, emailId),
+          repository.listWebhookDeliveriesForEmail(userId, emailId),
+          repository.findSuppressionForEmail(userId, emailId, primaryRecipient),
+        ],
+      );
+
+      const traceItems = [
+        ...queueItems(email),
+        ...logItems(requestLogs),
+        ...eventItems(events),
+        ...webhookItems(webhookRows),
+        ...(suppression ? [suppressionItem(suppression)] : []),
+      ];
+
+      return {
+        object: "email_trace",
+        email_id: email.id,
+        data: sortTraceItems(traceItems),
+      };
+    },
+  };
+}
+
+export const emailTraceService = createEmailTraceService();

--- a/packages/core/src/services/logs.ts
+++ b/packages/core/src/services/logs.ts
@@ -56,6 +56,8 @@ export type LogRepository = {
     dateTo?: Date;
     userAgent?: string;
     search?: string;
+    tagName?: string;
+    tagValue?: string;
   }): Promise<{ data: LogListRow[]; hasMore: boolean }>;
   findByIdForUser(id: string, userId: string): Promise<LogRow | undefined>;
 };
@@ -88,6 +90,8 @@ export type ListLogsInput = {
   dateTo?: string | null;
   userAgent?: string | null;
   search?: string | null;
+  tagName?: string | null;
+  tagValue?: string | null;
 };
 
 function normalizeLimit(limit: number | undefined): number {
@@ -160,6 +164,11 @@ export function createLogReadService({
         dateTo: parseDate(input.dateTo, true),
         userAgent: normalizeOptionalString(input.userAgent),
         search: normalizeSearch(input.search),
+        tagName: normalizeOptionalString(input.tagName),
+        tagValue:
+          input.tagName && input.tagValue !== null
+            ? (input.tagValue ?? "")
+            : undefined,
       });
 
       return {

--- a/public/docs/api-reference/emails/list-email-trace.md
+++ b/public/docs/api-reference/emails/list-email-trace.md
@@ -1,0 +1,31 @@
+# List Email Trace
+
+List the chronological trace for one sent email.
+
+`GET /emails/{id}/trace`
+
+Compatibility note: `GET /api/emails/{id}/trace` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above.
+
+## Authentication
+
+Use an OpenSend API key with full access in the Authorization header.
+
+```http
+Authorization: Bearer os_YOUR_API_KEY
+```
+
+## Response
+
+The response is tenant-scoped and ordered from oldest to newest. Trace entries can include:
+
+- `request` evidence from sanitized API request logs linked by `emailId` or `emailIds` metadata.
+- `queue` state such as creation, scheduled delivery time, and worker handoff time.
+- `provider` lifecycle events and bounded retry/dead-letter state.
+- `webhook` delivery attempts for lifecycle events.
+- `suppression` evidence for the source email or primary recipient when a tenant-scoped suppression exists.
+
+Request-log metadata stays sanitized. OpenSend does not expose raw API keys, Authorization headers, cookies, attachment content, or message body fields in trace details.
+
+## Limits
+
+Trace reads are bounded to the selected email and authenticated tenant. Associated request logs are capped, webhook delivery evidence is capped, and tag details are shown as `name=value` pairs from the stored email record.

--- a/public/docs/api-reference/emails/retrieve-email.md
+++ b/public/docs/api-reference/emails/retrieve-email.md
@@ -18,7 +18,7 @@ Dashboard session cookies are not API credentials.
 
 ## Parameters
 
-Returns message metadata, status, tags, timestamps, and delivery detail fields.
+Returns message metadata, status, tags, timestamps, and delivery detail fields. For a chronological operational view, call `GET /emails/{id}/trace`; it combines sanitized request-log evidence, queue/scheduled state, provider events, webhook deliveries, and suppression evidence where available.
 
 ## Response
 

--- a/public/docs/api-reference/logs/list-logs.md
+++ b/public/docs/api-reference/logs/list-logs.md
@@ -18,7 +18,14 @@ Dashboard session cookies are not API credentials.
 
 ## Parameters
 
-Supports filters such as status, method, API key, date range, and text search.
+Supports filters such as status, method, API key, date range, text search, and email tag filters.
+
+Tag filters use the same validation semantics as send-time tags:
+
+- `tag_name` / `tagName`: ASCII letters, numbers, underscores, or dashes; 1-256 characters.
+- `tag_value` / `tagValue`: optional; ASCII letters, numbers, underscores, or dashes; up to 256 characters; may be empty.
+
+`tag_value` requires `tag_name`. Tag-filtered logs only match request logs linked to tenant-owned emails through sanitized log metadata (`emailId` or `emailIds`).
 
 ## Response
 

--- a/public/docs/dashboard/emails/tags.md
+++ b/public/docs/dashboard/emails/tags.md
@@ -14,3 +14,14 @@ Tags should be stable and low-cardinality when they are used for reporting. Avoi
 ## Where tags help
 
 Tags are most useful when support or operations needs to connect a dashboard email to the application event that created it. They complement idempotency keys: the idempotency key prevents duplicate acceptance, while tags help humans understand why a message exists.
+
+
+## Filtering logs and metrics by tag
+
+Email tags can be used in the dashboard Logs and Metrics views.
+
+- Logs accept tag name/value filters and return only request logs linked to emails with matching stored tags.
+- Metrics accept tag name/value filters over the supported dashboard date presets: Today, Yesterday, Last 3 days, Last 7 days, Last 15 days, and Last 30 days.
+- Metrics also show a bounded top-tag breakdown for the selected date range and tenant.
+
+Tag filters are tenant-scoped and backed by bounded date ranges plus tag indexes. Keep reporting tags low-cardinality so dashboards remain fast.

--- a/public/docs/dashboard/logs/introduction.md
+++ b/public/docs/dashboard/logs/introduction.md
@@ -12,3 +12,10 @@ Logs are the low-level request and operational records used to troubleshoot Open
 ## Audit log distinction
 
 Logs are for troubleshooting runtime/API behavior. The Audit Log is for user and account actions. Use both during incidents: logs explain what the system did, while audit events explain who changed configuration.
+
+
+## Tag filters
+
+The Logs page can filter request logs by an email tag name and optional value. OpenSend matches logs to emails through sanitized request-log metadata, then applies the stored email tag predicate within the current tenant. This keeps cross-tenant tag queries impossible and avoids exposing raw request secrets or message bodies.
+
+Use the same tag shape as send requests: names and values may contain ASCII letters, numbers, underscores, and dashes. Values may be empty when that is the stored tag value.

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -71,6 +71,7 @@
 - [Verify Domain](https://opensend.namuh.co/docs/api-reference/domains/verify-domain.md): Ask OpenSend to re-check DNS for a domain and return the current verification state.
 - [Cancel Email](https://opensend.namuh.co/docs/api-reference/emails/cancel-email.md): Cancel a scheduled email.
 - [List Email Attachments](https://opensend.namuh.co/docs/api-reference/emails/list-email-attachments.md): List attachments associated with a sent email.
+- [List Email Trace](https://opensend.namuh.co/docs/api-reference/emails/list-email-trace.md): List the chronological trace for one sent email.
 - [List Sent Emails](https://opensend.namuh.co/docs/api-reference/emails/list-emails.md): List sent, queued, and scheduled emails for the authenticated tenant.
 - [List Received Email Attachments](https://opensend.namuh.co/docs/api-reference/emails/list-received-email-attachments.md): List attachment metadata stored with one received email.
 - [List Received Emails](https://opensend.namuh.co/docs/api-reference/emails/list-received-emails.md): List inbound email rows stored for the authenticated OpenSend tenant.

--- a/src/app/(dashboard)/emails/[id]/page.tsx
+++ b/src/app/(dashboard)/emails/[id]/page.tsx
@@ -2,9 +2,11 @@ import { EmailDetail } from "@/components/email-detail";
 import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
 import { emailEvents, emailSuppressions, emails, logs } from "@/lib/db/schema";
-import { toEmailEventTraceItem } from "@opensend/core";
+import { createEmailTraceService, toEmailEventTraceItem } from "@opensend/core";
 import { and, asc, desc, eq, sql } from "drizzle-orm";
 import { notFound, redirect } from "next/navigation";
+
+const emailTraceService = createEmailTraceService();
 
 export default async function EmailDetailPage({
   params,
@@ -52,14 +54,17 @@ export default async function EmailDetailPage({
     .limit(10);
 
   const primaryRecipient = emailResult.to[0]?.toLowerCase();
-  const suppression = primaryRecipient
-    ? await db.query.emailSuppressions.findFirst({
-        where: and(
-          eq(emailSuppressions.userId, userId),
-          eq(emailSuppressions.email, primaryRecipient),
-        ),
-      })
-    : null;
+  const [suppression, trace] = await Promise.all([
+    primaryRecipient
+      ? db.query.emailSuppressions.findFirst({
+          where: and(
+            eq(emailSuppressions.userId, userId),
+            eq(emailSuppressions.email, primaryRecipient),
+          ),
+        })
+      : null,
+    emailTraceService.getTrace(userId, id),
+  ]);
 
   const emailData = {
     id: emailResult.id,
@@ -95,6 +100,16 @@ export default async function EmailDetailPage({
       endpoint: log.endpoint ?? "",
       statusCode: log.status ?? 0,
       createdAt: log.createdAt.toISOString(),
+    })),
+    trace: trace.data.map((item) => ({
+      id: item.id,
+      source: item.source,
+      type: item.type,
+      timestamp: item.created_at.toISOString(),
+      summary: item.summary,
+      details: item.details,
+      relatedId: item.related_id,
+      relatedUrl: item.related_url,
     })),
   };
 

--- a/src/app/(dashboard)/logs/page.tsx
+++ b/src/app/(dashboard)/logs/page.tsx
@@ -1,7 +1,7 @@
 import { LogsListPage } from "@/components/logs-list-page";
 import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
-import { logs } from "@/lib/db/schema";
+import { emails, logs } from "@/lib/db/schema";
 import { type SQL, and, desc, eq, gte, lte, sql } from "drizzle-orm";
 import { redirect } from "next/navigation";
 
@@ -15,6 +15,10 @@ export default async function LogsPage(props: {
     apiKeyId?: string;
     q?: string;
     search?: string;
+    tag_name?: string;
+    tagName?: string;
+    tag_value?: string;
+    tagValue?: string;
   }>;
 }) {
   const session = await getServerSession();
@@ -28,6 +32,9 @@ export default async function LogsPage(props: {
   const userAgent = searchParams.userAgent;
   const apiKeyId = searchParams.apiKeyId;
   const search = (searchParams.q || searchParams.search || "").trim();
+  const tagName = (searchParams.tag_name || searchParams.tagName || "").trim();
+  const tagValueRaw = searchParams.tag_value ?? searchParams.tagValue;
+  const tagValue = tagValueRaw === undefined ? null : tagValueRaw.trim();
 
   const conditions: SQL[] = [eq(logs.userId, session.user.id)];
 
@@ -63,6 +70,26 @@ export default async function LogsPage(props: {
 
   if (apiKeyId) {
     conditions.push(eq(logs.apiKeyId, apiKeyId));
+  }
+
+  if (tagName) {
+    const tagPredicate = JSON.stringify(
+      tagValue === null
+        ? [{ name: tagName }]
+        : [{ name: tagName, value: tagValue }],
+    );
+    conditions.push(
+      sql`exists (
+        select 1 from ${emails}
+        where ${emails.userId} = ${session.user.id}
+          and ${emails.userId} = ${logs.userId}
+          and (
+            ${emails.id}::text = ${logs.document}->>'emailId'
+            or coalesce(${logs.document}->'emailIds', '[]'::jsonb) ? ${emails.id}::text
+          )
+          and ${emails.tags} @> ${tagPredicate}::jsonb
+      )`,
+    );
   }
 
   if (search) {

--- a/src/app/api/emails/[id]/trace/route.ts
+++ b/src/app/api/emails/[id]/trace/route.ts
@@ -1,0 +1,38 @@
+import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
+import {
+  EmailTraceServiceError,
+  createEmailTraceService,
+} from "@opensend/core";
+import { type NextRequest, NextResponse } from "next/server";
+
+const emailTraceService = createEmailTraceService();
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const auth = await validateApiKey(request.headers.get("authorization"));
+  if (!auth || !auth.userId) return unauthorizedResponse();
+  const permissionError = requireFullAccessApiKey(auth);
+  if (permissionError) return permissionError;
+
+  try {
+    const { id } = await params;
+    const trace = await emailTraceService.getTrace(auth.userId, id);
+    return NextResponse.json(trace);
+  } catch (error) {
+    if (
+      error instanceof EmailTraceServiceError &&
+      error.code === "email_not_found"
+    ) {
+      return NextResponse.json({ error: "Email not found" }, { status: 404 });
+    }
+
+    console.error("Failed to fetch email trace:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch email trace" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -1,5 +1,7 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
+import { publicApiError } from "@/lib/api-errors";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
+import { parseTagQueryParams } from "@/lib/tag-query-params";
 import { createLogReadService } from "@opensend/core";
 
 const logReadService = createLogReadService();
@@ -11,6 +13,18 @@ export async function GET(request: Request): Promise<Response> {
   if (permissionError) return permissionError;
 
   const url = new URL(request.url);
+  const parsedTags = parseTagQueryParams(url.searchParams);
+  if (!parsedTags.ok) {
+    return Response.json(
+      publicApiError(
+        "validation_error",
+        "Validation failed.",
+        422,
+        parsedTags.details,
+      ),
+      { status: 422 },
+    );
+  }
 
   try {
     const result = await logReadService.listLogs({
@@ -31,6 +45,8 @@ export async function GET(request: Request): Promise<Response> {
       userAgent:
         url.searchParams.get("user_agent") || url.searchParams.get("userAgent"),
       search: url.searchParams.get("q") || url.searchParams.get("search"),
+      tagName: parsedTags.value.tagName,
+      tagValue: parsedTags.value.tagValue,
     });
 
     return Response.json(result);

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Metrics API endpoint — returns aggregated email stats, daily chart data, and per-domain breakdown
 
 import { getServerSession, unauthorizedResponse } from "@/lib/api-auth";
+import { publicApiError } from "@/lib/api-errors";
 import {
   DASHBOARD_METRICS_CACHE_TTL_SECONDS,
   getMetricsAggregateCacheKey,
@@ -8,6 +9,7 @@ import {
   writeDashboardAggregateCache,
 } from "@/lib/cache/dashboard-aggregates";
 import { getDateRangeBounds } from "@/lib/date-range";
+import { parseTagQueryParams } from "@/lib/tag-query-params";
 import { createDashboardAggregateService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 
@@ -42,10 +44,20 @@ export async function GET(request: NextRequest) {
     const range = searchParams.get("range") || "last_15_days";
     const domain = searchParams.get("domain");
     const eventType = searchParams.get("event_type");
-    const tagName = normalizeOptionalQueryParam(searchParams.get("tag_name"));
-    const rawTagValue = searchParams.get("tag_value");
-    const tagValue =
-      tagName && rawTagValue !== null ? rawTagValue.trim() : null;
+    const parsedTags = parseTagQueryParams(searchParams);
+    if (!parsedTags.ok) {
+      return NextResponse.json(
+        publicApiError(
+          "validation_error",
+          "Validation failed.",
+          422,
+          parsedTags.details,
+        ),
+        { status: 422 },
+      );
+    }
+    const tagName = parsedTags.value.tagName;
+    const tagValue = parsedTags.value.tagValue;
     const userId = session.user.id;
     const cacheKey = getMetricsAggregateCacheKey({
       userId,

--- a/src/components/email-detail.tsx
+++ b/src/components/email-detail.tsx
@@ -123,6 +123,16 @@ export interface EmailDetailData {
     statusCode: number;
     createdAt: string;
   }>;
+  trace?: Array<{
+    id: string;
+    source: "request" | "queue" | "provider" | "webhook" | "suppression";
+    type: string;
+    timestamp: string;
+    summary: string;
+    details: Record<string, string | number | boolean | string[]>;
+    relatedId: string | null;
+    relatedUrl: string | null;
+  }>;
 }
 
 interface EmailDetailProps {
@@ -157,6 +167,23 @@ function formatStatusLabel(status: string): string {
     .split("_")
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(" ");
+}
+
+function formatSourceLabel(source: string): string {
+  switch (source) {
+    case "request":
+      return "Request";
+    case "queue":
+      return "Queue";
+    case "provider":
+      return "Provider";
+    case "webhook":
+      return "Webhook";
+    case "suppression":
+      return "Suppression";
+    default:
+      return formatStatusLabel(source);
+  }
 }
 
 function formatEventTimestamp(dateStr: string): string {
@@ -282,6 +309,19 @@ export function EmailDetail({ email }: EmailDetailProps) {
     (i) => i.status === "needs_attention",
   );
   const doingGreat = DEFAULT_INSIGHTS.filter((i) => i.status === "doing_great");
+
+  const timelineItems =
+    email.trace ??
+    email.events.map((event) => ({
+      id: event.id,
+      source: "provider" as const,
+      type: event.type,
+      timestamp: event.timestamp,
+      summary: event.summary,
+      details: event.details,
+      relatedId: event.id,
+      relatedUrl: null,
+    }));
 
   const handleCopyTabContent = useCallback(() => {
     let content = "";
@@ -438,14 +478,14 @@ export function EmailDetail({ email }: EmailDetailProps) {
         </div>
       </div>
 
-      {/* Email Events */}
+      {/* Message Trace */}
       <div className="mb-8">
         <p className="text-[11px] font-medium text-fg-2 tracking-wider mb-4">
-          EMAIL EVENT TRACE
+          MESSAGE TRACE
         </p>
         <div className="space-y-3" data-testid="event-timeline">
-          {email.events.length > 0 ? (
-            email.events.map((event) => {
+          {timelineItems.length > 0 ? (
+            timelineItems.map((event) => {
               const details = Object.entries(event.details);
               return (
                 <div
@@ -457,11 +497,17 @@ export function EmailDetail({ email }: EmailDetailProps) {
                     <div
                       className={clsx(
                         "w-2 h-2 rounded-full mt-1.5 shrink-0",
-                        event.type === "delivered" || event.type === "sent"
-                          ? "bg-accent"
-                          : event.type === "bounced" || event.type === "failed"
-                            ? "bg-red-500"
-                            : "bg-blue-500",
+                        event.source === "request"
+                          ? "bg-purple-400"
+                          : event.source === "queue"
+                            ? "bg-amber-400"
+                            : event.type === "delivered" ||
+                                event.type === "sent"
+                              ? "bg-accent"
+                              : event.type === "bounced" ||
+                                  event.type === "failed"
+                                ? "bg-red-500"
+                                : "bg-blue-500",
                       )}
                     />
                     <div className="min-w-0 flex-1">
@@ -472,6 +518,12 @@ export function EmailDetail({ email }: EmailDetailProps) {
                         >
                           {formatStatusLabel(event.type)}
                         </span>
+                        <span
+                          className="rounded border border-line px-1.5 py-0.5 text-[11px] uppercase tracking-wide text-fg-2"
+                          data-testid="trace-source"
+                        >
+                          {formatSourceLabel(event.source)}
+                        </span>
                         <span className="text-fg-4">
                           {formatEventTimestamp(event.timestamp)}
                         </span>
@@ -479,8 +531,16 @@ export function EmailDetail({ email }: EmailDetailProps) {
                           className="font-mono text-[11px] text-fg-2"
                           data-testid="event-id"
                         >
-                          event_id: {event.id}
+                          trace_id: {event.id}
                         </span>
+                        {event.relatedUrl && (
+                          <Link
+                            href={event.relatedUrl}
+                            className="font-mono text-[11px] text-fg-2 hover:text-fg"
+                          >
+                            open related
+                          </Link>
+                        )}
                       </div>
                       <p className="mt-1 text-fg">{event.summary}</p>
                       {details.length > 0 && (
@@ -507,7 +567,7 @@ export function EmailDetail({ email }: EmailDetailProps) {
             })
           ) : (
             <div className="py-4 px-4 rounded-lg bg-bg-2 border border-dashed border-line text-center text-[13px] text-fg-4">
-              No events recorded yet
+              No trace entries recorded yet
             </div>
           )}
         </div>

--- a/src/components/logs-list-page.tsx
+++ b/src/components/logs-list-page.tsx
@@ -88,6 +88,12 @@ export function LogsListPage({ logs }: { logs: LogRow[] }) {
   const [query, setQuery] = useState<string>(
     searchParams.get("q") || searchParams.get("search") || "",
   );
+  const [tagName, setTagName] = useState<string>(
+    searchParams.get("tag_name") || searchParams.get("tagName") || "",
+  );
+  const [tagValue, setTagValue] = useState<string>(
+    searchParams.get("tag_value") || searchParams.get("tagValue") || "",
+  );
 
   const updateFilters = useCallback(
     (updates: Record<string, string>) => {
@@ -112,8 +118,10 @@ export function LogsListPage({ logs }: { logs: LogRow[] }) {
     if (dateFrom) params.set("after", dateFrom);
     if (dateTo) params.set("before", dateTo);
     if (query.trim()) params.set("q", query.trim());
+    if (tagName.trim()) params.set("tag_name", tagName.trim());
+    if (tagName.trim() && tagValue) params.set("tag_value", tagValue);
     void exportCsv(params);
-  }, [dateFrom, dateTo, exportCsv, query, statusFilter]);
+  }, [dateFrom, dateTo, exportCsv, query, statusFilter, tagName, tagValue]);
 
   const columns = [
     {
@@ -204,6 +212,36 @@ export function LogsListPage({ logs }: { logs: LogRow[] }) {
           className="min-w-[320px] bg-bg-3 border border-line text-fg text-[13px] rounded-md px-3 py-1.5 focus:outline-none focus:ring-1 focus:ring-[rgba(176,199,217,0.3)]"
         />
 
+        <div className="flex items-center gap-2">
+          <label htmlFor="tag-name" className="text-[12px] text-fg-2">
+            Tag
+          </label>
+          <input
+            id="tag-name"
+            type="text"
+            value={tagName}
+            onChange={(e) => {
+              const val = e.target.value;
+              setTagName(val);
+              updateFilters({ tag_name: val, tag_value: val ? tagValue : "" });
+            }}
+            placeholder="campaign"
+            className="w-32 bg-bg-3 border border-line text-fg text-[13px] rounded-md px-3 py-1.5 focus:outline-none focus:ring-1 focus:ring-[rgba(176,199,217,0.3)]"
+          />
+          <input
+            id="tag-value"
+            type="text"
+            value={tagValue}
+            onChange={(e) => {
+              const val = e.target.value;
+              setTagValue(val);
+              updateFilters({ tag_value: tagName ? val : "" });
+            }}
+            placeholder="launch"
+            className="w-32 bg-bg-3 border border-line text-fg text-[13px] rounded-md px-3 py-1.5 focus:outline-none focus:ring-1 focus:ring-[rgba(176,199,217,0.3)]"
+          />
+        </div>
+
         <select
           value={statusFilter}
           onChange={(e) => {
@@ -253,7 +291,12 @@ export function LogsListPage({ logs }: { logs: LogRow[] }) {
           />
         </div>
 
-        {(statusFilter !== "all" || dateFrom || dateTo || query) && (
+        {(statusFilter !== "all" ||
+          dateFrom ||
+          dateTo ||
+          query ||
+          tagName ||
+          tagValue) && (
           <button
             type="button"
             onClick={() => {
@@ -261,7 +304,16 @@ export function LogsListPage({ logs }: { logs: LogRow[] }) {
               setDateFrom("");
               setDateTo("");
               setQuery("");
-              updateFilters({ status: "", after: "", before: "", q: "" });
+              setTagName("");
+              setTagValue("");
+              updateFilters({
+                status: "",
+                after: "",
+                before: "",
+                q: "",
+                tag_name: "",
+                tag_value: "",
+              });
             }}
             className="text-[12px] text-fg-2 hover:text-fg transition-colors"
           >

--- a/src/components/metrics-page.tsx
+++ b/src/components/metrics-page.tsx
@@ -61,6 +61,13 @@ interface TagOption {
   values: string[];
 }
 
+interface TagBreakdownEntry {
+  name: string;
+  value: string;
+  count: number;
+  rate: number;
+}
+
 interface MetricsData {
   totalEmails: number;
   deliverabilityRate: number;
@@ -69,6 +76,7 @@ interface MetricsData {
   complained: number;
   domains: string[];
   tagOptions: TagOption[];
+  tagBreakdown: TagBreakdownEntry[];
   dailyData: DailyDataPoint[];
   domainBreakdown: DomainBreakdownEntry[];
   bounceBreakdown: BounceBreakdown;
@@ -265,6 +273,32 @@ export function MetricsPage() {
 
       {/* Deliverability Rate section */}
       <div className="space-y-4">
+        {(data?.tagBreakdown?.length ?? 0) > 0 && (
+          <Card>
+            <div className="flex items-center justify-between mb-3">
+              <span className="kicker">TAG BREAKDOWN</span>
+              <span className="text-[12px] text-fg-3">Top 50 by volume</span>
+            </div>
+            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+              {(data?.tagBreakdown ?? []).map((tag) => (
+                <div
+                  key={`${tag.name}:${tag.value}`}
+                  className="rounded-lg border border-line bg-bg-2 px-3 py-2"
+                  data-testid="tag-breakdown-row"
+                >
+                  <div className="font-mono text-[12px] text-fg">
+                    <span className="text-fg-2">{tag.name}:</span>{" "}
+                    {tag.value === "" ? "(empty)" : tag.value}
+                  </div>
+                  <div className="mt-1 text-[12px] text-fg-3">
+                    {tag.count} emails · {tag.rate}% delivered
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Card>
+        )}
+
         <MetricSection
           title="DELIVERABILITY RATE"
           value={loading ? "—" : `${data?.deliverabilityRate ?? 0}%`}

--- a/src/lib/dashboard-export-api.ts
+++ b/src/lib/dashboard-export-api.ts
@@ -84,6 +84,12 @@ export function filtersFromSearchParams(
     domain: searchParam(params, "domain"),
     topicId: searchParam(params, "topic_id", "topicId"),
     userAgent: searchParam(params, "user_agent", "userAgent"),
+    tagName: searchParam(params, "tag_name", "tagName"),
+    tagValue: params.has("tag_value")
+      ? (params.get("tag_value") ?? "").trim()
+      : params.has("tagValue")
+        ? (params.get("tagValue") ?? "").trim()
+        : undefined,
   };
 }
 
@@ -117,6 +123,13 @@ export function filtersFromInput(
     domain: stringInput(input, "domain"),
     topicId: stringInput(input, "topic_id", "topicId"),
     userAgent: stringInput(input, "user_agent", "userAgent"),
+    tagName: stringInput(input, "tag_name", "tagName"),
+    tagValue:
+      typeof input.tag_value === "string"
+        ? input.tag_value.trim()
+        : typeof input.tagValue === "string"
+          ? input.tagValue.trim()
+          : undefined,
   };
 }
 

--- a/src/lib/dashboard-export-service.ts
+++ b/src/lib/dashboard-export-service.ts
@@ -43,6 +43,8 @@ export type DashboardExportFilters = {
   domain?: string;
   topicId?: string;
   userAgent?: string;
+  tagName?: string;
+  tagValue?: string;
 };
 
 export type DashboardCsvExportResult = {
@@ -610,6 +612,29 @@ async function logsExport(
   const userAgentPattern = likePattern(filters.userAgent);
   if (userAgentPattern)
     conditions.push(sql`${logs.userAgent} ILIKE ${userAgentPattern}`);
+
+  const tagName = nonEmpty(filters.tagName);
+  if (tagName) {
+    const tagValue =
+      filters.tagValue === undefined ? undefined : filters.tagValue;
+    const tagPredicate = JSON.stringify(
+      tagValue === undefined
+        ? [{ name: tagName }]
+        : [{ name: tagName, value: tagValue.trim() }],
+    );
+    conditions.push(
+      sql`exists (
+        select 1 from ${emails}
+        where ${emails.userId} = ${userId}
+          and ${emails.userId} = ${logs.userId}
+          and (
+            ${emails.id}::text = ${logs.document}->>'emailId'
+            or coalesce(${logs.document}->'emailIds', '[]'::jsonb) ? ${emails.id}::text
+          )
+          and ${emails.tags} @> ${tagPredicate}::jsonb
+      )`,
+    );
+  }
 
   const pattern = likePattern(filters.search);
   if (pattern) {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -245,6 +245,7 @@ export const emails = pgTable(
     index("emails_created_at_idx").on(table.createdAt),
     index("emails_status_created_at_idx").on(table.status, table.createdAt),
     index("emails_user_created_at_idx").on(table.userId, table.createdAt),
+    index("emails_tags_gin_idx").using("gin", table.tags),
     uniqueIndex("emails_user_id_idempotency_key_idx").on(
       table.userId,
       table.idempotencyKey,
@@ -415,21 +416,28 @@ export const templates = pgTable("templates", {
   userId: text("user_id"),
 });
 
-export const logs = pgTable("logs", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  endpoint: text("endpoint"),
-  status: integer("status"),
-  method: varchar("method", { length: 10 }),
-  userAgent: text("user_agent"),
-  requestBody: jsonb("request_body"),
-  responseBody: jsonb("response_body"),
-  createdAt: timestamp("created_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-  document: jsonb("document"),
-  userId: text("user_id"),
-  apiKeyId: uuid("api_key_id"),
-});
+export const logs = pgTable(
+  "logs",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    endpoint: text("endpoint"),
+    status: integer("status"),
+    method: varchar("method", { length: 10 }),
+    userAgent: text("user_agent"),
+    requestBody: jsonb("request_body"),
+    responseBody: jsonb("response_body"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    document: jsonb("document"),
+    userId: text("user_id"),
+    apiKeyId: uuid("api_key_id"),
+  },
+  (table) => [
+    index("logs_user_created_at_idx").on(table.userId, table.createdAt),
+    index("logs_document_gin_idx").using("gin", table.document),
+  ],
+);
 
 export const auditEvents = pgTable(
   "audit_events",

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -558,6 +558,26 @@ export const openApiDocument = {
         },
       },
     },
+    "/api/emails/{id}/trace": {
+      get: {
+        tags: ["Emails"],
+        summary: "List the chronological trace for an email",
+        operationId: "listEmailTrace",
+        security: bearerSecurity,
+        parameters: [idPathParameter],
+        responses: {
+          "200": {
+            description:
+              "Chronological trace entries for request, queue, provider, webhook, and suppression evidence.",
+            content: jsonContent({
+              $ref: "#/components/schemas/EmailTrace",
+            }),
+          },
+          "404": { $ref: "#/components/responses/NotFound" },
+          ...errorResponses,
+        },
+      },
+    },
     "/api/emails/{id}/attachments": {
       get: {
         tags: ["Emails"],
@@ -2354,6 +2374,28 @@ export const openApiDocument = {
             description: "Full-text search.",
             schema: { type: "string" },
           },
+          {
+            name: "tag_name",
+            in: "query",
+            description:
+              "Filter logs to requests linked to emails with this tag name. Uses the same tag validation as send requests.",
+            schema: {
+              type: "string",
+              maxLength: 256,
+              pattern: "^[A-Za-z0-9_-]+$",
+            },
+          },
+          {
+            name: "tag_value",
+            in: "query",
+            description:
+              "Optional tag value filter. Requires tag_name and may be an empty string.",
+            schema: {
+              type: "string",
+              maxLength: 256,
+              pattern: "^[A-Za-z0-9_-]*$",
+            },
+          },
         ],
         responses: {
           "200": {
@@ -2929,6 +2971,46 @@ export const openApiDocument = {
           },
         },
         required: ["object", "data"],
+      },
+      EmailTraceEvent: {
+        type: "object",
+        properties: {
+          object: { type: "string", enum: ["email_trace_event"] },
+          id: { type: "string" },
+          source: {
+            type: "string",
+            enum: ["request", "queue", "provider", "webhook", "suppression"],
+          },
+          type: { type: "string" },
+          created_at: { type: "string", format: "date-time" },
+          summary: { type: "string" },
+          details: { type: "object", additionalProperties: true },
+          related_id: { type: "string", nullable: true },
+          related_url: { type: "string", nullable: true },
+        },
+        required: [
+          "object",
+          "id",
+          "source",
+          "type",
+          "created_at",
+          "summary",
+          "details",
+          "related_id",
+          "related_url",
+        ],
+      },
+      EmailTrace: {
+        type: "object",
+        properties: {
+          object: { type: "string", enum: ["email_trace"] },
+          email_id: { type: "string", format: "uuid" },
+          data: {
+            type: "array",
+            items: { $ref: "#/components/schemas/EmailTraceEvent" },
+          },
+        },
+        required: ["object", "email_id", "data"],
       },
       EmailAttachmentDetail: {
         type: "object",

--- a/src/lib/tag-query-params.ts
+++ b/src/lib/tag-query-params.ts
@@ -1,0 +1,83 @@
+import { tagSchema } from "@/lib/validation/emails";
+
+export type ParsedTagQueryParams = {
+  tagName: string | null;
+  tagValue: string | null;
+};
+
+export type TagQueryValidationDetails = {
+  formErrors: string[];
+  fieldErrors: Record<string, string[]>;
+};
+
+export type ParseTagQueryParamsResult =
+  | { ok: true; value: ParsedTagQueryParams }
+  | { ok: false; details: TagQueryValidationDetails };
+
+function readTrimmedParam(
+  params: URLSearchParams,
+  ...keys: string[]
+): string | null {
+  for (const key of keys) {
+    const value = params.get(key);
+    if (value === null) continue;
+    const trimmed = value.trim();
+    if (trimmed !== "") return trimmed;
+  }
+  return null;
+}
+
+function hasParam(params: URLSearchParams, ...keys: string[]): boolean {
+  return keys.some((key) => params.has(key));
+}
+
+function tagValidationError(
+  fieldErrors: Record<string, string[]>,
+): ParseTagQueryParamsResult {
+  return {
+    ok: false,
+    details: {
+      formErrors: [],
+      fieldErrors,
+    },
+  };
+}
+
+export function parseTagQueryParams(
+  params: URLSearchParams,
+): ParseTagQueryParamsResult {
+  const tagName = readTrimmedParam(params, "tag_name", "tagName");
+  const tagValuePresent = hasParam(params, "tag_value", "tagValue");
+  const tagValue = tagValuePresent
+    ? (params.get("tag_value") ?? params.get("tagValue") ?? "").trim()
+    : null;
+
+  if (!tagName && tagValuePresent) {
+    return tagValidationError({
+      tag_name: ["tag_name is required when tag_value is provided."],
+    });
+  }
+
+  if (!tagName) {
+    return { ok: true, value: { tagName: null, tagValue: null } };
+  }
+
+  const parsed = tagSchema.safeParse({ name: tagName, value: tagValue ?? "" });
+  if (!parsed.success) {
+    const fieldErrors: Record<string, string[]> = {};
+    for (const issue of parsed.error.issues) {
+      const firstPath = issue.path[0];
+      const field = firstPath === "value" ? "tag_value" : "tag_name";
+      fieldErrors[field] = [...(fieldErrors[field] ?? []), issue.message];
+    }
+    return tagValidationError(fieldErrors);
+  }
+
+  return {
+    ok: true,
+    value: {
+      tagName: parsed.data.name,
+      tagValue: tagValuePresent ? parsed.data.value : null,
+    },
+  };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -313,7 +313,12 @@ function isEmailReadAlias(pathname: string, method: string): boolean {
   const parts = pathname.split("/").filter(Boolean);
   if (parts[0] !== "emails") return false;
   if (parts.length === 2) return ["GET", "PATCH"].includes(method);
-  if (parts.length === 3 && parts[2] === "attachments") return method === "GET";
+  if (
+    parts.length === 3 &&
+    ["attachments", "events", "trace"].includes(parts[2] ?? "")
+  ) {
+    return method === "GET";
+  }
   if (parts.length === 4 && parts[2] === "attachments") return method === "GET";
   if (parts[1] === "receiving") {
     if (parts.length === 2) return method === "GET";

--- a/tests/api-email-trace.test.ts
+++ b/tests/api-email-trace.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockCreateEmailTraceService = vi.hoisted(() => vi.fn());
+const mockGetTrace = vi.hoisted(() => vi.fn());
+const MockEmailTraceServiceError = vi.hoisted(
+  () =>
+    class EmailTraceServiceError extends Error {
+      constructor(
+        readonly code: "email_not_found",
+        message: string,
+      ) {
+        super(message);
+        this.name = "EmailTraceServiceError";
+      }
+    },
+);
+
+vi.mock("@/lib/api-auth", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/api-auth")>("@/lib/api-auth");
+  return {
+    validateApiKey: mockValidateApiKey,
+    unauthorizedResponse: actual.unauthorizedResponse,
+  };
+});
+
+vi.mock("@opensend/core", () => ({
+  createEmailTraceService: mockCreateEmailTraceService,
+  EmailTraceServiceError: MockEmailTraceServiceError,
+}));
+
+function request(url: string) {
+  return new Request(url, {
+    headers: { Authorization: "Bearer os_test" },
+  });
+}
+
+function fullAccessAuth() {
+  return {
+    apiKeyId: "api-key-a",
+    permission: "full_access",
+    domain: null,
+    userId: "user-a",
+  };
+}
+
+describe("/api/emails/[id]/trace route", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue(fullAccessAuth());
+    mockCreateEmailTraceService.mockReturnValue({ getTrace: mockGetTrace });
+    mockGetTrace.mockResolvedValue({
+      object: "email_trace",
+      email_id: "email-1",
+      data: [
+        {
+          object: "email_trace_event",
+          id: "email:email-1:created",
+          source: "queue",
+          type: "created",
+          created_at: new Date("2026-05-01T00:00:00.000Z"),
+          summary: "Email record created in queued state",
+          details: { tags: ["campaign=launch"] },
+          related_id: "email-1",
+          related_url: "/emails/email-1",
+        },
+      ],
+    });
+  });
+
+  it("returns the tenant-scoped trace envelope", async () => {
+    const { GET } = await import("@/app/api/emails/[id]/trace/route");
+    const res = await GET(
+      request("http://localhost/api/emails/email-1/trace") as never,
+      {
+        params: Promise.resolve({ id: "email-1" }),
+      } as never,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockGetTrace).toHaveBeenCalledWith("user-a", "email-1");
+    await expect(res.json()).resolves.toMatchObject({
+      object: "email_trace",
+      email_id: "email-1",
+      data: [
+        {
+          source: "queue",
+          type: "created",
+          details: { tags: ["campaign=launch"] },
+        },
+      ],
+    });
+  });
+
+  it("preserves full-access auth and cross-tenant not found behavior", async () => {
+    mockValidateApiKey.mockResolvedValueOnce({
+      ...fullAccessAuth(),
+      permission: "sending_access",
+    });
+    const { GET } = await import("@/app/api/emails/[id]/trace/route");
+    const forbidden = await GET(
+      request("http://localhost/api/emails/email-1/trace") as never,
+      { params: Promise.resolve({ id: "email-1" }) } as never,
+    );
+    expect(forbidden.status).toBe(403);
+
+    mockValidateApiKey.mockResolvedValueOnce(fullAccessAuth());
+    mockGetTrace.mockRejectedValueOnce(
+      new MockEmailTraceServiceError("email_not_found", "Email not found"),
+    );
+    const missing = await GET(
+      request("http://localhost/api/emails/email-2/trace") as never,
+      {
+        params: Promise.resolve({ id: "email-2" }),
+      } as never,
+    );
+    expect(missing.status).toBe(404);
+    await expect(missing.json()).resolves.toEqual({ error: "Email not found" });
+  });
+});

--- a/tests/api-logs.test.ts
+++ b/tests/api-logs.test.ts
@@ -93,6 +93,8 @@ describe("log read service", () => {
       dateTo: "2026-05-06",
       userAgent: "test",
       search: "  email-1  ",
+      tagName: "campaign",
+      tagValue: "launch",
     });
 
     expect(response).toEqual({
@@ -121,6 +123,8 @@ describe("log read service", () => {
       before: "log-0",
       userAgent: "test",
       search: "email-1",
+      tagName: "campaign",
+      tagValue: "launch",
     });
     expect(calls[0].dateFrom).toBeInstanceOf(Date);
     expect(calls[0].dateTo).toBeInstanceOf(Date);
@@ -219,7 +223,7 @@ describe("/api/logs routes", () => {
     const { GET } = await import("@/app/api/logs/route");
     const res = await GET(
       request(
-        "http://localhost:3015/api/logs?q=email-1&user_agent=test&date_from=2026-05-01&date_to=2026-05-06&api_key_id=api-key-a&after=log-z&before=log-0&method=post&status=200&limit=50",
+        "http://localhost:3015/api/logs?q=email-1&user_agent=test&date_from=2026-05-01&date_to=2026-05-06&api_key_id=api-key-a&after=log-z&before=log-0&method=post&status=200&limit=50&tag_name=campaign&tag_value=launch",
       ),
     );
 
@@ -251,6 +255,8 @@ describe("/api/logs routes", () => {
       dateTo: "2026-05-06",
       userAgent: "test",
       search: "email-1",
+      tagName: "campaign",
+      tagValue: "launch",
     });
   });
 
@@ -278,6 +284,29 @@ describe("/api/logs routes", () => {
         dateTo: "2026-05-06",
       }),
     );
+  });
+
+  it("returns validation_error envelopes for invalid tag filters", async () => {
+    const { GET } = await import("@/app/api/logs/route");
+    const res = await GET(
+      request(
+        "http://localhost:3015/api/logs?tag_name=bad.name&tag_value=bad value",
+      ),
+    );
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      name: "validation_error",
+      code: "validation_error",
+      statusCode: 422,
+      details: {
+        fieldErrors: {
+          tag_name: [expect.stringContaining("ASCII")],
+          tag_value: [expect.stringContaining("ASCII")],
+        },
+      },
+    });
+    expect(mockListLogs).not.toHaveBeenCalled();
   });
 
   it("requires full-access API keys for log reads", async () => {

--- a/tests/dashboard-aggregates-service.test.ts
+++ b/tests/dashboard-aggregates-service.test.ts
@@ -41,6 +41,9 @@ function makeRepository(
     async listDomainBreakdown() {
       return [];
     },
+    async listTagBreakdown() {
+      return [];
+    },
     async listTagOptions() {
       return [];
     },
@@ -134,6 +137,7 @@ describe("dashboard aggregate service", () => {
       tagOptions: [],
       dailyData: [{ date: "2026-04-23", count: 7 }],
       domainBreakdown: [{ domain: "example.com", count: 10, rate: 70 }],
+      tagBreakdown: [],
       bounceBreakdown: {
         permanent: 1,
         transient: 1,
@@ -151,7 +155,8 @@ describe("dashboard aggregate service", () => {
     const end = new Date("2026-05-11T23:59:59.999Z");
     const metricInputs: MetricsBaseInput[] = [];
     const dailyInputs: DailyCountsInput[] = [];
-    let tagOptionsUserId: string | undefined;
+    let tagOptionsInput: MetricsBaseInput | undefined;
+    let tagBreakdownInput: MetricsBaseInput | undefined;
 
     const service = createDashboardAggregateService({
       repository: makeRepository({
@@ -183,8 +188,14 @@ describe("dashboard aggregate service", () => {
           metricInputs.push(input);
           return [];
         },
-        async listTagOptions(userId) {
-          tagOptionsUserId = userId;
+        async listTagBreakdown(input) {
+          tagBreakdownInput = input;
+          return [
+            { name: "campaign", value: "launch", total: 5, delivered: 4 },
+          ];
+        },
+        async listTagOptions(input) {
+          tagOptionsInput = input;
           return [{ name: "campaign", values: ["launch"] }];
         },
       }),
@@ -215,9 +226,13 @@ describe("dashboard aggregate service", () => {
       expectedBase,
     ]);
     expect(dailyInputs).toEqual([{ ...expectedBase, statuses: ["delivered"] }]);
-    expect(tagOptionsUserId).toBe("tenant-1");
+    expect(tagBreakdownInput).toEqual(expectedBase);
+    expect(tagOptionsInput).toEqual(expectedBase);
     expect(payload.tagOptions).toEqual([
       { name: "campaign", values: ["launch"] },
+    ]);
+    expect(payload.tagBreakdown).toEqual([
+      { name: "campaign", value: "launch", count: 5, rate: 80 },
     ]);
     expect(payload.totalEmails).toBe(0);
     expect(payload.dailyData).toEqual([]);

--- a/tests/e2e/email-detail-trace.spec.ts
+++ b/tests/e2e/email-detail-trace.spec.ts
@@ -173,7 +173,10 @@ test("dashboard email detail trace shows sanitized event details and linked logs
   await expect(
     page.getByRole("link", { name: /View all logs/i }),
   ).toHaveAttribute("href", `/logs?q=${encodeURIComponent(emailId)}`);
-  await expect(page.locator(`a[href="/logs/${logId}"]`)).toBeVisible();
+  const associatedLogLink = page
+    .getByTestId("associated-logs")
+    .locator(`a[href="/logs/${logId}"]`);
+  await expect(associatedLogLink).toBeVisible();
 
   const metricsResponse = await page.request.get(
     `/api/metrics?range=last_30_days&tag_name=campaign&tag_value=${encodeURIComponent(tagValue)}`,
@@ -194,8 +197,8 @@ test("dashboard email detail trace shows sanitized event details and linked logs
   ).toBeVisible();
 
   await page.goto(`/emails/${emailId}`);
-  await expect(page.locator(`a[href="/logs/${logId}"]`)).toBeVisible();
-  await page.locator(`a[href="/logs/${logId}"]`).click();
+  await expect(associatedLogLink).toBeVisible();
+  await associatedLogLink.click();
   await expect(
     page.getByRole("heading", { name: "POST /api/emails" }),
   ).toBeVisible();

--- a/tests/e2e/email-detail-trace.spec.ts
+++ b/tests/e2e/email-detail-trace.spec.ts
@@ -11,11 +11,12 @@ test("dashboard email detail trace shows sanitized event details and linked logs
   const otherRecipient = `other-trace@${e2eRunId}.e2e.opensend.test`;
   const rawSecret = `Bearer e2e-secret-${e2eRunId}`;
   const rawBody = `raw-html-secret-${e2eRunId}`;
+  const tagValue = `trace-${e2eRunId}`;
   const otherTenantMarker = `other-tenant-marker-${e2eRunId}`;
 
   const insertedEmail = await e2eDb.query<{ id: string }>(
-    `insert into emails ("from", "to", subject, html, text, status, user_id, created_at)
-     values ($1, $2::jsonb, $3, $4, $5, 'bounced', $6, $7)
+    `insert into emails ("from", "to", subject, html, text, status, tags, user_id, created_at)
+     values ($1, $2::jsonb, $3, $4, $5, 'bounced', $6::jsonb, $7, $8)
      returning id`,
     [
       "sender@example.com",
@@ -23,8 +24,9 @@ test("dashboard email detail trace shows sanitized event details and linked logs
       "Trace detail e2e",
       "<p>Hello trace</p>",
       "Hello trace",
+      JSON.stringify([{ name: "campaign", value: tagValue }]),
       e2eTenant.user.id,
-      "2026-05-11T00:00:00.000Z",
+      "2026-05-28T00:00:00.000Z",
     ],
   );
   const emailId = insertedEmail.rows[0]?.id ?? "";
@@ -39,7 +41,7 @@ test("dashboard email detail trace shows sanitized event details and linked logs
       JSON.stringify([otherRecipient]),
       otherTenantMarker,
       otherTenant.user.id,
-      "2026-05-11T00:00:00.000Z",
+      "2026-05-28T00:00:00.000Z",
     ],
   );
   const otherEmailId = insertedOtherEmail.rows[0]?.id ?? "";
@@ -54,7 +56,7 @@ test("dashboard email detail trace shows sanitized event details and linked logs
       `e2e-trace-sent-${e2eRunId}`,
       JSON.stringify({ messageId: `ses-message-${e2eRunId}` }),
       e2eTenant.user.id,
-      "2026-05-11T00:01:00.000Z",
+      "2026-05-28T00:01:00.000Z",
     ],
   );
   const sentEventId = sentEvent.rows[0]?.id ?? "";
@@ -81,7 +83,7 @@ test("dashboard email detail trace shows sanitized event details and linked logs
         html: rawBody,
       }),
       e2eTenant.user.id,
-      "2026-05-11T00:02:00.000Z",
+      "2026-05-28T00:02:00.000Z",
     ],
   );
   const bounceEventId = bounceEvent.rows[0]?.id ?? "";
@@ -96,7 +98,7 @@ test("dashboard email detail trace shows sanitized event details and linked logs
       `e2e-trace-other-${e2eRunId}`,
       JSON.stringify({ bounceType: "Transient", reason: otherTenantMarker }),
       otherTenant.user.id,
-      "2026-05-11T00:02:00.000Z",
+      "2026-05-28T00:02:00.000Z",
     ],
   );
 
@@ -115,7 +117,7 @@ test("dashboard email detail trace shows sanitized event details and linked logs
       JSON.stringify({ emailId, test_run_id: e2eRunId }),
       e2eTenant.user.id,
       e2eTenant.apiKey.id,
-      "2026-05-11T00:03:00.000Z",
+      "2026-05-27T23:59:59.000Z",
     ],
   );
   const logId = logResult.rows[0]?.id ?? "";
@@ -129,20 +131,29 @@ test("dashboard email detail trace shows sanitized event details and linked logs
       JSON.stringify({ emailId: otherEmailId, test_run_id: e2eRunId }),
       otherTenant.user.id,
       otherTenant.apiKey.id,
-      "2026-05-11T00:03:00.000Z",
+      "2026-05-28T00:03:00.000Z",
     ],
   );
 
   await page.goto(`/emails/${emailId}`);
 
-  await expect(page.getByText("EMAIL EVENT TRACE")).toBeVisible();
+  await expect(page.getByText("MESSAGE TRACE")).toBeVisible();
   const eventRows = page.getByTestId("event-trace-row");
-  await expect(eventRows).toHaveCount(2);
-  await expect(eventRows.nth(0).getByTestId("event-badge")).toHaveText("Sent");
+  await expect(eventRows).toHaveCount(4);
+  await expect(eventRows.nth(0).getByTestId("event-badge")).toHaveText(
+    "Api Request",
+  );
   await expect(eventRows.nth(1).getByTestId("event-badge")).toHaveText(
+    "Created",
+  );
+  await expect(eventRows.nth(2).getByTestId("event-badge")).toHaveText("Sent");
+  await expect(eventRows.nth(3).getByTestId("event-badge")).toHaveText(
     "Bounced",
   );
-  await expect(page.getByText(`event_id: ${bounceEventId}`)).toBeVisible();
+  await expect(
+    page.getByText(`trace_id: event:${bounceEventId}`),
+  ).toBeVisible();
+  await expect(page.getByText(`campaign=${tagValue}`)).toBeVisible();
   await expect(
     page.getByText("Permanent bounce", { exact: false }),
   ).toBeVisible();
@@ -162,6 +173,27 @@ test("dashboard email detail trace shows sanitized event details and linked logs
   await expect(
     page.getByRole("link", { name: /View all logs/i }),
   ).toHaveAttribute("href", `/logs?q=${encodeURIComponent(emailId)}`);
+  await expect(page.locator(`a[href="/logs/${logId}"]`)).toBeVisible();
+
+  const metricsResponse = await page.request.get(
+    `/api/metrics?range=last_30_days&tag_name=campaign&tag_value=${encodeURIComponent(tagValue)}`,
+  );
+  expect(metricsResponse.ok()).toBeTruthy();
+  const metricsJson = (await metricsResponse.json()) as {
+    totalEmails: number;
+    tagBreakdown: Array<{ name: string; value: string; count: number }>;
+  };
+  expect(metricsJson.totalEmails).toBeGreaterThanOrEqual(1);
+  expect(metricsJson.tagBreakdown).toContainEqual(
+    expect.objectContaining({ name: "campaign", value: tagValue, count: 1 }),
+  );
+
+  await page.goto("/metrics");
+  await expect(
+    page.getByTestId("tag-breakdown-row").filter({ hasText: tagValue }),
+  ).toBeVisible();
+
+  await page.goto(`/emails/${emailId}`);
   await expect(page.locator(`a[href="/logs/${logId}"]`)).toBeVisible();
   await page.locator(`a[href="/logs/${logId}"]`).click();
   await expect(

--- a/tests/e2e/email-detail.spec.ts
+++ b/tests/e2e/email-detail.spec.ts
@@ -30,7 +30,7 @@ test.describe("Email Detail Page", () => {
       await expect(page.getByText("ID")).toBeVisible();
 
       // Verify Email Events section
-      await expect(page.getByText("EMAIL EVENT TRACE")).toBeVisible();
+      await expect(page.getByText("MESSAGE TRACE")).toBeVisible();
 
       // Verify content tabs
       await expect(page.getByText("Preview")).toBeVisible();

--- a/tests/email-detail.test.tsx
+++ b/tests/email-detail.test.tsx
@@ -61,7 +61,7 @@ describe("EmailDetail", () => {
   it("renders event timeline in chronological order", () => {
     render(<EmailDetail email={mockEmail} />);
 
-    expect(screen.getByText("EMAIL EVENT TRACE")).toBeTruthy();
+    expect(screen.getByText("MESSAGE TRACE")).toBeTruthy();
 
     const sentBadge = screen.getByText("Sent");
     const deliveredBadge = screen.getByText("Delivered");
@@ -79,7 +79,7 @@ describe("EmailDetail", () => {
   it("renders event ids and sanitized payload-backed details", () => {
     render(<EmailDetail email={mockEmail} />);
 
-    expect(screen.getByText("event_id: event-delivered")).toBeTruthy();
+    expect(screen.getByText("trace_id: event-delivered")).toBeTruthy();
     expect(
       screen.getByText("Delivered to jaeyunha0317@gmail.com — 250 Ok"),
     ).toBeTruthy();

--- a/tests/email-trace-service.test.ts
+++ b/tests/email-trace-service.test.ts
@@ -1,0 +1,210 @@
+import {
+  type EmailTraceRepository,
+  EmailTraceServiceError,
+  createEmailTraceService,
+} from "@opensend/core";
+import { describe, expect, it } from "vitest";
+
+type TraceEmail = NonNullable<
+  Awaited<ReturnType<EmailTraceRepository["findEmailForUser"]>>
+>;
+type TraceEvent = Awaited<
+  ReturnType<EmailTraceRepository["listEventsByEmailIdAsc"]>
+>[number];
+type TraceLog = Awaited<
+  ReturnType<EmailTraceRepository["listLogsForEmail"]>
+>[number];
+type TraceWebhook = Awaited<
+  ReturnType<EmailTraceRepository["listWebhookDeliveriesForEmail"]>
+>[number];
+type TraceSuppression = NonNullable<
+  Awaited<ReturnType<EmailTraceRepository["findSuppressionForEmail"]>>
+>;
+
+function makeEmail(overrides: Partial<TraceEmail> = {}): TraceEmail {
+  return {
+    id: "email-1",
+    to: ["recipient@example.com"],
+    subject: "Trace me",
+    status: "queued",
+    scheduledAt: null,
+    sentAt: null,
+    createdAt: new Date("2026-05-01T00:01:00.000Z"),
+    providerRetryCount: 0,
+    providerLastAttemptedAt: null,
+    providerNextRetryAt: null,
+    providerLastErrorCode: null,
+    providerLastErrorMessage: null,
+    providerDeadLetteredAt: null,
+    tags: [{ name: "campaign", value: "launch" }],
+    ...overrides,
+  };
+}
+
+function makeEvent(overrides: Partial<TraceEvent> = {}): TraceEvent {
+  return {
+    id: "event-1",
+    emailId: "email-1",
+    sourceId: "ses-1",
+    type: "delivered",
+    payload: { smtpResponse: "250 ok" },
+    userId: "user-1",
+    receivedAt: new Date("2026-05-01T00:03:00.000Z"),
+    ...overrides,
+  };
+}
+
+function makeLog(overrides: Partial<TraceLog> = {}): TraceLog {
+  return {
+    id: "log-1",
+    method: "POST",
+    endpoint: "/api/emails",
+    status: 202,
+    apiKeyId: "11111111-1111-1111-1111-111111111111",
+    createdAt: new Date("2026-05-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function makeWebhook(overrides: Partial<TraceWebhook> = {}): TraceWebhook {
+  return {
+    id: "delivery-1",
+    webhookId: "22222222-2222-2222-2222-222222222222",
+    webhookUrl: "https://example.com/webhook",
+    eventId: "event-1",
+    eventType: "delivered",
+    attempt: 1,
+    status: "success",
+    statusCode: 200,
+    attemptedAt: new Date("2026-05-01T00:04:00.000Z"),
+    nextRetryAt: null,
+    createdAt: new Date("2026-05-01T00:04:00.000Z"),
+    ...overrides,
+  };
+}
+
+function makeSuppression(
+  overrides: Partial<TraceSuppression> = {},
+): TraceSuppression {
+  return {
+    id: "suppression-1",
+    email: "recipient@example.com",
+    reason: "bounced",
+    sourceEmailId: "email-1",
+    sourceMessageId: "ses-1",
+    metadata: { source: "ses" },
+    suppressedAt: new Date("2026-05-01T00:05:00.000Z"),
+    ...overrides,
+  };
+}
+
+function makeRepository(
+  overrides: Partial<EmailTraceRepository> = {},
+): EmailTraceRepository {
+  return {
+    async findEmailForUser() {
+      return makeEmail();
+    },
+    async listEventsByEmailIdAsc() {
+      return [];
+    },
+    async listLogsForEmail() {
+      return [];
+    },
+    async listWebhookDeliveriesForEmail() {
+      return [];
+    },
+    async findSuppressionForEmail() {
+      return undefined;
+    },
+    ...overrides,
+  };
+}
+
+describe("email trace service", () => {
+  it("combines request, queue, provider, webhook, and suppression events chronologically", async () => {
+    const captured: Array<{ method: string; userId: string; emailId: string }> =
+      [];
+    const service = createEmailTraceService({
+      repository: makeRepository({
+        async findEmailForUser(emailId, userId) {
+          captured.push({ method: "findEmailForUser", userId, emailId });
+          return makeEmail({ id: emailId });
+        },
+        async listLogsForEmail(userId, emailId) {
+          captured.push({ method: "listLogsForEmail", userId, emailId });
+          return [makeLog()];
+        },
+        async listEventsByEmailIdAsc(emailId) {
+          expect(emailId).toBe("email-1");
+          return [makeEvent()];
+        },
+        async listWebhookDeliveriesForEmail(userId, emailId) {
+          captured.push({
+            method: "listWebhookDeliveriesForEmail",
+            userId,
+            emailId,
+          });
+          return [makeWebhook()];
+        },
+        async findSuppressionForEmail(userId, emailId, recipient) {
+          expect(recipient).toBe("recipient@example.com");
+          captured.push({ method: "findSuppressionForEmail", userId, emailId });
+          return makeSuppression();
+        },
+      }),
+    });
+
+    const trace = await service.getTrace("user-1", "email-1");
+
+    expect(captured).toEqual([
+      { method: "findEmailForUser", userId: "user-1", emailId: "email-1" },
+      { method: "listLogsForEmail", userId: "user-1", emailId: "email-1" },
+      {
+        method: "listWebhookDeliveriesForEmail",
+        userId: "user-1",
+        emailId: "email-1",
+      },
+      {
+        method: "findSuppressionForEmail",
+        userId: "user-1",
+        emailId: "email-1",
+      },
+    ]);
+    expect(trace.object).toBe("email_trace");
+    expect(trace.email_id).toBe("email-1");
+    expect(trace.data.map((item) => item.source)).toEqual([
+      "request",
+      "queue",
+      "provider",
+      "webhook",
+      "suppression",
+    ]);
+    expect(trace.data[1]).toMatchObject({
+      type: "created",
+      details: { status: "queued", tags: ["campaign=launch"] },
+    });
+    expect(trace.data[2]).toMatchObject({
+      source: "provider",
+      type: "delivered",
+      details: { smtp_response: "250 ok" },
+    });
+  });
+
+  it("raises not found before loading child evidence", async () => {
+    const service = createEmailTraceService({
+      repository: makeRepository({
+        async findEmailForUser() {
+          return undefined;
+        },
+        async listLogsForEmail() {
+          throw new Error("should not run");
+        },
+      }),
+    });
+
+    await expect(service.getTrace("user-1", "missing")).rejects.toEqual(
+      new EmailTraceServiceError("email_not_found", "Email not found"),
+    );
+  });
+});

--- a/tests/metrics-route.test.ts
+++ b/tests/metrics-route.test.ts
@@ -82,6 +82,7 @@ const freshPayload = {
   complained: 1,
   domains: ["example.com"],
   tagOptions: [{ name: "campaign", values: ["launch"] }],
+  tagBreakdown: [{ name: "campaign", value: "launch", count: 10, rate: 70 }],
   dailyData: [{ date: "2026-04-23", count: 7 }],
   domainBreakdown: [{ domain: "example.com", count: 10, rate: 70 }],
   bounceBreakdown: {
@@ -177,6 +178,26 @@ describe("metrics route adapter", () => {
       60,
     );
     await expect(response.json()).resolves.toEqual(freshPayload);
+  });
+
+  it("returns validation_error envelopes for invalid tag query params", async () => {
+    const metricsRoute = await import("@/app/api/metrics/route");
+    const response = await metricsRoute.GET(
+      makeNextRequest("http://localhost/api/metrics?tag_value=launch") as never,
+    );
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({
+      name: "validation_error",
+      code: "validation_error",
+      statusCode: 422,
+      details: {
+        fieldErrors: {
+          tag_name: ["tag_name is required when tag_value is provided."],
+        },
+      },
+    });
+    expect(mockGetMetrics).not.toHaveBeenCalled();
   });
 
   it("matches Yesterday exactly instead of leaking into today", async () => {

--- a/tests/middleware-rate-limit.test.ts
+++ b/tests/middleware-rate-limit.test.ts
@@ -170,6 +170,8 @@ describe("middleware rate limiting", () => {
       ["/logs/log_123", "/api/logs/log_123"],
       ["/emails", "/api/emails"],
       ["/emails/email_123", "/api/emails/email_123"],
+      ["/emails/email_123/events", "/api/emails/email_123/events"],
+      ["/emails/email_123/trace", "/api/emails/email_123/trace"],
       ["/emails/email_123/attachments", "/api/emails/email_123/attachments"],
       [
         "/emails/email_123/attachments/attachment_123",


### PR DESCRIPTION
## Summary
- Adds a tenant-scoped per-message trace endpoint and dashboard timeline combining request logs, queue/scheduled/provider state, provider events, webhook delivery evidence, suppressions, and stored tags.
- Adds shared tag query validation plus tag name/value filters for logs, metrics, and log exports using existing send-tag semantics.
- Adds bounded tag options/breakdown aggregation over dashboard date windows with JSONB/tenant indexes and updated docs/OpenAPI/LLM docs index.

## Validation
- `make check` — passed
- `make test` — passed (189 files, 1521 tests)
- `bun run docs:check` — passed (191 pages)
- `bunx playwright test tests/e2e/email-detail-trace.spec.ts` — 1 skipped because this worktree has no `.env`/`DATABASE_URL`; the auth-backed E2E fixture requires `DATABASE_URL` before it can create real tenant rows.

## Notes / residual risk
- The focused Playwright scenario is committed and covers tagged sends in trace + filtered metrics when a real database-backed E2E environment is available.
- Trace evidence remains bounded: request logs capped, webhook deliveries capped, metrics/tag options capped to safe dashboard windows.
- No merge performed; base is `staging`.

Closes #558.
