### PR TITLE
Add inbound receiving quota and webhooks

### DIFF
--- a/packages/core/src/db/repositories/inboundProviderEventRepo.ts
+++ b/packages/core/src/db/repositories/inboundProviderEventRepo.ts
@@ -9,6 +9,7 @@ export type InboundProviderEventStatus =
   | "missing_domain"
   | "oversized_message"
   | "storage_failure"
+  | "quota_exceeded"
   | "duplicate_provider_event";
 
 type CreateProcessingInput = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,7 @@ export * from "./services/configurationSet";
 export * from "./services/tracking";
 export * from "./services/trackingRoute";
 export * from "./services/sandboxTestRecipients";
+export * from "./services/usageQuota";
 export * from "./services/storage";
 export * from "./services/template";
 export * from "./services/template-renderer";

--- a/packages/core/src/services/inboundEmailIngestion.ts
+++ b/packages/core/src/services/inboundEmailIngestion.ts
@@ -1,7 +1,13 @@
 import { createHash, randomUUID } from "node:crypto";
+import { and, eq, sql } from "drizzle-orm";
 import { db } from "../db/client";
 import { inboundProviderEventRepo } from "../db/repositories/inboundProviderEventRepo";
-import { emailEvents, receivedEmails } from "../db/schema";
+import {
+  emailEvents,
+  receivedEmails,
+  webhookDeliveries,
+  webhooks,
+} from "../db/schema";
 import {
   UnsafeOutboundUrlError,
   safeOutboundFetch,
@@ -21,6 +27,10 @@ import {
   resolveInboundReply,
 } from "./replyThreading";
 import { storageService } from "./storage";
+import {
+  releaseTransactionalEmailQuota,
+  reserveTransactionalEmailQuota,
+} from "./usageQuota";
 
 export type InboundProviderNotification = {
   provider: string;
@@ -39,6 +49,7 @@ export type InboundEmailIngestionStatus =
   | "missing_domain"
   | "oversized_message"
   | "storage_failure"
+  | "quota_exceeded"
   | "duplicate_provider_event";
 
 export type InboundEmailIngestionOutcome =
@@ -66,6 +77,8 @@ export type InboundEmailIngestionDependencies = {
   ) => Promise<{ key: string; url: string }>;
   deleteFile?: (key: string) => Promise<void>;
   maxBytes?: number;
+  reserveEmailQuota?: typeof reserveTransactionalEmailQuota;
+  releaseEmailQuota?: typeof releaseTransactionalEmailQuota;
 };
 
 type StoredAttachment = {
@@ -325,6 +338,10 @@ export function createInboundEmailIngestionService(
   const deleteFile =
     dependencies.deleteFile ?? storageService.deleteFile.bind(storageService);
   const maxBytes = dependencies.maxBytes;
+  const reserveEmailQuota =
+    dependencies.reserveEmailQuota ?? reserveTransactionalEmailQuota;
+  const releaseEmailQuota =
+    dependencies.releaseEmailQuota ?? releaseTransactionalEmailQuota;
   const receivingRouteService = createReceivingRouteService();
 
   async function markTerminal(input: {
@@ -441,6 +458,18 @@ export function createInboundEmailIngestionService(
         });
       }
 
+      const quota = await reserveEmailQuota(tenant.userId, 1);
+      if (!quota.ok) {
+        return await markTerminal({
+          eventId: created.event.id,
+          providerEventId,
+          status: "quota_exceeded",
+          reason: `Monthly email quota exceeded for plan ${quota.info.plan}`,
+          userId: tenant.userId,
+        });
+      }
+      const quotaReserved = !quota.bypassed;
+
       const receivedEmailId = randomUUID();
       const storedAttachments: StoredAttachment[] = [];
       const uploadedKeys: string[] = [];
@@ -464,6 +493,9 @@ export function createInboundEmailIngestionService(
           });
         }
       } catch (error) {
+        if (quotaReserved) {
+          await releaseEmailQuota(tenant.userId, 1);
+        }
         await cleanupStoredAttachments(uploadedKeys, deleteFile);
         return await markTerminal({
           eventId: created.event.id,
@@ -531,6 +563,29 @@ export function createInboundEmailIngestionService(
             })
             .returning();
 
+          const matchingWebhooks = await tx
+            .select({ id: webhooks.id })
+            .from(webhooks)
+            .where(
+              and(
+                eq(webhooks.userId, tenant.userId),
+                eq(webhooks.status, "active"),
+                sql`${webhooks.eventTypes} ? ${"email.received"}`,
+              ),
+            );
+
+          if (matchingWebhooks.length > 0) {
+            await tx.insert(webhookDeliveries).values(
+              matchingWebhooks.map((webhook) => ({
+                webhookId: webhook.id,
+                eventId: event.id,
+                status: "pending",
+                attempt: 0,
+                nextRetryAt: null,
+              })),
+            );
+          }
+
           return { received, event };
         });
 
