### PR TITLE
fix(dashboard): wire meatball menu + regroup DMARC under Sending

### DIFF
--- a/src/components/domain-detail.tsx
+++ b/src/components/domain-detail.tsx
@@ -697,9 +697,9 @@ function RecordsTab({ domain }: { domain: DomainDetailData }) {
         <DNSRecordTable records={dkimRecords.length > 0 ? dkimRecords : null} />
       </div>
 
-      {/* Section 2: Enable Sending (SPF) */}
+      {/* Section 2: Enable Sending — SPF + DMARC live here */}
       <div className="mb-8 border-t border-line pt-6">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center justify-between mb-1">
           <h3 className="text-[14px] font-semibold text-fg">Enable Sending</h3>
           <button
             type="button"
@@ -723,24 +723,39 @@ function RecordsTab({ domain }: { domain: DomainDetailData }) {
             />
           </button>
         </div>
-        <DNSRecordTable
-          records={sendingRecords.length > 0 ? sendingRecords : null}
-        />
-      </div>
-
-      {/* Section 3: DMARC guidance */}
-      <div className="mb-8 border-t border-line pt-6">
-        <h3 className="text-[14px] font-semibold text-fg mb-1">DMARC Policy</h3>
         <p className="text-[13px] text-fg-2 mb-4">
-          Publish this starter TXT record so receivers can evaluate SPF and DKIM
-          alignment before you enforce a stricter policy.
+          DNS records that let receiving mail servers accept and authenticate
+          messages from this domain.
         </p>
-        <DNSRecordTable
-          records={dmarcRecords.length > 0 ? dmarcRecords : null}
-        />
+
+        {/* SPF + Return-Path */}
+        <div className="mb-6">
+          <p className="text-[13px] text-blue-400 mb-2">
+            SPF &amp; Return-Path
+          </p>
+          <DNSRecordTable
+            records={sendingRecords.length > 0 ? sendingRecords : null}
+          />
+        </div>
+
+        {/* DMARC — nested under Sending so it reads as send-side, not receive-side */}
+        <div>
+          <p className="text-[13px] text-blue-400 mb-1">DMARC Policy</p>
+          <p className="text-[12px] text-fg-2 mb-3">
+            Tells other mail servers what to do with messages claiming to be
+            from your domain that fail SPF/DKIM. Starter record uses{" "}
+            <span className="font-mono text-fg">p=none</span> (monitor only) —
+            tighten to <span className="font-mono text-fg">quarantine</span> or{" "}
+            <span className="font-mono text-fg">reject</span> once you trust
+            your sending setup.
+          </p>
+          <DNSRecordTable
+            records={dmarcRecords.length > 0 ? dmarcRecords : null}
+          />
+        </div>
       </div>
 
-      {/* Section 4: Tracking CNAME */}
+      {/* Section 3: Tracking CNAME */}
       <div className="mb-8 border-t border-line pt-6">
         <h3 className="text-[14px] font-semibold text-fg mb-1">
           Tracking CNAME
@@ -754,7 +769,7 @@ function RecordsTab({ domain }: { domain: DomainDetailData }) {
         />
       </div>
 
-      {/* Section 5: Enable Receiving */}
+      {/* Section 4: Enable Receiving */}
       <div className="border-t border-line pt-6">
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-[14px] font-semibold text-fg">

--- a/src/components/domains-page.tsx
+++ b/src/components/domains-page.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/use-dashboard-csv-export";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 export interface DomainListItem {
   id: string;
@@ -90,7 +90,52 @@ export function DomainsPage({ domains }: DomainsPageProps) {
   const [regionFilter, setRegionFilter] = useState("");
   const [page, setPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(40);
+  const [actionMenuId, setActionMenuId] = useState<string | null>(null);
+  const [actingId, setActingId] = useState<string | null>(null);
+  const actionMenuRef = useRef<HTMLDivElement>(null);
   const { exportState, exportCsv } = useDashboardCsvExport("domains");
+
+  useEffect(() => {
+    if (!actionMenuId) return;
+    const handleClick = (e: MouseEvent) => {
+      if (
+        actionMenuRef.current &&
+        !actionMenuRef.current.contains(e.target as Node)
+      ) {
+        setActionMenuId(null);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [actionMenuId]);
+
+  const handleVerify = async (id: string) => {
+    setActingId(id);
+    setActionMenuId(null);
+    try {
+      await fetch(`/api/domains/${id}/verify`, { method: "POST" });
+      router.refresh();
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const handleDelete = async (id: string, name: string) => {
+    setActionMenuId(null);
+    if (!confirm(`Delete domain "${name}"? This cannot be undone.`)) return;
+    setActingId(id);
+    try {
+      await fetch(`/api/domains/${id}`, { method: "DELETE" });
+      router.refresh();
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const handleCopyId = (id: string) => {
+    setActionMenuId(null);
+    void navigator.clipboard?.writeText(id);
+  };
 
   const filteredDomains = useMemo(() => {
     let result = domains;
@@ -192,7 +237,21 @@ export function DomainsPage({ domains }: DomainsPageProps) {
           </thead>
           <tbody>
             {paginatedDomains.map((domain) => (
-              <DomainRow key={domain.id} domain={domain} />
+              <DomainRow
+                key={domain.id}
+                domain={domain}
+                menuOpen={actionMenuId === domain.id}
+                acting={actingId === domain.id}
+                menuRef={actionMenuId === domain.id ? actionMenuRef : null}
+                onToggleMenu={() =>
+                  setActionMenuId((current) =>
+                    current === domain.id ? null : domain.id,
+                  )
+                }
+                onVerify={() => handleVerify(domain.id)}
+                onDelete={() => handleDelete(domain.id, domain.name)}
+                onCopyId={() => handleCopyId(domain.id)}
+              />
             ))}
           </tbody>
         </table>
@@ -326,7 +385,28 @@ export function DomainsPage({ domains }: DomainsPageProps) {
   );
 }
 
-function DomainRow({ domain }: { domain: DomainListItem }) {
+interface DomainRowProps {
+  domain: DomainListItem;
+  menuOpen: boolean;
+  acting: boolean;
+  menuRef: React.RefObject<HTMLDivElement | null> | null;
+  onToggleMenu: () => void;
+  onVerify: () => void;
+  onDelete: () => void;
+  onCopyId: () => void;
+}
+
+function DomainRow({
+  domain,
+  menuOpen,
+  acting,
+  menuRef,
+  onToggleMenu,
+  onVerify,
+  onDelete,
+  onCopyId,
+}: DomainRowProps) {
+  const isVerified = domain.status === "verified";
   return (
     <tr className="border-b border-line hover:bg-bg-2 transition-colors">
       <td className="px-3 py-2 text-[14px] text-fg">
@@ -353,23 +433,67 @@ function DomainRow({ domain }: { domain: DomainListItem }) {
         {formatRelativeTime(domain.createdAt)}
       </td>
       <td className="w-10 px-3 py-2 relative">
-        <button
-          type="button"
-          aria-label="More actions"
-          className="p-1 rounded hover:bg-white/[0.14] text-fg-2 hover:text-fg transition-colors"
-        >
-          <svg
-            aria-hidden="true"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="currentColor"
+        <div ref={menuRef}>
+          <button
+            type="button"
+            aria-label="More actions"
+            aria-haspopup="menu"
+            aria-expanded={menuOpen}
+            disabled={acting}
+            onClick={onToggleMenu}
+            className="p-1 rounded hover:bg-white/[0.14] text-fg-2 hover:text-fg transition-colors disabled:opacity-50"
           >
-            <circle cx="12" cy="5" r="1.5" />
-            <circle cx="12" cy="12" r="1.5" />
-            <circle cx="12" cy="19" r="1.5" />
-          </svg>
-        </button>
+            <svg
+              aria-hidden="true"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+            >
+              <circle cx="12" cy="5" r="1.5" />
+              <circle cx="12" cy="12" r="1.5" />
+              <circle cx="12" cy="19" r="1.5" />
+            </svg>
+          </button>
+          {menuOpen && (
+            <div
+              role="menu"
+              className="absolute right-0 top-full mt-1 w-[180px] bg-bg-card border border-line rounded-md shadow-lg z-50 py-1"
+            >
+              {!isVerified && (
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={onVerify}
+                  className="w-full px-3 py-1.5 text-left text-[13px] text-fg-2 hover:bg-white/[0.08] hover:text-fg transition-colors"
+                >
+                  Verify now
+                </button>
+              )}
+              <button
+                type="button"
+                role="menuitem"
+                onClick={onCopyId}
+                className="w-full px-3 py-1.5 text-left text-[13px] text-fg-2 hover:bg-white/[0.08] hover:text-fg transition-colors"
+              >
+                Copy ID
+              </button>
+              {isVerified && (
+                <>
+                  <div className="my-1 border-t border-line" />
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={onDelete}
+                    className="w-full px-3 py-1.5 text-left text-[13px] text-red-400 hover:bg-white/[0.08] hover:text-red-300 transition-colors"
+                  >
+                    Delete domain
+                  </button>
+                </>
+              )}
+            </div>
+          )}
+        </div>
       </td>
     </tr>
   );

--- a/tests/domain-dns-records.test.tsx
+++ b/tests/domain-dns-records.test.tsx
@@ -109,10 +109,13 @@ describe("Domain DNS Records Tab (feature-025)", () => {
     expect(sendingToggle.getAttribute("data-state")).toBe("checked");
   });
 
-  it("renders DMARC as a separate policy section", () => {
+  it("renders DMARC nested under Sending with starter-policy guidance", () => {
     render(<DomainDetail domain={domainWithRecords} />);
     expect(screen.getByText("DMARC Policy")).toBeTruthy();
-    expect(screen.getByText(/evaluate SPF and DKIM alignment/)).toBeTruthy();
+    // Helper copy explains DMARC is send-side, not receive-side.
+    expect(
+      screen.getByText(/Tells other mail servers what to do/),
+    ).toBeTruthy();
     expect(screen.getByText("_dmarc.updates.foreverbrowsing.com")).toBeTruthy();
     expect(screen.getByText("v=DMARC1; p=none;")).toBeTruthy();
   });


### PR DESCRIPTION
## Summary

Two small but user-visible fixes to the domains UI.

- **Meatball menu** on each `/domains` row was a dead button — styled, no onClick, no menu. Wired to an actual dropdown with status-conditional actions: not_started/pending → \"Verify now\" + \"Copy ID\"; verified → \"Copy ID\" + \"Delete domain\" (with confirm).
- **DMARC Policy** on the domain detail page sat between Enable Sending and Enable Receiving, reading ambiguously like a receive-side concern. Nested under Enable Sending alongside SPF & Return-Path with copy that explains the p=none → quarantine → reject progression. Updated the matching DMARC test in \`tests/domain-dns-records.test.tsx\`.

## Test plan

- [x] \`make check\` (TypeScript + Biome)
- [x] \`make test\` — 1488/1488 pass
- [ ] Manual smoke on \`/domains\`: click meatball on a not-verified row → "Verify now" + "Copy ID" appear; click meatball on a verified row → "Copy ID" + "Delete domain" appear; click outside dismisses; delete prompts confirm.
- [ ] Manual smoke on \`/domains/[id]\` Records tab: DMARC Policy appears nested under Enable Sending with the p=none / quarantine / reject copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)