### PR TITLE
Deploy scheduler as dedicated ECS service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,5 @@ screenshots
 clone-product-docs
 tests
 .omc
+.claude
+.handoffs

--- a/agent_docs/learnings/active/2026-06-01-scheduler-ecs-deploy-boundary.md
+++ b/agent_docs/learnings/active/2026-06-01-scheduler-ecs-deploy-boundary.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-01
+issue: scheduler-ecs-deploy
+type: pattern
+promoted_to: null
+---
+
+# Scheduler ECS deploy boundary
+
+When deploying the ingester scheduler as its own ECS service, clone the ingester task's DB and auth secret boundary instead of treating the scheduler as a pure unauthenticated HTTP loop. `job-scheduler.js` imports `@opensend/core`, which can initialize Better Auth code paths; omitting `BETTER_AUTH_SECRET` caused the scheduler task to run one batch and then exit with `BetterAuthError: You are using the default secret`.
+
+The dedicated scheduler task should include at minimum `DATABASE_URL`, `BETTER_AUTH_SECRET`, and `INGESTER_JOB_TOKEN`, plus Google OAuth secrets if present to avoid startup warning noise from imported auth config.
+
+Also keep local agent state out of Docker build contexts: `.claude/` worktrees inflated an ingester build context above 2 GB until `.dockerignore` excluded `.claude` and `.handoffs`.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,9 +3,10 @@
 # ABOUTME: Idempotent. Run anytime to ship the current branch to prod.
 #
 # Usage:
-#   bash scripts/deploy.sh                  # both app and ingester
+#   bash scripts/deploy.sh                  # app, ingester, and scheduler
 #   bash scripts/deploy.sh app              # just the app
 #   bash scripts/deploy.sh ingester         # just the ingester
+#   bash scripts/deploy.sh scheduler        # just the scheduler
 #   bash scripts/deploy.sh migrate          # just run database migrations
 #
 # Requires: docker (with buildx), aws CLI, AWS creds with ECR + ECS permissions.
@@ -47,6 +48,16 @@ ING_CONTAINER_NAME="${ING_CONTAINER_NAME:-${PRODUCT}-ingester}"
 ING_DOCKERFILE="${ING_DOCKERFILE:-packages/ingester/Dockerfile}"
 INGESTER_JOB_TOKEN_SECRET_ID="${INGESTER_JOB_TOKEN_SECRET_ID:-${PRODUCT}/ingester-job-token}"
 INGESTER_JOB_TOKEN_SECRET_ARN="${INGESTER_JOB_TOKEN_SECRET_ARN:-}"
+
+SCHED_SERVICE="${SCHED_SERVICE:-${PRODUCT}-scheduler}"
+SCHED_CONTAINER_NAME="${SCHED_CONTAINER_NAME:-${PRODUCT}-scheduler}"
+SCHED_TASK_FAMILY="${SCHED_TASK_FAMILY:-${PRODUCT}-scheduler}"
+SCHED_CPU="${SCHED_CPU:-256}"
+SCHED_MEMORY="${SCHED_MEMORY:-512}"
+SCHED_LOG_GROUP="${SCHED_LOG_GROUP:-/ecs/${SCHED_SERVICE}}"
+SCHED_LOG_STREAM_PREFIX="${SCHED_LOG_STREAM_PREFIX:-scheduler}"
+SCHED_INGESTER_URL="${SCHED_INGESTER_URL:-https://events.${PRODUCT}.namuh.co}"
+SCHED_INTERVAL_SECONDS="${SCHED_INTERVAL_SECONDS:-60}"
 
 color() { printf "\033[1;%sm%s\033[0m\n" "$1" "$2"; }
 info()  { color 36 "$*"; }
