### PR TITLE
Fix SES receipt notification ingestion

### DIFF
--- a/packages/ingester/src/sns-message.ts
+++ b/packages/ingester/src/sns-message.ts
@@ -77,6 +77,20 @@ function readOptionalString(record: Record<string, unknown>, key: string) {
   throw new SnsValidationError(`SNS payload has invalid ${key}`, 400);
 }
 
+function readSesEventType(record: Record<string, unknown>): string {
+  for (const key of ["eventType", "notificationType"] as const) {
+    const value = record[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+
+  throw new SnsValidationError(
+    "SES notification is missing eventType or notificationType",
+    400,
+  );
+}
+
 function normalizeSnsType(type: string): SnsMessageType {
   if (
     type === "Notification" ||
@@ -242,7 +256,7 @@ export function parseSesNotification(rawMessage: string): SesNotification {
     );
   }
 
-  const eventType = readString(parsed, "eventType");
+  const eventType = readSesEventType(parsed);
   const mail = parsed.mail;
 
   if (!isRecord(mail)) {

--- a/tests/ingester-ses-route.test.ts
+++ b/tests/ingester-ses-route.test.ts
@@ -526,7 +526,7 @@ describe("SES SNS ingestion route", () => {
     const app = (await import("../packages/ingester/src/index")).default;
     const envelope = createSignedEnvelope({
       sesMessage: {
-        eventType: "Received",
+        notificationType: "Received",
         mail: {
           messageId: "ses-inbound-msg-1",
           destination: ["support@example.test"],


### PR DESCRIPTION
## Summary
- accept AWS SES receipt-rule SNS payloads that use notificationType instead of eventType
- keep internal SES event normalization unchanged by mapping notificationType to eventType
- update the inbound S3 notification test to match the real AWS payload shape

## Verification
- bunx vitest run tests/ingester-ses-route.test.ts
- make check
- bun run build:ingester

## Production evidence
- inbound.opliora.com MX resolves to SES
- SES stored live probe MIME in S3 at rc-storage-e469a71830a5/ses-inbound/inbound.opliora.com/of4dr83pjd779bvsosmmcecakt3e9idgsu2hea81
- existing ingester rejected the live SNS notification with: SNS payload is missing eventType
