### PR TITLE
fix: capture initial PostHog pageview

### DIFF
--- a/src/components/observability/posthog-provider.tsx
+++ b/src/components/observability/posthog-provider.tsx
@@ -29,6 +29,7 @@ function initOnce() {
       maskTextSelector: "[data-private], input, textarea",
     },
   });
+  posthog.capture("$pageview");
   initialized = true;
 }
 

--- a/tests/posthog-provider.test.tsx
+++ b/tests/posthog-provider.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const posthogMock = vi.hoisted(() => ({
+  capture: vi.fn(),
+  init: vi.fn(),
+}));
+
+vi.mock("posthog-js", () => ({
+  default: {
+    capture: posthogMock.capture,
+    init: posthogMock.init,
+  },
+}));
+
+vi.mock("posthog-js/react", () => ({
+  PostHogProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="posthog-provider">{children}</div>
+  ),
+}));
+
+describe("PosthogProvider", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    posthogMock.capture.mockClear();
+    posthogMock.init.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllEnvs();
+  });
+
+  it("captures the initial browser pageview when PostHog is configured", async () => {
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_test");
+
+    const { PosthogProvider } = await import(
+      "@/components/observability/posthog-provider"
+    );
+
+    render(
+      <PosthogProvider>
+        <span>App</span>
+      </PosthogProvider>,
+    );
+
+    await waitFor(() => {
+      expect(posthogMock.init).toHaveBeenCalledWith(
+        "phc_test",
+        expect.objectContaining({
+          capture_pageview: "history_change",
+          capture_pageleave: true,
+        }),
+      );
+      expect(posthogMock.capture).toHaveBeenCalledWith("$pageview");
+    });
+  });
+
+  it("does not initialize or capture when PostHog is not configured", async () => {
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "");
+
+    const { PosthogProvider } = await import(
+      "@/components/observability/posthog-provider"
+    );
+
+    render(
+      <PosthogProvider>
+        <span>App</span>
+      </PosthogProvider>,
+    );
+
+    await waitFor(() => {
+      expect(posthogMock.init).not.toHaveBeenCalled();
+      expect(posthogMock.capture).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- explicitly capture the initial PostHog  after browser initialization
- preserve route-change pageview tracking and the existing CSP asset allowance
- add focused provider coverage for configured and unconfigured PostHog states

## Verification
- bun run test tests/posthog-provider.test.tsx tests/deploy.test.ts
- make check