@@ -122,11 +133,11 @@ ingester_job_token_secret_arn() {
 }
 
 write_service_network_configuration() {
-  local output_file="$1"
+  local output_file="$1" service="${2:-${APP_SERVICE}}"
 
   aws ecs describe-services \
     --cluster "${CLUSTER}" \
-    --services "${APP_SERVICE}" \
+    --services "${service}" \
     --region "${AWS_REGION}" \
     --query 'services[0].networkConfiguration' \
     --output json > "${output_file}"
@@ -321,6 +332,200 @@ register_ingester_task_definition() {
     --region "${AWS_REGION}" \
     --query 'taskDefinition.taskDefinitionArn' \
     --output text
+}
+
+create_log_group_if_missing() {
+  local log_group="$1"
+
+  aws logs create-log-group \
+    --log-group-name "${log_group}" \
+    --region "${AWS_REGION}" 2>/dev/null || true
+}
+
+write_scheduler_task_definition() {
+  local base_task_definition="$1" scheduler_image="$2" job_token_arn="$3" output_file="$4"
+  local base_task_file
+  base_task_file="$(mktemp)"
+
+  aws ecs describe-task-definition \
+    --task-definition "${base_task_definition}" \
+    --region "${AWS_REGION}" \
+    --query 'taskDefinition' \
+    --output json > "${base_task_file}"
+
+  python3 - \
+    "${base_task_file}" \
+    "${scheduler_image}" \
+    "${SCHED_TASK_FAMILY}" \
+    "${ING_CONTAINER_NAME}" \
+    "${SCHED_CONTAINER_NAME}" \
+    "${job_token_arn}" \
+    "${SCHED_CPU}" \
+    "${SCHED_MEMORY}" \
+    "${SCHED_LOG_GROUP}" \
+    "${AWS_REGION}" \
+    "${SCHED_LOG_STREAM_PREFIX}" \
+    "${SCHED_INGESTER_URL}" \
+    "${SCHED_INTERVAL_SECONDS}" \
+    > "${output_file}" <<'PY'
+import copy
+import json
+import sys
+
+(
+    base_task_file,
+    scheduler_image,
+    family,
+    ingester_container_name,
+    scheduler_container_name,
+    job_token_arn,
+    cpu,
+    memory,
+    log_group,
+    aws_region,
+    log_stream_prefix,
+    ingester_url,
+    interval_seconds,
+) = sys.argv[1:14]
+
+with open(base_task_file, "r", encoding="utf-8") as handle:
+    task = json.load(handle)
+
+allowed_task_keys = [
+    "taskRoleArn",
+    "executionRoleArn",
+    "networkMode",
+    "volumes",
+    "placementConstraints",
+    "requiresCompatibilities",
+    "runtimePlatform",
+    "ephemeralStorage",
+    "proxyConfiguration",
+    "inferenceAccelerators",
+    "pidMode",
+    "ipcMode",
+]
+
+definition = {
+    "family": family,
+    "cpu": cpu,
+    "memory": memory,
+}
+for key in allowed_task_keys:
+    value = task.get(key)
+    if value not in (None, [], {}):
+        definition[key] = value
+
+containers = task.get("containerDefinitions") or []
+selected = next(
+    (
+        container
+        for container in containers
+        if container.get("name") == ingester_container_name
+    ),
+    containers[0] if containers else None,
+)
+if selected is None:
+    raise SystemExit("base task definition has no containers")
+
+scheduler = copy.deepcopy(selected)
+scheduler["name"] = scheduler_container_name
+scheduler["image"] = scheduler_image
+scheduler["essential"] = True
+scheduler["command"] = ["bun", "/app/job-scheduler.js"]
+scheduler.pop("portMappings", None)
+scheduler.pop("healthCheck", None)
+
+scheduler["environment"] = [
+    {"name": "NODE_ENV", "value": "production"},
+    {"name": "INGESTER_URL", "value": ingester_url},
+    {"name": "INGESTER_SCHEDULER_INTERVAL_SECONDS", "value": interval_seconds},
+]
+
+base_secrets = {
+    secret.get("name"): secret
+    for secret in (selected.get("secrets") or [])
+    if secret.get("name")
+}
+required_secret_names = ["DATABASE_URL", "BETTER_AUTH_SECRET", "INGESTER_JOB_TOKEN"]
+optional_secret_names = ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"]
+if "DATABASE_URL" not in base_secrets:
+    raise SystemExit("base ingester task definition has no DATABASE_URL secret")
+if "BETTER_AUTH_SECRET" not in base_secrets:
+    raise SystemExit("base ingester task definition has no BETTER_AUTH_SECRET secret")
+
+scheduler["secrets"] = []
+for name in required_secret_names + [
+    name for name in optional_secret_names if name in base_secrets
+]:
+    if name == "INGESTER_JOB_TOKEN":
+        scheduler["secrets"].append({"name": name, "valueFrom": job_token_arn})
+    else:
+        scheduler["secrets"].append(copy.deepcopy(base_secrets[name]))
+
+scheduler["logConfiguration"] = {
+    "logDriver": "awslogs",
+    "options": {
+        "awslogs-group": log_group,
+        "awslogs-region": aws_region,
+        "awslogs-stream-prefix": log_stream_prefix,
+    },
+}
+
+definition["containerDefinitions"] = [scheduler]
+json.dump(definition, sys.stdout)
+PY
+}
+
+register_scheduler_task_definition() {
+  local scheduler_image="$1" base_task_definition job_token_arn task_file
+  base_task_definition="$(ingester_task_definition)"
+  job_token_arn="$(ingester_job_token_secret_arn)"
+  task_file="$(mktemp)"
+
+  write_scheduler_task_definition "${base_task_definition}" "${scheduler_image}" "${job_token_arn}" "${task_file}"
+
+  aws ecs register-task-definition \
+    --cli-input-json "file://${task_file}" \
+    --region "${AWS_REGION}" \
+    --query 'taskDefinition.taskDefinitionArn' \
+    --output text
+}
+
+scheduler_service_exists() {
+  local status
+  status="$(aws ecs describe-services \
+    --cluster "${CLUSTER}" \
+    --services "${SCHED_SERVICE}" \
+    --region "${AWS_REGION}" \
+    --query 'services[0].status' \
+    --output text 2>/dev/null || true)"
+
+  [[ "${status}" == "ACTIVE" || "${status}" == "DRAINING" ]]
+}
+
+create_or_redeploy_scheduler_service() {
+  local task_definition="$1" network_file
+
+  network_file="$(mktemp)"
+  write_service_network_configuration "${network_file}" "${ING_SERVICE}"
+
+  if scheduler_service_exists; then
+    redeploy "${SCHED_SERVICE}" "${task_definition}"
+    return
+  fi
+
+  info "→ Create ECS service: ${SCHED_SERVICE}"
+  aws ecs create-service \
+    --cluster "${CLUSTER}" \
+    --service-name "${SCHED_SERVICE}" \
+    --task-definition "${task_definition}" \
+    --desired-count 1 \
+    --launch-type FARGATE \
+    --network-configuration "file://${network_file}" \
+    --region "${AWS_REGION}" \
+    --query 'service.{status:status,desired:desiredCount,running:runningCount}' \
+    --output table
 }
 
 write_migrator_task_definition() {
@@ -533,6 +738,17 @@ deploy_ingester() {
   ok "  registered ${ING_TASK_DEFINITION}"
 }
 
+deploy_scheduler() {
+  local scheduler_image="${ECR_BASE}/${ING_REPO}:${IMAGE_TAG}"
+
+  build_and_push "${ING_REPO}" "${ING_DOCKERFILE}" ""
+  create_log_group_if_missing "${SCHED_LOG_GROUP}"
+
+  info "→ Register ECS scheduler task definition"
+  SCHED_TASK_DEFINITION="$(register_scheduler_task_definition "${scheduler_image}")"
+  ok "  registered ${SCHED_TASK_DEFINITION}"
+}
+
 target="${1:-all}"
 
 case "${target}" in
@@ -548,29 +764,39 @@ case "${target}" in
     redeploy "${ING_SERVICE}" "${ING_TASK_DEFINITION}"
     wait_stable "${ING_SERVICE}"
     ;;
+  scheduler)
+    deploy_scheduler
+    create_or_redeploy_scheduler_service "${SCHED_TASK_DEFINITION}"
+    wait_stable "${SCHED_SERVICE}"
+    ;;
   migrate)
     run_migrations
     ;;
   all)
     deploy_app
     deploy_ingester
