### PR TITLE
Fix ingester deploy job-token secret wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
         run: |
           cp .env.example .env
           node -e "const fs=require('fs'); const path='.env'; let env=fs.readFileSync(path,'utf8'); if(/^DASHBOARD_KEY=$/m.test(env)){ env=env.replace(/^DASHBOARD_KEY=$/m, 'DASHBOARD_KEY=ci-test-key'); } else if(!/^DASHBOARD_KEY=/m.test(env)){ env += '\nDASHBOARD_KEY=ci-test-key\n'; } fs.writeFileSync(path, env);"
+          printf '\nINGESTER_JOB_TOKEN=ci-test-ingester-job-token-000000\n' >> .env
 
       - name: Validate Docker Compose config
         run: docker compose config

--- a/agent_docs/learnings/active/2026-05-31-issue-581-ingester-job-token-taskdef.md
+++ b/agent_docs/learnings/active/2026-05-31-issue-581-ingester-job-token-taskdef.md
@@ -1,0 +1,19 @@
+---
+date: 2026-05-31
+issue: 581
+type: pattern
+promoted_to: null
+---
+
+# Required ingester secrets need task-definition registration
+
+Production ingester startup now fails closed when `INGESTER_JOB_TOKEN` is missing
+or shorter than 32 characters. ECS service redeploys that only rebuild/push the
+image and call `update-service --force-new-deployment` will keep reusing the old
+task definition, so new required ingester secrets never appear in the container.
+
+When adding required production ingester env, update `scripts/deploy.sh` to
+register a fresh ingester task definition from the current service task,
+preserve existing container settings, and upsert a `secrets[]` entry by env name
+before `aws ecs update-service --task-definition ...`. Use Secrets Manager/SSM
+ARN lookup or an ARN override; never commit or print secret values.

