### PR TITLE
Fix onboarding CI compose token placeholder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,26 @@ jobs:
       - name: Prepare documented local env
         run: |
           cp .env.example .env
-          node -e "const fs=require('fs'); const path='.env'; let env=fs.readFileSync(path,'utf8'); if(/^DASHBOARD_KEY=$/m.test(env)){ env=env.replace(/^DASHBOARD_KEY=$/m, 'DASHBOARD_KEY=ci-test-key'); } else if(!/^DASHBOARD_KEY=/m.test(env)){ env += '\nDASHBOARD_KEY=ci-test-key\n'; } fs.writeFileSync(path, env);"
+          node <<'NODE'
+          const fs = require("node:fs");
+          const path = ".env";
+          let env = fs.readFileSync(path, "utf8");
+
+          function upsertEnv(name, value) {
+            const active = new RegExp(`^${name}=.*$`, "m");
+            const commented = new RegExp(`^# ${name}=.*$`, "m");
+            if (active.test(env)) {
+              env = env.replace(active, `${name}=${value}`);
+            } else if (commented.test(env)) {
+              env = env.replace(commented, `${name}=${value}`);
+            } else {
+              env += `\n${name}=${value}\n`;
+            }
+          }
+
+          upsertEnv("INGESTER_JOB_TOKEN", "ci-test-ingester-job-token-000000");
+          fs.writeFileSync(path, env);
+          NODE
 
       - name: Validate Docker Compose config
         run: docker compose config


### PR DESCRIPTION
## Summary
- Updates the main CI onboarding `.env` preparation step to add only a test-only `INGESTER_JOB_TOKEN` placeholder.
- Removes the legacy `DASHBOARD_KEY` population from this onboarding CI path.
- Keeps `docker-compose.yml` strict: real self-host/prod Compose runs still require a 32+ character `INGESTER_JOB_TOKEN` in `.env`.

## Context
- Refs #581 follow-up after merged PR #583.
- Main CI run 26705775067 failed at merge SHA `7ad6242ee882ec88e087f952dac020b4dbbc5d53` because `docker compose config` interpolated required `INGESTER_JOB_TOKEN` from `.env`.
- No production secret values were read or printed; this branch only uses a CI-only placeholder token.

## Validation
- `docker compose config` with the CI-prepared `.env` path and no `DASHBOARD_KEY`: passed
- `make check`: passed
- `bunx vitest run tests/ingester-job-scheduler-coverage.test.ts`: passed (2 tests)
- Live PR CI: passed, including `Onboarding acceptance`