### PR TITLE
Harden tenant and outbound security boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,9 +103,11 @@ GOOGLE_CLIENT_SECRET=
 # ─────────────────────────────────────────────────────────────────
 # Ingester / cron auth tokens
 # ─────────────────────────────────────────────────────────────────
-# Shared secret between the scheduler/EventBridge and the ingester service for /jobs/* calls.
-# When set, the scheduler sends Authorization: Bearer ${INGESTER_JOB_TOKEN}.
-# INGESTER_JOB_TOKEN=
+# Required in production and Docker Compose. Shared secret between the scheduler/EventBridge and the ingester service for /jobs/* calls.
+# Use at least 32 random characters; the scheduler sends Authorization: Bearer ${INGESTER_JOB_TOKEN}.
+# INGESTER_JOB_TOKEN=replace-with-32-random-characters
+# Optional for local dev, but production /events/inbound rejects requests without it.
+# INGESTER_INBOUND_TOKEN=
 # Durable scheduler cadence for /jobs/scheduled-emails, /jobs/webhooks, and /jobs/domain-verify.
 # INGESTER_SCHEDULER_INTERVAL_SECONDS=60
 # Bearer token required by /api/cron/* scheduled-email endpoints.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@
 #   - POSTGRES_PASSWORD           : Postgres password (REQUIRED; set in .env before `docker compose up`)
 #   - AWS_*                       : SES + S3 credentials. If unset, email sending is disabled.
 #   - BACKGROUND_JOBS_*           : SQS/EventBridge wiring for async send pipeline.
-#   - INGESTER_JOB_TOKEN          : optional bearer token protecting ingester /jobs/* scans.
+#   - INGESTER_JOB_TOKEN          : required bearer token protecting ingester /jobs/* scans.
 #   - INGESTER_SCHEDULER_INTERVAL_SECONDS: scheduler cadence (default 60; minimum 10).
 #   - CLOUDFLARE_API_TOKEN/ZONE_ID: enables auto-DKIM/SPF/DMARC when adding a domain.
 #   - S3_BUCKET_NAME              : S3 bucket for email attachments.
@@ -123,7 +123,8 @@ services:
       BACKGROUND_JOBS_EVENT_BUS_NAME: ${BACKGROUND_JOBS_EVENT_BUS_NAME:-}
       BACKGROUND_JOBS_REQUIRE_QUEUE: ${BACKGROUND_JOBS_REQUIRE_QUEUE:-false}
       BACKGROUND_WORKER_POLL: ${BACKGROUND_WORKER_POLL:-false}
-      INGESTER_JOB_TOKEN: ${INGESTER_JOB_TOKEN:-}
+      INGESTER_JOB_TOKEN: ${INGESTER_JOB_TOKEN:?Set INGESTER_JOB_TOKEN in .env (32+ chars)}
+      INGESTER_INBOUND_TOKEN: ${INGESTER_INBOUND_TOKEN:-}
       # Stripe billing webhook cutover. STRIPE_SECRET_KEY is passed for hosted
       # parity with the app even though webhook verification only uses STRIPE_WEBHOOK_SECRET today.
       BILLING_BACKEND: ${BILLING_BACKEND:-disabled}
@@ -156,14 +157,14 @@ services:
   #   - /jobs/scheduled-emails
   #   - /jobs/webhooks
   #   - /jobs/domain-verify
-  # If INGESTER_JOB_TOKEN is set, the scheduler sends Authorization: Bearer <token>.
+  # The scheduler sends Authorization: Bearer <INGESTER_JOB_TOKEN>.
   scheduler:
     image: opensend-ingester:local
     restart: unless-stopped
     command: ["bun", "/app/job-scheduler.js"]
     environment:
       INGESTER_URL: http://ingester:3016
-      INGESTER_JOB_TOKEN: ${INGESTER_JOB_TOKEN:-}
+      INGESTER_JOB_TOKEN: ${INGESTER_JOB_TOKEN:?Set INGESTER_JOB_TOKEN in .env (32+ chars)}
       INGESTER_SCHEDULER_INTERVAL_SECONDS: ${INGESTER_SCHEDULER_INTERVAL_SECONDS:-60}
     depends_on:
       ingester:

--- a/docs/ingester-deploy.md
+++ b/docs/ingester-deploy.md
@@ -88,7 +88,9 @@ Set these on the ingester service:
 
 ```bash
 BACKGROUND_WORKER_POLL=true
-INGESTER_JOB_TOKEN=<random-bearer-token>
+INGESTER_JOB_TOKEN=<32+-char-random-bearer-token>
+# Required only when using /events/inbound in production.
+INGESTER_INBOUND_TOKEN=<32+-char-random-bearer-token>
 ```
 
 For hosted Stripe billing cutover, also set these on the ingester service from
@@ -112,7 +114,7 @@ environment before sending Stripe traffic to the endpoint. See
 [`hosted-stripe-cutover.md`](hosted-stripe-cutover.md) for the full validation
 checklist.
 
-Set the same `INGESTER_JOB_TOKEN` on any scheduler that calls `/jobs/*`. Compose also accepts an optional scheduler cadence override:
+Set the same 32+ character `INGESTER_JOB_TOKEN` on any scheduler that calls `/jobs/*`; production ingesters reject missing job tokens. Compose also accepts an optional scheduler cadence override:
 
 ```bash
 INGESTER_SCHEDULER_INTERVAL_SECONDS=60
@@ -224,7 +226,7 @@ Before pointing production SES SNS at a freshly stood-up ingester, verify:
   `https://events.<your-domain>/webhooks/stripe` and the ingester has
   `BILLING_BACKEND=stripe`, `STRIPE_SECRET_KEY`, and `STRIPE_WEBHOOK_SECRET`.
 - The SQS queue exists with a redrive policy + DLQ.
-- Periodic scan rules (`/jobs/scheduled-emails`, `/jobs/webhooks`, `/jobs/domain-verify`) are scheduled on a 1-minute cadence and use `Authorization: Bearer ${INGESTER_JOB_TOKEN}` when the token is configured.
+- Periodic scan rules (`/jobs/scheduled-emails`, `/jobs/webhooks`, `/jobs/domain-verify`) are scheduled on a 1-minute cadence and use `Authorization: Bearer ${INGESTER_JOB_TOKEN}`.
 - Domain verification runbook passed: create/use a pending domain, confirm SES is verified, do not click **Verify DNS Records**, wait for the scheduler, and confirm the OpenSend DB/dashboard flips to `verified`.
 - Migrations ran successfully against the production database before the new
   image started.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -122,7 +122,8 @@ contributor-facing set; the table below adds the production-only entries.
 | `BACKGROUND_JOBS_REQUIRE_QUEUE=true` | Fail API publish when the queue URL is missing instead of silently skipping. Required in production. |
 | `BACKGROUND_JOBS_EVENT_BUS_NAME` | Optional EventBridge bus for job lifecycle events. |
 | `BACKGROUND_WORKER_POLL=true` | Set on the **ingester** service only. Enables long-poll SQS consumer. |
-| `INGESTER_JOB_TOKEN` | Bearer token required for `/jobs/*` endpoints when the scheduler/EventBridge invokes them over HTTP. |
+| `INGESTER_JOB_TOKEN` | Required 32+ character bearer token for `/jobs/*` endpoints when the scheduler/EventBridge invokes them over HTTP. Docker Compose refuses to start the ingester/scheduler without it. |
+| `INGESTER_INBOUND_TOKEN` | Optional for local development. In production, `/events/inbound` rejects requests unless this bearer token is configured and sent by the inbound provider. |
 | `INGESTER_SCHEDULER_INTERVAL_SECONDS` | Compose scheduler cadence for `/jobs/scheduled-emails`, `/jobs/webhooks`, and `/jobs/domain-verify`. Default `60`; minimum `10`. |
 | `RATE_LIMIT_BACKEND` | `disabled` (single-process dev), or `redis` (production). |
 | `REDIS_URL` | TLS Redis endpoint, e.g. `rediss://default:<password>@<endpoint>:6379`. Used for rate limiting AND auth/domain metadata cache. |
@@ -366,7 +367,7 @@ Three periodic scans need to run every minute:
 - **Domain verification**: reconcile SES-verified domains and flip OpenSend
   domain/record status to `verified` without clicking **Verify DNS Records**.
 
-Docker Compose runs the durable `scheduler` sidecar by default. It posts to all three ingester job endpoints every `INGESTER_SCHEDULER_INTERVAL_SECONDS` seconds and includes `Authorization: Bearer ${INGESTER_JOB_TOKEN}` when the token is configured.
+Docker Compose runs the durable `scheduler` sidecar by default. It posts to all three ingester job endpoints every `INGESTER_SCHEDULER_INTERVAL_SECONDS` seconds and includes `Authorization: Bearer ${INGESTER_JOB_TOKEN}`. Set a 32+ character `INGESTER_JOB_TOKEN` before starting Compose.
 
 Two other production patterns can drive the same endpoints:
 
@@ -396,7 +397,7 @@ To verify the automatic domain reconciler in a deployment:
 3. Do **not** click **Verify DNS Records** in OpenSend.
 4. Wait one scheduler interval plus SES/API latency (normally 1-2 minutes with the default 60-second cadence).
 5. Confirm the OpenSend dashboard or database now shows the domain status and DNS record badges as `verified`.
-6. If it does not flip, inspect the scheduler and ingester logs for `/jobs/domain-verify` responses and verify the scheduler is sending `Authorization: Bearer ${INGESTER_JOB_TOKEN}` when `INGESTER_JOB_TOKEN` is set on the ingester.
+6. If it does not flip, inspect the scheduler and ingester logs for `/jobs/domain-verify` responses and verify the scheduler and ingester share the same `INGESTER_JOB_TOKEN`.
 
 ### Local dev fallback
 

--- a/packages/core/src/contracts/send.ts
+++ b/packages/core/src/contracts/send.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { parseAndValidateUrlSync } from "../security/url-safety";
 import { publicApiErrorEnvelopeSchema } from "./public-api-errors";
 
 // ── Common Fragments ──────────────────────────────────────────────
@@ -29,15 +30,6 @@ export const tagSchema = z.object({
     .max(256, EMAIL_TAG_LENGTH_MESSAGE)
     .regex(EMAIL_TAG_PATTERN, EMAIL_TAG_PATTERN_MESSAGE),
 });
-
-function hasAllowedAttachmentUrlScheme(value: string): boolean {
-  try {
-    const url = new URL(value);
-    return url.protocol === "https:" || url.protocol === "http:";
-  } catch {
-    return false;
-  }
-}
 
 function getBase64EncodedSize(byteLength: number): number {
   return Math.ceil(byteLength / 3) * 4;
@@ -84,10 +76,17 @@ export const attachmentSchema = z
       });
     }
 
