### PR TITLE
Add SES S3 inbound receiving ingestion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,8 @@ GOOGLE_CLIENT_SECRET=
 # INGESTER_JOB_TOKEN=replace-with-32-random-characters
 # Optional for local dev, but production /events/inbound rejects requests without it.
 # INGESTER_INBOUND_TOKEN=
+# Optional allowlist for SES receipt-rule S3 ingestion. Defaults to S3_BUCKET_NAME.
+# SES_INBOUND_BUCKET_NAME=
 # Durable scheduler cadence for /jobs/scheduled-emails, /jobs/webhooks, and /jobs/domain-verify.
 # INGESTER_SCHEDULER_INTERVAL_SECONDS=60
 # Bearer token required by /api/cron/* scheduled-email endpoints.

--- a/docs/ingester-deploy.md
+++ b/docs/ingester-deploy.md
@@ -91,6 +91,8 @@ BACKGROUND_WORKER_POLL=true
 INGESTER_JOB_TOKEN=<32+-char-random-bearer-token>
 # Required only when using /events/inbound in production.
 INGESTER_INBOUND_TOKEN=<32+-char-random-bearer-token>
+# Optional allowlist for SES receipt-rule S3 ingestion. Defaults to S3_BUCKET_NAME.
+SES_INBOUND_BUCKET_NAME=<private-raw-mail-bucket>
 ```
 
 For hosted Stripe billing cutover, also set these on the ingester service from
@@ -108,6 +110,53 @@ The Stripe webhook endpoint is:
 ```text
 https://events.yourdomain.com/webhooks/stripe
 ```
+
+## Inbound receiving through SES receipt rules
+
+For hosted receiving, route AWS SES receipt-rule notifications to the ingester instead of building a separate mailbox service. The supported production path is:
+
+1. SES receipt rule accepts mail for the receiving domain.
+2. The rule stores the raw MIME object in a private S3 bucket.
+3. The rule publishes an SNS notification for the S3 action.
+4. SNS delivers the signed notification to:
+
+```text
+https://events.yourdomain.com/events/inbound/ses-s3
+```
+
+The ingester verifies the SNS signature, checks the receipt notification's S3 bucket against `SES_INBOUND_BUCKET_NAME` or `S3_BUCKET_NAME`, reads the raw MIME object, then calls the same inbound MIME ingestion service as `POST /events/inbound`. That means receiving routes, quota accounting, attachment storage, forwarding, reply threading, and `email.received` webhook queueing all use one code path.
+
+Minimum AWS wiring:
+
+```bash
+aws sns create-topic --name opensend-inbound-mail
+aws sns subscribe \
+  --topic-arn <topic-arn> \
+  --protocol https \
+  --notification-endpoint https://events.yourdomain.com/events/inbound/ses-s3
+
+aws ses create-receipt-rule-set --rule-set-name opensend-inbound
+aws ses set-active-receipt-rule-set --rule-set-name opensend-inbound
+aws ses create-receipt-rule \
+  --rule-set-name opensend-inbound \
+  --rule '{
+    "Name": "opensend-example-com",
+    "Enabled": true,
+    "Recipients": ["example.com"],
+    "Actions": [
+      {
+        "S3Action": {
+          "BucketName": "<private-raw-mail-bucket>",
+          "ObjectKeyPrefix": "ses-inbound/example.com/",
+          "TopicArn": "<topic-arn>"
+        }
+      }
+    ],
+    "ScanEnabled": true
+  }'
+```
+
+Also grant SES permission to write to the bucket and SNS permission to publish from SES in your account/region. Keep the bucket private; OpenSend stores parsed attachment bodies through its normal storage boundary after ingestion.
 
 Run `bun run billing:preflight -- --service ingester` in the release
 environment before sending Stripe traffic to the endpoint. See

--- a/packages/ingester/src/index.ts
+++ b/packages/ingester/src/index.ts
@@ -1,3 +1,4 @@
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import {
   createBackgroundJob,
   createDomainService,
@@ -38,6 +39,9 @@ import {
 } from "./stripe-webhook";
 
 const app = new Hono();
+const inboundS3Client = new S3Client({
+  region: process.env.AWS_REGION ?? "us-east-1",
+});
 
 type SesSuppressionOutcome = {
   reason: "bounced" | "complained";
@@ -103,6 +107,99 @@ function isAuthorizedInboundRequest(authHeader: string | undefined): boolean {
   const token = process.env.INGESTER_INBOUND_TOKEN?.trim();
   if (!token) return process.env.NODE_ENV !== "production";
   return timingSafeStringEqual(authHeader, `Bearer ${token}`);
+}
+
+function readStringField(
+  value: Record<string, unknown>,
+  key: string,
+): string | null {
+  const field = value[key];
+  return typeof field === "string" && field.length > 0 ? field : null;
+}
+
+function readStringArrayField(
+  value: Record<string, unknown>,
+  key: string,
+): string[] | undefined {
+  const field = value[key];
+  if (!Array.isArray(field)) return undefined;
+  const strings = field.filter(
+    (item): item is string => typeof item === "string",
+  );
+  return strings.length > 0 ? strings : undefined;
+}
+
+function extractSesReceiptS3Action(message: Record<string, unknown>): {
+  bucketName: string;
+  objectKey: string;
+} {
+  const receipt = message.receipt;
+  if (!isRecord(receipt)) {
+    throw new SnsValidationError(
+      "SES receipt notification is missing receipt",
+      400,
+    );
+  }
+
+  const action = receipt.action;
+  if (!isRecord(action)) {
+    throw new SnsValidationError(
+      "SES receipt notification is missing action",
+      400,
+    );
+  }
+
+  const actionType = readStringField(action, "type");
+  const bucketName = readStringField(action, "bucketName");
+  const objectKey = readStringField(action, "objectKey");
+  if (actionType !== "S3" || !bucketName || !objectKey) {
+    throw new SnsValidationError(
+      "SES receipt notification must reference an S3 action",
+      400,
+    );
+  }
+
+  const expectedBucket =
+    process.env.SES_INBOUND_BUCKET_NAME?.trim() ||
+    process.env.S3_BUCKET_NAME?.trim();
+  if (expectedBucket && bucketName !== expectedBucket) {
+    throw new SnsValidationError("SES receipt S3 bucket is not allowed", 400);
+  }
+
+  return { bucketName, objectKey };
+}
+
+async function objectBodyToBuffer(body: unknown): Promise<Buffer> {
+  if (!body) throw new Error("S3 object body is empty");
+  if (Buffer.isBuffer(body)) return body;
+  if (body instanceof Uint8Array) return Buffer.from(body);
+  if (typeof body === "string") return Buffer.from(body, "utf8");
+  if (
+    typeof body === "object" &&
+    body !== null &&
+    "transformToByteArray" in body &&
+    typeof body.transformToByteArray === "function"
+  ) {
+    return Buffer.from(await body.transformToByteArray());
+  }
+  if (Symbol.asyncIterator in Object(body)) {
+    const chunks: Buffer[] = [];
+    for await (const chunk of body as AsyncIterable<Uint8Array | string>) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks);
+  }
+  throw new Error("Unsupported S3 object body");
+}
+
+async function readInboundS3Object(input: {
+  bucketName: string;
+  objectKey: string;
+}): Promise<Buffer> {
+  const response = await inboundS3Client.send(
+    new GetObjectCommand({ Bucket: input.bucketName, Key: input.objectKey }),
+  );
+  return await objectBodyToBuffer(response.Body);
 }
 
 async function runJobEndpoint<T>(
@@ -403,6 +500,148 @@ app.post("/events/inbound", async (c) => {
       },
     });
     return c.json({ ok: false, error: "Internal Server Error" }, 500);
+  }
+});
+
+app.post("/events/inbound/ses-s3", async (c) => {
+  const telemetry = createTelemetryContext({
+    service: "ingester",
+    operation: "POST /events/inbound/ses-s3",
+    headers: {
+      traceparent: c.req.header("traceparent"),
+      tracestate: c.req.header("tracestate"),
+      "x-correlation-id": c.req.header("x-correlation-id"),
+    },
+  });
+
+  try {
+    const body = await c.req.json();
+    const snsType = c.req.header("x-amz-sns-message-type");
+    const snsMessage = parseSnsEnvelope(body, snsType);
+
+    await verifySnsSignature(snsMessage);
+
+    if (snsMessage.Type === "SubscriptionConfirmation") {
+      logTelemetry(
+        "info",
+        "inbound.ses_s3.subscription_confirmation",
+        telemetry,
+        {
+          sns_message_id: snsMessage.MessageId,
+        },
+      );
+      if (snsMessage.SubscribeURL) {
+        if (!isAllowedSnsSubscribeUrl(snsMessage.SubscribeURL)) {
+          logTelemetry(
+            "warn",
+            "inbound.ses_s3.subscription_url_rejected",
+            telemetry,
+            {
+              sns_message_id: snsMessage.MessageId,
+            },
+          );
+        } else {
+          const response = await fetch(snsMessage.SubscribeURL);
+          logTelemetry(
+            "info",
+            "inbound.ses_s3.subscription_confirmed",
+            telemetry,
+            {
+              sns_message_id: snsMessage.MessageId,
+              confirm_status: response.status,
+            },
+          );
+        }
+      }
+      return c.text("OK");
+    }
+
+    if (snsMessage.Type === "UnsubscribeConfirmation") {
+      logTelemetry(
+        "warn",
+        "inbound.ses_s3.unsubscribe_confirmation",
+        telemetry,
+        {
+          sns_message_id: snsMessage.MessageId,
+        },
+      );
+      return c.text("OK");
+    }
+
+    const sesMessage = parseSesNotification(snsMessage.Message);
+    const rawSesMessage = JSON.parse(snsMessage.Message) as Record<
+      string,
+      unknown
+    >;
+    const { bucketName, objectKey } = extractSesReceiptS3Action(rawSesMessage);
+    const rawMime = await readInboundS3Object({ bucketName, objectKey });
+
+    const mail = isRecord(rawSesMessage.mail) ? rawSesMessage.mail : {};
+    const receipt = isRecord(rawSesMessage.receipt)
+      ? rawSesMessage.receipt
+      : {};
+    const recipients =
+      readStringArrayField(mail, "destination") ??
+      readStringArrayField(receipt, "recipients");
+
+    const outcome = await createInboundEmailIngestionService().process({
+      provider: "aws-ses-receiving",
+      eventId: snsMessage.MessageId,
+      messageId: sesMessage.mail.messageId,
+      recipients,
+      rawMimeBase64: rawMime.toString("base64"),
+      metadata: {
+        sns_message_id: snsMessage.MessageId,
+        sns_topic_arn: snsMessage.TopicArn,
+        ses_event_type: sesMessage.eventType,
+        ses_message_id: sesMessage.mail.messageId,
+        s3_bucket: bucketName,
+        s3_key: objectKey,
+      },
+    });
+
+    logTelemetry("info", "inbound.ses_s3.ingested", telemetry, {
+      inbound_status: outcome.status,
+      provider_event_id: outcome.provider_event_id,
+      received_email_id:
+        "received_email_id" in outcome ? outcome.received_email_id : undefined,
+      s3_bucket: bucketName,
+      s3_key: objectKey,
+    });
+
+    emitCloudWatchMetric(telemetry, {
+      metrics: [{ name: "InboundSesS3EventIngested", value: 1, unit: "Count" }],
+      dimensions: {
+        Service: "ingester",
+        Operation: "inbound.ses_s3",
+        Outcome: outcome.status,
+      },
+    });
+
+    const status = outcome.status === "processed" ? 202 : 200;
+    return c.json({ ok: outcome.status === "processed", ...outcome }, status);
+  } catch (error) {
+    if (error instanceof SnsValidationError) {
+      recordTelemetryError(
+        telemetry,
+        "inbound.ses_s3.validation_failed",
+        error,
+      );
+      return new Response(error.message, { status: error.status });
+    }
+
+    recordTelemetryError(telemetry, "inbound.ses_s3.failed", error);
+    emitCloudWatchMetric(telemetry, {
+      metrics: [
+        { name: "InboundSesS3EventIngestFailed", value: 1, unit: "Count" },
+      ],
+      dimensions: {
+        Service: "ingester",
+        Operation: "inbound.ses_s3",
+        Outcome: "failed",
+      },
+    });
+    return new Response("Internal Server Error", { status: 500 });
   }
 });
 

--- a/public/docs/dashboard/receiving/custom-domains.md
+++ b/public/docs/dashboard/receiving/custom-domains.md
@@ -19,7 +19,7 @@ OpenSend received-email rows must include the tenant `user_id`. Your inbound wor
 
 ## Dashboard status
 
-The dashboard can show receiving-capable domains, but MX validation and provider receipt-rule creation are still operator-owned. Label your internal runbook clearly so users know whether receiving is enabled for a domain or only prepared in DNS.
+The dashboard can show receiving-capable domains, but MX validation and provider receipt-rule creation are still operator-owned. For hosted SES receiving, create a receipt rule that stores raw MIME in S3 and publishes SNS notifications to the ingester `/events/inbound/ses-s3` endpoint. Label your internal runbook clearly so users know whether receiving is enabled for a domain or only prepared in DNS.
 
 ## Routing rules
 

--- a/public/docs/dashboard/receiving/introduction.md
+++ b/public/docs/dashboard/receiving/introduction.md
@@ -2,7 +2,7 @@
 
 Receiving is the OpenSend area for inbound email rows that your deployment stores for a verified domain.
 
-The current product surface includes a dashboard entry point, received-email read APIs, attachment metadata, short-lived attachment URLs, receiving routes, automatic forwarding rules, and a standalone ingester endpoint for provider-to-Postgres MIME ingestion. Operators still own MX records and provider receipt-rule wiring for their deployment.
+The current product surface includes a dashboard entry point, received-email read APIs, attachment metadata, short-lived attachment URLs, receiving routes, automatic forwarding rules, and standalone ingester endpoints for provider-to-Postgres MIME ingestion. Operators still own MX records and provider receipt-rule wiring for their deployment.
 
 ## What is implemented
 
@@ -12,11 +12,13 @@ The current product surface includes a dashboard entry point, received-email rea
 - First-class receiving routes for exact addresses, aliases, and catch-all fallback on verified receiving domains.
 - Automatic forwarding rules with persisted queued, skipped, and failed attempt visibility.
 - Standalone ingester MIME ingestion through `POST /events/inbound`, including route resolution, attachment storage, provider-event idempotency, terminal failure records, and an internal durable `received` event after commit.
+- SES receipt-rule ingestion through `POST /events/inbound/ses-s3`, where SNS points OpenSend at a raw MIME object saved by SES in S3.
+- Hosted quota accounting and `email.received` webhook delivery rows after inbound commit.
 
 ## What operators must add
 
 - MX records that route inbound messages to your provider.
-- Provider receiving rules, such as SES receipt rules that deliver raw messages or S3 object notifications to the ingester boundary.
+- Provider receiving rules, such as SES receipt rules that store raw messages in S3 and publish SNS notifications to the ingester boundary.
 - Deployment-specific authentication for provider callbacks. Production ingesters require `INGESTER_INBOUND_TOKEN` on inbound MIME callbacks, and provider-side network controls are still recommended.
 - Optional forwarding, reply workflows, or public webhook emission after storage; those are not part of the ingestion foundation.
 
@@ -24,7 +26,7 @@ The current product surface includes a dashboard entry point, received-email rea
 
 1. Verify the sending domain first so ownership and tenant mapping are clear.
 2. Add MX records only after deciding how inbound messages will be stored.
-3. Keep raw MIME and attachments in a private bucket.
+3. Keep raw MIME and attachments in a private bucket. For SES, set `SES_INBOUND_BUCKET_NAME` or reuse `S3_BUCKET_NAME` so the ingester only reads expected receipt-rule objects.
 4. Resolve route decisions with exact-address, alias, catch-all, then unrouteable precedence.
-5. Point provider notifications at the standalone ingester `/events/inbound` endpoint.
+5. Point provider notifications at the standalone ingester. Use `/events/inbound/ses-s3` for SES receipt-rule S3/SNS notifications, or `/events/inbound` for a trusted provider that can POST raw MIME directly.
 6. Read messages through the tenant API rather than handing mailbox credentials to apps or agents.

--- a/public/docs/dashboard/receiving/reply-to-emails.md
+++ b/public/docs/dashboard/receiving/reply-to-emails.md
@@ -33,7 +33,7 @@ Open an outbound email detail page to see the generated reply address and conver
 
 1. Verify the sending domain in OpenSend and enable the `receiving` capability.
 2. Publish inbound MX/provider records for that domain.
-3. Route provider notifications or raw MIME fetches to the standalone ingester `POST /events/inbound` endpoint.
+3. Route provider notifications or raw MIME fetches to the standalone ingester. Use `POST /events/inbound/ses-s3` for SES receipt-rule S3/SNS notifications, or `POST /events/inbound` for a trusted provider that can POST raw MIME directly.
 4. Configure `INGESTER_INBOUND_TOKEN` for production provider callbacks; production ingesters reject inbound MIME requests without it.
 5. Set `OPENSEND_REPLY_TOKEN_SECRET` consistently for the app and ingester processes. If omitted, OpenSend falls back to the auth secret variables when present; production deployments should use an explicit secret so reply tokens survive app restarts and deploys.
 6. Keep route/catch-all policies narrow enough to avoid receiving mail for unrelated tenants. Cross-tenant or invalid tokens are stored as unmatched messages for the resolved recipient-domain tenant; arbitrary unrouted mail without a reply token remains rejected as missing-domain.

--- a/src/components/domain-detail.tsx
+++ b/src/components/domain-detail.tsx
@@ -814,9 +814,10 @@ function RecordsTab({ domain }: { domain: DomainDetailData }) {
           </button>
         </div>
         <p className="text-[13px] text-fg-2 mb-4">
-          Receive inbound mail for this domain. Publish the MX record only after
-          your SES receipt rules and OpenSend ingester are ready; changing root
-          domain MX can move existing mailbox traffic.
+          Receive inbound mail for this domain. For hosted SES receiving, point
+          the receipt rule S3/SNS notification at the OpenSend ingester before
+          publishing MX; changing root domain MX can move existing mailbox
+          traffic.
         </p>
         <p className="text-[13px] text-blue-400 mb-2">Inbound MX</p>
         <DNSRecordTable

--- a/tests/ingester-ses-route.test.ts
+++ b/tests/ingester-ses-route.test.ts
@@ -18,6 +18,8 @@ const mockInvalidateDomainCaches = vi
   .mockResolvedValue(undefined);
 
 const mockCreateOrIgnoreDuplicate = vi.fn();
+const mockCreateInboundEmailIngestionService = vi.fn();
+const mockInboundProcess = vi.fn();
 const mockDomainReconcileAllPendingVerifications = vi.fn();
 const mockEnqueueDomainEvent = vi.fn();
 const mockWebhookList = vi.fn();
@@ -28,6 +30,18 @@ const mockEmitCloudWatchMetric = vi.fn();
 const mockLogTelemetry = vi.fn();
 const mockRecordTelemetryError = vi.fn();
 const mockSuppressFromSesEvent = vi.fn();
+const mockS3Send = vi.fn();
+
+vi.mock("@aws-sdk/client-s3", () => ({
+  GetObjectCommand: class MockGetObjectCommand {
+    constructor(readonly input: Record<string, unknown>) {}
+  },
+  S3Client: class MockS3Client {
+    send(command: unknown) {
+      return mockS3Send(command);
+    }
+  },
+}));
 
 vi.mock("@opensend/core", () => {
   const testTraceparent =
@@ -48,6 +62,7 @@ vi.mock("@opensend/core", () => {
       ...job,
       requestedAt: "2026-04-28T00:00:00.000Z",
     }),
+    createInboundEmailIngestionService: mockCreateInboundEmailIngestionService,
     createTelemetryContext: (input: {
       service: string;
       operation: string;
@@ -327,6 +342,22 @@ describe("SES SNS ingestion route", () => {
     mockLogTelemetry.mockReset();
     mockRecordTelemetryError.mockReset();
     mockSuppressFromSesEvent.mockResolvedValue([]);
+    mockInboundProcess.mockResolvedValue({
+      status: "processed",
+      provider_event_id: "sns-inbound-msg-1",
+      received_email_id: "received-1",
+      event_id: "event-1",
+      user_id: "user-1",
+      attachments: 0,
+    });
+    mockCreateInboundEmailIngestionService.mockReturnValue({
+      process: mockInboundProcess,
+    });
+    mockS3Send.mockResolvedValue({
+      Body: Buffer.from(
+        "From: sender@example.test\r\nTo: support@example.test\r\nSubject: SES inbound\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nHello",
+      ),
+    });
 
     vi.stubGlobal(
       "fetch",
@@ -488,6 +519,111 @@ describe("SES SNS ingestion route", () => {
 
     expect(response.status).toBe(401);
     expect(await response.text()).toBe("Unauthorized");
+  });
+
+  it("ingests signed SES receipt-rule S3 notifications through the inbound MIME service", async () => {
+    vi.stubEnv("SES_INBOUND_BUCKET_NAME", "opensend-inbound-mail");
+    const app = (await import("../packages/ingester/src/index")).default;
+    const envelope = createSignedEnvelope({
+      sesMessage: {
+        eventType: "Received",
+        mail: {
+          messageId: "ses-inbound-msg-1",
+          destination: ["support@example.test"],
+          headers: [],
+        },
+        receipt: {
+          recipients: ["support@example.test"],
+          action: {
+            type: "S3",
+            bucketName: "opensend-inbound-mail",
+            objectKey: "inbound/example/ses-inbound-msg-1",
+          },
+        },
+      },
+    });
+
+    const response = await app.request(
+      "http://localhost/events/inbound/ses-s3",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-amz-sns-message-type": "Notification",
+        },
+        body: JSON.stringify(envelope),
+      },
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      status: "processed",
+      received_email_id: "received-1",
+    });
+    expect(mockS3Send).toHaveBeenCalledTimes(1);
+    expect(mockS3Send.mock.calls[0]?.[0]).toMatchObject({
+      input: {
+        Bucket: "opensend-inbound-mail",
+        Key: "inbound/example/ses-inbound-msg-1",
+      },
+    });
+    expect(mockInboundProcess).toHaveBeenCalledWith({
+      provider: "aws-ses-receiving",
+      eventId: "sns-msg-1",
+      messageId: "ses-inbound-msg-1",
+      recipients: ["support@example.test"],
+      rawMimeBase64: Buffer.from(
+        "From: sender@example.test\r\nTo: support@example.test\r\nSubject: SES inbound\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nHello",
+      ).toString("base64"),
+      metadata: {
+        sns_message_id: "sns-msg-1",
+        sns_topic_arn: "arn:aws:sns:us-east-1:123456789012:ses-events",
+        ses_event_type: "Received",
+        ses_message_id: "ses-inbound-msg-1",
+        s3_bucket: "opensend-inbound-mail",
+        s3_key: "inbound/example/ses-inbound-msg-1",
+      },
+    });
+  });
+
+  it("rejects SES receipt-rule S3 notifications from an unexpected bucket", async () => {
+    vi.stubEnv("SES_INBOUND_BUCKET_NAME", "opensend-inbound-mail");
+    const app = (await import("../packages/ingester/src/index")).default;
+    const envelope = createSignedEnvelope({
+      sesMessage: {
+        eventType: "Received",
+        mail: {
+          messageId: "ses-inbound-msg-2",
+          destination: ["support@example.test"],
+          headers: [],
+        },
+        receipt: {
+          action: {
+            type: "S3",
+            bucketName: "attacker-bucket",
+            objectKey: "mail",
+          },
+        },
+      },
+    });
+
+    const response = await app.request(
+      "http://localhost/events/inbound/ses-s3",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-amz-sns-message-type": "Notification",
+        },
+        body: JSON.stringify(envelope),
+      },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("S3 bucket is not allowed");
+    expect(mockS3Send).not.toHaveBeenCalled();
+    expect(mockInboundProcess).not.toHaveBeenCalled();
   });
 
   it("verifies the SNS signature, persists a normalized event, and queues webhook delivery", async () => {


### PR DESCRIPTION
## Summary
- Add a signed SNS endpoint for SES receipt-rule S3 notifications at /events/inbound/ses-s3
- Read raw MIME from the receipt-rule S3 object and feed the existing inbound ingestion service
- Document the SES receipt-rule + S3 + SNS receiving setup and update dashboard receiving copy

## Verification
- bun run test -- tests/ingester-ses-route.test.ts tests/docs-content.test.ts tests/domain-detail.test.tsx tests/domain-dns-records.test.tsx
- make check
- bun run docs:check
- make test