--- a/docs/ingester-deploy.md
+++ b/docs/ingester-deploy.md
@@ -93,6 +93,13 @@ INGESTER_JOB_TOKEN=<32+-char-random-bearer-token>
 INGESTER_INBOUND_TOKEN=<32+-char-random-bearer-token>
 ```
 
+For ECS deploys through `scripts/deploy.sh`, store the job token in AWS Secrets
+Manager. The script injects it into the ingester task definition as
+`INGESTER_JOB_TOKEN` without reading or printing the value. With the default
+`PRODUCT=opensend`, the lookup name is `opensend/ingester/job-token`; override
+with `INGESTER_JOB_TOKEN_SECRET_ID` or pass an exact
+`INGESTER_JOB_TOKEN_SECRET_ARN` if your deployment uses a different name.
+
 For hosted Stripe billing cutover, also set these on the ingester service from
 the deployment secret manager:
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -131,14 +131,19 @@ contributor-facing set; the table below adds the production-only entries.
 
 ### AWS ECS deploy secret wiring
 
-The repo deploy script registers a fresh app task definition before updating
-the ECS app service. It injects `WEBHOOK_SECRET_ENCRYPTION_KEY` from AWS
-Secrets Manager and never reads or prints the secret value. By default it looks
-up the secret named `opensend/webhook/secret-encryption-key` when
-`PRODUCT=opensend`; override that lookup with
-`WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ID` or pass an exact
-`WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ARN` when your bootstrap uses a different
-name.
+The repo deploy script registers fresh app and ingester task definitions before
+updating ECS services. It injects required production secrets from AWS Secrets
+Manager and never reads or prints secret values. By default, when
+`PRODUCT=opensend`, it looks up:
+
+- `opensend/webhook/secret-encryption-key` for app
+  `WEBHOOK_SECRET_ENCRYPTION_KEY`.
+- `opensend/ingester/job-token` for ingester `INGESTER_JOB_TOKEN`.
+
+Override those lookups with `WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ID` or
+`INGESTER_JOB_TOKEN_SECRET_ID`; pass exact
+`WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ARN` or `INGESTER_JOB_TOKEN_SECRET_ARN`
+when your bootstrap uses different names.
 
 ### Hosted Stripe billing
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -43,7 +43,10 @@ WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ARN="${WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET
 
 ING_REPO="${PRODUCT}-ingester"
 ING_SERVICE="${PRODUCT}-ingester"
+ING_CONTAINER_NAME="${ING_CONTAINER_NAME:-${PRODUCT}-ingester}"
 ING_DOCKERFILE="${ING_DOCKERFILE:-packages/ingester/Dockerfile}"
+INGESTER_JOB_TOKEN_SECRET_ID="${INGESTER_JOB_TOKEN_SECRET_ID:-${PRODUCT}/ingester/job-token}"
+INGESTER_JOB_TOKEN_SECRET_ARN="${INGESTER_JOB_TOKEN_SECRET_ARN:-}"
 
 color() { printf "\033[1;%sm%s\033[0m\n" "$1" "$2"; }
 info()  { color 36 "$*"; }
@@ -100,6 +103,19 @@ webhook_secret_encryption_key_secret_arn() {
 
   aws secretsmanager describe-secret \
     --secret-id "${WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ID}" \
+    --region "${AWS_REGION}" \
+    --query 'ARN' \
+    --output text
+}
+
+ingester_job_token_secret_arn() {
+  if [[ -n "${INGESTER_JOB_TOKEN_SECRET_ARN}" ]]; then
+    printf "%s\n" "${INGESTER_JOB_TOKEN_SECRET_ARN}"
+    return
+  fi
+
+  aws secretsmanager describe-secret \
+    --secret-id "${INGESTER_JOB_TOKEN_SECRET_ID}" \
     --region "${AWS_REGION}" \
     --query 'ARN' \
     --output text
@@ -192,6 +208,99 @@ register_app_task_definition() {
   task_file="$(mktemp)"
 
   write_app_task_definition "${base_task_definition}" "${app_image}" "${webhook_secret_arn}" "${task_file}"
+
+  aws ecs register-task-definition \
+    --cli-input-json "file://${task_file}" \
+    --region "${AWS_REGION}" \
+    --query 'taskDefinition.taskDefinitionArn' \
+    --output text
+}
+
+ingester_task_definition() {
+  aws ecs describe-services \
+    --cluster "${CLUSTER}" \
+    --services "${ING_SERVICE}" \
+    --region "${AWS_REGION}" \
+    --query 'services[0].taskDefinition' \
+    --output text
+}
+
+write_ingester_task_definition() {
+  local base_task_definition="$1" ingester_image="$2" job_token_secret_arn="$3" output_file="$4"
+  local base_task_file
+  base_task_file="$(mktemp)"
+
+  aws ecs describe-task-definition \
+    --task-definition "${base_task_definition}" \
+    --region "${AWS_REGION}" \
+    --query 'taskDefinition' \
+    --output json > "${base_task_file}"
+
+  python3 - "${base_task_file}" "${ingester_image}" "${ING_CONTAINER_NAME}" "${job_token_secret_arn}" > "${output_file}" <<'PY'
+import copy
+import json
+import sys
+
+base_task_file, ingester_image, container_name, job_token_secret_arn = sys.argv[1:5]
+with open(base_task_file, "r", encoding="utf-8") as handle:
+    task = json.load(handle)
+
+allowed_task_keys = [
+    "taskRoleArn",
+    "executionRoleArn",
+    "networkMode",
+    "volumes",
+    "placementConstraints",
+    "requiresCompatibilities",
+    "cpu",
+    "memory",
+    "runtimePlatform",
+    "ephemeralStorage",
+    "proxyConfiguration",
+    "inferenceAccelerators",
+    "pidMode",
+    "ipcMode",
+]
+
+definition = {"family": task.get("family")}
+for key in allowed_task_keys:
+    value = task.get(key)
+    if value not in (None, [], {}):
+        definition[key] = value
+
+containers = copy.deepcopy(task.get("containerDefinitions") or [])
+selected = next(
+    (container for container in containers if container.get("name") == container_name),
+    None,
+)
+if selected is None:
+    raise SystemExit(f"base task definition has no {container_name!r} container")
+
+selected["image"] = ingester_image
+secrets = selected.setdefault("secrets", [])
+required_secret = {
+    "name": "INGESTER_JOB_TOKEN",
+    "valueFrom": job_token_secret_arn,
+}
+for index, secret in enumerate(secrets):
+    if secret.get("name") == required_secret["name"]:
+        secrets[index] = required_secret
+        break
+else:
+    secrets.append(required_secret)
+
+definition["containerDefinitions"] = containers
+json.dump(definition, sys.stdout)
+PY
+}
+
+register_ingester_task_definition() {
+  local ingester_image="$1" base_task_definition job_token_secret_arn task_file
+  base_task_definition="$(ingester_task_definition)"
+  job_token_secret_arn="$(ingester_job_token_secret_arn)"
+  task_file="$(mktemp)"
+
+  write_ingester_task_definition "${base_task_definition}" "${ingester_image}" "${job_token_secret_arn}" "${task_file}"
 
   aws ecs register-task-definition \
     --cli-input-json "file://${task_file}" \
@@ -402,7 +511,12 @@ deploy_app() {
 }
 
 deploy_ingester() {
+  local ingester_image="${ECR_BASE}/${ING_REPO}:${IMAGE_TAG}"
   build_and_push "${ING_REPO}" "${ING_DOCKERFILE}" ""
+
+  info "→ Register ECS ingester task definition"
+  ING_TASK_DEFINITION="$(register_ingester_task_definition "${ingester_image}")"
+  ok "  registered ${ING_TASK_DEFINITION}"
 }
 
 target="${1:-all}"
@@ -417,7 +531,7 @@ case "${target}" in
   ingester)
     deploy_ingester
     run_migrations
-    redeploy "${ING_SERVICE}"
+    redeploy "${ING_SERVICE}" "${ING_TASK_DEFINITION}"
     wait_stable "${ING_SERVICE}"
     ;;
   migrate)
@@ -428,7 +542,7 @@ case "${target}" in
     deploy_ingester
     run_migrations
     redeploy "${APP_SERVICE}" "${APP_TASK_DEFINITION}"
-    redeploy "${ING_SERVICE}"
+    redeploy "${ING_SERVICE}" "${ING_TASK_DEFINITION}"
     wait_stable "${APP_SERVICE}" &
     APP_PID=$!
     wait_stable "${ING_SERVICE}" &

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -59,6 +59,18 @@ describe("deploy-001: ECS Fargate deployment configuration", () => {
     );
   });
 
+  it("deploy script injects the required ingester job token into ECS task definitions", () => {
+    const script = readFileSync(join(root, "scripts", "deploy.sh"), "utf-8");
+    expect(script).toContain("INGESTER_JOB_TOKEN_SECRET_ID");
+    expect(script).toContain("${PRODUCT}/ingester/job-token");
+    expect(script).toContain("INGESTER_JOB_TOKEN_SECRET_ARN");
+    expect(script).toContain('"name": "INGESTER_JOB_TOKEN"');
+    expect(script).toContain("register_ingester_task_definition");
+    expect(script).toContain(
+      'redeploy "${ING_SERVICE}" "${ING_TASK_DEFINITION}"',
+    );
+  });
+
   it("deploy script runs migrations before ECS service redeploys", () => {
     const script = readFileSync(join(root, "scripts", "deploy.sh"), "utf-8");
     expect(script).toContain("bash scripts/deploy.sh migrate");


### PR DESCRIPTION
## Summary
- Register a fresh ECS task definition for `opensend-ingester` during deploys so required production secrets can be upserted instead of reusing stale task definitions.
- Inject `INGESTER_JOB_TOKEN` as an ECS secret reference from AWS Secrets Manager without reading or printing the secret value.
- Document the default secret lookup and ARN override pattern for operators, and keep CI's local Compose acceptance flow supplied with a test-only placeholder token.

Refs #581

## Production blocker
`opensend-ingester` currently boot-loops because production startup rejects a missing/short `INGESTER_JOB_TOKEN`. The current task definition secret-name list does not include `INGESTER_JOB_TOKEN`.

## Secret handling
- Default expected Secrets Manager secret name: `opensend/ingester/job-token`
- Override by name: `INGESTER_JOB_TOKEN_SECRET_ID`
- Override by exact ARN: `INGESTER_JOB_TOKEN_SECRET_ARN`
- Secret value is not committed, logged, included in this PR, or read by the deploy script.

## Validation
- `bash -n scripts/deploy.sh`
- `bun test tests/deploy.test.ts`
- Fake `PATH` deploy harness for `bash scripts/deploy.sh ingester` verified the rendered task definition contains a redacted `INGESTER_JOB_TOKEN` secret reference and `update-service --task-definition` uses the new ingester task definition.
- `docker compose --env-file .env.tmp-ci-probe config` with the CI placeholder token path.
- `bun test tests/deploy.test.ts tests/docs-content.test.ts`
- `make check && make test`
- Push hook reran `node scripts/check-changed-files.mjs` and full-project typecheck.

## Remaining production step
The default secret `opensend/ingester/job-token` was not present when probed by name (no secret value requested). Before merging/deploying, provision that secret with a 32+ character random token, or set `INGESTER_JOB_TOKEN_SECRET_ID` / `INGESTER_JOB_TOKEN_SECRET_ARN` for the deploy runner to an existing equivalent secret. After merge, verify the ingester service stabilizes and no new missing-token boot-loop logs appear.
