### PR TITLE
Guard receiving MX setup with subdomain guidance

### DIFF
--- a/agent_docs/learnings/active/2026-06-07-receiving-root-mx-subdomain-boundary.md
+++ b/agent_docs/learnings/active/2026-06-07-receiving-root-mx-subdomain-boundary.md
@@ -1,0 +1,19 @@
+---
+date: 2026-06-07
+issue: receiving-subdomain-boundary
+type: decision
+promoted_to: null
+---
+
+# Receiving setup must not imply root MX is safe to move
+
+Hosted receiving has three separate readiness layers: SES/S3/SNS provider ingress,
+customer DNS MX routing, and OpenSend tenant receiving routes. A receipt rule and
+confirmed SNS subscription do not make messages visible to a tenant unless the
+recipient domain is a verified OpenSend domain with receiving enabled and a
+matching receiving route.
+
+Do not auto-publish or recommend replacing root-domain MX when existing mailbox
+MX records are present. Prefer a receiving subdomain such as
+`inbound.example.com` added as its own OpenSend domain, then publish MX for that
+subdomain only.

--- a/src/components/domain-detail.tsx
+++ b/src/components/domain-detail.tsx
@@ -611,6 +611,10 @@ function buildReceivingRecord(domain: DomainDetailData): DomainDnsRecord {
   };
 }
 
+function recommendedReceivingSubdomain(domainName: string): string {
+  return `inbound.${domainName}`;
+}
+
 function RecordsTab({ domain }: { domain: DomainDetailData }) {
   const router = useRouter();
   const [sendingEnabled, setSendingEnabled] = useState(domain.sendingEnabled);
@@ -814,11 +818,19 @@ function RecordsTab({ domain }: { domain: DomainDetailData }) {
           </button>
         </div>
         <p className="text-[13px] text-fg-2 mb-4">
-          Receive inbound mail for this domain. For hosted SES receiving, point
-          the receipt rule S3/SNS notification at the OpenSend ingester before
-          publishing MX; changing root domain MX can move existing mailbox
-          traffic.
+          Receive inbound mail for this exact domain after your provider receipt
+          rule is connected to the OpenSend ingester.
         </p>
+        <div className="mb-4 rounded-md border border-amber-400/30 bg-amber-400/10 px-3 py-2">
+          <p className="text-[12px] leading-5 text-amber-200">
+            Changing MX on a domain with an existing mailbox can move that
+            mailbox traffic to OpenSend. To keep current inboxes untouched, add{" "}
+            <span className="font-mono text-fg">
+              {recommendedReceivingSubdomain(domain.name)}
+            </span>{" "}
+            as a separate domain and enable receiving there instead.
+          </p>
+        </div>
         <p className="text-[13px] text-blue-400 mb-2">Inbound MX</p>
         <DNSRecordTable
           records={receivingRecords.length > 0 ? receivingRecords : null}

--- a/tests/domain-dns-records.test.tsx
+++ b/tests/domain-dns-records.test.tsx
@@ -230,6 +230,19 @@ describe("Domain DNS Records Tab (feature-025)", () => {
     expect(screen.getByText("Manual")).toBeTruthy();
   });
 
+  it("warns users to use a receiving subdomain when root MX may host mailboxes", () => {
+    render(
+      <DomainDetail
+        domain={{ ...domainWithRecords, receivingEnabled: true }}
+      />,
+    );
+
+    expect(screen.getByText(/Changing MX on a domain/)).toBeTruthy();
+    expect(
+      screen.getByText("inbound.updates.foreverbrowsing.com"),
+    ).toBeTruthy();
+  });
+
   it("does not show an inbound MX target before receiving is enabled", () => {
     render(<DomainDetail domain={domainWithRecords} />);
 


### PR DESCRIPTION
## Summary
- clarify that receiving MX applies to the exact domain being configured
- warn users that changing root-domain MX can move existing mailbox traffic
- recommend adding a receiving subdomain as a separate OpenSend domain when existing inboxes must stay untouched
- capture the root-MX/subdomain receiving boundary in learnings

## Verification
- bun run vitest run tests/domain-dns-records.test.tsx
- make check
- make test

## Live infra note
- SES receipt rules are active for opliora.com and inbound.opliora.com
- SNS subscription to events.opensend.namuh.co/events/inbound/ses-s3 is confirmed
- S3 policy permits SES writes for both ses-inbound/opliora.com/ and ses-inbound/inbound.opliora.com/
- Cloudflare MX for inbound.opliora.com was not published because the deployed CLOUDFLARE_API_TOKEN currently returns Authentication error
- opliora.com root MX remains on iCloud and was not changed