### PR TITLE
Fix initial PostHog pageview ingestion

### DIFF
--- a/src/components/observability/posthog-provider.tsx
+++ b/src/components/observability/posthog-provider.tsx
@@ -7,8 +7,55 @@ import { useEffect } from "react";
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 const POSTHOG_HOST =
   process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com";
+const INITIAL_PAGEVIEW_DISTINCT_ID_KEY = "opensend_posthog_distinct_id";
 
 let initialized = false;
+
+function getDistinctId() {
+  try {
+    const existing = window.localStorage.getItem(
+      INITIAL_PAGEVIEW_DISTINCT_ID_KEY,
+    );
+    if (existing) return existing;
+
+    const generated =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    window.localStorage.setItem(INITIAL_PAGEVIEW_DISTINCT_ID_KEY, generated);
+    return generated;
+  } catch {
+    return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  }
+}
+
+function captureInitialPageview() {
+  if (!POSTHOG_KEY) return;
+
+  const currentUrl = window.location.href;
+  const payload = {
+    api_key: POSTHOG_KEY,
+    event: "$pageview",
+    distinct_id: getDistinctId(),
+    properties: {
+      token: POSTHOG_KEY,
+      $current_url: currentUrl,
+      $host: window.location.host,
+      $pathname: window.location.pathname,
+      $referrer: document.referrer,
+      $lib: "opensend-web",
+    },
+  };
+
+  void fetch(`${POSTHOG_HOST.replace(/\/$/, "")}/capture/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    keepalive: true,
+  }).catch(() => {
+    posthog.capture("$pageview");
+  });
+}
 
 function initOnce() {
   if (initialized || typeof window === "undefined") return;
@@ -37,7 +84,7 @@ export function PosthogProvider({ children }: { children: React.ReactNode }) {
     initOnce();
     if (!POSTHOG_KEY) return;
     const pageviewTimer = window.setTimeout(() => {
-      posthog.capture("$pageview");
+      captureInitialPageview();
     }, 1000);
     return () => window.clearTimeout(pageviewTimer);
   }, []);

--- a/tests/posthog-provider.test.tsx
+++ b/tests/posthog-provider.test.tsx
@@ -6,6 +6,16 @@ const posthogMock = vi.hoisted(() => ({
   capture: vi.fn(),
   init: vi.fn(),
 }));
+const storageMock = vi.hoisted(() => {
+  const entries = new Map<string, string>();
+  return {
+    clear: vi.fn(() => entries.clear()),
+    getItem: vi.fn((key: string) => entries.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      entries.set(key, value);
+    }),
+  };
+});
 
 vi.mock("posthog-js", () => ({
   default: {
@@ -25,14 +35,24 @@ describe("PosthogProvider", () => {
     vi.resetModules();
     vi.unstubAllEnvs();
     vi.useRealTimers();
+    storageMock.clear();
     posthogMock.capture.mockClear();
     posthogMock.init.mockClear();
+    vi.stubGlobal("localStorage", storageMock);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response('{"status":"Ok"}'))),
+    );
+    vi.stubGlobal("crypto", {
+      randomUUID: vi.fn(() => "test-distinct-id"),
+    });
   });
 
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
     vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
   });
 
   it("captures the initial browser pageview when PostHog is configured", async () => {
@@ -59,11 +79,31 @@ describe("PosthogProvider", () => {
       }),
     );
 
-    expect(posthogMock.capture).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
     act(() => {
       vi.advanceTimersByTime(1000);
     });
-    expect(posthogMock.capture).toHaveBeenCalledWith("$pageview");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://us.i.posthog.com/capture/",
+      expect.objectContaining({
+        method: "POST",
+        keepalive: true,
+        body: expect.stringContaining('"event":"$pageview"'),
+      }),
+    );
+    expect(
+      JSON.parse(vi.mocked(fetch).mock.calls[0]?.[1]?.body as string),
+    ).toEqual(
+      expect.objectContaining({
+        api_key: "phc_test",
+        distinct_id: "test-distinct-id",
+        event: "$pageview",
+        properties: expect.objectContaining({
+          $lib: "opensend-web",
+          token: "phc_test",
+        }),
+      }),
+    );
   });
 
   it("does not initialize or capture when PostHog is not configured", async () => {


### PR DESCRIPTION
## Summary
- keep the PostHog SDK initialized for browser observability
- send the initial browser `` directly to PostHog's capture endpoint after mount
- persist a stable anonymous distinct id in localStorage for the initial pageview payload

## Verification
- `bun run test tests/posthog-provider.test.tsx tests/deploy.test.ts`
- `make check`

## Live evidence before this fix
- deployed SDK initialized and loaded PostHog remote config/assets, but no browser capture request was emitted
- direct capture with the deployed phc key landed in PostHog project 438436 after ingestion delay
