### PR TITLE
fix: allow PostHog browser assets in CSP

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -26,7 +26,7 @@ const securityHeaders = [
       // Next.js inlines runtime JS; the explicit nonce path requires more
       // wiring than this lockdown commit. Use 'unsafe-inline' for now and
       // tighten with nonces in a follow-up.
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us-assets.i.posthog.com",
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob: https:",
       "font-src 'self' data:",

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -13,6 +13,12 @@ describe("deploy-001: ECS Fargate deployment configuration", () => {
     expect(config).toContain('output: "standalone"');
   });
 
+  it("allows PostHog browser assets in the production CSP", () => {
+    const config = readFileSync(join(root, "next.config.js"), "utf-8");
+    expect(config).toContain("https://us-assets.i.posthog.com");
+    expect(config).toContain("connect-src 'self' https:");
+  });
+
   it("Dockerfile exists with multi-stage build", () => {
     const dockerfile = readFileSync(join(root, "Dockerfile"), "utf-8");
     expect(dockerfile).toContain("FROM oven/bun:1.3.8-alpine AS base");


### PR DESCRIPTION
## Summary
- allow PostHog browser asset scripts from us-assets.i.posthog.com in the production CSP
- add a deploy config regression test for the PostHog CSP allowance

## Verification
- bun run test tests/deploy.test.ts
- make check