-    if (attachment.path && !hasAllowedAttachmentUrlScheme(attachment.path)) {
+    const urlVerdict = attachment.path
+      ? parseAndValidateUrlSync(attachment.path, "dispatch")
+      : null;
+
+    if (urlVerdict && !urlVerdict.ok) {
       ctx.addIssue({
         code: "custom",
-        message: "attachment path must use http or https",
+        message:
+          urlVerdict.reason === "blocked_protocol"
+            ? "attachment path must use http or https"
+            : "attachment path is not allowed",
         path: ["path"],
       });
     }

--- a/packages/core/src/security/url-safety.ts
+++ b/packages/core/src/security/url-safety.ts
@@ -1,5 +1,8 @@
 import { promises as dns } from "node:dns";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 import net from "node:net";
+import { Readable } from "node:stream";
 import { LRUCache } from "lru-cache";
 
 export class UnsafeOutboundUrlError extends Error {
@@ -14,6 +17,13 @@ export class UnsafeOutboundUrlError extends Error {
 }
 
 export type UrlSafetyVerdict = { ok: true } | { ok: false; reason: string };
+
+type ResolvedOutboundTarget = {
+  url: URL;
+  host: string;
+  address: string;
+  family: 4 | 6;
+};
 
 const BLOCKED_HOSTNAME_SUFFIXES = [
   ".internal",
@@ -53,16 +63,42 @@ function isPrivateIPv4(ip: string): boolean {
   return false;
 }
 
+function ipv4FromMappedIPv6(ip: string): string | null {
+  const lower = ip.toLowerCase();
+  if (!lower.startsWith("::ffff:")) return null;
+
+  const mapped = lower.slice("::ffff:".length);
+  if (net.isIPv4(mapped)) return mapped;
+
+  const parts = mapped.split(":");
+  if (parts.length !== 2) return null;
+
+  const high = Number.parseInt(parts[0] ?? "", 16);
+  const low = Number.parseInt(parts[1] ?? "", 16);
+  if (
+    !Number.isFinite(high) ||
+    !Number.isFinite(low) ||
+    high < 0 ||
+    high > 0xffff ||
+    low < 0 ||
+    low > 0xffff
+  ) {
+    return null;
+  }
+
+  return [(high >> 8) & 0xff, high & 0xff, (low >> 8) & 0xff, low & 0xff].join(
+    ".",
+  );
+}
+
 function isPrivateIPv6(ip: string): boolean {
   const lower = ip.toLowerCase();
   if (lower === "::1") return true;
   if (lower === "::") return true;
   if (lower.startsWith("fe80:") || lower.startsWith("fe80::")) return true;
   if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
-  if (lower.startsWith("::ffff:")) {
-    const mapped = lower.slice(7);
-    if (net.isIPv4(mapped)) return isPrivateIPv4(mapped);
-  }
+  const mapped = ipv4FromMappedIPv6(lower);
+  if (mapped) return isPrivateIPv4(mapped);
   return false;
 }
 
@@ -73,12 +109,16 @@ function isPrivateIp(ip: string): boolean {
 }
 
 function hostnameBlocked(hostname: string): boolean {
-  const h = hostname.toLowerCase();
+  const h = normalizeUrlHostname(hostname);
   if (BLOCKED_HOSTNAMES_EXACT.has(h)) return true;
   for (const suffix of BLOCKED_HOSTNAME_SUFFIXES) {
     if (h.endsWith(suffix)) return true;
   }
   return false;
+}
+
+function normalizeUrlHostname(hostname: string): string {
+  return hostname.toLowerCase().replace(/^\[|\]$/g, "");
 }
 
 function envFlag(name: string): boolean {
@@ -125,7 +165,7 @@ export function parseAndValidateUrlSync(
   if (url.username || url.password) {
     return { ok: false, reason: "credentials_in_url" };
   }
-  const host = url.hostname;
+  const host = normalizeUrlHostname(url.hostname);
   if (!host) return { ok: false, reason: "empty_host" };
 
   if (hostnameBlocked(host)) {
@@ -162,10 +202,8 @@ function isLoopbackOrLinkLocal(ip: string): boolean {
     const lower = ip.toLowerCase();
     if (lower === "::1") return true;
     if (lower.startsWith("fe80")) return true;
-    if (lower.startsWith("::ffff:")) {
-      const mapped = lower.slice(7);
-      if (net.isIPv4(mapped)) return isLoopbackOrLinkLocal(mapped);
-    }
+    const mapped = ipv4FromMappedIPv6(lower);
+    if (mapped) return isLoopbackOrLinkLocal(mapped);
     return false;
   }
   return false;
@@ -175,24 +213,36 @@ async function resolveAllAddresses(
   host: string,
   lookup?: AssertOptions["dnsLookup"],
 ): Promise<string[]> {
-  if (net.isIP(host)) return [host];
+  const normalizedHost = normalizeUrlHostname(host);
+  if (net.isIP(normalizedHost)) return [normalizedHost];
   if (lookup) {
-    const records = await lookup(host);
+    const records = await lookup(normalizedHost);
     return records.map((r) => r.address);
   }
-  const records = await dns.lookup(host, { all: true, verbatim: true });
+  const records = await dns.lookup(normalizedHost, {
+    all: true,
+    verbatim: true,
+  });
   return records.map((r) => r.address);
 }
 
-export async function assertSafeOutboundUrl(
+async function resolveSafeOutboundTarget(
   raw: string,
   options: AssertOptions,
-): Promise<void> {
+  useCache: boolean,
+): Promise<ResolvedOutboundTarget> {
   const cacheKey = `${options.context}::${raw}`;
-  const cached = verdictCache.get(cacheKey);
+  const cached = useCache ? verdictCache.get(cacheKey) : undefined;
   if (cached) {
-    if (cached.ok) return;
-    throw new UnsafeOutboundUrlError(cached.reason);
+    if (!cached.ok) throw new UnsafeOutboundUrlError(cached.reason);
+    const url = new URL(raw);
+    const host = normalizeUrlHostname(url.hostname);
+    return {
+      url,
+      host,
+      address: host,
+      family: net.isIPv6(host) ? 6 : 4,
+    };
   }
 
   const syncVerdict = parseAndValidateUrlSync(raw, options.context);
@@ -201,23 +251,31 @@ export async function assertSafeOutboundUrl(
     throw new UnsafeOutboundUrlError(syncVerdict.reason);
   }
 
-  let host: string;
+  let url: URL;
   try {
-    host = new URL(raw).hostname;
+    url = new URL(raw);
   } catch {
     const v: UrlSafetyVerdict = { ok: false, reason: "invalid_url" };
     verdictCache.set(cacheKey, v);
     throw new UnsafeOutboundUrlError(v.reason);
   }
 
-  // Skip DNS rebind check when running under vitest or when the operator
-  // explicitly opts out. Sync IP/scheme/hostname blocks above still apply.
+  const host = normalizeUrlHostname(url.hostname);
+
+  // Skip DNS rebind check only for preflight validation. Pinned fetches always
+  // resolve and connect to the checked address.
   if (
+    useCache &&
     !options.dnsLookup &&
     (envFlag("URL_SAFETY_SKIP_DNS") || process.env.VITEST === "true")
   ) {
     verdictCache.set(cacheKey, { ok: true });
-    return;
+    return {
+      url,
+      host,
+      address: host,
+      family: net.isIPv6(host) ? 6 : 4,
+    };
   }
 
   let addresses: string[];
@@ -225,13 +283,13 @@ export async function assertSafeOutboundUrl(
     addresses = await resolveAllAddresses(host, options.dnsLookup);
   } catch {
     const v: UrlSafetyVerdict = { ok: false, reason: "dns_resolution_failed" };
-    verdictCache.set(cacheKey, v);
+    if (useCache) verdictCache.set(cacheKey, v);
     throw new UnsafeOutboundUrlError(v.reason);
   }
 
   if (addresses.length === 0) {
     const v: UrlSafetyVerdict = { ok: false, reason: "no_dns_records" };
-    verdictCache.set(cacheKey, v);
+    if (useCache) verdictCache.set(cacheKey, v);
     throw new UnsafeOutboundUrlError(v.reason);
   }
 
@@ -245,10 +303,136 @@ export async function assertSafeOutboundUrl(
         continue;
       }
       const v: UrlSafetyVerdict = { ok: false, reason: "private_ip_resolved" };
-      verdictCache.set(cacheKey, v);
+      if (useCache) verdictCache.set(cacheKey, v);
       throw new UnsafeOutboundUrlError(v.reason);
     }
   }
 
-  verdictCache.set(cacheKey, { ok: true });
+  if (useCache) verdictCache.set(cacheKey, { ok: true });
+  const address = addresses[0];
+  if (!address) {
+    throw new UnsafeOutboundUrlError("no_dns_records");
+  }
+
+  return {
+    url,
+    host,
+    address,
+    family: net.isIPv6(address) ? 6 : 4,
+  };
+}
+
+export async function assertSafeOutboundUrl(
+  raw: string,
+  options: AssertOptions,
+): Promise<void> {
+  await resolveSafeOutboundTarget(raw, options, true);
+}
+
+function headersToNodeHeaders(headers: HeadersInit | undefined): Headers {
+  return new Headers(headers);
+}
+
+async function bodyToBuffer(body: BodyInit | null | undefined) {
+  if (body === null || body === undefined) return undefined;
+  return Buffer.from(await new Response(body).arrayBuffer());
+}
+
+function hasHeader(headers: Headers, name: string): boolean {
+  for (const key of headers.keys()) {
+    if (key.toLowerCase() === name.toLowerCase()) return true;
+  }
+  return false;
+}
+
+function toNodeHeaderRecord(headers: Headers): Record<string, string> {
+  const result: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    result[key] = value;
+  });
+  return result;
+}
+
+export async function safeOutboundFetch(
+  raw: string,
+  init: RequestInit,
+  options: AssertOptions,
+): Promise<Response> {
+  const target = await resolveSafeOutboundTarget(raw, options, false);
+  const headers = headersToNodeHeaders(init.headers);
+  headers.set("host", target.url.host);
+
+  const body = await bodyToBuffer(init.body);
+  if (body && !hasHeader(headers, "content-length")) {
+    headers.set("content-length", String(body.byteLength));
+  }
+
+  return await new Promise<Response>((resolve, reject) => {
+    const requestImpl =
+      target.url.protocol === "https:" ? httpsRequest : httpRequest;
+    const request = requestImpl(
+      {
+        protocol: target.url.protocol,
+        hostname: target.address,
+        family: target.family,
+        port:
+          target.url.port || (target.url.protocol === "https:" ? "443" : "80"),
+        path: `${target.url.pathname}${target.url.search}`,
+        method: init.method ?? "GET",
+        headers: toNodeHeaderRecord(headers),
+        servername: net.isIP(target.host) ? undefined : target.host,
+      },
+      (message) => {
+        if (
+          init.redirect === "error" &&
+          message.statusCode &&
+          message.statusCode >= 300 &&
+          message.statusCode < 400
+        ) {
+          message.destroy();
+          reject(new TypeError("Redirect received for safe outbound fetch"));
+          return;
+        }
+
+        const responseHeaders = new Headers();
+        for (const [key, value] of Object.entries(message.headers)) {
+          if (Array.isArray(value)) {
+            for (const item of value) responseHeaders.append(key, item);
+          } else if (value !== undefined) {
+            responseHeaders.set(key, value);
+          }
+        }
+
+        resolve(
+          new Response(Readable.toWeb(message) as ReadableStream, {
+            status: message.statusCode ?? 599,
+            statusText: message.statusMessage,
+            headers: responseHeaders,
+          }),
+        );
+      },
+    );
+
+    const abort = () => {
+      request.destroy(
+        new DOMException("The operation was aborted", "AbortError"),
+      );
+    };
+
+    if (init.signal?.aborted) {
+      abort();
+      return;
+    }
+
+    init.signal?.addEventListener("abort", abort, { once: true });
+    request.on("error", (error) => {
+      init.signal?.removeEventListener("abort", abort);
+      reject(error);
+    });
+    request.on("close", () => {
+      init.signal?.removeEventListener("abort", abort);
+    });
+    if (body) request.write(body);
+    request.end();
+  });
 }

--- a/packages/core/src/services/customEvents.ts
+++ b/packages/core/src/services/customEvents.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "../db/client";
 import { automationRepo } from "../db/repositories/automationRepo";
 import { automationRunRepo } from "../db/repositories/automationRunRepo";
@@ -151,14 +151,25 @@ function defaultRepository(): CustomEventBoundaryRepository {
     findByName: (name, userId) => customEventRepo.findByName(name, userId),
     deleteForUser: (id, userId) => customEventRepo.deleteForUser(id, userId),
     resolveContactId: async (input) => {
-      if (input.contactId) return input.contactId;
+      if (!input.userId) return null;
+
+      if (input.contactId) {
+        const existing = await db.query.contacts.findFirst({
+          where: and(
+            eq(contacts.id, input.contactId),
+            eq(contacts.userId, input.userId),
+          ),
+        });
+        return existing?.id ?? null;
+      }
       if (!input.email) return null;
 
       const normalizedEmail = input.email.toLowerCase().trim();
       const existing = await db.query.contacts.findFirst({
         where: eq(contacts.email, normalizedEmail),
       });
-      if (existing) return existing.id;
+      if (existing)
+        return existing.userId === input.userId ? existing.id : null;
 
       const [created] = await db
         .insert(contacts)

--- a/packages/core/src/services/deliveryFailureExport.ts
+++ b/packages/core/src/services/deliveryFailureExport.ts
@@ -6,6 +6,7 @@ import {
   type DeliveryFailureSuppressionRow,
   deliveryFailureExportRepo,
 } from "../db/repositories/deliveryFailureExportRepo";
+import { escapeCsvValue } from "../security/csv-escape";
 
 export const DELIVERY_FAILURE_EXPORT_STATUSES = [
   "bounced",
@@ -193,14 +194,6 @@ function suppressionRowToCsvRow(
   };
 }
 
-function escapeCsv(value: unknown): string {
-  const raw = String(value ?? "");
-  if (/[",\n\r]/.test(raw)) {
-    return `"${raw.replace(/"/g, '""')}"`;
-  }
-  return raw;
-}
-
 export function serializeDeliveryFailureCsv(
   rows: DeliveryFailureExportCsvRow[],
 ): string {
@@ -208,7 +201,7 @@ export function serializeDeliveryFailureCsv(
     DELIVERY_FAILURE_EXPORT_HEADERS.join(","),
     ...rows.map((row) =>
       DELIVERY_FAILURE_EXPORT_HEADERS.map((header) =>
-        escapeCsv(row[header]),
+        escapeCsvValue(row[header]),
       ).join(","),
     ),
   ].join("\n");

--- a/packages/core/src/services/emailProvider.ts
+++ b/packages/core/src/services/emailProvider.ts
@@ -8,7 +8,11 @@ import {
   SESv2Client,
   SendEmailCommand,
 } from "@aws-sdk/client-sesv2";
-import { sanitizeHeaderName, sanitizeHeaderValue } from "../security";
+import {
+  safeMimeBoundary,
+  sanitizeHeaderName,
+  sanitizeHeaderValue,
+} from "../security";
 import {
   type EncryptedBlob,
   decryptSecret,
@@ -330,16 +334,20 @@ function buildMimeMessage(params: {
   headers?: Record<string, string>;
   attachments?: EmailAttachment[];
 }): string {
-  const boundary = `----=_Part_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+  const boundary = safeMimeBoundary("----=_Part");
   const lines: string[] = [];
 
-  lines.push(`From: ${params.from}`);
-  lines.push(`To: ${params.to.join(", ")}`);
-  if (params.cc?.length) lines.push(`Cc: ${params.cc.join(", ")}`);
-  if (params.bcc?.length) lines.push(`Bcc: ${params.bcc.join(", ")}`);
-  lines.push(`Subject: ${params.subject}`);
+  lines.push(`From: ${sanitizeHeaderValue("From", params.from)}`);
+  lines.push(`To: ${sanitizeHeaderValue("To", params.to.join(", "))}`);
+  if (params.cc?.length)
+    lines.push(`Cc: ${sanitizeHeaderValue("Cc", params.cc.join(", "))}`);
+  if (params.bcc?.length)
+    lines.push(`Bcc: ${sanitizeHeaderValue("Bcc", params.bcc.join(", "))}`);
+  lines.push(`Subject: ${sanitizeHeaderValue("Subject", params.subject)}`);
   if (params.replyTo?.length)
-    lines.push(`Reply-To: ${params.replyTo.join(", ")}`);
+    lines.push(
+      `Reply-To: ${sanitizeHeaderValue("Reply-To", params.replyTo.join(", "))}`,
+    );
   if (params.headers) {
     for (const [key, value] of Object.entries(params.headers)) {
       const safeName = sanitizeHeaderName(key);
@@ -364,20 +372,25 @@ function buildMimeMessage(params: {
   }
 
   for (const attachment of params.attachments ?? []) {
-    const contentType =
+    const safeFilename = sanitizeAttachmentFilename(attachment.filename);
+    const contentType = sanitizeHeaderValue(
+      "Content-Type",
       attachment.contentType ??
-      attachment.content_type ??
-      inferContentType(attachment.filename);
+        attachment.content_type ??
+        inferContentType(attachment.filename),
+    );
     const contentId = attachment.contentId ?? attachment.content_id;
 
     lines.push(`--${boundary}`);
-    lines.push(`Content-Type: ${contentType}; name="${attachment.filename}"`);
+    lines.push(`Content-Type: ${contentType}; name="${safeFilename}"`);
     lines.push("Content-Transfer-Encoding: base64");
     if (contentId) {
-      lines.push(`Content-ID: ${formatContentId(contentId)}`);
+      lines.push(
+        `Content-ID: ${sanitizeHeaderValue("Content-ID", formatContentId(contentId))}`,
+      );
     }
     lines.push(
-      `Content-Disposition: ${contentId ? "inline" : "attachment"}; filename="${attachment.filename}"`,
+      `Content-Disposition: ${contentId ? "inline" : "attachment"}; filename="${safeFilename}"`,
     );
     lines.push("");
     lines.push(attachment.content);
@@ -385,6 +398,13 @@ function buildMimeMessage(params: {
 
   lines.push(`--${boundary}--`);
   return lines.join("\r\n");
+}
+
+function sanitizeAttachmentFilename(name: string): string {
+  return sanitizeHeaderValue("attachment.filename", name).replace(
+    /["\\]/g,
+    "_",
+  );
 }
 
 function inferContentType(filename: string): string {

--- a/packages/core/src/services/inboundEmailIngestion.ts
+++ b/packages/core/src/services/inboundEmailIngestion.ts
@@ -2,6 +2,10 @@ import { createHash, randomUUID } from "node:crypto";
 import { db } from "../db/client";
 import { inboundProviderEventRepo } from "../db/repositories/inboundProviderEventRepo";
 import { emailEvents, receivedEmails } from "../db/schema";
+import {
+  UnsafeOutboundUrlError,
+  safeOutboundFetch,
+} from "../security/url-safety";
 import { forwardingRuleService } from "./forwardingRules";
 import {
   InboundMimeParseError,
@@ -54,7 +58,7 @@ export type InboundEmailIngestionOutcome =
     };
 
 export type InboundEmailIngestionDependencies = {
-  fetchImpl?: typeof fetch;
+  safeFetch?: typeof safeOutboundFetch;
   uploadFile?: (
     key: string,
     body: Buffer,
@@ -74,6 +78,8 @@ type StoredAttachment = {
 
 const DEFAULT_PROVIDER = "generic";
 const MAX_METADATA_STRING = 512;
+const DEFAULT_MAX_RAW_MIME_BYTES = 25 * 1024 * 1024;
+const RAW_MIME_FETCH_TIMEOUT_MS = 10_000;
 const SECRET_KEY_PATTERN = /secret|token|authorization|signature|password|key/i;
 
 function normalizeProvider(value: string | undefined): string {
@@ -129,7 +135,8 @@ function decodeRawMime(input: InboundProviderNotification): Buffer | null {
 
 async function fetchRawMime(
   input: InboundProviderNotification,
-  fetchImpl: typeof fetch,
+  safeFetch: typeof safeOutboundFetch,
+  maxBytes = DEFAULT_MAX_RAW_MIME_BYTES,
 ): Promise<Buffer> {
   const local = decodeRawMime(input);
   if (local) return local;
@@ -141,16 +148,91 @@ async function fetchRawMime(
     );
   }
 
-  const response = await fetchImpl(input.rawMimeUrl, {
-    headers: { Accept: "message/rfc822, text/plain, */*" },
-  });
-  if (!response.ok) {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    RAW_MIME_FETCH_TIMEOUT_MS,
+  );
+
+  try {
+    let response: Response;
+    try {
+      response = await safeFetch(
+        input.rawMimeUrl,
+        {
+          headers: { Accept: "message/rfc822, text/plain, */*" },
+          redirect: "error",
+          signal: controller.signal,
+        },
+        { context: "dispatch" },
+      );
+    } catch (error) {
+      if (error instanceof UnsafeOutboundUrlError) {
+        throw new InboundMimeParseError(
+          "malformed_mime",
+          "Raw MIME URL is not allowed",
+        );
+      }
+      throw error;
+    }
+    if (!response.ok) {
+      throw new InboundMimeParseError(
+        "malformed_mime",
+        `Raw MIME fetch failed with HTTP ${response.status}`,
+      );
+    }
+    return await readResponseBufferWithLimit(response, maxBytes);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function readResponseBufferWithLimit(
+  response: Response,
+  maxBytes: number,
+): Promise<Buffer> {
+  const contentLength = response.headers.get("content-length");
+  if (
+    contentLength &&
+    Number.isFinite(Number(contentLength)) &&
+    Number(contentLength) > maxBytes
+  ) {
     throw new InboundMimeParseError(
-      "malformed_mime",
-      `Raw MIME fetch failed with HTTP ${response.status}`,
+      "oversized_message",
+      `MIME payload exceeds ${maxBytes} bytes`,
     );
   }
-  return Buffer.from(await response.arrayBuffer());
+
+  if (!response.body) {
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > maxBytes) {
+      throw new InboundMimeParseError(
+        "oversized_message",
+        `MIME payload exceeds ${maxBytes} bytes`,
+      );
+    }
+    return buffer;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  while (true) {
+    const result = await reader.read();
+    if (result.done) break;
+
+    totalBytes += result.value.byteLength;
+    if (totalBytes > maxBytes) {
+      throw new InboundMimeParseError(
+        "oversized_message",
+        `MIME payload exceeds ${maxBytes} bytes`,
+      );
+    }
+    chunks.push(result.value);
+  }
+
+  return Buffer.concat(chunks, totalBytes);
 }
 
 function mergeRecipients(
@@ -237,7 +319,7 @@ async function cleanupStoredAttachments(
 export function createInboundEmailIngestionService(
   dependencies: InboundEmailIngestionDependencies = {},
 ) {
-  const fetchImpl = dependencies.fetchImpl ?? fetch;
+  const safeFetch = dependencies.safeFetch ?? safeOutboundFetch;
   const uploadFile =
     dependencies.uploadFile ?? storageService.uploadFile.bind(storageService);
   const deleteFile =
@@ -307,9 +389,10 @@ export function createInboundEmailIngestionService(
 
       let parsed: ParsedInboundMime;
       try {
-        parsed = parseInboundMime(await fetchRawMime(notification, fetchImpl), {
-          maxBytes,
-        });
+        parsed = parseInboundMime(
+          await fetchRawMime(notification, safeFetch, maxBytes),
+          { maxBytes },
+        );
       } catch (error) {
         if (error instanceof InboundMimeParseError) {
           return await markTerminal({

--- a/packages/ingester/src/dispatcher.ts
+++ b/packages/ingester/src/dispatcher.ts
@@ -1,8 +1,8 @@
 import {
   UnsafeOutboundUrlError,
-  assertSafeOutboundUrl,
   emailEventRepo,
   resolveWebhookSigningSecret,
+  safeOutboundFetch,
   signWebhookPayload,
   toWebhookEventType,
   webhookDeliveryRepo,
@@ -15,7 +15,7 @@ const DEFAULT_MAX_ATTEMPTS = DEFAULT_RETRY_DELAYS_SECONDS.length + 1;
 const RESPONSE_BODY_SNIPPET_LIMIT = 1_000;
 
 type WebhookDispatcherOptions = {
-  fetchImpl?: typeof fetch;
+  fetchImpl?: typeof safeOutboundFetch;
   now?: () => Date;
   retryDelaysSeconds?: number[];
   maxAttempts?: number;
@@ -23,14 +23,14 @@ type WebhookDispatcherOptions = {
 };
 
 export class WebhookDispatcher {
-  private readonly fetchImpl: typeof fetch;
+  private readonly fetchImpl: typeof safeOutboundFetch;
   private readonly now: () => Date;
   private readonly retryDelaysSeconds: number[];
   private readonly maxAttempts: number;
   private readonly timeoutMs: number;
 
   constructor(options: WebhookDispatcherOptions = {}) {
-    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.fetchImpl = options.fetchImpl ?? safeOutboundFetch;
     this.now = options.now ?? (() => new Date());
     this.retryDelaysSeconds =
       options.retryDelaysSeconds ?? DEFAULT_RETRY_DELAYS_SECONDS;
@@ -96,8 +96,23 @@ export class WebhookDispatcher {
     );
 
     try {
+      let response: Response;
       try {
-        await assertSafeOutboundUrl(webhook.url, { context: "dispatch" });
+        response = await this.fetchImpl(
+          webhook.url,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "svix-id": msgId,
+              "svix-timestamp": timestamp,
+              "svix-signature": signature,
+            },
+            body,
+            signal: AbortSignal.timeout(this.timeoutMs),
+          },
+          { context: "dispatch" },
+        );
       } catch (err) {
         if (err instanceof UnsafeOutboundUrlError) {
           return await this.markTerminal(
@@ -107,17 +122,6 @@ export class WebhookDispatcher {
         }
         throw err;
       }
-      const response = await this.fetchImpl(webhook.url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "svix-id": msgId,
-          "svix-timestamp": timestamp,
-          "svix-signature": signature,
-        },
-        body,
-        signal: AbortSignal.timeout(this.timeoutMs),
-      });
 
       const responseBody = this.toSnippet(await response.text());
       const nextRetryAt = response.ok

--- a/packages/ingester/src/index.ts
+++ b/packages/ingester/src/index.ts
@@ -95,13 +95,13 @@ function getSesSuppressionOutcome(
 
 function isAuthorizedJobRequest(authHeader: string | undefined): boolean {
   const token = process.env.INGESTER_JOB_TOKEN?.trim();
-  if (!token) return true;
+  if (!token) return process.env.NODE_ENV !== "production";
   return timingSafeStringEqual(authHeader, `Bearer ${token}`);
 }
 
 function isAuthorizedInboundRequest(authHeader: string | undefined): boolean {
   const token = process.env.INGESTER_INBOUND_TOKEN?.trim();
-  if (!token) return true;
+  if (!token) return process.env.NODE_ENV !== "production";
   return timingSafeStringEqual(authHeader, `Bearer ${token}`);
 }
 

--- a/packages/ingester/src/queue-worker.ts
+++ b/packages/ingester/src/queue-worker.ts
@@ -29,6 +29,7 @@ import {
   parseBackgroundJob,
   publishBackgroundJob,
   recordTelemetryError,
+  safeOutboundFetch,
   startTelemetrySpan,
   suppressionRepo,
   toWebhookEventType,
@@ -954,7 +955,14 @@ async function fetchAttachmentContent(path: string): Promise<Uint8Array> {
   );
 
   try {
-    const response = await fetch(path, { signal: controller.signal });
+    const response = await safeOutboundFetch(
+      path,
+      {
+        redirect: "error",
+        signal: controller.signal,
+      },
+      { context: "dispatch" },
+    );
     if (!response.ok) {
       throw new Error(
         `Attachment fetch failed for ${path}: ${response.status} ${response.statusText}`,

--- a/packages/ingester/src/startup-checks.ts
+++ b/packages/ingester/src/startup-checks.ts
@@ -34,9 +34,19 @@ export function runIngesterStartupChecks(): void {
   const jobToken = process.env.INGESTER_JOB_TOKEN?.trim();
   if (isProd() && (!jobToken || jobToken.length < 32)) {
     logJson(
-      "warn",
+      "error",
       { event: "security.startup.weak_job_token" },
-      "INGESTER_JOB_TOKEN missing or shorter than 32 chars in production",
+      "INGESTER_JOB_TOKEN missing/too short — refusing to boot",
+    );
+    throw new Error("INGESTER_JOB_TOKEN missing/too short in production");
+  }
+
+  const inboundToken = process.env.INGESTER_INBOUND_TOKEN?.trim();
+  if (isProd() && (!inboundToken || inboundToken.length < 32)) {
+    logJson(
+      "warn",
+      { event: "security.startup.weak_inbound_token" },
+      "INGESTER_INBOUND_TOKEN missing/too short — /events/inbound rejects requests until configured",
     );
   }
 }

--- a/public/docs/dashboard/receiving/introduction.md
+++ b/public/docs/dashboard/receiving/introduction.md
@@ -17,7 +17,7 @@ The current product surface includes a dashboard entry point, received-email rea
 
 - MX records that route inbound messages to your provider.
 - Provider receiving rules, such as SES receipt rules that deliver raw messages or S3 object notifications to the ingester boundary.
-- Deployment-specific authentication for provider callbacks, usually `INGESTER_INBOUND_TOKEN` plus provider-side network controls.
+- Deployment-specific authentication for provider callbacks. Production ingesters require `INGESTER_INBOUND_TOKEN` on inbound MIME callbacks, and provider-side network controls are still recommended.
 - Optional forwarding, reply workflows, or public webhook emission after storage; those are not part of the ingestion foundation.
 
 ## Recommended setup order

--- a/public/docs/dashboard/receiving/reply-to-emails.md
+++ b/public/docs/dashboard/receiving/reply-to-emails.md
@@ -34,6 +34,6 @@ Open an outbound email detail page to see the generated reply address and conver
 1. Verify the sending domain in OpenSend and enable the `receiving` capability.
 2. Publish inbound MX/provider records for that domain.
 3. Route provider notifications or raw MIME fetches to the standalone ingester `POST /events/inbound` endpoint.
-4. Configure `INGESTER_INBOUND_TOKEN` if the provider callback path should require bearer auth.
+4. Configure `INGESTER_INBOUND_TOKEN` for production provider callbacks; production ingesters reject inbound MIME requests without it.
 5. Set `OPENSEND_REPLY_TOKEN_SECRET` consistently for the app and ingester processes. If omitted, OpenSend falls back to the auth secret variables when present; production deployments should use an explicit secret so reply tokens survive app restarts and deploys.
 6. Keep route/catch-all policies narrow enough to avoid receiving mail for unrelated tenants. Cross-tenant or invalid tokens are stored as unmatched messages for the resolved recipient-domain tenant; arbitrary unrouted mail without a reply token remains rejected as missing-domain.

--- a/public/docs/ingester-deploy.md
+++ b/public/docs/ingester-deploy.md
@@ -6,9 +6,9 @@ Deploy the standalone ingester and queue worker. Provider callbacks should targe
 
 - `POST /events/ses` — SES/SNS sending lifecycle notifications for delivered, bounced, complained, opened, and clicked events.
 - `POST /events/inbound` — inbound MIME provider notifications. The payload must include `event_id` and either `raw_mime`, `raw_mime_base64`, or `raw_mime_url`.
-- `POST /jobs/poll`, `/jobs/scheduled-emails`, `/jobs/webhooks`, `/jobs/domain-verify` — internal job endpoints, optionally protected by `INGESTER_JOB_TOKEN`.
+- `POST /jobs/poll`, `/jobs/scheduled-emails`, `/jobs/webhooks`, `/jobs/domain-verify` — internal job endpoints protected by a required production `INGESTER_JOB_TOKEN`.
 
-Set `INGESTER_INBOUND_TOKEN` to require `Authorization: Bearer <token>` on inbound MIME notifications.
+Set `INGESTER_INBOUND_TOKEN` to require `Authorization: Bearer <token>` on inbound MIME notifications. Production ingesters reject `/events/inbound` requests when the token is missing.
 
 ## Inbound payload
 

--- a/src/app/api/broadcasts/[id]/metrics/route.ts
+++ b/src/app/api/broadcasts/[id]/metrics/route.ts
@@ -1,4 +1,3 @@
-import { unauthorizedResponse } from "@/lib/api-auth";
 import {
   BROADCAST_METRICS_CACHE_TTL_SECONDS,
   getBroadcastMetricsCacheKey,
@@ -26,10 +25,11 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const userId = await resolveBroadcastRouteUserId(
+  const userIdOrResponse = await resolveBroadcastRouteUserId(
     request.headers.get("authorization"),
   );
-  if (!userId) return unauthorizedResponse();
+  if (userIdOrResponse instanceof Response) return userIdOrResponse;
+  const userId = userIdOrResponse;
 
   try {
     const { id } = await params;

--- a/src/app/api/broadcasts/[id]/route.ts
+++ b/src/app/api/broadcasts/[id]/route.ts
@@ -1,4 +1,3 @@
-import { unauthorizedResponse } from "@/lib/api-auth";
 import { BroadcastServiceError, createBroadcastService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 import { resolveBroadcastRouteUserId } from "../auth";
@@ -43,10 +42,11 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const userId = await resolveBroadcastRouteUserId(
+  const userIdOrResponse = await resolveBroadcastRouteUserId(
     request.headers.get("authorization"),
   );
-  if (!userId) return unauthorizedResponse();
+  if (userIdOrResponse instanceof Response) return userIdOrResponse;
+  const userId = userIdOrResponse;
 
   try {
     const { id } = await params;
@@ -69,10 +69,11 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const userId = await resolveBroadcastRouteUserId(
+  const userIdOrResponse = await resolveBroadcastRouteUserId(
     request.headers.get("authorization"),
   );
-  if (!userId) return unauthorizedResponse();
+  if (userIdOrResponse instanceof Response) return userIdOrResponse;
+  const userId = userIdOrResponse;
 
   try {
     const { id } = await params;
@@ -101,10 +102,11 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const userId = await resolveBroadcastRouteUserId(
+  const userIdOrResponse = await resolveBroadcastRouteUserId(
     request.headers.get("authorization"),
   );
-  if (!userId) return unauthorizedResponse();
+  if (userIdOrResponse instanceof Response) return userIdOrResponse;
+  const userId = userIdOrResponse;
 
   try {
     const { id } = await params;

--- a/src/app/api/broadcasts/[id]/send/route.ts
+++ b/src/app/api/broadcasts/[id]/send/route.ts
@@ -1,4 +1,3 @@
-import { unauthorizedResponse } from "@/lib/api-auth";
 import { BroadcastServiceError, createBroadcastService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 import { resolveBroadcastRouteUserId } from "../../auth";
@@ -13,10 +12,11 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const userId = await resolveBroadcastRouteUserId(
+  const userIdOrResponse = await resolveBroadcastRouteUserId(
     request.headers.get("authorization"),
   );
-  if (!userId) return unauthorizedResponse();
+  if (userIdOrResponse instanceof Response) return userIdOrResponse;
+  const userId = userIdOrResponse;
 
   try {
     const { id } = await params;

--- a/src/app/api/broadcasts/auth.ts
+++ b/src/app/api/broadcasts/auth.ts
@@ -1,4 +1,9 @@
-import { authorizeDashboardOrApiKey, getServerSession } from "@/lib/api-auth";
+import {
+  authorizeDashboardOrApiKey,
+  getServerSession,
+  unauthorizedResponse,
+} from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
 
 type BroadcastRouteAuth = NonNullable<
   Awaited<ReturnType<typeof authorizeDashboardOrApiKey>>
@@ -15,9 +20,12 @@ async function getUserIdFromAuth(
 
 export async function resolveBroadcastRouteUserId(
   authHeader: string | null | undefined,
-): Promise<string | null> {
+): Promise<string | Response> {
   const auth = await authorizeDashboardOrApiKey(authHeader);
-  if (!auth) return null;
+  if (!auth) return unauthorizedResponse();
 
-  return getUserIdFromAuth(auth);
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
+
+  return (await getUserIdFromAuth(auth)) ?? unauthorizedResponse();
 }

--- a/src/app/api/broadcasts/route.ts
+++ b/src/app/api/broadcasts/route.ts
@@ -1,4 +1,3 @@
-import { unauthorizedResponse } from "@/lib/api-auth";
 import { BroadcastServiceError, createBroadcastService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 import { resolveBroadcastRouteUserId } from "./auth";
@@ -24,10 +23,11 @@ function broadcastListResponse(
 }
 
 export async function GET(request: NextRequest) {
-  const userId = await resolveBroadcastRouteUserId(
+  const userIdOrResponse = await resolveBroadcastRouteUserId(
     request.headers.get("authorization"),
   );
-  if (!userId) return unauthorizedResponse();
+  if (userIdOrResponse instanceof Response) return userIdOrResponse;
+  const userId = userIdOrResponse;
 
   try {
     const url = request.nextUrl;
@@ -52,10 +52,11 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const userId = await resolveBroadcastRouteUserId(
+  const userIdOrResponse = await resolveBroadcastRouteUserId(
     request.headers.get("authorization"),
   );
-  if (!userId) return unauthorizedResponse();
+  if (userIdOrResponse instanceof Response) return userIdOrResponse;
+  const userId = userIdOrResponse;
 
   try {
     const body = await request.json();

--- a/src/app/api/dedicated-ips/[id]/route.ts
+++ b/src/app/api/dedicated-ips/[id]/route.ts
@@ -3,6 +3,7 @@ import {
   getServerSession,
   unauthorizedResponse,
 } from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
 import { configurationSetService, dedicatedIpPoolRepo } from "@opensend/core";
 import { NextResponse } from "next/server";
 
@@ -11,6 +12,9 @@ async function resolveUserId(req: Request): Promise<string | Response> {
     req.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
 
   if ("dashboard" in auth) {
     const session = await getServerSession();

--- a/src/app/api/dedicated-ips/route.ts
+++ b/src/app/api/dedicated-ips/route.ts
@@ -3,6 +3,7 @@ import {
   getServerSession,
   unauthorizedResponse,
 } from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
 import { db } from "@/lib/db";
 import { plans, subscriptions } from "@/lib/db/schema";
 import { configurationSetService, dedicatedIpPoolRepo } from "@opensend/core";
@@ -21,6 +22,9 @@ async function resolveUserId(req: Request): Promise<string | Response> {
     req.headers.get("authorization"),
   );
   if (!auth) return unauthorizedResponse();
+
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
+  if (permissionError) return permissionError;
 
   if ("dashboard" in auth) {
     const session = await getServerSession();

--- a/src/lib/workers/automation-runner.ts
+++ b/src/lib/workers/automation-runner.ts
@@ -60,14 +60,18 @@ export interface AutomationRunnerDeps {
   getAutomation: (id: string) => Promise<Automation | null>;
   listSteps: (automationId: string) => Promise<AutomationStep[]>;
   getDelivery: (id: string) => Promise<CustomEventDelivery | null>;
-  getContact: (id: string) => Promise<Contact | null>;
+  getContact: (id: string, userId?: string | null) => Promise<Contact | null>;
   getTemplate: (id: string) => Promise<Template | null>;
   sendEmail: (input: RunnerSendEmailInput) => Promise<{ id: string }>;
   updateContact: (
     id: string,
+    userId: string | null | undefined,
     data: Partial<typeof contacts.$inferInsert>,
   ) => Promise<Contact | null>;
-  deleteContact: (id: string) => Promise<{ id: string } | null>;
+  deleteContact: (
+    id: string,
+    userId?: string | null,
+  ) => Promise<{ id: string } | null>;
   getSegment: (id: string, userId?: string | null) => Promise<Segment | null>;
   addContactToSegmentMembership: (input: {
     contactId: string;
@@ -116,10 +120,12 @@ const defaultDeps: AutomationRunnerDeps = {
       })) ?? null
     );
   },
-  async getContact(id) {
+  async getContact(id, userId) {
+    if (!userId) return null;
     return (
-      (await db.query.contacts.findFirst({ where: eq(contacts.id, id) })) ??
-      null
+      (await db.query.contacts.findFirst({
+        where: and(eq(contacts.id, id), eq(contacts.userId, userId)),
+      })) ?? null
     );
   },
   async getTemplate(id) {
@@ -131,18 +137,20 @@ const defaultDeps: AutomationRunnerDeps = {
   async sendEmail(input) {
     return await emailService.send(input);
   },
-  async updateContact(id, data) {
+  async updateContact(id, userId, data) {
+    if (!userId) return null;
     const [updated] = await db
       .update(contacts)
       .set(data)
-      .where(eq(contacts.id, id))
+      .where(and(eq(contacts.id, id), eq(contacts.userId, userId)))
       .returning();
     return updated ?? null;
   },
-  async deleteContact(id) {
+  async deleteContact(id, userId) {
+    if (!userId) return null;
     const [deleted] = await db
       .delete(contacts)
-      .where(eq(contacts.id, id))
+      .where(and(eq(contacts.id, id), eq(contacts.userId, userId)))
       .returning({ id: contacts.id });
     return deleted ?? null;
   },
@@ -583,7 +591,10 @@ async function processConditionStep(
   const delivery = run.triggerEventId
     ? await deps.getDelivery(run.triggerEventId)
     : null;
-  const contact = run.contactId ? await deps.getContact(run.contactId) : null;
+  const userId = run.userId ?? automation.userId ?? null;
+  const contact = run.contactId
+    ? await deps.getContact(run.contactId, userId)
+    : null;
   const matched = evaluateConditionPredicate(
     config,
     buildConditionContext(delivery, contact, states),
@@ -818,7 +829,8 @@ async function processContactUpdateStep(
     );
   }
 
-  const contact = await deps.getContact(run.contactId);
+  const userId = run.userId ?? automation.userId ?? null;
+  const contact = await deps.getContact(run.contactId, userId);
   if (!contact) {
     return await failRun(
       deps,
@@ -839,7 +851,7 @@ async function processContactUpdateStep(
 
   if (changedFields.length > 0) {
     try {
-      const updated = await deps.updateContact(contact.id, data);
+      const updated = await deps.updateContact(contact.id, userId, data);
       if (!updated) {
         return await failRun(
           deps,
@@ -874,6 +886,7 @@ async function processContactUpdateStep(
 async function processContactDeleteStep(
   deps: AutomationRunnerDeps,
   run: AutomationRun,
+  automation: Automation,
   step: AutomationStep,
   states: StepStates,
   now: Date,
@@ -897,7 +910,8 @@ async function processContactDeleteStep(
     });
   }
 
-  const contact = await deps.getContact(run.contactId);
+  const userId = run.userId ?? automation.userId ?? null;
+  const contact = await deps.getContact(run.contactId, userId);
   if (!contact) {
     return await failRun(
       deps,
@@ -909,7 +923,7 @@ async function processContactDeleteStep(
     );
   }
 
-  const deleted = await deps.deleteContact(contact.id);
+  const deleted = await deps.deleteContact(contact.id, userId);
   if (!deleted) {
     return await failRun(
       deps,
@@ -957,7 +971,8 @@ async function processAddToSegmentStep(
     );
   }
 
-  const contact = await deps.getContact(run.contactId);
+  const userId = run.userId ?? automation.userId ?? null;
+  const contact = await deps.getContact(run.contactId, userId);
   if (!contact) {
     return await failRun(
       deps,
@@ -970,7 +985,6 @@ async function processAddToSegmentStep(
   }
 
   const config = normalizeAddToSegmentConfig(step.config ?? {});
-  const userId = run.userId ?? automation.userId ?? null;
   const segment = await deps.getSegment(config.segment_id, userId);
   if (!segment) {
     return await failRun(
@@ -1016,7 +1030,8 @@ async function processSendEmailStep(
     );
   }
 
-  const contact = await deps.getContact(run.contactId);
+  const userId = run.userId ?? automation.userId ?? null;
+  const contact = await deps.getContact(run.contactId, userId);
   if (!contact) {
     return await failRun(deps, run, step.key, states, now, "contact not found");
   }
@@ -1266,7 +1281,14 @@ export async function processAutomationRunStep(
     }
 
     if (step.type === "contact_delete") {
-      return await processContactDeleteStep(deps, run, step, states, now);
+      return await processContactDeleteStep(
+        deps,
+        run,
+        automation,
+        step,
+        states,
+        now,
+      );
     }
 
     if (step.type === "add_to_segment") {

--- a/src/lib/workers/broadcast-sender.ts
+++ b/src/lib/workers/broadcast-sender.ts
@@ -55,12 +55,29 @@ export async function processScheduledBroadcasts() {
         lastName: string | null;
       }[] = [];
 
+      const broadcastUserId = broadcast.userId;
+      if (!broadcastUserId) {
+        await db
+          .update(broadcasts)
+          .set({ status: "failed" })
+          .where(eq(broadcasts.id, broadcast.id));
+        console.error(
+          `Failed to process broadcast ${broadcast.id}: missing owner`,
+        );
+        continue;
+      }
+
       if (broadcast.audienceId) {
         // Resolve segment contacts (naive JSON check for now)
         const [segment] = await db
           .select({ name: segments.name })
           .from(segments)
-          .where(eq(segments.id, broadcast.audienceId))
+          .where(
+            and(
+              eq(segments.id, broadcast.audienceId),
+              eq(segments.userId, broadcastUserId),
+            ),
+          )
           .limit(1);
         if (segment) {
           targetContacts = await db
@@ -74,6 +91,7 @@ export async function processScheduledBroadcasts() {
             .where(
               and(
                 eq(contacts.unsubscribed, false),
+                eq(contacts.userId, broadcastUserId),
                 sql`${contacts.segments} ? ${segment.name}`,
               ),
             );
@@ -88,7 +106,12 @@ export async function processScheduledBroadcasts() {
             lastName: contacts.lastName,
           })
           .from(contacts)
-          .where(eq(contacts.unsubscribed, false));
+          .where(
+            and(
+              eq(contacts.unsubscribed, false),
+              eq(contacts.userId, broadcastUserId),
+            ),
+          );
       }
 
       // 4. Perform fanout (create individual email records)

--- a/tests/automation-runner.test.ts
+++ b/tests/automation-runner.test.ts
@@ -882,12 +882,16 @@ describe("automation runner", () => {
       setup.deps,
     );
 
-    expect(setup.deps.updateContact).toHaveBeenCalledWith(contact.id, {
-      email: "new@example.com",
-      firstName: "Grace",
-      unsubscribed: true,
-      customProperties: { plan: "pro", invoice: "inv_1" },
-    });
+    expect(setup.deps.updateContact).toHaveBeenCalledWith(
+      contact.id,
+      "user_1",
+      {
+        email: "new@example.com",
+        firstName: "Grace",
+        unsubscribed: true,
+        customProperties: { plan: "pro", invoice: "inv_1" },
+      },
+    );
     expect(setup.updates[0]).toMatchObject({
       status: "queued",
       currentStepKey: "end",
@@ -1025,7 +1029,7 @@ describe("automation runner", () => {
       setup.deps,
     );
 
-    expect(setup.deps.deleteContact).toHaveBeenCalledWith(contact.id);
+    expect(setup.deps.deleteContact).toHaveBeenCalledWith(contact.id, "user_1");
     expect(setup.sendEmail).not.toHaveBeenCalled();
     expect(setup.updates[0]).toMatchObject({
       status: "completed",
@@ -1035,6 +1039,36 @@ describe("automation runner", () => {
     expect(setup.updates[0]?.stepStates?.delete).toMatchObject({
       status: "completed",
       output: { deleted_contact_id: contact.id },
+    });
+  });
+
+  it("uses the automation tenant when deleting from a legacy run without user_id", async () => {
+    const deleteStep: AutomationStep = {
+      ...steps[1],
+      key: "delete",
+      type: "contact_delete",
+      config: {},
+      position: 0,
+    };
+    const getContact = vi.fn().mockResolvedValue(contact);
+    const deleteContact = vi.fn().mockResolvedValue({ id: contact.id });
+    const setup = deps({
+      listSteps: vi.fn().mockResolvedValue([deleteStep]),
+      getContact,
+      deleteContact,
+    });
+
+    await processAutomationRunStep(
+      run({ currentStepKey: "delete", userId: null }),
+      setup.deps,
+    );
+
+    expect(getContact).toHaveBeenCalledWith(contact.id, automation.userId);
+    expect(deleteContact).toHaveBeenCalledWith(contact.id, automation.userId);
+    expect(setup.updates[0]).toMatchObject({
+      status: "completed",
+      currentStepKey: null,
+      contactId: null,
     });
   });
 

--- a/tests/broadcast-metrics-route.test.ts
+++ b/tests/broadcast-metrics-route.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
 const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockRequireFullAccessForApiKeyCaller = vi.hoisted(() => vi.fn());
 const mockReadDashboardAggregateCache = vi.hoisted(() => vi.fn());
 const mockWriteDashboardAggregateCache = vi.hoisted(() => vi.fn());
 const mockBroadcastService = vi.hoisted(() => ({
@@ -40,6 +41,10 @@ vi.mock("@/lib/api-auth", () => ({
   getServerSession: mockGetServerSession,
 }));
 
+vi.mock("@/lib/api-key-permissions", () => ({
+  requireFullAccessForApiKeyCaller: mockRequireFullAccessForApiKeyCaller,
+}));
+
 vi.mock("@/lib/cache/dashboard-aggregates", () => ({
   BROADCAST_METRICS_CACHE_TTL_SECONDS: 120,
   getBroadcastMetricsCacheKey: (params: {
@@ -62,9 +67,12 @@ describe("broadcast metrics route cache", () => {
     vi.clearAllMocks();
     mockAuthorizeDashboardOrApiKey.mockResolvedValue({
       apiKeyId: "k1",
+      permission: "full_access",
+      domain: null,
       userId: "user-1",
     });
     mockGetServerSession.mockResolvedValue(null);
+    mockRequireFullAccessForApiKeyCaller.mockReturnValue(null);
     mockReadDashboardAggregateCache.mockResolvedValue(null);
     mockWriteDashboardAggregateCache.mockResolvedValue(undefined);
   });

--- a/tests/broadcast-sender.integration.test.ts
+++ b/tests/broadcast-sender.integration.test.ts
@@ -1,0 +1,134 @@
+import { randomUUID } from "node:crypto";
+import { processScheduledBroadcasts } from "@/lib/workers/broadcast-sender";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const databaseUrl = process.env.DATABASE_URL;
+const describeIfDb = databaseUrl ? describe : describe.skip;
+
+async function cleanup(client: Client, marker: string): Promise<void> {
+  await client.query("delete from emails where user_id like $1", [
+    `${marker}%`,
+  ]);
+  await client.query("delete from broadcasts where user_id like $1", [
+    `${marker}%`,
+  ]);
+  await client.query("delete from broadcasts where name like $1", [
+    `${marker}%`,
+  ]);
+  await client.query("delete from contacts where user_id like $1", [
+    `${marker}%`,
+  ]);
+  await client.query("delete from segments where user_id like $1", [
+    `${marker}%`,
+  ]);
+  await client.query('delete from "session" where user_id like $1', [
+    `${marker}%`,
+  ]);
+  await client.query('delete from "account" where user_id like $1', [
+    `${marker}%`,
+  ]);
+  await client.query('delete from "user" where id like $1', [`${marker}%`]);
+}
+
+describeIfDb("broadcast sender tenant isolation", () => {
+  const marker = `it-broadcast-${randomUUID()}`;
+  const tenantA = `${marker}-tenant-a`;
+  const tenantB = `${marker}-tenant-b`;
+  const client = new Client({ connectionString: databaseUrl });
+
+  beforeAll(async () => {
+    await client.connect();
+    await cleanup(client, marker);
+    await client.query(
+      'insert into "user" (id, name, email, email_verified, created_at, updated_at) values ($1, $2, $3, true, now(), now()), ($4, $5, $6, true, now(), now())',
+      [
+        tenantA,
+        "Tenant A",
+        `${tenantA}@example.test`,
+        tenantB,
+        "Tenant B",
+        `${tenantB}@example.test`,
+      ],
+    );
+  });
+
+  afterAll(async () => {
+    await cleanup(client, marker);
+    await client.end();
+  });
+
+  it("fans out only to contacts owned by the broadcast tenant when segment names collide", async () => {
+    const segmentA = randomUUID();
+    const segmentB = randomUUID();
+    const contactA = randomUUID();
+    const contactB = randomUUID();
+    const broadcastId = randomUUID();
+
+    await client.query(
+      "insert into segments (id, name, user_id) values ($1, 'vip', $2), ($3, 'vip', $4)",
+      [segmentA, tenantA, segmentB, tenantB],
+    );
+    await client.query(
+      "insert into contacts (id, email, first_name, unsubscribed, segments, user_id) values ($1, $2, 'Ada', false, $3::jsonb, $4), ($5, $6, 'Grace', false, $7::jsonb, $8)",
+      [
+        contactA,
+        `${marker}-a@example.test`,
+        JSON.stringify(["vip"]),
+        tenantA,
+        contactB,
+        `${marker}-b@example.test`,
+        JSON.stringify(["vip"]),
+        tenantB,
+      ],
+    );
+    await client.query(
+      "insert into broadcasts (id, name, status, audience_id, subject, html, scheduled_at, user_id) values ($1, 'Launch', 'queued', $2, 'Hello {{FIRST_NAME}}', '<p>Hello {{EMAIL}}</p>', now() - interval '1 minute', $3)",
+      [broadcastId, segmentA, tenantA],
+    );
+
+    await expect(processScheduledBroadcasts()).resolves.toMatchObject({
+      processed: 1,
+    });
+
+    const created = await client.query<{
+      to: string[];
+      subject: string;
+      user_id: string;
+    }>(
+      'select "to", subject, user_id from emails where user_id = $1 and tags @> $2::jsonb order by created_at asc',
+      [tenantA, JSON.stringify([{ name: "broadcast_id", value: broadcastId }])],
+    );
+
+    expect(created.rows).toHaveLength(1);
+    expect(created.rows[0]).toMatchObject({
+      to: [`${marker}-a@example.test`],
+      subject: "Hello Ada",
+      user_id: tenantA,
+    });
+  });
+
+  it("fails ownerless queued broadcasts instead of marking them sent", async () => {
+    const broadcastId = randomUUID();
+    await client.query(
+      "insert into broadcasts (id, name, status, subject, html, scheduled_at, user_id) values ($1, $2, 'queued', 'Owner missing', '<p>Hello</p>', now() - interval '1 minute', null)",
+      [broadcastId, `${marker}-ownerless`],
+    );
+
+    await expect(processScheduledBroadcasts()).resolves.toMatchObject({
+      processed: 1,
+    });
+
+    const broadcast = await client.query<{ status: string }>(
+      "select status from broadcasts where id = $1",
+      [broadcastId],
+    );
+    expect(broadcast.rows[0]?.status).toBe("failed");
+
+    const emails = await client.query<{ count: string }>(
+      "select count(*) from emails where tags @> $1::jsonb",
+      [JSON.stringify([{ name: "broadcast_id", value: broadcastId }])],
+    );
+    expect(emails.rows[0]?.count).toBe("0");
+  });
+});

--- a/tests/broadcast-tenant-routes.test.ts
+++ b/tests/broadcast-tenant-routes.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockAuthorizeDashboardOrApiKey = vi.hoisted(() => vi.fn());
 const mockGetServerSession = vi.hoisted(() => vi.fn());
+const mockRequireFullAccessForApiKeyCaller = vi.hoisted(() => vi.fn());
 const mockReadDashboardAggregateCache = vi.hoisted(() => vi.fn());
 const mockWriteDashboardAggregateCache = vi.hoisted(() => vi.fn());
 const mockBroadcastService = vi.hoisted(() => ({
@@ -38,6 +39,10 @@ vi.mock("@/lib/api-auth", () => ({
   getServerSession: mockGetServerSession,
   unauthorizedResponse: () =>
     Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/api-key-permissions", () => ({
+  requireFullAccessForApiKeyCaller: mockRequireFullAccessForApiKeyCaller,
 }));
 
 vi.mock("@/lib/cache/dashboard-aggregates", async () => {
@@ -83,6 +88,7 @@ beforeEach(() => {
     userId: "user-b",
   });
   mockGetServerSession.mockResolvedValue(null);
+  mockRequireFullAccessForApiKeyCaller.mockReturnValue(null);
   mockReadDashboardAggregateCache.mockResolvedValue(null);
   mockWriteDashboardAggregateCache.mockResolvedValue(undefined);
 });
@@ -176,6 +182,37 @@ describe("broadcast tenant isolation", () => {
       segmentId: "segment-1",
       after: "b0",
     });
+  });
+
+  it("rejects sending-only API keys before broadcast management", async () => {
+    mockAuthorizeDashboardOrApiKey.mockResolvedValueOnce({
+      apiKeyId: "key-send",
+      permission: "sending_access",
+      domain: null,
+      userId: "user-b",
+    });
+    mockRequireFullAccessForApiKeyCaller.mockReturnValueOnce(
+      Response.json(
+        {
+          error:
+            "This API key does not have permission to access this resource.",
+        },
+        { status: 403 },
+      ),
+    );
+
+    const { POST } = await import("@/app/api/broadcasts/route");
+    const response = await POST(
+      jsonRequest("http://localhost:3015/api/broadcasts", {
+        name: "Launch",
+        from: "team@example.com",
+        subject: "Hello",
+        segment_id: "segment-1",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockBroadcastService.createBroadcast).not.toHaveBeenCalled();
   });
 
   it("passes created broadcast payloads with the authenticated user id", async () => {

--- a/tests/core-email-provider.test.ts
+++ b/tests/core-email-provider.test.ts
@@ -105,6 +105,25 @@ describe("EmailProviderService", () => {
     expect(raw).toContain("aW1hZ2U=");
   });
 
+  it("rejects CRLF injection in raw MIME headers before sending", async () => {
+    const { EmailProviderService } = await import(
+      "../packages/core/src/services/emailProvider"
+    );
+    const provider = new EmailProviderService();
+
+    await expect(
+      provider.sendEmail({
+        from: "hello@example.com",
+        to: ["user@example.com"],
+        subject: "Hello\r\nBcc: attacker@example.com",
+        html: "<p>Hello</p>",
+        attachments: [{ filename: "note.txt", content: "aGVsbG8=" }],
+      }),
+    ).rejects.toMatchObject({ code: "MIME_HEADER_INJECTION" });
+
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
   it("creates and reuses SES clients per requested region", async () => {
     mockSend
       .mockResolvedValueOnce({ MessageId: "eu-message" })

--- a/tests/custom-event-tenant-isolation.integration.test.ts
+++ b/tests/custom-event-tenant-isolation.integration.test.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from "node:crypto";
+import { createCustomEventService } from "@opensend/core";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const databaseUrl = process.env.DATABASE_URL;
+const describeIfDb = databaseUrl ? describe : describe.skip;
+
+async function cleanup(client: Client, marker: string): Promise<void> {
+  await client.query("delete from automation_runs where user_id like $1", [
+    `${marker}%`,
+  ]);
+  await client.query(
+    "delete from custom_event_deliveries where user_id like $1",
+    [`${marker}%`],
+  );
+  await client.query("delete from custom_events where user_id like $1", [
+    `${marker}%`,
+  ]);
+  await client.query("delete from contacts where user_id like $1", [
+    `${marker}%`,
+  ]);
+  await client.query('delete from "session" where user_id like $1', [
+    `${marker}%`,
+  ]);
+  await client.query('delete from "account" where user_id like $1', [
+    `${marker}%`,
+  ]);
+  await client.query('delete from "user" where id like $1', [`${marker}%`]);
+}
+
+describeIfDb("custom event contact tenant isolation", () => {
+  const marker = `it-events-${randomUUID()}`;
+  const tenantA = `${marker}-tenant-a`;
+  const tenantB = `${marker}-tenant-b`;
+  const contactB = randomUUID();
+  const client = new Client({ connectionString: databaseUrl });
+
+  beforeAll(async () => {
+    await client.connect();
+    await cleanup(client, marker);
+    await client.query(
+      'insert into "user" (id, name, email, email_verified, created_at, updated_at) values ($1, $2, $3, true, now(), now()), ($4, $5, $6, true, now(), now())',
+      [
+        tenantA,
+        "Tenant A",
+        `${tenantA}@example.test`,
+        tenantB,
+        "Tenant B",
+        `${tenantB}@example.test`,
+      ],
+    );
+    await client.query(
+      "insert into contacts (id, email, first_name, unsubscribed, user_id) values ($1, $2, 'Grace', false, $3)",
+      [contactB, `${marker}-foreign@example.test`, tenantB],
+    );
+    await client.query(
+      "insert into custom_events (name, schema, user_id) values ('user.signed_up', null, $1)",
+      [tenantA],
+    );
+  });
+
+  afterAll(async () => {
+    await cleanup(client, marker);
+    await client.end();
+  });
+
+  it("does not attach another tenant's contact id to a custom event delivery", async () => {
+    const service = createCustomEventService();
+
+    const result = await service.sendCustomEvent({
+      userId: tenantA,
+      data: {
+        event: "user.signed_up",
+        contact_id: contactB,
+        payload: { plan: "pro" },
+      },
+    });
+
+    expect(result.delivery).toMatchObject({
+      event: "user.signed_up",
+      contact_id: null,
+    });
+
+    const delivery = await client.query<{ contact_id: string | null }>(
+      "select contact_id from custom_event_deliveries where user_id = $1 and event_name = 'user.signed_up' order by received_at desc limit 1",
+      [tenantA],
+    );
+    expect(delivery.rows[0]?.contact_id).toBeNull();
+  });
+});

--- a/tests/dedicated-ip-plan-gating.test.ts
+++ b/tests/dedicated-ip-plan-gating.test.ts
@@ -7,6 +7,7 @@ const mockUnauthorizedResponse = vi.hoisted(
   () => () =>
     new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
 );
+const mockRequireFullAccessForApiKeyCaller = vi.hoisted(() => vi.fn());
 const mockListForUser = vi.hoisted(() => vi.fn());
 const mockCountForUser = vi.hoisted(() => vi.fn());
 const mockCreate = vi.hoisted(() => vi.fn());
@@ -18,6 +19,10 @@ vi.mock("@/lib/api-auth", () => ({
   authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
   getServerSession: mockGetServerSession,
   unauthorizedResponse: mockUnauthorizedResponse,
+}));
+
+vi.mock("@/lib/api-key-permissions", () => ({
+  requireFullAccessForApiKeyCaller: mockRequireFullAccessForApiKeyCaller,
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -59,7 +64,10 @@ import { GET, POST } from "@/app/api/dedicated-ips/route";
 const SESSION = { user: { id: "user-1", email: "test@example.com" } };
 
 describe("GET /api/dedicated-ips", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireFullAccessForApiKeyCaller.mockReturnValue(null);
+  });
 
   it("returns 401 when unauthenticated", async () => {
     mockAuthorizeDashboardOrApiKey.mockResolvedValueOnce(null);
@@ -83,7 +91,10 @@ describe("GET /api/dedicated-ips", () => {
 });
 
 describe("POST /api/dedicated-ips — plan gating", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireFullAccessForApiKeyCaller.mockReturnValue(null);
+  });
 
   it("returns 401 when unauthenticated", async () => {
     mockAuthorizeDashboardOrApiKey.mockResolvedValueOnce(null);
@@ -93,6 +104,32 @@ describe("POST /api/dedicated-ips — plan gating", () => {
     });
     const res = await POST(req);
     expect(res.status).toBe(401);
+  });
+
+  it("rejects sending-only API keys before provisioning provider resources", async () => {
+    mockAuthorizeDashboardOrApiKey.mockResolvedValueOnce({
+      apiKeyId: "key-send",
+      permission: "sending_access",
+      domain: null,
+      userId: "user-1",
+    });
+    mockRequireFullAccessForApiKeyCaller.mockReturnValueOnce(
+      Response.json(
+        {
+          error:
+            "This API key does not have permission to access this resource.",
+        },
+        { status: 403 },
+      ),
+    );
+
+    const req = new Request("http://localhost/api/dedicated-ips", {
+      method: "POST",
+      body: JSON.stringify({ name: "Pool", ses_pool_name: "ses-pool" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+    expect(mockCreateDedicatedIpPool).not.toHaveBeenCalled();
   });
 
   it("returns 403 when plan has dedicatedIpsEnabled=false", async () => {

--- a/tests/delivery-failure-export-service.test.ts
+++ b/tests/delivery-failure-export-service.test.ts
@@ -159,4 +159,23 @@ describe("delivery failure export service", () => {
       'id,recipient,status,reason,source_email_id,source_message_id,created_at,updated_at\nid-1,"quoted,""recipient""@example.com",bounced,"smtp\nfailed",id-1,,2026-05-01T12:00:00.000Z,',
     );
   });
+
+  it("neutralizes spreadsheet formulas in CSV exports", () => {
+    const rows: DeliveryFailureExportCsvRow[] = [
+      {
+        id: "id-1",
+        recipient: '=HYPERLINK("https://evil.example")',
+        status: "suppressed",
+        reason: "+cmd",
+        source_email_id: "id-1",
+        source_message_id: "",
+        created_at: "2026-05-01T12:00:00.000Z",
+        updated_at: "",
+      },
+    ];
+
+    expect(serializeDeliveryFailureCsv(rows)).toContain(
+      '"\'=HYPERLINK(""https://evil.example"")",suppressed,\'+cmd',
+    );
+  });
 });

--- a/tests/inbound-ingestion.integration.test.ts
+++ b/tests/inbound-ingestion.integration.test.ts
@@ -236,6 +236,23 @@ describeIfDb("inbound MIME ingestion with real Postgres", () => {
     expect(duplicateRows.rows[0]?.status).toBe("duplicate_provider_event");
   });
 
+  it("rejects unsafe raw MIME URLs before fetching remote content", async () => {
+    const service = createInboundEmailIngestionService();
+
+    await expect(
+      service.process({
+        provider: "fixture",
+        eventId: `${marker}-raw-url-ssrf`,
+        recipients: [`support@${domainA}`],
+        rawMimeUrl: "http://169.254.169.254/latest/meta-data",
+        metadata: { test_run_id: marker },
+      }),
+    ).resolves.toMatchObject({
+      status: "malformed_mime",
+      reason: "Raw MIME URL is not allowed",
+    });
+  });
+
   it("creates a persisted forwarding attempt and outbound send row after inbound routing", async () => {
     const routeRows = await client.query<{ id: string }>(
       "select id from receiving_routes where user_id = $1 and local_part = 'support' limit 1",

--- a/tests/ingester-job-scheduler-coverage.test.ts
+++ b/tests/ingester-job-scheduler-coverage.test.ts
@@ -56,7 +56,9 @@ describe("ingester job scheduler coverage", () => {
 
     expect(schedulerSource).toContain('getEnv("INGESTER_JOB_TOKEN")');
     expect(schedulerSource).toContain("authorization: `Bearer ${token}`");
-    expect(compose).toContain("INGESTER_JOB_TOKEN: ${INGESTER_JOB_TOKEN:-}");
+    expect(compose).toContain(
+      "INGESTER_JOB_TOKEN: ${INGESTER_JOB_TOKEN:?Set INGESTER_JOB_TOKEN in .env (32+ chars)}",
+    );
     expect(docs).toContain("Authorization: Bearer ${INGESTER_JOB_TOKEN}");
   });
 });

--- a/tests/ingester-ses-route.test.ts
+++ b/tests/ingester-ses-route.test.ts
@@ -461,6 +461,35 @@ describe("SES SNS ingestion route", () => {
     expect(mockDomainReconcileAllPendingVerifications).not.toHaveBeenCalled();
   });
 
+  it("fails closed for production job endpoints when no bearer token is configured", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("INGESTER_JOB_TOKEN", "");
+
+    const app = (await import("../packages/ingester/src/index")).default;
+    const response = await app.request("http://localhost/jobs/domain-verify", {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.text()).toBe("Unauthorized");
+    expect(mockDomainReconcileAllPendingVerifications).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for production inbound MIME callbacks when no bearer token is configured", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("INGESTER_INBOUND_TOKEN", "");
+
+    const app = (await import("../packages/ingester/src/index")).default;
+    const response = await app.request("http://localhost/events/inbound", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ event_id: "evt-1" }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.text()).toBe("Unauthorized");
+  });
+
   it("verifies the SNS signature, persists a normalized event, and queues webhook delivery", async () => {
     const persistedEvent = {
       id: "evt-1",

--- a/tests/ingester-startup-checks.test.ts
+++ b/tests/ingester-startup-checks.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runIngesterStartupChecks } from "../packages/ingester/src/startup-checks";
+
+const ENV_KEYS = [
+  "NODE_ENV",
+  "WEBHOOK_SECRET_ENCRYPTION_KEY",
+  "INGESTER_JOB_TOKEN",
+  "INGESTER_INBOUND_TOKEN",
+];
+
+describe("ingester startup checks", () => {
+  const snapshot: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      snapshot[key] = process.env[key];
+      delete process.env[key];
+    }
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    for (const key of ENV_KEYS) {
+      if (snapshot[key] === undefined) delete process.env[key];
+      else process.env[key] = snapshot[key];
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("throws in production when the job token is missing", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    process.env.WEBHOOK_SECRET_ENCRYPTION_KEY = "x".repeat(32);
+
+    expect(() => runIngesterStartupChecks()).toThrow(
+      "INGESTER_JOB_TOKEN missing/too short in production",
+    );
+  });
+
+  it("warns but does not boot-fail when the optional inbound token is absent", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    process.env.WEBHOOK_SECRET_ENCRYPTION_KEY = "x".repeat(32);
+    process.env.INGESTER_JOB_TOKEN = "j".repeat(32);
+
+    expect(() => runIngesterStartupChecks()).not.toThrow();
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("security.startup.weak_inbound_token"),
+    );
+  });
+});

--- a/tests/queue-worker.test.ts
+++ b/tests/queue-worker.test.ts
@@ -18,12 +18,14 @@ const mockLogTelemetry = vi.hoisted(() => vi.fn());
 const mockRecordTelemetryError = vi.hoisted(() => vi.fn());
 const mockApplyEmailTracking = vi.hoisted(() => vi.fn());
 const mockCreateEmailTrackingToken = vi.hoisted(() => vi.fn());
+const mockSafeOutboundFetch = vi.hoisted(() => vi.fn());
 
 vi.mock("@opensend/core", () => ({
   createBackgroundJob: (job: Record<string, unknown>) => ({
     ...job,
     requestedAt: "2026-04-28T00:00:00.000Z",
   }),
+  safeOutboundFetch: mockSafeOutboundFetch,
   createEmailTrackingToken: mockCreateEmailTrackingToken,
   createTelemetryContext: (input: {
     service: string;
@@ -150,6 +152,7 @@ describe("QueueWorker", () => {
           ? `${payload.kind}:${payload.targetUrl}`
           : payload.kind,
     );
+    mockSafeOutboundFetch.mockResolvedValue(new Response("remote file"));
   });
 
   afterEach(() => {
@@ -423,6 +426,60 @@ describe("QueueWorker", () => {
     );
   });
 
+  it("validates remote attachment URLs before fetching provider payloads", async () => {
+    const unsafeUrl = "http://169.254.169.254/latest/meta-data";
+    mockFindById.mockResolvedValue({
+      id: "email-unsafe-attachment",
+      from: "sender@example.com",
+      to: ["user@example.com"],
+      cc: [],
+      bcc: [],
+      replyTo: [],
+      subject: "Hello",
+      html: "<p>Hello</p>",
+      text: "",
+      headers: {},
+      attachments: [{ filename: "secret.txt", path: unsafeUrl }],
+      status: "queued",
+      scheduledAt: null,
+      userId: "user-1",
+    });
+    mockSafeOutboundFetch.mockRejectedValueOnce(
+      new Error("Unsafe outbound URL"),
+    );
+
+    const { QueueWorker } = await import(
+      "../packages/ingester/src/queue-worker"
+    );
+    const worker = new QueueWorker({
+      providerMaxAttempts: 1,
+      queueUrl: null,
+    });
+
+    await expect(
+      worker.processJob({
+        id: "email.send:email-unsafe-attachment",
+        type: "email.send",
+        source: "api",
+        requestedAt: "2026-04-28T00:00:00.000Z",
+        emailId: "email-unsafe-attachment",
+      }),
+    ).resolves.toEqual({
+      status: "failed",
+      reason: "provider_retries_exhausted",
+    });
+
+    expect(mockSafeOutboundFetch).toHaveBeenCalledWith(
+      unsafeUrl,
+      {
+        redirect: "error",
+        signal: expect.any(AbortSignal),
+      },
+      { context: "dispatch" },
+    );
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
   it("simulates delivered resend.dev recipients without calling the provider", async () => {
     mockFindById.mockResolvedValue({
       id: "email-sandbox-delivered",
@@ -621,14 +678,11 @@ describe("QueueWorker", () => {
   });
 
   it("resolves URL path attachments and preserves content_type and content_id", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        new Response("remote file", {
-          status: 200,
-          headers: { "content-length": "11" },
-        }),
-      ),
+    mockSafeOutboundFetch.mockResolvedValueOnce(
+      new Response("remote file", {
+        status: 200,
+        headers: { "content-length": "11" },
+      }),
     );
     mockFindById.mockResolvedValue({
       id: "email-path",
@@ -668,11 +722,13 @@ describe("QueueWorker", () => {
       }),
     ).resolves.toEqual({ status: "sent" });
 
-    expect(fetch).toHaveBeenCalledWith(
+    expect(mockSafeOutboundFetch).toHaveBeenCalledWith(
       "https://cdn.example.com/remote-logo.png",
       {
+        redirect: "error",
         signal: expect.any(AbortSignal),
       },
+      { context: "dispatch" },
     );
     expect(mockSendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -689,14 +745,11 @@ describe("QueueWorker", () => {
   });
 
   it("fails queued delivery explicitly when fetched attachments exceed 40MB encoded", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        new Response("", {
-          status: 200,
-          headers: { "content-length": String(30 * 1024 * 1024 + 1) },
-        }),
-      ),
+    mockSafeOutboundFetch.mockResolvedValueOnce(
+      new Response("", {
+        status: 200,
+        headers: { "content-length": String(30 * 1024 * 1024 + 1) },
+      }),
     );
     mockFindById.mockResolvedValue({
       id: "email-large-path",

--- a/tests/security-url-safety.test.ts
+++ b/tests/security-url-safety.test.ts
@@ -3,6 +3,7 @@ import {
   _resetUrlSafetyCacheForTests,
   assertSafeOutboundUrl,
   parseAndValidateUrlSync,
+  safeOutboundFetch,
 } from "@opensend/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -46,6 +47,16 @@ describe("url-safety / parseAndValidateUrlSync", () => {
     expect(parseAndValidateUrlSync("http://10.0.0.5/", "create").ok).toBe(
       false,
     );
+  });
+
+  it.each([
+    "http://[::1]/",
+    "http://[fe80::1]/",
+    "http://[fd00::1]/",
+    "http://[::ffff:127.0.0.1]/",
+    "http://[::ffff:169.254.169.254]/",
+  ])("rejects private IPv6 literal %s", (url) => {
+    expect(parseAndValidateUrlSync(url, "create").ok).toBe(false);
   });
 
   it("rejects metadata.google.internal", () => {
@@ -153,5 +164,44 @@ describe("url-safety / assertSafeOutboundUrl (DNS-resolved)", () => {
         dnsLookup: lookup,
       }),
     ).rejects.toBeInstanceOf(UnsafeOutboundUrlError);
+  });
+});
+
+describe("url-safety / safeOutboundFetch", () => {
+  beforeEach(() => {
+    _resetUrlSafetyCacheForTests();
+    process.env.ALLOW_PRIVATE_WEBHOOK_URLS = undefined;
+  });
+
+  it("rejects private literals before opening an outbound request", async () => {
+    await expect(
+      safeOutboundFetch(
+        "http://[::ffff:169.254.169.254]/latest/meta-data",
+        { redirect: "error" },
+        { context: "dispatch" },
+      ),
+    ).rejects.toBeInstanceOf(UnsafeOutboundUrlError);
+  });
+
+  it("resolves DNS for every pinned fetch instead of trusting the preflight cache", async () => {
+    const lookup = vi
+      .fn()
+      .mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }])
+      .mockResolvedValueOnce([{ address: "10.0.0.5", family: 4 }]);
+
+    await assertSafeOutboundUrl("https://cached-fetch.example/hook", {
+      context: "dispatch",
+      dnsLookup: lookup,
+    });
+
+    await expect(
+      safeOutboundFetch(
+        "https://cached-fetch.example/hook",
+        { redirect: "error" },
+        { context: "dispatch", dnsLookup: lookup },
+      ),
+    ).rejects.toBeInstanceOf(UnsafeOutboundUrlError);
+
+    expect(lookup).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/send-contract.test.ts
+++ b/tests/send-contract.test.ts
@@ -84,6 +84,35 @@ describe("send email public contract boundary", () => {
     expect(oversized.success).toBe(false);
   });
 
+  it("rejects private-network attachment URLs at the public contract boundary", () => {
+    for (const path of [
+      "http://169.254.169.254/latest/meta-data",
+      "http://[::1]/metadata",
+      "http://[fe80::1]/metadata",
+      "http://[fd00::1]/metadata",
+      "http://[::ffff:127.0.0.1]/metadata",
+      "http://[::ffff:169.254.169.254]/metadata",
+    ]) {
+      const result = sendEmailSchema.safeParse({
+        ...validSendPayload,
+        attachments: [
+          {
+            filename: "metadata.txt",
+            path,
+          },
+        ],
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const details = zodValidationDetails(result.error);
+        expect(details.fieldErrors["attachments.0.path"]).toContain(
+          "attachment path is not allowed",
+        );
+      }
+    }
+  });
+
   it("defines public success response fields and casing for send and batch send", () => {
     expect(sendEmailResponseSchema.parse({ id: "email_123" })).toEqual({
       id: "email_123",

--- a/tests/webhook-dispatcher.test.ts
+++ b/tests/webhook-dispatcher.test.ts
@@ -13,7 +13,7 @@ vi.mock("@opensend/core", () => ({
     findById: mockFindEventById,
   },
   signWebhookPayload: mockSignWebhookPayload,
-  assertSafeOutboundUrl: vi.fn(async () => {}),
+  safeOutboundFetch: vi.fn(async () => new Response("ok")),
   UnsafeOutboundUrlError: class extends Error {},
   resolveWebhookSigningSecret: (row: { signingSecretEnc: string | null }) =>
     row.signingSecretEnc ?? "",
@@ -140,22 +140,26 @@ describe("WebhookDispatcher", () => {
         data: { smtpResponse: "250 ok" },
       }),
     );
-    expect(fetchMock).toHaveBeenCalledWith("https://example.com/webhook", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "svix-id": "whd_delivery-1_1",
-        "svix-timestamp": "1777334400",
-        "svix-signature": "v1,test-signature",
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/webhook",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "svix-id": "whd_delivery-1_1",
+          "svix-timestamp": "1777334400",
+          "svix-signature": "v1,test-signature",
+        },
+        body: JSON.stringify({
+          id: "whd_delivery-1_1",
+          type: "email.delivered",
+          created_at: "2026-04-28T00:00:00.000Z",
+          data: { smtpResponse: "250 ok" },
+        }),
+        signal: expect.any(AbortSignal),
       },
-      body: JSON.stringify({
-        id: "whd_delivery-1_1",
-        type: "email.delivered",
-        created_at: "2026-04-28T00:00:00.000Z",
-        data: { smtpResponse: "250 ok" },
-      }),
-      signal: expect.any(AbortSignal),
-    });
+      { context: "dispatch" },
+    );
     expect(mockUpdate).toHaveBeenCalledWith(
       "delivery-1",
       expect.objectContaining({


### PR DESCRIPTION
## Summary
- Harden tenant isolation for broadcast fanout, custom event contact resolution, and automation contact actions.
- Require full-access keys for sensitive broadcast and dedicated-IP API routes, and make ingester job/event auth fail closed in production.
- Replace validate-then-fetch remote URL handling with pinned-address `safeOutboundFetch` for raw MIME, webhook, and attachment fetch paths.
- Sanitize MIME headers/filenames/content IDs/boundaries and CSV exports against injection/formula abuse.
- Document production `INGESTER_JOB_TOKEN` requirements.

## Validation
- `make check` passed.
- `make test` passed: 197 passed / 3 skipped; 1568 passed / 8 skipped.
- Focused security Vitest suite passed: 13 files / 133 tests.
- Disposable Postgres integration passed for broadcast sender, custom event tenant isolation, and inbound ingestion: 3 files / 8 tests.
- `safeOutboundFetch` live HTTPS smoke to `https://example.com/` returned 200.
- `git diff --check` passed.
- Secret-like diff scan passed with no hits.
- Independent final review: code-reviewer APPROVE and architect CLEAR.

## Known residuals
- `bun audit` still reports four moderate pre-existing advisories (`ws`, `postcss`, `vite`, `esbuild`). This branch does not change package manifests or lockfiles.