@@ -563,6 +618,9 @@ export function createInboundEmailIngestionService(
           attachments: storedAttachments.length,
         };
       } catch (error) {
+        if (quotaReserved) {
+          await releaseEmailQuota(tenant.userId, 1);
+        }
         await cleanupStoredAttachments(uploadedKeys, deleteFile);
         return await markTerminal({
           eventId: created.event.id,

--- a/packages/core/src/services/usageQuota.ts
+++ b/packages/core/src/services/usageQuota.ts
@@ -1,0 +1,229 @@
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "../db/client";
+import { plans, subscriptions, usagePeriods } from "../db/schema";
+import { FREE_PLAN_DEFAULTS, FREE_PLAN_SLUG } from "../dto";
+
+type BillingDb = Pick<typeof db, "insert" | "query" | "update">;
+
+const PAST_DUE_GRACE_MS = 3 * 24 * 60 * 60 * 1000;
+const ACTIVE_STATUSES = new Set(["active", "trialing", "past_due"]);
+
+export type UsageQuotaResult =
+  | { ok: true; bypassed: boolean }
+  | {
+      ok: false;
+      info: {
+        resource: "emails";
+        plan: string;
+        limit: number;
+        used: number;
+      };
+    };
+
+function startOfMonthUtc(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
+}
+
+function startOfNextMonthUtc(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 1));
+}
+
+function billingEnabled(env: Record<string, string | undefined>): boolean {
+  return (
+    env.BILLING_BACKEND?.trim().toLowerCase() === "stripe" &&
+    Boolean(env.STRIPE_SECRET_KEY?.trim())
+  );
+}
+
+async function ensureFreePlan(database: BillingDb) {
+  const [created] = await database
+    .insert(plans)
+    .values({
+      slug: FREE_PLAN_DEFAULTS.slug,
+      name: FREE_PLAN_DEFAULTS.name,
+      monthlyPriceCents: FREE_PLAN_DEFAULTS.monthlyPriceCents,
+      monthlyEmailQuota: FREE_PLAN_DEFAULTS.monthlyEmailQuota,
+      dailyEmailQuota: FREE_PLAN_DEFAULTS.dailyEmailQuota,
+      maxDomains: FREE_PLAN_DEFAULTS.maxDomains,
+      maxApiKeys: FREE_PLAN_DEFAULTS.maxApiKeys,
+      maxContacts: FREE_PLAN_DEFAULTS.maxContacts,
+      maxSegments: FREE_PLAN_DEFAULTS.maxSegments,
+      maxBroadcasts: FREE_PLAN_DEFAULTS.maxBroadcasts,
+      ratePerSecond: FREE_PLAN_DEFAULTS.ratePerSecond,
+      isPublic: FREE_PLAN_DEFAULTS.isPublic,
+    })
+    .onConflictDoNothing({ target: plans.slug })
+    .returning();
+  if (created) return created;
+
+  const existing = await database.query.plans.findFirst({
+    where: eq(plans.slug, FREE_PLAN_SLUG),
+  });
+  if (!existing) {
+    throw new Error("Free plan ensure failed: insert ignored but no row");
+  }
+  return existing;
+}
+
+async function loadPlanContext(userId: string, now: Date, database: BillingDb) {
+  const sub = await database.query.subscriptions.findFirst({
+    where: eq(subscriptions.userId, userId),
+  });
+
+  if (sub && ACTIVE_STATUSES.has(sub.status)) {
+    if (sub.status === "past_due") {
+      const periodEnd = sub.currentPeriodEnd;
+      if (
+        !periodEnd ||
+        now.getTime() - periodEnd.getTime() > PAST_DUE_GRACE_MS
+      ) {
+        return "blocked" as const;
+      }
+    }
+
+    const plan = await database.query.plans.findFirst({
+      where: eq(plans.id, sub.planId),
+    });
+    if (plan) {
+      return {
+        plan,
+        periodStart: sub.currentPeriodStart ?? startOfMonthUtc(now),
+        periodEnd: sub.currentPeriodEnd ?? startOfNextMonthUtc(now),
+      };
+    }
+  }
+
+  const plan = await ensureFreePlan(database);
+  return {
+    plan,
+    periodStart: startOfMonthUtc(now),
+    periodEnd: startOfNextMonthUtc(now),
+  };
+}
+
+async function ensureUsagePeriod(input: {
+  userId: string;
+  periodStart: Date;
+  periodEnd: Date;
+  database: BillingDb;
+}) {
+  const existing = await input.database.query.usagePeriods.findFirst({
+    where: and(
+      eq(usagePeriods.userId, input.userId),
+      eq(usagePeriods.periodStart, input.periodStart),
+    ),
+  });
+  if (existing) return existing;
+
+  const [created] = await input.database
+    .insert(usagePeriods)
+    .values({
+      userId: input.userId,
+      periodStart: input.periodStart,
+      periodEnd: input.periodEnd,
+      emailsSent: 0,
+    })
+    .onConflictDoNothing({
+      target: [usagePeriods.userId, usagePeriods.periodStart],
+    })
+    .returning();
+  if (created) return created;
+
+  const reread = await input.database.query.usagePeriods.findFirst({
+    where: and(
+      eq(usagePeriods.userId, input.userId),
+      eq(usagePeriods.periodStart, input.periodStart),
+    ),
+  });
+  if (!reread) throw new Error("Failed to ensure usage_periods row");
+  return reread;
+}
+
+export async function reserveTransactionalEmailQuota(
+  userId: string | null | undefined,
+  delta: number,
+  now: Date = new Date(),
+  env: Record<string, string | undefined> = process.env,
+  database: BillingDb = db,
+): Promise<UsageQuotaResult> {
+  if (delta <= 0 || !userId || !billingEnabled(env)) {
+    return { ok: true, bypassed: true };
+  }
+
+  const ctx = await loadPlanContext(userId, now, database);
+  if (ctx === "blocked") {
+    return {
+      ok: false,
+      info: { resource: "emails", plan: "past_due", limit: 0, used: 0 },
+    };
+  }
+
+  await ensureUsagePeriod({
+    userId,
+    periodStart: ctx.periodStart,
+    periodEnd: ctx.periodEnd,
+    database,
+  });
+
+  const updated = await database
+    .update(usagePeriods)
+    .set({
+      emailsSent: sql`${usagePeriods.emailsSent} + ${delta}`,
+      lastIncrementAt: now,
+    })
+    .where(
+      and(
+        eq(usagePeriods.userId, userId),
+        eq(usagePeriods.periodStart, ctx.periodStart),
+        sql`${usagePeriods.emailsSent} + ${delta} <= ${ctx.plan.monthlyEmailQuota}`,
+      ),
+    )
+    .returning({ emailsSent: usagePeriods.emailsSent });
+
+  if (updated.length > 0) return { ok: true, bypassed: false };
+
+  const current = await database.query.usagePeriods.findFirst({
+    where: and(
+      eq(usagePeriods.userId, userId),
+      eq(usagePeriods.periodStart, ctx.periodStart),
+    ),
+  });
+
+  return {
+    ok: false,
+    info: {
+      resource: "emails",
+      plan: ctx.plan.slug,
+      limit: ctx.plan.monthlyEmailQuota,
+      used: current?.emailsSent ?? 0,
+    },
+  };
+}
+
+export async function releaseTransactionalEmailQuota(
+  userId: string | null | undefined,
+  delta: number,
+  now: Date = new Date(),
+  env: Record<string, string | undefined> = process.env,
+  database: BillingDb = db,
+): Promise<void> {
+  if (delta <= 0 || !userId || !billingEnabled(env)) return;
+
+  try {
+    const ctx = await loadPlanContext(userId, now, database);
+    if (ctx === "blocked") return;
+    await database
+      .update(usagePeriods)
+      .set({
+        emailsSent: sql`GREATEST(${usagePeriods.emailsSent} - ${delta}, 0)`,
+      })
+      .where(
+        and(
+          eq(usagePeriods.userId, userId),
+          eq(usagePeriods.periodStart, ctx.periodStart),
+        ),
+      );
+  } catch {
+    // Best-effort compensation only.
+  }
+}

--- a/packages/core/src/webhook-events.ts
+++ b/packages/core/src/webhook-events.ts
@@ -7,6 +7,7 @@ export const SUPPORTED_WEBHOOK_EVENT_TYPES = [
   "email.scheduled",
   "email.delayed",
   "email.suppressed",
+  "email.received",
   "email.opened",
   "email.clicked",
   "email.failed",

--- a/public/docs/dashboard/webhooks/introduction.md
+++ b/public/docs/dashboard/webhooks/introduction.md
@@ -12,4 +12,4 @@ The Webhooks dashboard manages outbound event subscriptions. Use it to create en
 
 ## Caveats
 
-Webhook delivery requires the dispatcher/worker path. In self-hosted deployments, configure the ingester/worker and keep endpoint timeouts under the documented delivery timeout. The reserved `email.received` contract is for operator-owned inbound ingestion and is not part of default subscription creation.
+Webhook delivery requires the dispatcher/worker path. In self-hosted deployments, configure the ingester/worker and keep endpoint timeouts under the documented delivery timeout. `email.received` subscriptions are available for receiving-enabled domains and are queued after inbound MIME ingestion commits the received email row.

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -171,7 +171,7 @@
 - [email.deliverydelayed](https://opensend.namuh.co/docs/webhooks/emails/delivery-delayed.md): Provider delivery delay notification received.
 - [email.failed](https://opensend.namuh.co/docs/webhooks/emails/failed.md): Provider reject, rendering failure, or retry exhaustion recorded.
 - [email.opened](https://opensend.namuh.co/docs/webhooks/emails/opened.md): Open tracking pixel was requested.
-- [email.received](https://opensend.namuh.co/docs/webhooks/emails/received.md): Inbound receiving is currently a deployment integration point: the repository includes read APIs and storage schema for received email rows, but it does not include a complete SES inbound MIME parser that emits this event automatically. If you build that parser for your self-hosted deployment, use the payload shape below so downstream agents and webhook consumers can rely on a stable contract.
+- [email.received](https://opensend.namuh.co/docs/webhooks/emails/received.md): OpenSend emits email.received after committing an inbound email row for a receiving-enabled domain.
 - [email.scheduled](https://opensend.namuh.co/docs/webhooks/emails/scheduled.md): Future delivery accepted and stored.
 - [email.sent](https://opensend.namuh.co/docs/webhooks/emails/sent.md): Provider send notification received.
 - [email.suppressed](https://opensend.namuh.co/docs/webhooks/emails/suppressed.md): Send rejected by suppression policy.

--- a/public/docs/webhooks/emails/received.md
+++ b/public/docs/webhooks/emails/received.md
@@ -1,8 +1,10 @@
 # email.received
 
-`email.received` is the event name OpenSend reserves for inbound email notifications.
+OpenSend emits `email.received` after committing an inbound email row for a receiving-enabled domain.
 
-Inbound receiving is currently a deployment integration point: the repository includes read APIs and storage schema for received email rows, but it does not include a complete SES inbound MIME parser that emits this event automatically. If you build that parser for your self-hosted deployment, use the payload shape below so downstream agents and webhook consumers can rely on a stable contract.
+## When it is emitted
+
+OpenSend emits this event after the standalone ingester accepts an inbound provider notification, parses the raw MIME message, resolves the recipient to one tenant, stores the received email row, and commits attachment metadata. The event is not emitted for malformed messages, duplicate provider events, unrouteable messages, oversized messages, storage failures, or messages blocked by hosted quota.
 
 ## Recommended payload
 
@@ -33,7 +35,3 @@ Keep the webhook payload metadata-only. Retrieve bodies with `GET /emails/receiv
 ## Delivery and verification
 
 OpenSend webhook deliveries use the same signing and retry guidance as other events. Verify the `svix-id`, `svix-timestamp`, and `svix-signature` headers before acting on the inbound email. See [Verify webhook requests](../verify-webhooks-requests.md) and [Retries and replays](../retries-and-replays.md).
-
-## Operator status
-
-This page documents the first-party contract to use when inbound ingestion is enabled in your deployment. Hosted or self-hosted installs that only run the default SES/SNS lifecycle ingester should not expect `email.received` events until an inbound receiving worker is added.

--- a/public/docs/webhooks/event-types.md
+++ b/public/docs/webhooks/event-types.md
@@ -22,9 +22,9 @@ OpenSend accepts the following webhook subscription event types.
 | `domain.updated` | Domain update, verify, or reconcile paths | Includes verification-state changes when available. |
 | `domain.deleted` | Domain delete API | Emitted after domain deletion succeeds. |
 
-## Reserved but not currently emitted by default
+## Inbound receiving
 
-`email.received` is documented as an inbound receiving contract for deployments that add their own MIME ingestion worker. It is not part of the default webhook subscription validation list in this repository today.
+`email.received` is emitted after the OpenSend ingester commits an inbound email row for a receiving-enabled domain. Its webhook payload is metadata-only; retrieve content and attachments through the received-email APIs.
 
 ## Payload shape
 

--- a/tests/docs-content.test.ts
+++ b/tests/docs-content.test.ts
@@ -291,8 +291,6 @@ describe("webhook event docs", () => {
       expect(eventTypes).toContain(`\`${eventType}\``);
     }
     expect(eventTypes).toContain("email.received");
-    expect(eventTypes).toContain(
-      "not part of the default webhook subscription",
-    );
+    expect(eventTypes).toContain("metadata-only");
   });
 });

--- a/tests/email-webhook-events.test.ts
+++ b/tests/email-webhook-events.test.ts
@@ -19,6 +19,7 @@ describe("enqueueEmailWebhookEvent", () => {
     ["email.scheduled", "scheduled"],
     ["email.delayed", "delayed"],
     ["email.suppressed", "suppressed"],
+    ["email.received", "received"],
   ] as const)(
     "persists %s and tenant-scoped pending delivery rows",
     async (webhookEventType, storedEventType) => {
@@ -56,15 +57,19 @@ describe("enqueueEmailWebhookEvent", () => {
         "../packages/core/src/services/email-webhook-events"
       );
       const receivedAt = new Date("2026-05-28T00:00:00.000Z");
+      const payload =
+        webhookEventType === "email.received"
+          ? { received_email_id: "received-1" }
+          : {
+              email_id: "email-1",
+              happened_at: receivedAt.toISOString(),
+            };
       const result = await enqueueEmailWebhookEvent({
         type: webhookEventType,
         userId: "user-1",
-        emailId: "email-1",
+        emailId: webhookEventType === "email.received" ? null : "email-1",
         sourceId: `${storedEventType}:email-1`,
-        payload: {
-          email_id: "email-1",
-          happened_at: receivedAt.toISOString(),
-        },
+        payload,
         receivedAt,
       });
 
@@ -75,13 +80,10 @@ describe("enqueueEmailWebhookEvent", () => {
       const eventValues =
         tx.insert.mock.results[0]?.value.values.mock.calls[0]?.[0];
       expect(eventValues).toMatchObject({
-        emailId: "email-1",
+        emailId: webhookEventType === "email.received" ? null : "email-1",
         sourceId: `${storedEventType}:email-1`,
         type: storedEventType,
-        payload: {
-          email_id: "email-1",
-          happened_at: receivedAt.toISOString(),
-        },
+        payload,
         userId: "user-1",
         receivedAt,
       });
@@ -107,11 +109,11 @@ describe("enqueueEmailWebhookEvent", () => {
 
     await expect(
       enqueueEmailWebhookEvent({
-        type: "email.received" as never,
+        type: "email.unknown" as never,
         userId: "user-1",
         payload: {},
       }),
-    ).rejects.toThrow("Unsupported webhook event type: email.received");
+    ).rejects.toThrow("Unsupported webhook event type: email.unknown");
     expect(mockTransaction).not.toHaveBeenCalled();
   });
 });

--- a/tests/inbound-ingestion.integration.test.ts
+++ b/tests/inbound-ingestion.integration.test.ts
@@ -34,6 +34,9 @@ async function cleanup(client: Client, marker: string): Promise<void> {
   await client.query("delete from email_events where user_id like $1", [
     `${marker}%`,
   ]);
+  await client.query("delete from webhooks where user_id like $1", [
+    `${marker}%`,
+  ]);
   await client.query("delete from forwarding_attempts where user_id like $1", [
     `${marker}%`,
   ]);
@@ -234,6 +237,131 @@ describeIfDb("inbound MIME ingestion with real Postgres", () => {
       [eventId],
     );
     expect(duplicateRows.rows[0]?.status).toBe("duplicate_provider_event");
+  });
+
+  it("queues pending email.received webhook deliveries for subscribed tenant webhooks", async () => {
+    const webhookId = randomUUID();
+    await client.query(
+      "insert into webhooks (id, url, event_types, status, user_id) values ($1, $2, $3::jsonb, 'active', $4)",
+      [
+        webhookId,
+        "https://example.test/inbound-webhook",
+        JSON.stringify(["email.received"]),
+        tenantA,
+      ],
+    );
+
+    const outcome = await createInboundEmailIngestionService().process({
+      provider: "fixture",
+      eventId: `${marker}-received-webhook`,
+      messageId: `${marker}-received-webhook-msg`,
+      recipients: [`support@${domainA}`],
+      rawMime: buildMime({
+        from: "sender@example.test",
+        to: `support@${domainA}`,
+        subject: "Webhook me",
+      }),
+      metadata: { test_run_id: marker },
+    });
+
+    expect(outcome).toMatchObject({ status: "processed", user_id: tenantA });
+    if (outcome.status !== "processed") {
+      throw new Error("Expected processed inbound message");
+    }
+
+    const deliveryRows = await client.query<{
+      webhook_id: string;
+      status: string;
+      attempt: number;
+      event_type: string;
+      email_id: string | null;
+      payload: { received_email_id?: string };
+    }>(
+      `select
+        wd.webhook_id,
+        wd.status,
+        wd.attempt,
+        ee.type as event_type,
+        ee.email_id,
+        ee.payload
+       from webhook_deliveries wd
+       join email_events ee on ee.id = wd.event_id
+       where wd.webhook_id = $1 and ee.id = $2`,
+      [webhookId, outcome.event_id],
+    );
+
+    expect(deliveryRows.rows).toEqual([
+      {
+        webhook_id: webhookId,
+        status: "pending",
+        attempt: 0,
+        event_type: "received",
+        email_id: null,
+        payload: expect.objectContaining({
+          received_email_id: outcome.received_email_id,
+        }),
+      },
+    ]);
+  });
+
+  it("marks inbound messages over quota before storage or received-email persistence", async () => {
+    let uploadCalls = 0;
+    const service = createInboundEmailIngestionService({
+      reserveEmailQuota: async () => ({
+        ok: false,
+        info: {
+          resource: "emails",
+          plan: "free",
+          limit: 1,
+          used: 1,
+        },
+      }),
+      uploadFile: async () => {
+        uploadCalls += 1;
+        throw new Error("upload should not be reached");
+      },
+    });
+
+    const eventId = `${marker}-quota-exceeded`;
+    const outcome = await service.process({
+      provider: "fixture",
+      eventId,
+      messageId: `${marker}-quota-exceeded-msg`,
+      recipients: [`support@${domainA}`],
+      rawMime: buildMime({
+        from: "sender@example.test",
+        to: `support@${domainA}`,
+        subject: "Quota blocked",
+        attachment: true,
+      }),
+      metadata: { test_run_id: marker },
+    });
+
+    expect(outcome).toMatchObject({
+      status: "quota_exceeded",
+      reason: "Monthly email quota exceeded for plan free",
+    });
+    expect(uploadCalls).toBe(0);
+
+    const receivedRows = await client.query<{ count: string }>(
+      "select count(*) from received_emails where user_id = $1 and subject = 'Quota blocked'",
+      [tenantA],
+    );
+    expect(receivedRows.rows[0]?.count).toBe("0");
+
+    const providerRows = await client.query<{
+      status: string;
+      user_id: string | null;
+      terminal_reason: string | null;
+    }>(
+      "select status, user_id, terminal_reason from inbound_provider_events where provider_event_id = $1",
+      [eventId],
+    );
+    expect(providerRows.rows[0]).toEqual({
+      status: "quota_exceeded",
+      user_id: tenantA,
+      terminal_reason: "Monthly email quota exceeded for plan free",
+    });
   });
 
   it("rejects unsafe raw MIME URLs before fetching remote content", async () => {

--- a/tests/webhook-event-types.test.tsx
+++ b/tests/webhook-event-types.test.tsx
@@ -41,13 +41,15 @@ describe("webhook event type support", () => {
         events: ["delivered"],
       }).success,
     ).toBe(false);
+  });
 
+  it("accepts email.received subscriptions", () => {
     expect(
       createWebhookSchema.safeParse({
         endpoint: "https://example.com/webhooks",
         events: ["email.received"],
       }).success,
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("renders dashboard event labels from the shared supported set", () => {


### PR DESCRIPTION
## Summary
- Count inbound received messages against the shared transactional email quota when billing is enabled
- Allow email.received webhook subscriptions and queue pending deliveries after inbound commit
- Update webhook docs and tests for productized receiving events

## Verification
- bun run test -- tests/email-webhook-events.test.ts tests/webhook-event-types.test.tsx tests/docs-content.test.ts tests/inbound-ingestion.integration.test.ts
- set -a; source .env; set +a; bun run db:push
- set -a; source .env; set +a; bun run test -- tests/inbound-ingestion.integration.test.ts
- bun run docs:generate
- bun run docs:check
- make check
- make test