### PR TITLE
fix: capture PostHog pageview after init

### DIFF
--- a/src/components/observability/posthog-provider.tsx
+++ b/src/components/observability/posthog-provider.tsx
@@ -28,8 +28,10 @@ function initOnce() {
       maskAllInputs: true,
       maskTextSelector: "[data-private], input, textarea",
     },
+    loaded: (client) => {
+      client.capture("$pageview");
+    },
   });
-  posthog.capture("$pageview");
   initialized = true;
 }
 

--- a/tests/posthog-provider.test.tsx
+++ b/tests/posthog-provider.test.tsx
@@ -52,8 +52,17 @@ describe("PosthogProvider", () => {
         expect.objectContaining({
           capture_pageview: "history_change",
           capture_pageleave: true,
+          loaded: expect.any(Function),
         }),
       );
+    });
+
+    const initConfig = posthogMock.init.mock.calls[0]?.[1];
+    initConfig.loaded({
+      capture: posthogMock.capture,
+    });
+
+    await waitFor(() => {
       expect(posthogMock.capture).toHaveBeenCalledWith("$pageview");
     });
   });


### PR DESCRIPTION
## Summary
- move explicit initial  capture into PostHog's  callback so it fires after SDK initialization
- keep route-change pageview tracking and existing CSP allowance
- update provider test to exercise the loaded callback

## Verification
- bun run test tests/posthog-provider.test.tsx tests/deploy.test.ts
- make check