+    deploy_scheduler
     run_migrations
     redeploy "${APP_SERVICE}" "${APP_TASK_DEFINITION}"
     redeploy "${ING_SERVICE}" "${ING_TASK_DEFINITION}"
+    create_or_redeploy_scheduler_service "${SCHED_TASK_DEFINITION}"
     wait_stable "${APP_SERVICE}" &
     APP_PID=$!
     wait_stable "${ING_SERVICE}" &
     ING_PID=$!
-    APP_RC=0; ING_RC=0
+    wait_stable "${SCHED_SERVICE}" &
+    SCHED_PID=$!
+    APP_RC=0; ING_RC=0; SCHED_RC=0
     wait "${APP_PID}" || APP_RC=$?
     wait "${ING_PID}" || ING_RC=$?
-    if [[ "${APP_RC}" -ne 0 || "${ING_RC}" -ne 0 ]]; then
+    wait "${SCHED_PID}" || SCHED_RC=$?
+    if [[ "${APP_RC}" -ne 0 || "${ING_RC}" -ne 0 || "${SCHED_RC}" -ne 0 ]]; then
       err "One or more services failed to stabilize."
       exit 1
     fi
     ;;
   *)
-    err "Unknown target: ${target} (expected: app | ingester | migrate | all)"
+    err "Unknown target: ${target} (expected: app | ingester | scheduler | migrate | all)"
     exit 2
     ;;
 esac
@@ -580,3 +806,4 @@ echo
 echo "App:      https://${PRODUCT}.namuh.co"
 echo "API:      https://api.${PRODUCT}.namuh.co"
 echo "Events:   https://events.${PRODUCT}.namuh.co"
+echo "Health:   https://${PRODUCT}.namuh.co/api/health/scheduler"


### PR DESCRIPTION
## Summary
- add `scripts/deploy.sh scheduler` target that builds the ingester image, registers an `opensend-scheduler` Fargate task, and creates/redeploys the scheduler ECS service
- clone the ingester network/role boundary while removing listener-specific ports and health checks for the outbound-only scheduler
- keep local `.claude/` worktrees and `.handoffs/` out of Docker build contexts
- record the Better Auth secret/Docker-context deploy learning

## Production verification
- Created ECS service: `opensend-scheduler`
- Running task definition: `opensend-scheduler:3`
- Live health: `https://opensend.namuh.co/api/health/scheduler` returned 200 with all jobs healthy
- Latest scheduler logs show repeated 200s for `scheduled-emails`, `webhooks`, and `domain-verify`

## Local validation
- `bash -n scripts/deploy.sh`
- `make check`
- `make test` (passed before final deploy-script-only secret-noise patch; final patch re-ran `make check`)
