### PR TITLE
Wire deliverability metrics to SES feedback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,9 @@ GOOGLE_CLIENT_SECRET=
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=
 # AWS_REGION=us-east-1
+# Optional SES/SNS destination for provider delivery feedback. Point this SNS
+# topic at the ingester's /events/ses endpoint in staging/production.
+# SES_EVENTS_SNS_TOPIC_ARN=
 #
 # NOTE: New AWS accounts are in SES *sandbox* mode and can only send
 # to verified addresses. Request production access in the SES console.

--- a/agent_docs/learnings/active/2026-06-07-deliverability-provider-feedback-wiring.md
+++ b/agent_docs/learnings/active/2026-06-07-deliverability-provider-feedback-wiring.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-07
+issue: deliverability-provider-feedback
+type: pattern
+promoted_to: null
+---
+
+## Treat deliverability as provider feedback, not email status
+
+**What:** Today and Metrics deliverability values must be backed by `email_events` rows created from SES/SNS provider feedback. Email row statuses are queue/provider-send state and should not be used as a proxy for delivery/open/click rates.
+
+**Why:** Production can successfully mark an email `sent` while the domain row has no SES configuration set, no SNS event destination, or no trusted email-id carrier. In that state the dashboard should show provider feedback as not wired instead of showing misleading zeros.
+
+**Pattern:** For production repair, run `bun run deliverability:preflight` first, then `--repair` after IAM and `SES_EVENTS_SNS_TOPIC_ARN` are configured. Validate DB write-back, SES `opensend-sns-events`, trusted `X-Entity-ID`/message-tag correlation, user-scoped `email_events`, and dashboard state together.

--- a/agent_docs/learnings/active/2026-06-07-tracking-secret-prod-send-failure.md
+++ b/agent_docs/learnings/active/2026-06-07-tracking-secret-prod-send-failure.md
@@ -1,0 +1,24 @@
+---
+date: 2026-06-07
+issue: prod-tracking-secret-send-failure
+type: mistake
+promoted_to: null
+---
+
+# Missing TRACKING_SECRET blocks tracked production sends before SES
+
+Open/click tracking in production requires `TRACKING_SECRET` to be set to at
+least 16 characters. If a sending domain has tracking enabled and the ingester
+task lacks that secret, the worker fails while rendering tracked HTML before
+SES accepts the message.
+
+On 2026-06-07, two customer sends were accepted and queued, then exhausted
+provider retries with:
+
+`TRACKING_SECRET must be set to at least 16 chars in production`
+
+The fix was to create `opensend/tracking-secret`, wire it into both
+`opensend-app` and `opensend-ingester` ECS task definitions, redeploy, and
+requeue the failed emails. Future production deploy paths must treat
+`TRACKING_SECRET` as a required app + ingester secret whenever tracking can be
+enabled.

--- a/docs/ingester-deploy.md
+++ b/docs/ingester-deploy.md
@@ -225,6 +225,52 @@ Don't leave SES pointing at the app/API host once the split is active —
 events would be processed by the dashboard's request loop instead of the
 worker.
 
+## Deliverability feedback preflight and repair
+
+Delivery, bounce, complaint, and delivery-delay dashboard metrics require each
+sending domain's SES configuration set to publish provider events to the
+ingester SNS topic. Configure both the app and ingester runtime with:
+
+```bash
+SES_EVENTS_SNS_TOPIC_ARN=arn:aws:sns:<region>:<account>:<topic-name>
+```
+
+Run the read-only preflight before redeploying or repairing production:
+
+```bash
+bun run deliverability:preflight -- --domain example.com --json --strict
+```
+
+The report lists verified domains, the previous
+`domains.ses_configuration_set_name` value, the resulting value, whether the
+database write-back exists, and the SES event-destination state. It does not
+print secrets.
+
+After IAM, SNS topic subscription, and app/ingester runtime env are in place, repair a
+single domain first:
+
+```bash
+bun run deliverability:preflight -- --repair --domain example.com --json --strict
+```
+
+Then repair the verified-domain batch:
+
+```bash
+bun run deliverability:preflight -- --repair --limit 500 --json --strict
+```
+
+Live validation for a production incident should prove all of these boundaries:
+
+- IAM on the app task role allows SES configuration-set and event-destination
+  read/create/update actions.
+- `SES_EVENTS_SNS_TOPIC_ARN` is present on the app and ingester task definitions.
+- SES shows the `opensend-sns-events` destination enabled on the repaired
+  configuration set and pointing at the SNS topic.
+- The repaired domain row has `ses_configuration_set_name` populated.
+- A new validation send carries `X-Entity-ID`/SES message tag correlation,
+  creates an `email_events` row with `user_id`, and appears in the Today or
+  Metrics dashboard without showing the provider-feedback **Not wired** state.
+
 ## Observability
 
 The app and ingester emit structured JSON logs, W3C/OpenTelemetry-compatible

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check": "node scripts/check-changed-files.mjs",
     "check:full": "bun run typecheck && bun run lint",
     "billing:preflight": "bun src/lib/billing/cutover-preflight.ts",
+    "deliverability:preflight": "bun src/lib/deliverability/repair-preflight.ts",
     "hooks:install": "node scripts/install-git-hooks.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/core/src/db/repositories/emailEventRepo.ts
+++ b/packages/core/src/db/repositories/emailEventRepo.ts
@@ -8,6 +8,17 @@ const STATUS_BY_EVENT_TYPE: Record<string, string> = {
   complained: "complained",
 };
 
+async function withDerivedUserId(data: typeof emailEvents.$inferInsert) {
+  if (data.userId || !data.emailId) return data;
+
+  const email = await db.query.emails.findFirst({
+    columns: { userId: true },
+    where: eq(emails.id, data.emailId),
+  });
+
+  return email?.userId ? { ...data, userId: email.userId } : data;
+}
+
 export const emailEventRepo = {
   async findById(id: string) {
     return await db.query.emailEvents.findFirst({
@@ -16,15 +27,19 @@ export const emailEventRepo = {
   },
 
   async create(data: typeof emailEvents.$inferInsert) {
+    const eventData = await withDerivedUserId(data);
     return await db.transaction(async (tx) => {
-      const [event] = await tx.insert(emailEvents).values(data).returning();
-      const nextStatus = STATUS_BY_EVENT_TYPE[data.type];
+      const [event] = await tx
+        .insert(emailEvents)
+        .values(eventData)
+        .returning();
+      const nextStatus = STATUS_BY_EVENT_TYPE[eventData.type];
 
-      if (nextStatus && data.emailId) {
+      if (nextStatus && eventData.emailId) {
         await tx
           .update(emails)
           .set({ status: nextStatus })
-          .where(eq(emails.id, data.emailId));
+          .where(eq(emails.id, eventData.emailId));
       }
 
       return event;
@@ -38,14 +53,15 @@ export const emailEventRepo = {
   },
 
   async createOrIgnoreDuplicate(data: typeof emailEvents.$inferInsert) {
+    const eventData = await withDerivedUserId(data);
     if (!data.sourceId) {
-      return { event: await this.create(data), created: true };
+      return { event: await this.create(eventData), created: true };
     }
 
     const insertedEvent = await db.transaction(async (tx) => {
       const [event] = await tx
         .insert(emailEvents)
-        .values(data)
+        .values(eventData)
         .onConflictDoNothing({ target: emailEvents.sourceId })
         .returning();
 
@@ -53,13 +69,13 @@ export const emailEventRepo = {
         return null;
       }
 
-      const nextStatus = STATUS_BY_EVENT_TYPE[data.type];
+      const nextStatus = STATUS_BY_EVENT_TYPE[eventData.type];
 
-      if (nextStatus && data.emailId) {
+      if (nextStatus && eventData.emailId) {
         await tx
           .update(emails)
           .set({ status: nextStatus })
-          .where(eq(emails.id, data.emailId));
+          .where(eq(emails.id, eventData.emailId));
       }
 
       return event;

--- a/packages/core/src/db/repositories/webhookRepo.ts
+++ b/packages/core/src/db/repositories/webhookRepo.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, lt } from "drizzle-orm";
+import { and, desc, eq, lt, sql } from "drizzle-orm";
 import { db } from "../client";
 import { webhooks } from "../schema";
 
@@ -78,6 +78,34 @@ export const webhookRepo = {
       .select()
       .from(webhooks)
       .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(desc(webhooks.id))
+      .limit(limit + 1);
+
+    const hasMore = results.length > limit;
+    const data = hasMore ? results.slice(0, limit) : results;
+
+    return { data, hasMore };
+  },
+
+  async listForUserDispatch(options: {
+    userId: string;
+    eventType: string;
+    limit?: number;
+    after?: string;
+  }) {
+    const { userId, eventType, limit = 20, after } = options;
+    const conditions = [
+      eq(webhooks.userId, userId),
+      eq(webhooks.status, "active"),
+      sql`${webhooks.eventTypes} ? ${eventType}`,
+    ];
+
+    if (after) conditions.push(lt(webhooks.id, after));
+
+    const results = await db
+      .select()
+      .from(webhooks)
+      .where(and(...conditions))
       .orderBy(desc(webhooks.id))
       .limit(limit + 1);
 

--- a/packages/core/src/services/configurationSet.ts
+++ b/packages/core/src/services/configurationSet.ts
@@ -2,11 +2,16 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import {
   CreateConfigurationSetCommand,
+  CreateConfigurationSetEventDestinationCommand,
   CreateDedicatedIpPoolCommand,
   DeleteConfigurationSetCommand,
   DeleteDedicatedIpPoolCommand,
+  type EventDestinationDefinition,
+  type EventType,
+  GetConfigurationSetEventDestinationsCommand,
   PutConfigurationSetDeliveryOptionsCommand,
   SESv2Client,
+  UpdateConfigurationSetEventDestinationCommand,
 } from "@aws-sdk/client-sesv2";
 
 const hasAwsCredentials =
@@ -17,6 +22,16 @@ const hasAwsCredentials =
 const useDevStub = process.env.NODE_ENV === "development" && !hasAwsCredentials;
 
 const DEFAULT_SES_REGION = "us-east-1";
+export const SES_EVENTS_DESTINATION_NAME = "opensend-sns-events";
+export const SES_EVENTS_MATCHING_EVENT_TYPES = [
+  "SEND",
+  "DELIVERY",
+  "BOUNCE",
+  "COMPLAINT",
+  "DELIVERY_DELAY",
+  "REJECT",
+  "RENDERING_FAILURE",
+] as const satisfies readonly EventType[];
 
 function normalizeSesRegion(region: string | null | undefined): string {
   const trimmed = region?.trim();
@@ -147,6 +162,115 @@ export class ConfigurationSetService {
   }
 
   /**
+   * Upsert the SNS event destination used by the SES/SNS ingester.
+   */
+  async upsertConfigurationSetEventDestination(input: {
+    configurationSetName: string;
+    topicArn: string;
+    region?: string;
+  }): Promise<void> {
+    const topicArn = input.topicArn.trim();
+    if (!topicArn) return;
+
+    const eventDestination = buildSesEventsSnsDestination(topicArn);
+
+    if (useDevStub) {
+      console.log(
+        `[DEV] Would upsert SES config set event destination: ${input.configurationSetName}/${SES_EVENTS_DESTINATION_NAME}`,
+      );
+      return;
+    }
+
+    const client = this.getClient(input.region);
+    const current = await client.send(
+      new GetConfigurationSetEventDestinationsCommand({
+        ConfigurationSetName: input.configurationSetName,
+      }),
+    );
+    const existing = current.EventDestinations?.find(
+      (destination) => destination.Name === SES_EVENTS_DESTINATION_NAME,
+    );
+
+    if (existing) {
+      await client.send(
+        new UpdateConfigurationSetEventDestinationCommand({
+          ConfigurationSetName: input.configurationSetName,
+          EventDestinationName: SES_EVENTS_DESTINATION_NAME,
+          EventDestination: eventDestination,
+        }),
+      );
+      return;
+    }
+
+    try {
+      await client.send(
+        new CreateConfigurationSetEventDestinationCommand({
+          ConfigurationSetName: input.configurationSetName,
+          EventDestinationName: SES_EVENTS_DESTINATION_NAME,
+          EventDestination: eventDestination,
+        }),
+      );
+    } catch (err) {
+      if (!isAlreadyExistsError(err)) throw err;
+      await client.send(
+        new UpdateConfigurationSetEventDestinationCommand({
+          ConfigurationSetName: input.configurationSetName,
+          EventDestinationName: SES_EVENTS_DESTINATION_NAME,
+          EventDestination: eventDestination,
+        }),
+      );
+    }
+  }
+
+  async getConfigurationSetEventDestinationState(input: {
+    configurationSetName: string;
+    region?: string;
+  }): Promise<{
+    configured: boolean;
+    enabled: boolean | null;
+    topicArn: string | null;
+    matchingEventTypes: string[];
+  }> {
+    if (useDevStub) {
+      return {
+        configured: false,
+        enabled: null,
+        topicArn: null,
+        matchingEventTypes: [],
+      };
+    }
+
+    const current = await this.getClient(input.region).send(
+      new GetConfigurationSetEventDestinationsCommand({
+        ConfigurationSetName: input.configurationSetName,
+      }),
+    );
+    const destination = current.EventDestinations?.find(
+      (item) => item.Name === SES_EVENTS_DESTINATION_NAME,
+    );
+
+    return {
+      configured: Boolean(destination),
+      enabled: destination?.Enabled ?? null,
+      topicArn: destination?.SnsDestination?.TopicArn ?? null,
+      matchingEventTypes: destination?.MatchingEventTypes ?? [],
+    };
+  }
+
+  async getDomainConfigurationSetEventDestinationState(input: {
+    domainId: string;
+    existingConfigSetName?: string | null;
+    region?: string;
+  }) {
+    const configurationSetName =
+      input.existingConfigSetName ?? `opensend-domain-${input.domainId}`;
+    return await this.getConfigurationSetEventDestinationState({
+      configurationSetName,
+      region: input.region,
+    });
+  }
+
+  /**
    * Delete a SES configuration set (best-effort, ignores not-found).
    */
   async deleteConfigurationSet(input: {
@@ -180,6 +304,7 @@ export class ConfigurationSetService {
     tls: string | null | undefined;
     dedicatedIpPoolSesName?: string | null;
     existingConfigSetName?: string | null;
+    eventDestinationTopicArn?: string | null;
     region?: string;
   }): Promise<string> {
     const configSetName =
@@ -216,8 +341,28 @@ export class ConfigurationSetService {
       }
     }
 
+    if (input.eventDestinationTopicArn?.trim()) {
+      await this.upsertConfigurationSetEventDestination({
+        configurationSetName: configSetName,
+        topicArn: input.eventDestinationTopicArn,
+        region: input.region,
+      });
+    }
+
     return configSetName;
   }
+}
+
+function buildSesEventsSnsDestination(
+  topicArn: string,
+): EventDestinationDefinition {
+  return {
+    Enabled: true,
+    MatchingEventTypes: [...SES_EVENTS_MATCHING_EVENT_TYPES],
+    SnsDestination: {
+      TopicArn: topicArn,
+    },
+  };
 }
 
 function isNotFoundException(error: unknown): boolean {

--- a/packages/core/src/services/dashboardAggregates.ts
+++ b/packages/core/src/services/dashboardAggregates.ts
@@ -1,6 +1,13 @@
-import { type SQL, and, eq, gte, inArray, lte, sql } from "drizzle-orm";
+import { type SQL, and, eq, gte, lte, sql } from "drizzle-orm";
 import { db } from "../db/client";
-import { contacts, domains, emails, plans, segments } from "../db/schema";
+import {
+  contacts,
+  domains,
+  emailEvents,
+  emails,
+  plans,
+  segments,
+} from "../db/schema";
 import { FREE_PLAN_DEFAULTS, FREE_PLAN_SLUG } from "../dto";
 
 // Last-resort fallback used only when the plans table is empty (cold start
@@ -55,7 +62,7 @@ async function defaultLoadPlanLimits(): Promise<PlanUsageLimits | null> {
   }
 }
 
-const EVENT_TYPE_TO_STATUS: Record<string, string[]> = {
+const EVENT_TYPE_TO_EVENT_TYPES: Record<string, string[]> = {
   received: ["delivered", "opened", "clicked"],
   delivered: ["delivered"],
   opened: ["opened"],
@@ -69,6 +76,25 @@ const EVENT_TYPE_TO_STATUS: Record<string, string[]> = {
 };
 
 const senderDomainSql = sql<string>`substring(${emails.from} from '@([^>]+)')`;
+
+function emailEventExists(eventTypes: string[]): SQL<unknown> {
+  return sql`exists (
+    select 1
+    from ${emailEvents}
+    where ${emailEvents.emailId} = ${emails.id}
+      and ${emailEvents.type} in ${eventTypes}
+  )`;
+}
+
+function bouncedEmailEventExists(extraCondition?: SQL<unknown>): SQL<unknown> {
+  return sql`exists (
+    select 1
+    from ${emailEvents}
+    where ${emailEvents.emailId} = ${emails.id}
+      and ${emailEvents.type} = 'bounced'
+      ${extraCondition ? sql`and ${extraCondition}` : sql``}
+  )`;
+}
 
 export type DashboardMetricsStats = {
   total: number;
@@ -317,12 +343,12 @@ const defaultDashboardAggregateRepository: DashboardAggregateRepository = {
     const [stats] = await db
       .select({
         total: sql<number>`count(*)::int`,
-        delivered: sql<number>`count(*) filter (where ${emails.status} = 'delivered')::int`,
-        bounced: sql<number>`count(*) filter (where ${emails.status} in ('bounced', 'hard_bounced', 'soft_bounced'))::int`,
-        hard_bounced: sql<number>`count(*) filter (where ${emails.status} = 'hard_bounced')::int`,
-        soft_bounced: sql<number>`count(*) filter (where ${emails.status} = 'soft_bounced')::int`,
-        undetermined_bounced: sql<number>`count(*) filter (where ${emails.status} = 'bounced')::int`,
-        complained: sql<number>`count(*) filter (where ${emails.status} = 'complained')::int`,
+        delivered: sql<number>`count(*) filter (where ${emailEventExists(["delivered"])})::int`,
+        bounced: sql<number>`count(*) filter (where ${bouncedEmailEventExists()})::int`,
+        hard_bounced: sql<number>`count(*) filter (where ${bouncedEmailEventExists(sql`${emailEvents.payload}->>'bounceType' = 'Permanent'`)})::int`,
+        soft_bounced: sql<number>`count(*) filter (where ${bouncedEmailEventExists(sql`${emailEvents.payload}->>'bounceType' = 'Transient'`)})::int`,
+        undetermined_bounced: sql<number>`count(*) filter (where ${bouncedEmailEventExists(sql`coalesce(${emailEvents.payload}->>'bounceType', '') not in ('Permanent', 'Transient')`)})::int`,
+        complained: sql<number>`count(*) filter (where ${emailEventExists(["complained"])})::int`,
       })
       .from(emails)
       .where(and(...metricConditions(input)));
@@ -333,7 +359,7 @@ const defaultDashboardAggregateRepository: DashboardAggregateRepository = {
   async listDailyCounts(input) {
     const conditions = metricConditions(input);
     if (input.statuses && input.statuses.length > 0) {
-      conditions.push(inArray(emails.status, input.statuses));
+      conditions.push(emailEventExists(input.statuses));
     }
 
     return await db
@@ -352,7 +378,7 @@ const defaultDashboardAggregateRepository: DashboardAggregateRepository = {
       .select({
         date: sql<string>`to_char(${emails.createdAt}::date, 'YYYY-MM-DD')`,
         total: sql<number>`count(*)::int`,
-        bounced: sql<number>`count(*) filter (where ${emails.status} in ('bounced', 'hard_bounced', 'soft_bounced'))::int`,
+        bounced: sql<number>`count(*) filter (where ${bouncedEmailEventExists()})::int`,
       })
       .from(emails)
       .where(and(...metricConditions(input)))
@@ -365,7 +391,7 @@ const defaultDashboardAggregateRepository: DashboardAggregateRepository = {
       .select({
         date: sql<string>`to_char(${emails.createdAt}::date, 'YYYY-MM-DD')`,
         total: sql<number>`count(*)::int`,
-        complained: sql<number>`count(*) filter (where ${emails.status} = 'complained')::int`,
+        complained: sql<number>`count(*) filter (where ${emailEventExists(["complained"])})::int`,
       })
       .from(emails)
       .where(and(...metricConditions(input)))
@@ -378,7 +404,7 @@ const defaultDashboardAggregateRepository: DashboardAggregateRepository = {
       .select({
         domain: senderDomainSql,
         total: sql<number>`count(*)::int`,
-        delivered: sql<number>`count(*) filter (where ${emails.status} = 'delivered')::int`,
+        delivered: sql<number>`count(*) filter (where ${emailEventExists(["delivered"])})::int`,
       })
       .from(emails)
       .where(and(...metricConditions(input)))
@@ -388,7 +414,10 @@ const defaultDashboardAggregateRepository: DashboardAggregateRepository = {
 
   async listTagBreakdown(input) {
     const rows = await db
-      .select({ tags: emails.tags, status: emails.status })
+      .select({
+        tags: emails.tags,
+        delivered: sql<boolean>`${emailEventExists(["delivered"])}`,
+      })
       .from(emails)
       .where(and(...metricConditions(input)))
       .orderBy(sql`${emails.createdAt} desc`)
@@ -407,7 +436,7 @@ const defaultDashboardAggregateRepository: DashboardAggregateRepository = {
           delivered: 0,
         };
         existing.total += 1;
-        if (row.status === "delivered") existing.delivered += 1;
+        if (row.delivered) existing.delivered += 1;
         statsByTag.set(key, existing);
       }
     }
@@ -476,7 +505,7 @@ function roundRate(numerator: number, denominator: number): number {
 
 function getEventStatuses(eventType: string | null): string[] | undefined {
   if (!eventType || eventType === "all") return undefined;
-  return EVENT_TYPE_TO_STATUS[eventType];
+  return EVENT_TYPE_TO_EVENT_TYPES[eventType];
 }
 
 function getUsageBounds(now: Date): DashboardUsageCountInput {

--- a/packages/core/src/services/domain-detail.ts
+++ b/packages/core/src/services/domain-detail.ts
@@ -4,7 +4,11 @@ import { dedicatedIpPoolRepo } from "../db/repositories/dedicatedIpPoolRepo";
 import { domainRepo } from "../db/repositories/domainRepo";
 import { domains } from "../db/schema";
 import { configurationSetService } from "./configurationSet";
-import { getEffectiveReturnPathLabel, syncTrackingCnameRecord } from "./domain";
+import {
+  getEffectiveReturnPathLabel,
+  getSesEventsSnsTopicArn,
+  syncTrackingCnameRecord,
+} from "./domain";
 import {
   cloudflareDnsCleanupProvider,
   domainIdentityProvider,
@@ -350,7 +354,7 @@ export function createDomainDetailService({
         };
       }
 
-      const updated = await updateDomainForUser({
+      let updated = await updateDomainForUser({
         id: input.id,
         userId: input.userId,
         updates,
@@ -379,13 +383,25 @@ export function createDomainDetailService({
             );
             dedicatedIpPoolSesName = pool?.sesPoolName ?? null;
           }
-          await configurationSetService.syncDomainConfigurationSet({
-            domainId: updated.id,
-            tls: updated.tls,
-            dedicatedIpPoolSesName,
-            existingConfigSetName: updated.sesConfigurationSetName ?? null,
-            region: updated.region,
-          });
+          const configSetName =
+            await configurationSetService.syncDomainConfigurationSet({
+              domainId: updated.id,
+              tls: updated.tls,
+              dedicatedIpPoolSesName,
+              existingConfigSetName: updated.sesConfigurationSetName ?? null,
+              eventDestinationTopicArn: getSesEventsSnsTopicArn(),
+              region: updated.region,
+            });
+          if (updated.sesConfigurationSetName !== configSetName) {
+            const updatedWithConfigSet = await updateDomainForUser({
+              id: input.id,
+              userId: input.userId,
+              updates: { sesConfigurationSetName: configSetName },
+            });
+            if (updatedWithConfigSet) {
+              updated = updatedWithConfigSet;
+            }
+          }
         } catch (configErr) {
           console.warn(
             `Failed to sync SES config set for domain ${updated.id}:`,

--- a/packages/core/src/services/domain.ts
+++ b/packages/core/src/services/domain.ts
@@ -1,3 +1,4 @@
+import { dedicatedIpPoolRepo } from "../db/repositories/dedicatedIpPoolRepo";
 import { domainRepo } from "../db/repositories/domainRepo";
 import type { domains } from "../db/schema";
 import { configurationSetService } from "./configurationSet";
@@ -56,6 +57,14 @@ export function getTrackingCnameTarget(): string {
     ) ||
     DEFAULT_TRACKING_CNAME_TARGET
   );
+}
+
+export function getSesEventsSnsTopicArn(): string | null {
+  const topicArn = process.env.SES_EVENTS_SNS_TOPIC_ARN?.trim();
+  if (!topicArn || topicArn === "undefined" || topicArn === "null") {
+    return null;
+  }
+  return topicArn;
 }
 
 export function buildTrackingSubdomainRecordName(
@@ -237,6 +246,7 @@ export type DomainServiceDependencies = {
     tls: string | null | undefined;
     dedicatedIpPoolSesName?: string | null;
     existingConfigSetName?: string | null;
+    eventDestinationTopicArn?: string | null;
     region?: string;
   }) => Promise<string>;
 };
@@ -370,6 +380,48 @@ export function createDomainService({
         "domain mutations without cache invalidation cause stale dashboard reads.",
     );
   }
+
+  async function resolveDedicatedIpPoolSesName(
+    domain: DomainRow,
+  ): Promise<string | null> {
+    if (!domain.dedicatedIpPoolId) return null;
+    const pool = await dedicatedIpPoolRepo.findById(domain.dedicatedIpPoolId);
+    return pool?.sesPoolName ?? null;
+  }
+
+  async function syncAndPersistDomainConfigurationSet(
+    domain: DomainRow,
+  ): Promise<DomainRow> {
+    try {
+      const configSetName = await syncDomainConfigurationSet({
+        domainId: domain.id,
+        tls: domain.tls,
+        dedicatedIpPoolSesName: await resolveDedicatedIpPoolSesName(domain),
+        existingConfigSetName: domain.sesConfigurationSetName ?? null,
+        eventDestinationTopicArn: getSesEventsSnsTopicArn(),
+        region: domain.region,
+      });
+
+      if (domain.sesConfigurationSetName === configSetName) {
+        return domain;
+      }
+
+      const [updated] = await repository.update(domain.id, {
+        sesConfigurationSetName: configSetName,
+      });
+      if (!updated) return domain;
+      return { ...domain, sesConfigurationSetName: configSetName };
+    } catch (configErr) {
+      // Config-set provisioning failure is non-fatal: callers may already have
+      // committed domain state. Log and proceed without claiming provider events.
+      console.warn(
+        `Failed to sync SES config set for domain ${domain.id}:`,
+        configErr,
+      );
+      return domain;
+    }
+  }
+
   return {
     async listDomains(options: {
       limit?: number;
@@ -427,33 +479,16 @@ export function createDomainService({
         dkimPrivateKeyIv: identity.dkimPrivateKeyEnc?.iv ?? null,
       });
 
-      // Provision the SES configuration set for TLS enforcement + pool assignment
-      try {
-        const configSetName = await syncDomainConfigurationSet({
-          domainId: row.id,
-          tls: row.tls,
-          dedicatedIpPoolSesName: null,
-          region: row.region,
-        });
-        await repository.update(row.id, {
-          sesConfigurationSetName: configSetName,
-        });
-      } catch (configErr) {
-        // Config-set provisioning failure is non-fatal: the domain row is
-        // already committed. Log and proceed without a config set.
-        console.warn(
-          `Failed to sync SES config set for domain ${row.id}:`,
-          configErr,
-        );
-      }
+      const domainWithConfigSet =
+        await syncAndPersistDomainConfigurationSet(row);
 
       await invalidateDomainCaches({
-        id: row.id,
-        name: row.name,
-        region: row.region,
+        id: domainWithConfigSet.id,
+        name: domainWithConfigSet.name,
+        region: domainWithConfigSet.region,
       });
 
-      return toDomainDetail(row);
+      return toDomainDetail(domainWithConfigSet);
     },
 
     async reconcileVerification(id: string): Promise<DomainReconcileResult> {
@@ -483,6 +518,10 @@ export function createDomainService({
       const statusChanged = domain.status !== nextStatus;
 
       if (!statusChanged && !recordsChanged) {
+        const repairedDomain =
+          nextStatus === "verified"
+            ? await syncAndPersistDomainConfigurationSet(domain)
+            : domain;
         console.log(
           JSON.stringify({
             level: "debug",
@@ -493,10 +532,10 @@ export function createDomainService({
         );
         await invalidateDomainCaches({
           id,
-          name: domain.name,
-          region: domain.region,
+          name: repairedDomain.name,
+          region: repairedDomain.region,
         });
-        return { status: "unchanged", domain };
+        return { status: "unchanged", domain: repairedDomain };
       }
 
       const previousStatus = domain.status;
@@ -514,19 +553,24 @@ export function createDomainService({
         return { status: "not_found" };
       }
 
+      const repairedUpdated =
+        nextStatus === "verified"
+          ? await syncAndPersistDomainConfigurationSet(updated)
+          : updated;
+
       await invalidateDomainCaches({
-        id: updated.id,
-        name: updated.name,
-        region: updated.region,
+        id: repairedUpdated.id,
+        name: repairedUpdated.name,
+        region: repairedUpdated.region,
       });
 
       if (!statusChanged) {
-        return { status: "unchanged", domain: updated };
+        return { status: "unchanged", domain: repairedUpdated };
       }
 
       return {
         status: "updated",
-        domain: updated,
+        domain: repairedUpdated,
         previousStatus,
       };
     },

--- a/packages/core/src/services/emailProvider.ts
+++ b/packages/core/src/services/emailProvider.ts
@@ -56,6 +56,7 @@ const hasAwsCredentials =
 const useDevStub = process.env.NODE_ENV === "development" && !hasAwsCredentials;
 
 const DEFAULT_SES_REGION = "us-east-1";
+const OPENSEND_ENTITY_ID_HEADER = "X-Entity-ID";
 
 function normalizeSesRegion(region: string | null | undefined): string {
   const trimmed = region?.trim();
@@ -88,7 +89,12 @@ export class EmailProviderService {
     attachments?: EmailAttachment[];
     region?: string;
     configurationSetName?: string | null;
+    emailId?: string | null;
   }) {
+    const headers = withOpenSendEntityIdHeader(params.headers, params.emailId);
+    const emailTags = params.emailId
+      ? [{ Name: OPENSEND_ENTITY_ID_HEADER, Value: params.emailId }]
+      : undefined;
     const command =
       params.attachments && params.attachments.length > 0
         ? new SendEmailCommand({
@@ -100,9 +106,12 @@ export class EmailProviderService {
             },
             Content: {
               Raw: {
-                Data: new TextEncoder().encode(buildMimeMessage(params)),
+                Data: new TextEncoder().encode(
+                  buildMimeMessage({ ...params, headers }),
+                ),
               },
             },
+            ...(emailTags ? { EmailTags: emailTags } : {}),
             ...(params.configurationSetName
               ? { ConfigurationSetName: params.configurationSetName }
               : {}),
@@ -121,8 +130,8 @@ export class EmailProviderService {
                   Html: params.html ? { Data: params.html } : undefined,
                   Text: params.text ? { Data: params.text } : undefined,
                 },
-                Headers: params.headers
-                  ? Object.entries(params.headers).map(([name, value]) => {
+                Headers: headers
+                  ? Object.entries(headers).map(([name, value]) => {
                       const safeName = sanitizeHeaderName(name);
                       return {
                         Name: safeName,
@@ -133,6 +142,7 @@ export class EmailProviderService {
               },
             },
             ReplyToAddresses: params.replyTo,
+            ...(emailTags ? { EmailTags: emailTags } : {}),
             ...(params.configurationSetName
               ? { ConfigurationSetName: params.configurationSetName }
               : {}),
@@ -321,6 +331,24 @@ function isAlreadyExistsError(error: unknown): boolean {
 }
 
 export const emailProvider = new EmailProviderService();
+
+function withOpenSendEntityIdHeader(
+  headers: Record<string, string> | undefined,
+  emailId: string | null | undefined,
+): Record<string, string> | undefined {
+  const nextHeaders = Object.fromEntries(
+    Object.entries(headers ?? {}).filter(
+      ([name]) =>
+        name.toLowerCase() !== OPENSEND_ENTITY_ID_HEADER.toLowerCase(),
+    ),
+  );
+
+  if (emailId) {
+    nextHeaders[OPENSEND_ENTITY_ID_HEADER] = emailId;
+  }
+
+  return Object.keys(nextHeaders).length > 0 ? nextHeaders : undefined;
+}
 
 function buildMimeMessage(params: {
   from: string;

--- a/packages/ingester/src/index.ts
+++ b/packages/ingester/src/index.ts
@@ -5,6 +5,7 @@ import {
   createInboundEmailIngestionService,
   createTelemetryContext,
   emailEventRepo,
+  emailRepo,
   emailService,
   emitCloudWatchMetric,
   enqueueDomainEvent,
@@ -107,6 +108,19 @@ function isAuthorizedInboundRequest(authHeader: string | undefined): boolean {
   const token = process.env.INGESTER_INBOUND_TOKEN?.trim();
   if (!token) return process.env.NODE_ENV !== "production";
   return timingSafeStringEqual(authHeader, `Bearer ${token}`);
+}
+
+function getExpectedSesEventsTopicArn(): string | null {
+  const raw = process.env.SES_EVENTS_SNS_TOPIC_ARN?.trim();
+  if (!raw || raw === "undefined" || raw === "null") return null;
+  return raw;
+}
+
+function assertAllowedSesEventsTopicArn(topicArn: string): void {
+  const expectedTopicArn = getExpectedSesEventsTopicArn();
+  if (!expectedTopicArn || topicArn !== expectedTopicArn) {
+    throw new SnsValidationError("SES SNS topic is not allowed", 403);
+  }
 }
 
 function readStringField(
@@ -662,6 +676,7 @@ app.post("/events/ses", async (c) => {
     const snsMessage = parseSnsEnvelope(body, snsType);
 
     await verifySnsSignature(snsMessage);
+    assertAllowedSesEventsTopicArn(snsMessage.TopicArn);
 
     if (snsMessage.Type === "SubscriptionConfirmation") {
       logTelemetry("info", "ses.sns.subscription_confirmation", telemetry, {
@@ -730,8 +745,28 @@ app.post("/events/ses", async (c) => {
       return c.text("OK");
     }
 
+    const email = await emailRepo.findById(emailId);
+    if (!email) {
+      logTelemetry("warn", "ses.event.unknown_email_id", telemetry, {
+        ses_message_id: sesId,
+        ses_event_type: eventType,
+        email_id: emailId,
+      });
+      return c.text("OK");
+    }
+
+    if (!email.userId) {
+      logTelemetry("warn", "ses.event.email_missing_user_id", telemetry, {
+        ses_message_id: sesId,
+        ses_event_type: eventType,
+        email_id: emailId,
+      });
+      return c.text("OK");
+    }
+
     const { event, created } = await emailEventRepo.createOrIgnoreDuplicate({
       emailId,
+      userId: email.userId,
       sourceId: snsMessage.MessageId,
       type: normalizedEvent.type,
       payload: sesMessage[normalizedEvent.payloadKey] || sesMessage,
@@ -780,25 +815,34 @@ app.post("/events/ses", async (c) => {
       return c.text("OK");
     }
 
-    const { data: hooks } = await webhookRepo.listForDispatch({ limit: 100 });
+    const { data: hooks } = await webhookRepo.listForUserDispatch({
+      userId: email.userId,
+      eventType: webhookEventType,
+      limit: 100,
+    });
     for (const hook of hooks) {
       const types = hook.eventTypes as string[];
-      if (hook.status === "active" && types.includes(webhookEventType)) {
-        const delivery = await webhookDispatcher.enqueue(hook.id, event.id);
-        await publishBackgroundJob(
-          createBackgroundJob({
-            id: `webhook.dispatch:${delivery.id}`,
-            type: "webhook.dispatch",
-            source: "ses-ingest",
-            deliveryId: delivery.id,
-            trace: getTelemetryCarrier(telemetry),
-          }),
-          {
-            deduplicationId: `webhook.dispatch:${delivery.id}`,
-            groupId: "webhook.dispatch",
-          },
-        );
+      if (
+        hook.userId !== email.userId ||
+        hook.status !== "active" ||
+        !types.includes(webhookEventType)
+      ) {
+        continue;
       }
+      const delivery = await webhookDispatcher.enqueue(hook.id, event.id);
+      await publishBackgroundJob(
+        createBackgroundJob({
+          id: `webhook.dispatch:${delivery.id}`,
+          type: "webhook.dispatch",
+          source: "ses-ingest",
+          deliveryId: delivery.id,
+          trace: getTelemetryCarrier(telemetry),
+        }),
+        {
+          deduplicationId: `webhook.dispatch:${delivery.id}`,
+          groupId: "webhook.dispatch",
+        },
+      );
     }
 
     return c.text("OK");

--- a/packages/ingester/src/queue-worker.ts
+++ b/packages/ingester/src/queue-worker.ts
@@ -460,6 +460,7 @@ export class QueueWorker {
         region: sesRegion,
         configurationSetName:
           deliveryDomain?.sesConfigurationSetName ?? undefined,
+        emailId: email.id,
       });
       const sendDurationMs = finishTelemetrySpan(sesSpan, { status: "ok" });
 

--- a/public/docs/ingester-deploy.md
+++ b/public/docs/ingester-deploy.md
@@ -10,6 +10,17 @@ Deploy the standalone ingester and queue worker. Provider callbacks should targe
 
 Set `INGESTER_INBOUND_TOKEN` to require `Authorization: Bearer <token>` on inbound MIME notifications. Production ingesters reject `/events/inbound` requests when the token is missing.
 
+## SES delivery feedback
+
+Delivery, bounce, complaint, and delivery-delay metrics require SES configuration sets to publish events to the ingester SNS topic. Set `SES_EVENTS_SNS_TOPIC_ARN` on both the app and ingester services, subscribe that topic to `https://events.yourdomain.com/events/ses`, then run:
+
+```bash
+bun run deliverability:preflight -- --domain example.com --json --strict
+bun run deliverability:preflight -- --repair --domain example.com --json --strict
+```
+
+The preflight/repair report lists the previous and resulting `ses_configuration_set_name`, database write-back status, and SES event-destination state. Start with one verified domain, prove a new validation send creates a user-scoped `email_events` row, then repair the verified-domain batch.
+
 ## Inbound payload
 
 ```json

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -41,6 +41,9 @@ APP_LOG_GROUP="${APP_LOG_GROUP:-/ecs/${APP_SERVICE}}"
 APP_LOG_STREAM_PREFIX="${APP_LOG_STREAM_PREFIX:-app}"
 WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ID="${WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ID:-${PRODUCT}/webhook/secret-encryption-key}"
 WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ARN="${WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ARN:-}"
+TRACKING_SECRET_SECRET_ID="${TRACKING_SECRET_SECRET_ID:-${PRODUCT}/tracking-secret}"
+TRACKING_SECRET_SECRET_ARN="${TRACKING_SECRET_SECRET_ARN:-}"
+SES_EVENTS_SNS_TOPIC_ARN="${SES_EVENTS_SNS_TOPIC_ARN:-}"
 
 ING_REPO="${PRODUCT}-ingester"
 ING_SERVICE="${PRODUCT}-ingester"
@@ -121,6 +124,19 @@ webhook_secret_encryption_key_secret_arn() {
     --output text
 }
 
+tracking_secret_secret_arn() {
+  if [[ -n "${TRACKING_SECRET_SECRET_ARN}" ]]; then
+    printf "%s\n" "${TRACKING_SECRET_SECRET_ARN}"
+    return
+  fi
+
+  aws secretsmanager describe-secret \
+    --secret-id "${TRACKING_SECRET_SECRET_ID}" \
+    --region "${AWS_REGION}" \
+    --query 'ARN' \
+    --output text
+}
+
 ingester_job_token_secret_arn() {
   if [[ -n "${INGESTER_JOB_TOKEN_SECRET_ARN}" ]]; then
     printf "%s\n" "${INGESTER_JOB_TOKEN_SECRET_ARN}"
@@ -159,7 +175,7 @@ write_service_network_configuration() {
 }
 
 write_app_task_definition() {
-  local base_task_definition="$1" app_image="$2" webhook_secret_arn="$3" output_file="$4"
+  local base_task_definition="$1" app_image="$2" webhook_secret_arn="$3" tracking_secret_arn="$4" ses_events_sns_topic_arn="$5" output_file="$6"
   local base_task_file
   base_task_file="$(mktemp)"
 
@@ -169,12 +185,19 @@ write_app_task_definition() {
     --query 'taskDefinition' \
     --output json > "${base_task_file}"
 
-  python3 - "${base_task_file}" "${app_image}" "${APP_CONTAINER_NAME}" "${webhook_secret_arn}" > "${output_file}" <<'PY'
+  python3 - "${base_task_file}" "${app_image}" "${APP_CONTAINER_NAME}" "${webhook_secret_arn}" "${tracking_secret_arn}" "${ses_events_sns_topic_arn}" > "${output_file}" <<'PY'
 import copy
 import json
 import sys
 
-base_task_file, app_image, container_name, webhook_secret_arn = sys.argv[1:5]
+(
+    base_task_file,
+    app_image,
+    container_name,
+    webhook_secret_arn,
+    tracking_secret_arn,
+    ses_events_sns_topic_arn,
+) = sys.argv[1:7]
 with open(base_task_file, "r", encoding="utf-8") as handle:
     task = json.load(handle)
 
@@ -210,17 +233,37 @@ if selected is None:
     raise SystemExit(f"base task definition has no {container_name!r} container")
 
 selected["image"] = app_image
+if ses_events_sns_topic_arn:
+    environment = selected.setdefault("environment", [])
+    required_environment = {
+        "name": "SES_EVENTS_SNS_TOPIC_ARN",
+        "value": ses_events_sns_topic_arn,
+    }
+    for index, item in enumerate(environment):
+        if item.get("name") == required_environment["name"]:
+            environment[index] = required_environment
+            break
+    else:
+        environment.append(required_environment)
+
 secrets = selected.setdefault("secrets", [])
-required_secret = {
-    "name": "WEBHOOK_SECRET_ENCRYPTION_KEY",
-    "valueFrom": webhook_secret_arn,
-}
-for index, secret in enumerate(secrets):
-    if secret.get("name") == required_secret["name"]:
-        secrets[index] = required_secret
-        break
-else:
-    secrets.append(required_secret)
+required_secrets = [
+    {
+        "name": "WEBHOOK_SECRET_ENCRYPTION_KEY",
+        "valueFrom": webhook_secret_arn,
+    },
+    {
+        "name": "TRACKING_SECRET",
+        "valueFrom": tracking_secret_arn,
+    },
+]
+for required_secret in required_secrets:
+    for index, secret in enumerate(secrets):
+        if secret.get("name") == required_secret["name"]:
+            secrets[index] = required_secret
+            break
+    else:
+        secrets.append(required_secret)
 
 definition["containerDefinitions"] = containers
 json.dump(definition, sys.stdout)
@@ -228,12 +271,13 @@ PY
 }
 
 register_app_task_definition() {
-  local app_image="$1" base_task_definition webhook_secret_arn task_file
+  local app_image="$1" base_task_definition webhook_secret_arn tracking_secret_arn task_file
   base_task_definition="$(app_task_definition)"
   webhook_secret_arn="$(webhook_secret_encryption_key_secret_arn)"
+  tracking_secret_arn="$(tracking_secret_secret_arn)"
   task_file="$(mktemp)"
 
-  write_app_task_definition "${base_task_definition}" "${app_image}" "${webhook_secret_arn}" "${task_file}"
+  write_app_task_definition "${base_task_definition}" "${app_image}" "${webhook_secret_arn}" "${tracking_secret_arn}" "${SES_EVENTS_SNS_TOPIC_ARN}" "${task_file}"
 
   aws ecs register-task-definition \
     --cli-input-json "file://${task_file}" \
@@ -252,7 +296,7 @@ ingester_task_definition() {
 }
 
 write_ingester_task_definition() {
-  local base_task_definition="$1" ingester_image="$2" job_token_arn="$3" inbound_token_arn="$4" app_task_definition="$5" output_file="$6"
+  local base_task_definition="$1" ingester_image="$2" job_token_arn="$3" inbound_token_arn="$4" tracking_secret_arn="$5" app_task_definition="$6" ses_events_sns_topic_arn="$7" output_file="$8"
   local base_task_file app_task_file
   base_task_file="$(mktemp)"
   app_task_file="$(mktemp)"
@@ -269,7 +313,7 @@ write_ingester_task_definition() {
     --query 'taskDefinition' \
     --output json > "${app_task_file}"
 
-  python3 - "${base_task_file}" "${app_task_file}" "${ingester_image}" "${ING_CONTAINER_NAME}" "${job_token_arn}" "${inbound_token_arn}" > "${output_file}" <<'PY'
+  python3 - "${base_task_file}" "${app_task_file}" "${ingester_image}" "${ING_CONTAINER_NAME}" "${job_token_arn}" "${inbound_token_arn}" "${tracking_secret_arn}" "${ses_events_sns_topic_arn}" > "${output_file}" <<'PY'
 import copy
 import json
 import sys
@@ -281,7 +325,9 @@ import sys
     container_name,
     job_token_arn,
     inbound_token_arn,
-) = sys.argv[1:7]
+    tracking_secret_arn,
+    ses_events_sns_topic_arn,
+) = sys.argv[1:9]
 with open(base_task_file, "r", encoding="utf-8") as handle:
     task = json.load(handle)
 with open(app_task_file, "r", encoding="utf-8") as handle:
@@ -332,9 +378,11 @@ required_environment = {
     "NODE_ENV": "production",
     "HOST": "0.0.0.0",
 }
-for name in ["AWS_REGION", "S3_BUCKET_NAME"]:
+for name in ["AWS_REGION", "S3_BUCKET_NAME", "SES_EVENTS_SNS_TOPIC_ARN"]:
     if name in app_environment:
         required_environment[name] = app_environment[name]
+if ses_events_sns_topic_arn:
+    required_environment["SES_EVENTS_SNS_TOPIC_ARN"] = ses_events_sns_topic_arn
 if "SES_INBOUND_BUCKET_NAME" in app_environment:
     required_environment["SES_INBOUND_BUCKET_NAME"] = app_environment[
         "SES_INBOUND_BUCKET_NAME"
@@ -352,7 +400,10 @@ required_secret = {
     "name": "INGESTER_JOB_TOKEN",
     "valueFrom": job_token_arn,
 }
-required_secrets = [required_secret]
+required_secrets = [
+    required_secret,
+    {"name": "TRACKING_SECRET", "valueFrom": tracking_secret_arn},
+]
 if inbound_token_arn:
     required_secrets.append(
         {"name": "INGESTER_INBOUND_TOKEN", "valueFrom": inbound_token_arn}
@@ -372,11 +423,12 @@ PY
 }
 
 register_ingester_task_definition() {
-  local ingester_image="$1" base_task_definition app_base_task_definition job_token_arn inbound_token_arn task_file
+  local ingester_image="$1" base_task_definition app_base_task_definition job_token_arn inbound_token_arn tracking_secret_arn task_file
   base_task_definition="$(ingester_task_definition)"
   app_base_task_definition="$(app_task_definition)"
   job_token_arn="$(ingester_job_token_secret_arn)"
   inbound_token_arn="$(ingester_inbound_token_secret_arn)"
+  tracking_secret_arn="$(tracking_secret_secret_arn)"
   task_file="$(mktemp)"
 
   write_ingester_task_definition \
@@ -384,7 +436,9 @@ register_ingester_task_definition() {
     "${ingester_image}" \
     "${job_token_arn}" \
     "${inbound_token_arn}" \
+    "${tracking_secret_arn}" \
     "${app_base_task_definition}" \
+    "${SES_EVENTS_SNS_TOPIC_ARN}" \
     "${task_file}"
 
   aws ecs register-task-definition \

--- a/src/app/(dashboard)/today/page.tsx
+++ b/src/app/(dashboard)/today/page.tsx
@@ -6,15 +6,26 @@ import {
   StatCard,
 } from "@/components/ui-new";
 import { getServerSession } from "@/lib/api-auth";
+import {
+  dashboardMetricStateLabel,
+  getOpenTrackingMetricState,
+  getProviderFeedbackMetricState,
+} from "@/lib/dashboard-deliverability-state";
+import {
+  type ProviderFeedbackCandidate,
+  areAllRecentSenderDomainsWired,
+  resolveProviderFeedbackWiring,
+} from "@/lib/dashboard-provider-feedback";
 import { db } from "@/lib/db";
 import { domains, emailEvents, emails } from "@/lib/db/schema";
-import { and, desc, eq, gte, sql } from "drizzle-orm";
+import { desc, eq, sql } from "drizzle-orm";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
 export const dynamic = "force-dynamic";
 
 const HOUR_MS = 60 * 60 * 1000;
+const RECENT_SENDER_DOMAIN_LIMIT = 50;
 
 type StatusKind = "verified" | "pending" | "warning";
 type HourBucket = {
@@ -24,22 +35,60 @@ type HourBucket = {
   bounced: number;
 };
 
-async function loadStats(userId: string) {
+type TodayStats = {
+  total: number;
+  delivered: number;
+  opened: number;
+  bounced: number;
+  openTrackingEnabled: boolean;
+};
+
+async function loadStats(userId: string): Promise<TodayStats> {
   const since = new Date(Date.now() - 24 * HOUR_MS);
   try {
-    const rows = await db
-      .select({
-        total: sql<number>`count(*)::int`,
-        delivered: sql<number>`count(*) filter (where ${emails.status} = 'delivered')::int`,
-        opened: sql<number>`count(*) filter (where ${emails.status} = 'opened')::int`,
-        bounced: sql<number>`count(*) filter (where ${emails.status} = 'bounced')::int`,
-      })
-      .from(emails)
-      .where(and(eq(emails.userId, userId), gte(emails.createdAt, since)));
-    const r = rows[0] ?? { total: 0, delivered: 0, opened: 0, bounced: 0 };
-    return r;
+    const result = await db.execute(sql`
+      SELECT
+        count(distinct e.id)::int AS total,
+        count(distinct e.id) FILTER (WHERE ev.type = 'delivered')::int AS delivered,
+        count(distinct e.id) FILTER (WHERE ev.type = 'opened')::int AS opened,
+        count(distinct e.id) FILTER (WHERE ev.type = 'bounced')::int AS bounced,
+        exists (
+          SELECT 1
+          FROM ${domains} d
+          JOIN ${emails} se
+            ON se.user_id = d.user_id
+           AND (
+             lower(se.from) LIKE '%@' || lower(d.name)
+             OR lower(se.from) LIKE '%@' || lower(d.name) || '>'
+           )
+          WHERE d.user_id = ${userId}
+            AND d.track_opens = true
+            AND se.created_at >= ${since}
+        ) AS open_tracking_enabled
+      FROM ${emails} e
+      LEFT JOIN ${emailEvents} ev ON ev.email_id = e.id
+      WHERE e.user_id = ${userId} AND e.created_at >= ${since}
+    `);
+    const rows = ((result as unknown as { rows?: unknown[] }).rows ??
+      result) as unknown[];
+    const row = (rows as Array<Record<string, unknown>>)[0];
+    return {
+      total: Number(row?.total ?? 0),
+      delivered: Number(row?.delivered ?? 0),
+      opened: Number(row?.opened ?? 0),
+      bounced: Number(row?.bounced ?? 0),
+      openTrackingEnabled:
+        row?.open_tracking_enabled === true ||
+        row?.open_tracking_enabled === "true",
+    };
   } catch {
-    return { total: 0, delivered: 0, opened: 0, bounced: 0 };
+    return {
+      total: 0,
+      delivered: 0,
+      opened: 0,
+      bounced: 0,
+      openTrackingEnabled: false,
+    };
   }
 }
 
@@ -55,17 +104,19 @@ async function loadHourly(userId: string): Promise<HourBucket[]> {
   try {
     const result = await db.execute(sql`
       SELECT
-        date_trunc('hour', created_at) AS bucket,
-        count(*)::int AS sent,
-        count(*) FILTER (WHERE status = 'delivered')::int AS delivered,
-        count(*) FILTER (WHERE status = 'opened')::int AS opened,
-        count(*) FILTER (WHERE status = 'bounced')::int AS bounced
-      FROM emails
-      WHERE user_id = ${userId} AND created_at >= ${since}
+        date_trunc('hour', e.created_at) AS bucket,
+        count(distinct e.id)::int AS sent,
+        count(distinct e.id) FILTER (WHERE ev.type = 'delivered')::int AS delivered,
+        count(distinct e.id) FILTER (WHERE ev.type = 'opened')::int AS opened,
+        count(distinct e.id) FILTER (WHERE ev.type = 'bounced')::int AS bounced
+      FROM ${emails} e
+      LEFT JOIN ${emailEvents} ev ON ev.email_id = e.id
+      WHERE e.user_id = ${userId} AND e.created_at >= ${since}
       GROUP BY bucket
       ORDER BY bucket ASC
     `);
-    const rows = (result as unknown as { rows?: unknown[] }).rows ?? result;
+    const rows = ((result as unknown as { rows?: unknown[] }).rows ??
+      result) as unknown[];
     const byBucket = new Map<number, HourBucket>();
     for (const raw of rows as Array<{
       bucket: Date | string;
@@ -131,21 +182,87 @@ type DomainRow = {
   id: string;
   name: string;
   status: string;
+  region: string;
+  configurationSetName: string | null;
   total: number;
   delivered: number;
   opened: number;
+  providerFeedbackWired: boolean;
+  providerFeedbackUnknown: boolean;
+  openTrackingEnabled: boolean;
 };
 
-async function loadDomainReputation(userId: string): Promise<DomainRow[]> {
+type DomainReputationRow = Omit<
+  DomainRow,
+  "providerFeedbackWired" | "providerFeedbackUnknown"
+>;
+type RecentSenderDomainsResult = {
+  candidates: ProviderFeedbackCandidate[];
+  truncated: boolean;
+  loadFailed: boolean;
+};
+
+async function loadRecentSenderDomains(
+  userId: string,
+): Promise<RecentSenderDomainsResult> {
+  const since = new Date(Date.now() - 24 * HOUR_MS);
+  try {
+    const result = await db.execute(sql`
+      SELECT
+        d.id::text AS id,
+        d.name AS name,
+        d.region AS region,
+        d.ses_configuration_set_name AS "configurationSetName",
+        max(e.created_at) AS "lastSentAt"
+      FROM ${domains} d
+      JOIN ${emails} e
+        ON e.user_id = d.user_id
+       AND e.created_at >= ${since}
+       AND (
+         lower(e.from) LIKE '%@' || lower(d.name)
+         OR lower(e.from) LIKE '%@' || lower(d.name) || '>'
+       )
+      WHERE d.user_id = ${userId}
+      GROUP BY d.id, d.name, d.region, d.ses_configuration_set_name
+      ORDER BY max(e.created_at) DESC
+      LIMIT ${RECENT_SENDER_DOMAIN_LIMIT + 1}
+    `);
+    const rawRows = (result as unknown as { rows?: unknown[] }).rows;
+    const rows: unknown[] = rawRows ?? (result as unknown as unknown[]);
+    const boundedRows = (rows as ProviderFeedbackCandidate[]).slice(
+      0,
+      RECENT_SENDER_DOMAIN_LIMIT,
+    );
+    return {
+      candidates: boundedRows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        region: row.region,
+        configurationSetName: row.configurationSetName ?? null,
+      })),
+      truncated: rows.length > RECENT_SENDER_DOMAIN_LIMIT,
+      loadFailed: false,
+    };
+  } catch {
+    return { candidates: [], truncated: false, loadFailed: true };
+  }
+}
+
+async function loadDomainReputation(
+  userId: string,
+): Promise<DomainReputationRow[]> {
   try {
     const result = await db.execute(sql`
       SELECT
         d.id::text AS id,
         d.name AS name,
         d.status AS status,
-        count(e.id)::int AS total,
-        count(e.id) FILTER (WHERE e.status = 'delivered')::int AS delivered,
-        count(e.id) FILTER (WHERE e.status = 'opened')::int AS opened
+        d.region AS region,
+        d.ses_configuration_set_name AS "configurationSetName",
+        d.track_opens = true AS "openTrackingEnabled",
+        count(distinct e.id)::int AS total,
+        count(distinct e.id) FILTER (WHERE ev.type = 'delivered')::int AS delivered,
+        count(distinct e.id) FILTER (WHERE ev.type = 'opened')::int AS opened
       FROM ${domains} d
       LEFT JOIN ${emails} e
         ON e.user_id = d.user_id
@@ -153,19 +270,25 @@ async function loadDomainReputation(userId: string): Promise<DomainRow[]> {
          lower(e.from) LIKE '%@' || lower(d.name)
          OR lower(e.from) LIKE '%@' || lower(d.name) || '>'
        )
+      LEFT JOIN ${emailEvents} ev ON ev.email_id = e.id
       WHERE d.user_id = ${userId}
-      GROUP BY d.id, d.name, d.status, d.created_at
+      GROUP BY d.id, d.name, d.status, d.region, d.ses_configuration_set_name, d.track_opens, d.created_at
       ORDER BY d.created_at DESC
       LIMIT 6
     `);
     const rows = (result as unknown as { rows?: unknown[] }).rows ?? result;
-    return (rows as DomainRow[]).map((r) => ({
+    return (rows as DomainReputationRow[]).map((r) => ({
       id: r.id,
       name: r.name,
       status: r.status,
+      region: r.region,
+      configurationSetName: r.configurationSetName ?? null,
       total: Number(r.total),
       delivered: Number(r.delivered),
       opened: Number(r.opened),
+      openTrackingEnabled:
+        r.openTrackingEnabled === true ||
+        String(r.openTrackingEnabled) === "true",
     }));
   } catch {
     return [];
@@ -238,12 +361,48 @@ export default async function TodayPage() {
   if (!session) redirect("/auth");
 
   const userId = session.user.id;
-  const [stats, hourly, activity, domainRows] = await Promise.all([
-    loadStats(userId),
-    loadHourly(userId),
-    loadActivity(userId),
-    loadDomainReputation(userId),
-  ]);
+  const [stats, hourly, activity, rawDomainRows, recentSenderDomainsResult] =
+    await Promise.all([
+      loadStats(userId),
+      loadHourly(userId),
+      loadActivity(userId),
+      loadDomainReputation(userId),
+      loadRecentSenderDomains(userId),
+    ]);
+  const recentSenderDomains = recentSenderDomainsResult.candidates;
+  const providerFeedbackReadErrorIds = new Set<string>();
+  const providerFeedbackWiring = await resolveProviderFeedbackWiring(
+    [
+      ...rawDomainRows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        region: row.region,
+        configurationSetName: row.configurationSetName,
+      })),
+      ...recentSenderDomains,
+    ],
+    {
+      onReadError: (candidate, error) => {
+        providerFeedbackReadErrorIds.add(candidate.id);
+        console.warn(
+          `Failed to read SES event destination for ${candidate.name}:`,
+          error,
+        );
+      },
+    },
+  );
+  const domainRows: DomainRow[] = rawDomainRows.map((row) => ({
+    ...row,
+    providerFeedbackWired: providerFeedbackWiring.get(row.id) ?? false,
+    providerFeedbackUnknown: providerFeedbackReadErrorIds.has(row.id),
+  }));
+  const providerFeedbackUnknown =
+    recentSenderDomainsResult.truncated ||
+    recentSenderDomainsResult.loadFailed ||
+    providerFeedbackReadErrorIds.size > 0;
+  const providerFeedbackWired =
+    !providerFeedbackUnknown &&
+    areAllRecentSenderDomainsWired(recentSenderDomains, providerFeedbackWiring);
   const firstName =
     (session.user.name || session.user.email || "there").split(/[\s@]/)[0] ||
     "there";
@@ -259,6 +418,17 @@ export default async function TodayPage() {
   const openedSpark = hourly.map((h) => h.opened);
   const bouncedSpark = hourly.map((h) => h.bounced);
   const chartMax = Math.max(1, ...sentSpark);
+  const deliveryState = getProviderFeedbackMetricState({
+    total: stats.total,
+    providerFeedbackWired,
+    providerFeedbackUnknown,
+  });
+  const openState = getOpenTrackingMetricState({
+    total: stats.total,
+    openTrackingEnabled: stats.openTrackingEnabled,
+  });
+  const deliveryStateLabel = dashboardMetricStateLabel(deliveryState);
+  const openStateLabel = dashboardMetricStateLabel(openState);
 
   const apiBase = getApiBaseUrl();
   const apiSendUrl = `${apiBase}/emails`;
@@ -296,20 +466,30 @@ export default async function TodayPage() {
           <StatCard
             kicker="Delivered"
             value={
-              <>
-                {formatPct(stats.delivered, stats.total)}
-                <span className="text-[24px] text-fg-3">%</span>
-              </>
+              deliveryStateLabel ? (
+                <span className="text-[18px] text-fg-3">
+                  {deliveryStateLabel}
+                </span>
+              ) : (
+                <>
+                  {formatPct(stats.delivered, stats.total)}
+                  <span className="text-[24px] text-fg-3">%</span>
+                </>
+              )
             }
             spark={deliveredSpark}
           />
           <StatCard
             kicker="Opens"
             value={
-              <>
-                {formatPct(stats.opened, stats.total)}
-                <span className="text-[24px] text-fg-3">%</span>
-              </>
+              openStateLabel ? (
+                <span className="text-[18px] text-fg-3">{openStateLabel}</span>
+              ) : (
+                <>
+                  {formatPct(stats.opened, stats.total)}
+                  <span className="text-[24px] text-fg-3">%</span>
+                </>
+              )
             }
             spark={openedSpark}
           />
@@ -452,6 +632,19 @@ export default async function TodayPage() {
                     d.total > 0 ? (d.delivered / d.total) * 100 : null;
                   const openedPct =
                     d.total > 0 ? (d.opened / d.total) * 100 : null;
+                  const rowDeliveryLabel = dashboardMetricStateLabel(
+                    getProviderFeedbackMetricState({
+                      total: d.total,
+                      providerFeedbackWired: d.providerFeedbackWired,
+                      providerFeedbackUnknown: d.providerFeedbackUnknown,
+                    }),
+                  );
+                  const rowOpenLabel = dashboardMetricStateLabel(
+                    getOpenTrackingMetricState({
+                      total: d.total,
+                      openTrackingEnabled: d.openTrackingEnabled,
+                    }),
+                  );
                   return (
                     <div
                       key={d.id}
@@ -474,12 +667,14 @@ export default async function TodayPage() {
                       <Meter
                         label="delivered"
                         value={deliveredPct}
+                        stateLabel={rowDeliveryLabel}
                         color="var(--accent)"
                         max={100}
                       />
                       <Meter
                         label="opens"
                         value={openedPct}
+                        stateLabel={rowOpenLabel}
                         color="var(--violet)"
                         max={100}
                       />
@@ -522,11 +717,13 @@ export default async function TodayPage() {
 function Meter({
   label,
   value,
+  stateLabel,
   max,
   color,
 }: {
   label: string;
   value: number | null;
+  stateLabel?: string | null;
   max: number;
   color: string;
 }) {
@@ -535,7 +732,9 @@ function Meter({
       <div className="mono mb-1 text-[10.5px] uppercase tracking-[0.12em] text-fg-3">
         {label}
       </div>
-      {value === null ? (
+      {stateLabel ? (
+        <span className="text-[12px] text-fg-4">{stateLabel}</span>
+      ) : value === null ? (
         <span className="text-[12px] text-fg-4">—</span>
       ) : (
         <div className="flex items-center gap-2.5">

--- a/src/lib/cache/dashboard-aggregates.ts
+++ b/src/lib/cache/dashboard-aggregates.ts
@@ -1,6 +1,6 @@
 import { getCached, setCache } from "@/lib/cache/redis";
 
-const DASHBOARD_AGGREGATE_CACHE_PREFIX = "dashboard-aggregate:v1";
+const DASHBOARD_AGGREGATE_CACHE_PREFIX = "dashboard-aggregate:v2";
 
 export const DASHBOARD_METRICS_CACHE_TTL_SECONDS = 60;
 export const BROADCAST_METRICS_CACHE_TTL_SECONDS = 120;

--- a/src/lib/dashboard-deliverability-state.ts
+++ b/src/lib/dashboard-deliverability-state.ts
@@ -1,0 +1,34 @@
+export type DashboardMetricState = "ready" | "not_wired" | "unknown" | "off";
+
+export function getProviderFeedbackMetricState(input: {
+  total: number;
+  providerFeedbackWired: boolean;
+  providerFeedbackUnknown?: boolean;
+}): DashboardMetricState {
+  if (input.total > 0 && input.providerFeedbackUnknown) {
+    return "unknown";
+  }
+  if (input.total > 0 && !input.providerFeedbackWired) {
+    return "not_wired";
+  }
+  return "ready";
+}
+
+export function getOpenTrackingMetricState(input: {
+  total: number;
+  openTrackingEnabled: boolean;
+}): DashboardMetricState {
+  if (input.total > 0 && !input.openTrackingEnabled) {
+    return "off";
+  }
+  return "ready";
+}
+
+export function dashboardMetricStateLabel(
+  state: DashboardMetricState,
+): string | null {
+  if (state === "not_wired") return "Not wired";
+  if (state === "unknown") return "Unknown";
+  if (state === "off") return "Off";
+  return null;
+}

--- a/src/lib/dashboard-provider-feedback.ts
+++ b/src/lib/dashboard-provider-feedback.ts
@@ -1,0 +1,139 @@
+import {
+  SES_EVENTS_MATCHING_EVENT_TYPES,
+  configurationSetService,
+  getSesEventsSnsTopicArn,
+} from "@opensend/core";
+
+export type ProviderFeedbackCandidate = {
+  id: string;
+  name: string;
+  region: string;
+  configurationSetName: string | null;
+};
+
+export type ProviderFeedbackDestinationState = {
+  configured: boolean;
+  enabled: boolean | null;
+  topicArn: string | null;
+  matchingEventTypes: string[];
+};
+
+export type ProviderFeedbackStateReader = (input: {
+  configurationSetName: string;
+  region?: string;
+}) => Promise<ProviderFeedbackDestinationState>;
+
+const DEFAULT_PROVIDER_FEEDBACK_CACHE_TTL_MS = 30_000;
+const providerFeedbackWiringCache = new Map<
+  string,
+  { expiresAt: number; promise: Promise<boolean> }
+>();
+
+export function clearProviderFeedbackWiringCache(): void {
+  providerFeedbackWiringCache.clear();
+}
+
+export function isSesEventsDestinationWired(
+  state: ProviderFeedbackDestinationState | null,
+  expectedTopicArn: string | null,
+): boolean {
+  if (!expectedTopicArn || !state?.configured || state.enabled !== true) {
+    return false;
+  }
+  if (state.topicArn !== expectedTopicArn) {
+    return false;
+  }
+  return SES_EVENTS_MATCHING_EVENT_TYPES.every((eventType) =>
+    state.matchingEventTypes.includes(eventType),
+  );
+}
+
+export function areAllRecentSenderDomainsWired(
+  candidates: ProviderFeedbackCandidate[],
+  wiredByDomain: Map<string, boolean>,
+): boolean {
+  return (
+    candidates.length > 0 &&
+    candidates.every((candidate) => wiredByDomain.get(candidate.id) === true)
+  );
+}
+
+export async function resolveProviderFeedbackWiring(
+  candidates: ProviderFeedbackCandidate[],
+  options: {
+    topicArn?: string | null;
+    cacheTtlMs?: number;
+    readState?: ProviderFeedbackStateReader;
+    onReadError?: (
+      candidate: ProviderFeedbackCandidate,
+      error: unknown,
+    ) => void;
+  } = {},
+): Promise<Map<string, boolean>> {
+  const topicArn = options.topicArn ?? getSesEventsSnsTopicArn();
+  const readState =
+    options.readState ??
+    ((input) =>
+      configurationSetService.getConfigurationSetEventDestinationState(input));
+  const cacheTtlMs =
+    options.cacheTtlMs ?? DEFAULT_PROVIDER_FEEDBACK_CACHE_TTL_MS;
+  const now = Date.now();
+  for (const [cacheKey, cached] of providerFeedbackWiringCache) {
+    if (cached.expiresAt <= now) {
+      providerFeedbackWiringCache.delete(cacheKey);
+    }
+  }
+  const wiredByDomain = new Map<string, boolean>();
+  const wiredByConfigSet = new Map<string, Promise<boolean>>();
+  const assignments: Array<Promise<void>> = [];
+
+  for (const candidate of candidates) {
+    const configSetName = candidate.configurationSetName?.trim() || null;
+    if (!topicArn || !configSetName) {
+      wiredByDomain.set(candidate.id, false);
+      continue;
+    }
+
+    const cacheKey = `${topicArn}:${candidate.region}:${configSetName}`;
+    let statePromise = wiredByConfigSet.get(cacheKey);
+    if (!statePromise) {
+      const cached =
+        cacheTtlMs > 0 ? providerFeedbackWiringCache.get(cacheKey) : undefined;
+      if (cached && cached.expiresAt > now) {
+        statePromise = cached.promise;
+      } else {
+        const readPromise = readState({
+          configurationSetName: configSetName,
+          region: candidate.region,
+        }).then((state) => isSesEventsDestinationWired(state, topicArn));
+        if (cacheTtlMs > 0) {
+          readPromise.then(
+            (wired) => {
+              providerFeedbackWiringCache.set(cacheKey, {
+                expiresAt: Date.now() + cacheTtlMs,
+                promise: Promise.resolve(wired),
+              });
+            },
+            () => {
+              providerFeedbackWiringCache.delete(cacheKey);
+            },
+          );
+        }
+        statePromise = readPromise.catch((error) => {
+          options.onReadError?.(candidate, error);
+          return false;
+        });
+      }
+      wiredByConfigSet.set(cacheKey, statePromise);
+    }
+    assignments.push(
+      statePromise.then((wired) => {
+        wiredByDomain.set(candidate.id, wired);
+      }),
+    );
+  }
+
+  await Promise.all(assignments);
+
+  return wiredByDomain;
+}

--- a/src/lib/deliverability/repair-preflight.ts
+++ b/src/lib/deliverability/repair-preflight.ts
@@ -1,0 +1,356 @@
+import {
+  SES_EVENTS_MATCHING_EVENT_TYPES,
+  configurationSetService,
+  db,
+  dedicatedIpPoolRepo,
+  domains,
+  getSesEventsSnsTopicArn,
+} from "@opensend/core";
+import { and, eq } from "drizzle-orm";
+
+type DomainRow = typeof domains.$inferSelect;
+
+export type CliOptions = {
+  repair: boolean;
+  strict: boolean;
+  json: boolean;
+  domain: string | null;
+  limit: number;
+};
+
+export type EventDestinationState = {
+  configured: boolean;
+  enabled: boolean | null;
+  topicArn: string | null;
+  matchingEventTypes: string[];
+};
+
+export type DomainReport = {
+  domainId: string;
+  domainName: string;
+  region: string;
+  previousConfigSetName: string | null;
+  resultingConfigSetName: string | null;
+  dbWriteBack: boolean;
+  eventDestination: EventDestinationState | null;
+  mode: "preflight" | "repair";
+  error: string | null;
+};
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SNS_TOPIC_ARN_REGEX =
+  /^arn:(aws|aws-us-gov|aws-cn):sns:[a-z0-9-]+:\d{12}:[A-Za-z0-9_.-]{1,256}$/;
+
+export function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    repair: false,
+    strict: false,
+    json: false,
+    domain: null,
+    limit: 100,
+  };
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === "--repair") {
+      options.repair = true;
+    } else if (arg === "--strict") {
+      options.strict = true;
+    } else if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--domain") {
+      options.domain = argv[++index] ?? null;
+    } else if (arg === "--limit") {
+      const parsed = Number(argv[++index]);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        options.limit = Math.min(Math.floor(parsed), 500);
+      }
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+  }
+
+  return options;
+}
+
+export function validateSesEventsSnsTopicArn(
+  topicArn: string | null,
+): string | null {
+  if (!topicArn) {
+    return "SES_EVENTS_SNS_TOPIC_ARN is required for --repair";
+  }
+  if (!SNS_TOPIC_ARN_REGEX.test(topicArn)) {
+    return "SES_EVENTS_SNS_TOPIC_ARN must be an SNS topic ARN";
+  }
+  return null;
+}
+
+function printHelp() {
+  console.log(`OpenSend deliverability preflight
+
+Usage:
+  bun run deliverability:preflight -- [--domain <id-or-name>] [--limit 100] [--json] [--strict]
+  bun run deliverability:preflight -- --repair [--domain <id-or-name>] [--json] [--strict]
+
+Default mode is read-only. --repair creates/updates SES configuration sets,
+attaches the SES_EVENTS_SNS_TOPIC_ARN event destination, and writes back
+domains.ses_configuration_set_name after a successful sync.`);
+}
+
+async function loadVerifiedDomains(options: CliOptions): Promise<DomainRow[]> {
+  const filters = [eq(domains.status, "verified")];
+  if (options.domain) {
+    filters.push(
+      UUID_REGEX.test(options.domain)
+        ? eq(domains.id, options.domain)
+        : eq(domains.name, options.domain.toLowerCase()),
+    );
+  }
+
+  return await db
+    .select()
+    .from(domains)
+    .where(and(...filters))
+    .limit(options.limit);
+}
+
+async function resolveDedicatedIpPoolSesName(
+  domain: DomainRow,
+): Promise<string | null> {
+  if (!domain.dedicatedIpPoolId) return null;
+  const pool = await dedicatedIpPoolRepo.findById(domain.dedicatedIpPoolId);
+  return pool?.sesPoolName ?? null;
+}
+
+async function readEventDestinationState(
+  domain: DomainRow,
+  configSetName: string | null,
+): Promise<EventDestinationState | null> {
+  if (!configSetName) return null;
+  return await configurationSetService.getConfigurationSetEventDestinationState(
+    {
+      configurationSetName: configSetName,
+      region: domain.region,
+    },
+  );
+}
+
+async function inspectDomain(
+  domain: DomainRow,
+  options: CliOptions,
+): Promise<DomainReport> {
+  const previousConfigSetName = domain.sesConfigurationSetName ?? null;
+  const topicArn = getSesEventsSnsTopicArn();
+
+  if (!options.repair) {
+    try {
+      return {
+        domainId: domain.id,
+        domainName: domain.name,
+        region: domain.region,
+        previousConfigSetName,
+        resultingConfigSetName: previousConfigSetName,
+        dbWriteBack: Boolean(previousConfigSetName),
+        eventDestination: await readEventDestinationState(
+          domain,
+          previousConfigSetName,
+        ),
+        mode: "preflight",
+        error: null,
+      };
+    } catch (error) {
+      return toErrorReport(domain, previousConfigSetName, "preflight", error);
+    }
+  }
+
+  try {
+    const configSetName =
+      await configurationSetService.syncDomainConfigurationSet({
+        domainId: domain.id,
+        tls: domain.tls,
+        dedicatedIpPoolSesName: await resolveDedicatedIpPoolSesName(domain),
+        existingConfigSetName: previousConfigSetName,
+        eventDestinationTopicArn: topicArn,
+        region: domain.region,
+      });
+    const [updated] = await db
+      .update(domains)
+      .set({ sesConfigurationSetName: configSetName })
+      .where(eq(domains.id, domain.id))
+      .returning({ id: domains.id });
+    const dbWriteBack = Boolean(updated);
+
+    return {
+      domainId: domain.id,
+      domainName: domain.name,
+      region: domain.region,
+      previousConfigSetName,
+      resultingConfigSetName: dbWriteBack ? configSetName : null,
+      dbWriteBack,
+      eventDestination: dbWriteBack
+        ? await readEventDestinationState(domain, configSetName)
+        : null,
+      mode: "repair",
+      error: null,
+    };
+  } catch (error) {
+    return toErrorReport(domain, previousConfigSetName, "repair", error);
+  }
+}
+
+function toErrorReport(
+  domain: DomainRow,
+  previousConfigSetName: string | null,
+  mode: "preflight" | "repair",
+  error: unknown,
+): DomainReport {
+  return {
+    domainId: domain.id,
+    domainName: domain.name,
+    region: domain.region,
+    previousConfigSetName,
+    resultingConfigSetName: previousConfigSetName,
+    dbWriteBack: false,
+    eventDestination: null,
+    mode,
+    error: error instanceof Error ? error.message : String(error),
+  };
+}
+
+export function reportIssues(
+  report: DomainReport,
+  expectedTopicArn: string | null = null,
+): string[] {
+  const issues: string[] = [];
+  if (!report.resultingConfigSetName) {
+    issues.push("missing_config_set_writeback");
+  }
+  if (!report.eventDestination?.configured) {
+    issues.push("missing_ses_event_destination");
+  } else if (!report.eventDestination.enabled) {
+    issues.push("disabled_ses_event_destination");
+  } else {
+    if (
+      expectedTopicArn &&
+      report.eventDestination.topicArn !== expectedTopicArn
+    ) {
+      issues.push("wrong_ses_event_destination_topic");
+    }
+    const configuredEventTypes = new Set(
+      report.eventDestination.matchingEventTypes,
+    );
+    if (
+      !SES_EVENTS_MATCHING_EVENT_TYPES.every((eventType) =>
+        configuredEventTypes.has(eventType),
+      )
+    ) {
+      issues.push("missing_ses_event_types");
+    }
+  }
+  if (report.error) {
+    issues.push("repair_or_preflight_error");
+  }
+  return issues;
+}
+
+function printTextReport(input: {
+  topicArnConfigured: boolean;
+  expectedTopicArn?: string | null;
+  error?: string | null;
+  reports: DomainReport[];
+}) {
+  console.log("OpenSend deliverability preflight");
+  console.log(
+    `SES_EVENTS_SNS_TOPIC_ARN: ${input.topicArnConfigured ? "configured" : "missing"}`,
+  );
+  if (input.error) {
+    console.log(`repair_aborted=${input.error}`);
+  }
+  console.log(`domains scanned: ${input.reports.length}`);
+
+  for (const report of input.reports) {
+    const issues = reportIssues(report, input.expectedTopicArn ?? null);
+    console.log(
+      [
+        `- ${report.domainName} (${report.domainId})`,
+        `previous=${report.previousConfigSetName ?? "null"}`,
+        `result=${report.resultingConfigSetName ?? "null"}`,
+        `db_writeback=${report.dbWriteBack ? "yes" : "no"}`,
+        `event_destination=${
+          report.eventDestination?.configured ? "configured" : "missing"
+        }`,
+        issues.length > 0 ? `issues=${issues.join(",")}` : "issues=none",
+      ].join(" "),
+    );
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const topicArn = getSesEventsSnsTopicArn();
+  const repairTopicArnError = options.repair
+    ? validateSesEventsSnsTopicArn(topicArn)
+    : null;
+
+  if (repairTopicArnError) {
+    const payload = {
+      ok: false,
+      mode: "repair",
+      topicArnConfigured: Boolean(topicArn),
+      scanned: 0,
+      error: repairTopicArnError,
+      reports: [] as DomainReport[],
+    };
+    if (options.json) {
+      console.log(JSON.stringify(payload, null, 2));
+    } else {
+      printTextReport({
+        topicArnConfigured: payload.topicArnConfigured,
+        expectedTopicArn: topicArn,
+        error: repairTopicArnError,
+        reports: payload.reports,
+      });
+    }
+    process.exit(1);
+  }
+
+  const verifiedDomains = await loadVerifiedDomains(options);
+  const reports: DomainReport[] = [];
+
+  for (const domain of verifiedDomains) {
+    reports.push(await inspectDomain(domain, options));
+  }
+
+  const payload = {
+    ok:
+      Boolean(topicArn) &&
+      reports.every((report) => reportIssues(report, topicArn).length === 0),
+    mode: options.repair ? "repair" : "preflight",
+    topicArnConfigured: Boolean(topicArn),
+    scanned: reports.length,
+    reports,
+  };
+
+  if (options.json) {
+    console.log(JSON.stringify(payload, null, 2));
+  } else {
+    printTextReport({
+      topicArnConfigured: payload.topicArnConfigured,
+      expectedTopicArn: topicArn,
+      reports,
+    });
+  }
+
+  if (options.strict && !payload.ok) {
+    process.exit(1);
+  }
+}
+
+if (process.argv[1]?.endsWith("repair-preflight.ts")) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/tests/broadcast-metrics-route.test.ts
+++ b/tests/broadcast-metrics-route.test.ts
@@ -51,7 +51,7 @@ vi.mock("@/lib/cache/dashboard-aggregates", () => ({
     userId: string;
     broadcastId: string;
   }) =>
-    `dashboard-aggregate:v1:broadcast-metrics:${params.userId}:${params.broadcastId}`,
+    `dashboard-aggregate:v2:broadcast-metrics:${params.userId}:${params.broadcastId}`,
   readDashboardAggregateCache: mockReadDashboardAggregateCache,
   writeDashboardAggregateCache: mockWriteDashboardAggregateCache,
 }));

--- a/tests/broadcast-service.test.ts
+++ b/tests/broadcast-service.test.ts
@@ -292,7 +292,7 @@ describe("broadcast service boundary", () => {
     const cache: BroadcastMetricsCache = {
       ttlSeconds: 120,
       getKey(input) {
-        return `dashboard-aggregate:v1:broadcast-metrics:${input.userId}:${input.broadcastId}`;
+        return `dashboard-aggregate:v2:broadcast-metrics:${input.userId}:${input.broadcastId}`;
       },
       async read() {
         return null;
@@ -351,7 +351,7 @@ describe("broadcast service boundary", () => {
     });
     expect(writes).toEqual([
       {
-        key: "dashboard-aggregate:v1:broadcast-metrics:user-5:broadcast-5",
+        key: "dashboard-aggregate:v2:broadcast-metrics:user-5:broadcast-5",
         value: result.payload,
         ttlSeconds: 120,
       },

--- a/tests/configuration-set-service.test.ts
+++ b/tests/configuration-set-service.test.ts
@@ -18,10 +18,28 @@ vi.mock("@aws-sdk/client-sesv2", () => {
       _name: "CreateConfigurationSetCommand",
       input,
     })),
+    CreateConfigurationSetEventDestinationCommand: vi
+      .fn()
+      .mockImplementation((input) => ({
+        _name: "CreateConfigurationSetEventDestinationCommand",
+        input,
+      })),
+    GetConfigurationSetEventDestinationsCommand: vi
+      .fn()
+      .mockImplementation((input) => ({
+        _name: "GetConfigurationSetEventDestinationsCommand",
+        input,
+      })),
     PutConfigurationSetDeliveryOptionsCommand: vi
       .fn()
       .mockImplementation((input) => ({
         _name: "PutConfigurationSetDeliveryOptionsCommand",
+        input,
+      })),
+    UpdateConfigurationSetEventDestinationCommand: vi
+      .fn()
+      .mockImplementation((input) => ({
+        _name: "UpdateConfigurationSetEventDestinationCommand",
         input,
       })),
     DeleteConfigurationSetCommand: vi.fn().mockImplementation((input) => ({
@@ -145,5 +163,104 @@ describe("ConfigurationSetService", () => {
     expect(mockSend).toHaveBeenCalledTimes(2);
     const updateCmd = mockSend.mock.calls[1][0];
     expect(updateCmd._name).toBe("PutConfigurationSetDeliveryOptionsCommand");
+  });
+
+  it("syncDomainConfigurationSet creates an SNS event destination when a topic ARN is configured", async () => {
+    mockSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ EventDestinations: [] })
+      .mockResolvedValueOnce({});
+    const svc = new ConfigurationSetService();
+
+    await svc.syncDomainConfigurationSet({
+      domainId: "domain-id-events",
+      tls: "required",
+      eventDestinationTopicArn:
+        "arn:aws:sns:us-east-1:123456789012:opensend-ses-events",
+    });
+
+    expect(mockSend).toHaveBeenCalledTimes(3);
+    expect(mockSend.mock.calls[1][0]._name).toBe(
+      "GetConfigurationSetEventDestinationsCommand",
+    );
+    const destinationCmd = mockSend.mock.calls[2][0];
+    expect(destinationCmd._name).toBe(
+      "CreateConfigurationSetEventDestinationCommand",
+    );
+    expect(destinationCmd.input).toMatchObject({
+      ConfigurationSetName: "opensend-domain-domain-id-events",
+      EventDestinationName: "opensend-sns-events",
+      EventDestination: {
+        Enabled: true,
+        MatchingEventTypes: [
+          "SEND",
+          "DELIVERY",
+          "BOUNCE",
+          "COMPLAINT",
+          "DELIVERY_DELAY",
+          "REJECT",
+          "RENDERING_FAILURE",
+        ],
+        SnsDestination: {
+          TopicArn: "arn:aws:sns:us-east-1:123456789012:opensend-ses-events",
+        },
+      },
+    });
+  });
+
+  it("syncDomainConfigurationSet updates an existing SNS event destination", async () => {
+    mockSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        EventDestinations: [{ Name: "opensend-sns-events" }],
+      })
+      .mockResolvedValueOnce({});
+    const svc = new ConfigurationSetService();
+
+    await svc.syncDomainConfigurationSet({
+      domainId: "domain-id-events",
+      tls: "opportunistic",
+      existingConfigSetName: "opensend-domain-domain-id-events",
+      eventDestinationTopicArn:
+        "arn:aws:sns:us-east-1:123456789012:opensend-ses-events",
+    });
+
+    expect(mockSend).toHaveBeenCalledTimes(3);
+    expect(mockSend.mock.calls[0][0]._name).toBe(
+      "PutConfigurationSetDeliveryOptionsCommand",
+    );
+    expect(mockSend.mock.calls[1][0]._name).toBe(
+      "GetConfigurationSetEventDestinationsCommand",
+    );
+    expect(mockSend.mock.calls[2][0]._name).toBe(
+      "UpdateConfigurationSetEventDestinationCommand",
+    );
+  });
+
+  it("reads the configured SNS event destination state", async () => {
+    mockSend.mockResolvedValueOnce({
+      EventDestinations: [
+        {
+          Name: "opensend-sns-events",
+          Enabled: true,
+          SnsDestination: {
+            TopicArn: "arn:aws:sns:us-east-1:123456789012:opensend-ses-events",
+          },
+          MatchingEventTypes: ["SEND", "DELIVERY"],
+        },
+      ],
+    });
+    const svc = new ConfigurationSetService();
+
+    await expect(
+      svc.getConfigurationSetEventDestinationState({
+        configurationSetName: "opensend-domain-domain-id-events",
+      }),
+    ).resolves.toEqual({
+      configured: true,
+      enabled: true,
+      topicArn: "arn:aws:sns:us-east-1:123456789012:opensend-ses-events",
+      matchingEventTypes: ["SEND", "DELIVERY"],
+    });
   });
 });

--- a/tests/core-email-event-repo.test.ts
+++ b/tests/core-email-event-repo.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFindFirst = vi.fn();
+const mockFindEmailFirst = vi.fn();
+const mockInsertValues = vi.fn();
 const mockInsertReturning = vi.fn();
 const mockOnConflictDoNothing = vi.fn();
 const mockUpdateWhere = vi.fn();
@@ -14,6 +16,9 @@ vi.mock("../packages/core/src/db/client", () => ({
       emailEvents: {
         findFirst: mockFindFirst,
       },
+      emails: {
+        findFirst: mockFindEmailFirst,
+      },
     },
     transaction: mockTransaction,
   },
@@ -24,6 +29,11 @@ describe("packages/core emailEventRepo.create", () => {
     vi.resetModules();
     vi.clearAllMocks();
 
+    mockFindEmailFirst.mockResolvedValue(null);
+    mockInsertValues.mockReturnValue({
+      returning: mockInsertReturning,
+      onConflictDoNothing: mockOnConflictDoNothing,
+    });
     mockUpdateWhere.mockResolvedValue(undefined);
     mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
     mockUpdate.mockReturnValue({ set: mockUpdateSet });
@@ -32,10 +42,7 @@ describe("packages/core emailEventRepo.create", () => {
     mockTransaction.mockImplementation(async (callback) =>
       callback({
         insert: () => ({
-          values: () => ({
-            returning: mockInsertReturning,
-            onConflictDoNothing: mockOnConflictDoNothing,
-          }),
+          values: mockInsertValues,
         }),
         update: mockUpdate,
       }),
@@ -58,6 +65,7 @@ describe("packages/core emailEventRepo.create", () => {
     const result = await emailEventRepo.create(event);
 
     expect(result).toEqual(event);
+    expect(mockInsertValues).toHaveBeenCalledWith(event);
     expect(mockUpdate).toHaveBeenCalledOnce();
     expect(mockUpdateSet).toHaveBeenCalledWith({ status: "delivered" });
     expect(mockUpdateWhere).toHaveBeenCalledOnce();
@@ -79,7 +87,31 @@ describe("packages/core emailEventRepo.create", () => {
     const result = await emailEventRepo.create(event);
 
     expect(result).toEqual(event);
+    expect(mockInsertValues).toHaveBeenCalledWith(event);
     expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("derives userId from the parent email when callers omit it", async () => {
+    const event = {
+      id: "evt_derived",
+      emailId: "email_1",
+      type: "delivered",
+      payload: { smtpResponse: "250 ok" },
+    };
+    mockFindEmailFirst.mockResolvedValue({ userId: "user-1" });
+    mockInsertReturning.mockResolvedValue([{ ...event, userId: "user-1" }]);
+
+    const { emailEventRepo } = await import(
+      "../packages/core/src/db/repositories/emailEventRepo"
+    );
+
+    await emailEventRepo.create(event);
+
+    expect(mockFindEmailFirst).toHaveBeenCalledOnce();
+    expect(mockInsertValues).toHaveBeenCalledWith({
+      ...event,
+      userId: "user-1",
+    });
   });
 
   it("returns the existing event when a source id hits the duplicate guard", async () => {

--- a/tests/dashboard-aggregates-cache.test.ts
+++ b/tests/dashboard-aggregates-cache.test.ts
@@ -17,7 +17,7 @@ describe("dashboard aggregate cache keys", () => {
         tagValue: null,
       }),
     ).toBe(
-      "dashboard-aggregate:v1:metrics:user-1:last_7_days:example.com:delivered:all:all",
+      "dashboard-aggregate:v2:metrics:user-1:last_7_days:example.com:delivered:all:all",
     );
     expect(
       getMetricsAggregateCacheKey({
@@ -26,7 +26,7 @@ describe("dashboard aggregate cache keys", () => {
         tagValue: null,
       }),
     ).toBe(
-      "dashboard-aggregate:v1:metrics:user-1:last_7_days:example.com:delivered:campaign:all",
+      "dashboard-aggregate:v2:metrics:user-1:last_7_days:example.com:delivered:campaign:all",
     );
     expect(
       getMetricsAggregateCacheKey({
@@ -35,7 +35,7 @@ describe("dashboard aggregate cache keys", () => {
         tagValue: "launch",
       }),
     ).toBe(
-      "dashboard-aggregate:v1:metrics:user-1:last_7_days:example.com:delivered:campaign:launch",
+      "dashboard-aggregate:v2:metrics:user-1:last_7_days:example.com:delivered:campaign:launch",
     );
   });
 });

--- a/tests/dashboard-deliverability-state.test.ts
+++ b/tests/dashboard-deliverability-state.test.ts
@@ -1,0 +1,54 @@
+import {
+  dashboardMetricStateLabel,
+  getOpenTrackingMetricState,
+  getProviderFeedbackMetricState,
+} from "@/lib/dashboard-deliverability-state";
+import { describe, expect, it } from "vitest";
+
+describe("dashboard deliverability display state", () => {
+  it("shows provider feedback as not wired when sends exist without SES feedback wiring", () => {
+    const state = getProviderFeedbackMetricState({
+      total: 2,
+      providerFeedbackWired: false,
+    });
+
+    expect(state).toBe("not_wired");
+    expect(dashboardMetricStateLabel(state)).toBe("Not wired");
+  });
+
+  it("shows provider feedback as unknown when the wiring check is inconclusive", () => {
+    const state = getProviderFeedbackMetricState({
+      total: 2,
+      providerFeedbackWired: false,
+      providerFeedbackUnknown: true,
+    });
+
+    expect(state).toBe("unknown");
+    expect(dashboardMetricStateLabel(state)).toBe("Unknown");
+  });
+
+  it("shows open tracking as off when sends exist but open tracking is disabled", () => {
+    const state = getOpenTrackingMetricState({
+      total: 2,
+      openTrackingEnabled: false,
+    });
+
+    expect(state).toBe("off");
+    expect(dashboardMetricStateLabel(state)).toBe("Off");
+  });
+
+  it("keeps empty accounts ready so zero-send cards can render as empty rates", () => {
+    expect(
+      getProviderFeedbackMetricState({
+        total: 0,
+        providerFeedbackWired: false,
+      }),
+    ).toBe("ready");
+    expect(
+      getOpenTrackingMetricState({
+        total: 0,
+        openTrackingEnabled: false,
+      }),
+    ).toBe("ready");
+  });
+});

--- a/tests/dashboard-provider-feedback.test.ts
+++ b/tests/dashboard-provider-feedback.test.ts
@@ -1,0 +1,304 @@
+import {
+  areAllRecentSenderDomainsWired,
+  clearProviderFeedbackWiringCache,
+  isSesEventsDestinationWired,
+  resolveProviderFeedbackWiring,
+} from "@/lib/dashboard-provider-feedback";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const topicArn = "arn:aws:sns:us-east-1:123456789012:opensend-ses-events";
+const matchingEventTypes = [
+  "SEND",
+  "DELIVERY",
+  "BOUNCE",
+  "COMPLAINT",
+  "DELIVERY_DELAY",
+  "REJECT",
+  "RENDERING_FAILURE",
+];
+
+describe("dashboard provider feedback wiring", () => {
+  beforeEach(() => {
+    clearProviderFeedbackWiringCache();
+  });
+
+  it("requires an enabled SES destination on the configured SNS topic", () => {
+    expect(
+      isSesEventsDestinationWired(
+        {
+          configured: true,
+          enabled: true,
+          topicArn,
+          matchingEventTypes,
+        },
+        topicArn,
+      ),
+    ).toBe(true);
+    expect(
+      isSesEventsDestinationWired(
+        {
+          configured: true,
+          enabled: true,
+          topicArn: "arn:aws:sns:us-east-1:123456789012:other-topic",
+          matchingEventTypes,
+        },
+        topicArn,
+      ),
+    ).toBe(false);
+    expect(
+      isSesEventsDestinationWired(
+        {
+          configured: true,
+          enabled: false,
+          topicArn,
+          matchingEventTypes,
+        },
+        topicArn,
+      ),
+    ).toBe(false);
+    expect(
+      isSesEventsDestinationWired(
+        {
+          configured: true,
+          enabled: true,
+          topicArn,
+          matchingEventTypes: ["DELIVERY"],
+        },
+        topicArn,
+      ),
+    ).toBe(false);
+  });
+
+  it("fails closed when the topic ARN is missing, the config set is missing, or SES read fails", async () => {
+    const readState = vi.fn(async () => {
+      throw new Error("ses unavailable");
+    });
+    const errors: string[] = [];
+
+    await expect(
+      resolveProviderFeedbackWiring(
+        [
+          {
+            id: "domain-no-topic",
+            name: "no-topic.example",
+            region: "us-east-1",
+            configurationSetName: "opensend-domain-no-topic",
+          },
+        ],
+        { topicArn: null, readState },
+      ),
+    ).resolves.toEqual(new Map([["domain-no-topic", false]]));
+    expect(readState).not.toHaveBeenCalled();
+
+    await expect(
+      resolveProviderFeedbackWiring(
+        [
+          {
+            id: "domain-missing-config",
+            name: "missing-config.example",
+            region: "us-east-1",
+            configurationSetName: null,
+          },
+        ],
+        { topicArn, readState },
+      ),
+    ).resolves.toEqual(new Map([["domain-missing-config", false]]));
+    expect(readState).not.toHaveBeenCalled();
+
+    await expect(
+      resolveProviderFeedbackWiring(
+        [
+          {
+            id: "domain-read-fails",
+            name: "read-fails.example",
+            region: "us-east-1",
+            configurationSetName: "opensend-domain-read-fails",
+          },
+        ],
+        {
+          topicArn,
+          readState,
+          onReadError: (candidate, error) => {
+            errors.push(
+              `${candidate.name}:${error instanceof Error ? error.message : String(error)}`,
+            );
+          },
+        },
+      ),
+    ).resolves.toEqual(new Map([["domain-read-fails", false]]));
+    expect(errors).toEqual(["read-fails.example:ses unavailable"]);
+  });
+
+  it("requires every recent sender domain to be provider-feedback wired", () => {
+    const candidates = [
+      {
+        id: "domain-wired",
+        name: "wired.example",
+        region: "us-east-1",
+        configurationSetName: "opensend-domain-wired",
+      },
+      {
+        id: "domain-unwired",
+        name: "unwired.example",
+        region: "us-east-1",
+        configurationSetName: "opensend-domain-unwired",
+      },
+    ];
+
+    expect(
+      areAllRecentSenderDomainsWired(
+        candidates,
+        new Map([
+          ["domain-wired", true],
+          ["domain-unwired", true],
+        ]),
+      ),
+    ).toBe(true);
+    expect(
+      areAllRecentSenderDomainsWired(
+        candidates,
+        new Map([
+          ["domain-wired", true],
+          ["domain-unwired", false],
+        ]),
+      ),
+    ).toBe(false);
+    expect(areAllRecentSenderDomainsWired([], new Map())).toBe(false);
+  });
+
+  it("keys provider feedback by domain id and parallelizes distinct SES reads", async () => {
+    let pendingReads = 0;
+    let maxConcurrentReads = 0;
+    const readState = vi.fn(
+      async ({ configurationSetName }: { configurationSetName: string }) => {
+        pendingReads += 1;
+        maxConcurrentReads = Math.max(maxConcurrentReads, pendingReads);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        pendingReads -= 1;
+        return {
+          configured: true,
+          enabled: true,
+          topicArn,
+          matchingEventTypes:
+            configurationSetName === "opensend-domain-b"
+              ? ["DELIVERY"]
+              : matchingEventTypes,
+        };
+      },
+    );
+
+    await expect(
+      resolveProviderFeedbackWiring(
+        [
+          {
+            id: "domain-a",
+            name: "same.example",
+            region: "us-east-1",
+            configurationSetName: "opensend-domain-a",
+          },
+          {
+            id: "domain-b",
+            name: "same.example",
+            region: "us-east-1",
+            configurationSetName: "opensend-domain-b",
+          },
+          {
+            id: "domain-a-alias",
+            name: "alias.example",
+            region: "us-east-1",
+            configurationSetName: "opensend-domain-a",
+          },
+        ],
+        { topicArn, readState },
+      ),
+    ).resolves.toEqual(
+      new Map([
+        ["domain-a", true],
+        ["domain-b", false],
+        ["domain-a-alias", true],
+      ]),
+    );
+    expect(readState).toHaveBeenCalledTimes(2);
+    expect(maxConcurrentReads).toBe(2);
+  });
+
+  it("uses a short TTL cache for repeated SES destination reads", async () => {
+    const readState = vi.fn(async () => ({
+      configured: true,
+      enabled: true,
+      topicArn,
+      matchingEventTypes,
+    }));
+    const candidates = [
+      {
+        id: "domain-cached",
+        name: "cached.example",
+        region: "us-east-1",
+        configurationSetName: "opensend-domain-cached",
+      },
+    ];
+
+    await expect(
+      resolveProviderFeedbackWiring(candidates, {
+        topicArn,
+        readState,
+        cacheTtlMs: 30_000,
+      }),
+    ).resolves.toEqual(new Map([["domain-cached", true]]));
+    await expect(
+      resolveProviderFeedbackWiring(candidates, {
+        topicArn,
+        readState,
+        cacheTtlMs: 30_000,
+      }),
+    ).resolves.toEqual(new Map([["domain-cached", true]]));
+
+    expect(readState).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache SES read failures as unwired", async () => {
+    const readState = vi.fn(async () => {
+      throw new Error("ses unavailable");
+    });
+    const errors: string[] = [];
+    const candidates = [
+      {
+        id: "domain-error-cache",
+        name: "error-cache.example",
+        region: "us-east-1",
+        configurationSetName: "opensend-domain-error-cache",
+      },
+    ];
+
+    await expect(
+      resolveProviderFeedbackWiring(candidates, {
+        topicArn,
+        readState,
+        cacheTtlMs: 30_000,
+        onReadError: (candidate, error) => {
+          errors.push(
+            `${candidate.name}:${error instanceof Error ? error.message : String(error)}`,
+          );
+        },
+      }),
+    ).resolves.toEqual(new Map([["domain-error-cache", false]]));
+    await expect(
+      resolveProviderFeedbackWiring(candidates, {
+        topicArn,
+        readState,
+        cacheTtlMs: 30_000,
+        onReadError: (candidate, error) => {
+          errors.push(
+            `${candidate.name}:${error instanceof Error ? error.message : String(error)}`,
+          );
+        },
+      }),
+    ).resolves.toEqual(new Map([["domain-error-cache", false]]));
+
+    expect(readState).toHaveBeenCalledTimes(2);
+    expect(errors).toEqual([
+      "error-cache.example:ses unavailable",
+      "error-cache.example:ses unavailable",
+    ]);
+  });
+});

--- a/tests/deliverability-preflight.test.ts
+++ b/tests/deliverability-preflight.test.ts
@@ -1,0 +1,201 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  type DomainReport,
+  parseArgs,
+  reportIssues,
+  validateSesEventsSnsTopicArn,
+} from "../src/lib/deliverability/repair-preflight";
+
+const root = join(__dirname, "..");
+const topicArn = "arn:aws:sns:us-east-1:123456789012:opensend-ses-events";
+const matchingEventTypes = [
+  "SEND",
+  "DELIVERY",
+  "BOUNCE",
+  "COMPLAINT",
+  "DELIVERY_DELAY",
+  "REJECT",
+  "RENDERING_FAILURE",
+];
+
+describe("deliverability preflight repair utility", () => {
+  it("parses read-only, strict, json, filter, and bounded limit options", () => {
+    expect(
+      parseArgs([
+        "--json",
+        "--strict",
+        "--domain",
+        "example.com",
+        "--limit",
+        "999",
+      ]),
+    ).toEqual({
+      repair: false,
+      strict: true,
+      json: true,
+      domain: "example.com",
+      limit: 500,
+    });
+
+    expect(parseArgs(["--repair", "--limit", "25"])).toEqual({
+      repair: true,
+      strict: false,
+      json: false,
+      domain: null,
+      limit: 25,
+    });
+  });
+
+  it("classifies missing write-back, missing destination, disabled destination, and command errors", () => {
+    const report: DomainReport = {
+      domainId: "domain-1",
+      domainName: "example.com",
+      region: "us-east-1",
+      previousConfigSetName: null,
+      resultingConfigSetName: null,
+      dbWriteBack: false,
+      eventDestination: {
+        configured: false,
+        enabled: null,
+        topicArn: null,
+        matchingEventTypes: [],
+      },
+      mode: "preflight",
+      error: "not found",
+    };
+
+    expect(reportIssues(report)).toEqual([
+      "missing_config_set_writeback",
+      "missing_ses_event_destination",
+      "repair_or_preflight_error",
+    ]);
+
+    expect(
+      reportIssues({
+        ...report,
+        resultingConfigSetName: "opensend-domain-domain-1",
+        dbWriteBack: true,
+        eventDestination: {
+          configured: true,
+          enabled: false,
+          topicArn,
+          matchingEventTypes: ["SEND"],
+        },
+        error: null,
+      }),
+    ).toEqual(["disabled_ses_event_destination"]);
+  });
+
+  it("classifies wrong-topic and incomplete SES event destinations as drift", () => {
+    const baseReport: DomainReport = {
+      domainId: "domain-1",
+      domainName: "example.com",
+      region: "us-east-1",
+      previousConfigSetName: "opensend-domain-domain-1",
+      resultingConfigSetName: "opensend-domain-domain-1",
+      dbWriteBack: true,
+      eventDestination: {
+        configured: true,
+        enabled: true,
+        topicArn,
+        matchingEventTypes,
+      },
+      mode: "preflight",
+      error: null,
+    };
+
+    expect(reportIssues(baseReport, topicArn)).toEqual([]);
+    expect(
+      reportIssues(
+        {
+          ...baseReport,
+          eventDestination: {
+            configured: true,
+            enabled: true,
+            topicArn: "arn:aws:sns:us-east-1:123456789012:other-topic",
+            matchingEventTypes,
+          },
+        },
+        topicArn,
+      ),
+    ).toEqual(["wrong_ses_event_destination_topic"]);
+    expect(
+      reportIssues(
+        {
+          ...baseReport,
+          eventDestination: {
+            configured: true,
+            enabled: true,
+            topicArn,
+            matchingEventTypes: ["SEND", "DELIVERY"],
+          },
+        },
+        topicArn,
+      ),
+    ).toEqual(["missing_ses_event_types"]);
+  });
+
+  it("requires a valid SNS topic ARN before repair can mutate state", () => {
+    expect(validateSesEventsSnsTopicArn(null)).toBe(
+      "SES_EVENTS_SNS_TOPIC_ARN is required for --repair",
+    );
+    expect(validateSesEventsSnsTopicArn("not-an-arn")).toBe(
+      "SES_EVENTS_SNS_TOPIC_ARN must be an SNS topic ARN",
+    );
+    expect(
+      validateSesEventsSnsTopicArn(
+        "arn:aws:sns:us-east-1:123456789012:opensend-ses-events",
+      ),
+    ).toBeNull();
+  });
+
+  it("documents that repair aborts before syncing when the topic ARN is missing", () => {
+    const source = readFileSync(
+      join(root, "src", "lib", "deliverability", "repair-preflight.ts"),
+      "utf-8",
+    );
+    expect(
+      source.indexOf("validateSesEventsSnsTopicArn(topicArn)"),
+    ).toBeLessThan(source.indexOf("loadVerifiedDomains(options)"));
+    expect(source.indexOf("process.exit(1);")).toBeLessThan(
+      source.indexOf("loadVerifiedDomains(options)"),
+    );
+  });
+
+  it("exposes the tracked preflight utility through package scripts", () => {
+    const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf-8"));
+    expect(pkg.scripts["deliverability:preflight"]).toBe(
+      "bun src/lib/deliverability/repair-preflight.ts",
+    );
+
+    const source = readFileSync(
+      join(root, "src", "lib", "deliverability", "repair-preflight.ts"),
+      "utf-8",
+    );
+    expect(source).toContain("--repair");
+    expect(source).toContain("SES_EVENTS_SNS_TOPIC_ARN");
+    expect(source).toContain("sesConfigurationSetName");
+    expect(source).toContain("getConfigurationSetEventDestinationState");
+  });
+
+  it("documents the operator repair flow without hardcoded production ARNs", () => {
+    const docs = readFileSync(
+      join(root, "docs", "ingester-deploy.md"),
+      "utf-8",
+    );
+    const publicDocs = readFileSync(
+      join(root, "public", "docs", "ingester-deploy.md"),
+      "utf-8",
+    );
+
+    expect(docs).toContain("bun run deliverability:preflight");
+    expect(docs).toContain("opensend-sns-events");
+    expect(docs).toContain("X-Entity-ID");
+    expect(publicDocs).toContain("bun run deliverability:preflight");
+    expect(`${docs}\n${publicDocs}`).not.toContain(
+      "arn:aws:sns:us-east-1:699486076867",
+    );
+  });
+});

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -57,11 +57,42 @@ describe("deploy-001: ECS Fargate deployment configuration", () => {
   it("deploy script injects required production app secrets into ECS task definitions", () => {
     const script = readFileSync(join(root, "scripts", "deploy.sh"), "utf-8");
     expect(script).toContain("WEBHOOK_SECRET_ENCRYPTION_KEY_SECRET_ID");
+    expect(script).toContain("TRACKING_SECRET_SECRET_ID");
     expect(script).toContain("aws secretsmanager describe-secret");
     expect(script).toContain('"name": "WEBHOOK_SECRET_ENCRYPTION_KEY"');
+    expect(script).toContain('"name": "TRACKING_SECRET"');
     expect(script).toContain("register_app_task_definition");
     expect(script).toContain(
       'redeploy "${APP_SERVICE}" "${APP_TASK_DEFINITION}"',
+    );
+  });
+
+  it("deploy script injects the SES events SNS topic ARN into the app task environment when configured", () => {
+    const script = readFileSync(join(root, "scripts", "deploy.sh"), "utf-8");
+    expect(script).toContain(
+      'SES_EVENTS_SNS_TOPIC_ARN="${SES_EVENTS_SNS_TOPIC_ARN:-}"',
+    );
+    expect(script).toContain('"name": "SES_EVENTS_SNS_TOPIC_ARN"');
+    expect(script).toContain('"value": ses_events_sns_topic_arn');
+    expect(script).toContain('"SES_EVENTS_SNS_TOPIC_ARN"');
+    expect(script).toContain(
+      'write_app_task_definition "${base_task_definition}" "${app_image}" "${webhook_secret_arn}" "${tracking_secret_arn}" "${SES_EVENTS_SNS_TOPIC_ARN}" "${task_file}"',
+    );
+  });
+
+  it("deploy script injects the SES events SNS topic ARN into the ingester task environment", () => {
+    const script = readFileSync(join(root, "scripts", "deploy.sh"), "utf-8");
+    expect(script).toContain(
+      'write_ingester_task_definition \\\n    "${base_task_definition}" \\\n    "${ingester_image}"',
+    );
+    expect(script).toContain(
+      '"${SES_EVENTS_SNS_TOPIC_ARN}" \\\n    "${task_file}"',
+    );
+    expect(script).toContain(
+      'for name in ["AWS_REGION", "S3_BUCKET_NAME", "SES_EVENTS_SNS_TOPIC_ARN"]',
+    );
+    expect(script).toContain(
+      'required_environment["SES_EVENTS_SNS_TOPIC_ARN"] = ses_events_sns_topic_arn',
     );
   });
 
@@ -70,7 +101,9 @@ describe("deploy-001: ECS Fargate deployment configuration", () => {
     expect(script).toContain("INGESTER_INBOUND_TOKEN_SECRET_ID");
     expect(script).toContain("ingester_inbound_token_secret_arn");
     expect(script).toContain('"name": "INGESTER_INBOUND_TOKEN"');
-    expect(script).toContain('for name in ["AWS_REGION", "S3_BUCKET_NAME"]');
+    expect(script).toContain(
+      'for name in ["AWS_REGION", "S3_BUCKET_NAME", "SES_EVENTS_SNS_TOPIC_ARN"]',
+    );
     expect(script).toContain('"SES_INBOUND_BUCKET_NAME"');
     expect(script).toContain("app_task_definition");
   });

--- a/tests/domain-detail-service.test.ts
+++ b/tests/domain-detail-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { domains } from "../packages/core/src/db/schema";
+import { configurationSetService } from "../packages/core/src/services/configurationSet";
 import {
   type DomainDetailServiceDependencies,
   DomainDetailServiceError,
@@ -310,6 +311,63 @@ describe("domain detail service", () => {
         process.env.TRACKING_CNAME_TARGET = undefined;
       } else {
         process.env.TRACKING_CNAME_TARGET = previousTrackingTarget;
+      }
+    }
+  });
+
+  it("writes back the config-set name returned by a successful SES resync", async () => {
+    const previousTopicArn = process.env.SES_EVENTS_SNS_TOPIC_ARN;
+    process.env.SES_EVENTS_SNS_TOPIC_ARN =
+      "arn:aws:sns:us-east-1:123456789012:opensend-ses-events";
+    const syncDomainConfigurationSet = vi
+      .spyOn(configurationSetService, "syncDomainConfigurationSet")
+      .mockResolvedValueOnce("opensend-domain-11111111");
+    const updateCalls: DomainUpdateInput[] = [];
+    let current = domainRow({ sesConfigurationSetName: null });
+    const service = createDomainDetailService({
+      getDomainById: async () => current,
+      updateDomainForUser: async (input) => {
+        updateCalls.push(input);
+        current = domainRow({ ...current, ...input.updates });
+        return current;
+      },
+    });
+
+    try {
+      const result = await service.updateDomainDetail({
+        id: current.id,
+        userId: "user-1",
+        updates: { tls: "required" },
+      });
+
+      expect(result.changedFields).toEqual(["tls"]);
+      expect(syncDomainConfigurationSet).toHaveBeenCalledWith({
+        domainId: current.id,
+        tls: "required",
+        dedicatedIpPoolSesName: null,
+        existingConfigSetName: null,
+        eventDestinationTopicArn:
+          "arn:aws:sns:us-east-1:123456789012:opensend-ses-events",
+        region: "us-east-1",
+      });
+      expect(updateCalls).toEqual([
+        {
+          id: current.id,
+          userId: "user-1",
+          updates: { tls: "required" },
+        },
+        {
+          id: current.id,
+          userId: "user-1",
+          updates: { sesConfigurationSetName: "opensend-domain-11111111" },
+        },
+      ]);
+    } finally {
+      syncDomainConfigurationSet.mockRestore();
+      if (previousTopicArn === undefined) {
+        process.env.SES_EVENTS_SNS_TOPIC_ARN = "";
+      } else {
+        process.env.SES_EVENTS_SNS_TOPIC_ARN = previousTopicArn;
       }
     }
   });

--- a/tests/domain-service.test.ts
+++ b/tests/domain-service.test.ts
@@ -91,6 +91,7 @@ describe("domain service", () => {
       const service = createDomainService({
         repository,
         invalidateDomainCaches: vi.fn(),
+        syncDomainConfigurationSet: vi.fn(async () => "cfg-created-domain"),
       });
       await service.createDomain({ name: "Example.COM", userId: "user-1" });
 
@@ -149,6 +150,7 @@ describe("domain service", () => {
       repository,
       createDomainIdentity,
       invalidateDomainCaches,
+      syncDomainConfigurationSet: vi.fn(async () => "cfg-created-domain"),
     });
 
     const previousTrackingTarget = process.env.TRACKING_CNAME_TARGET;
@@ -247,6 +249,58 @@ describe("domain service", () => {
     });
   });
 
+  it("passes the SES events topic ARN into config-set sync and persists the returned name", async () => {
+    const previousTopicArn = process.env.SES_EVENTS_SNS_TOPIC_ARN;
+    process.env.SES_EVENTS_SNS_TOPIC_ARN =
+      "arn:aws:sns:us-east-1:123456789012:opensend-ses-events";
+    const updates: Array<{ id: string; data: Partial<DomainInsert> }> = [];
+    const syncDomainConfigurationSet = vi.fn(async () => "cfg-created-domain");
+    const repository = createRepository({
+      async create(data) {
+        return [domainRow({ ...data, id: "created-domain" })];
+      },
+      async update(id, data) {
+        updates.push({ id, data });
+        return [domainRow({ id, ...data })];
+      },
+    });
+    const service = createDomainService({
+      repository,
+      createDomainIdentity: async () => ({ dkimTokens: [] }),
+      invalidateDomainCaches: vi.fn(),
+      syncDomainConfigurationSet,
+    });
+
+    try {
+      await service.createDomain({
+        name: "example.com",
+        userId: "user-1",
+      });
+
+      expect(syncDomainConfigurationSet).toHaveBeenCalledWith({
+        domainId: "created-domain",
+        tls: "opportunistic",
+        dedicatedIpPoolSesName: null,
+        existingConfigSetName: null,
+        eventDestinationTopicArn:
+          "arn:aws:sns:us-east-1:123456789012:opensend-ses-events",
+        region: "us-east-1",
+      });
+      expect(updates).toEqual([
+        {
+          id: "created-domain",
+          data: { sesConfigurationSetName: "cfg-created-domain" },
+        },
+      ]);
+    } finally {
+      if (previousTopicArn === undefined) {
+        process.env.SES_EVENTS_SNS_TOPIC_ARN = "";
+      } else {
+        process.env.SES_EVENTS_SNS_TOPIC_ARN = previousTopicArn;
+      }
+    }
+  });
+
   it("uses external API defaults when optional create fields are omitted", async () => {
     const inserted: DomainInsert[] = [];
     const service = createDomainService({
@@ -258,6 +312,7 @@ describe("domain service", () => {
       }),
       createDomainIdentity: async () => ({ dkimTokens: [] }),
       invalidateDomainCaches: vi.fn(),
+      syncDomainConfigurationSet: vi.fn(async () => "cfg-domain-1"),
     });
 
     await service.createDomain({ name: "example.com" });
@@ -327,6 +382,7 @@ describe("domain service", () => {
       ],
     });
     const getDomainIdentity = vi.fn(async () => ({ verified: true }));
+    const syncDomainConfigurationSet = vi.fn(async () => "cfg-dom-1");
     const repository = createRepository({
       async findById() {
         return existingDomain;
@@ -341,6 +397,7 @@ describe("domain service", () => {
       repository,
       getDomainIdentity,
       invalidateDomainCaches: vi.fn(),
+      syncDomainConfigurationSet,
     });
 
     const result = await service.reconcileVerification("dom-1");
@@ -349,7 +406,7 @@ describe("domain service", () => {
       region: "ap-northeast-1",
     });
     expect(result.status).toBe("updated");
-    expect(updates).toHaveLength(1);
+    expect(updates).toHaveLength(2);
     expect(updates[0].data.status).toBe("verified");
     expect(updates[0].data.records).toEqual([
       expect.objectContaining({
@@ -361,9 +418,77 @@ describe("domain service", () => {
         status: "verified",
       }),
     ]);
+    expect(updates[1]).toEqual({
+      id: "dom-1",
+      data: { sesConfigurationSetName: "cfg-dom-1" },
+    });
     if (result.status === "updated") {
       expect(result.previousStatus).toBe("pending");
       expect(result.domain.status).toBe("verified");
+      expect(result.domain.sesConfigurationSetName).toBe("cfg-dom-1");
+    }
+  });
+
+  it("repairs verified domains by writing back the authoritative config-set name", async () => {
+    const previousTopicArn = process.env.SES_EVENTS_SNS_TOPIC_ARN;
+    process.env.SES_EVENTS_SNS_TOPIC_ARN =
+      "arn:aws:sns:us-east-1:123456789012:opensend-ses-events";
+    const updates: Array<{ id: string; data: Partial<DomainInsert> }> = [];
+    const existingDomain = domainRow({
+      id: "dom-repair",
+      name: "example.com",
+      status: "verified",
+      sesConfigurationSetName: null,
+    });
+    const syncDomainConfigurationSet = vi.fn(
+      async () => "opensend-domain-dom-repair",
+    );
+    const repository = createRepository({
+      async findById() {
+        return existingDomain;
+      },
+      async update(id, data) {
+        updates.push({ id, data });
+        return [domainRow({ ...existingDomain, ...data })];
+      },
+    });
+    const service = createDomainService({
+      repository,
+      getDomainIdentity: async () => ({ verified: true }),
+      invalidateDomainCaches: vi.fn(),
+      syncDomainConfigurationSet,
+    });
+
+    try {
+      const result = await service.reconcileVerification("dom-repair");
+
+      expect(result.status).toBe("unchanged");
+      expect(syncDomainConfigurationSet).toHaveBeenCalledWith({
+        domainId: "dom-repair",
+        tls: "opportunistic",
+        dedicatedIpPoolSesName: null,
+        existingConfigSetName: null,
+        eventDestinationTopicArn:
+          "arn:aws:sns:us-east-1:123456789012:opensend-ses-events",
+        region: "us-east-1",
+      });
+      expect(updates).toEqual([
+        {
+          id: "dom-repair",
+          data: { sesConfigurationSetName: "opensend-domain-dom-repair" },
+        },
+      ]);
+      if (result.status === "unchanged") {
+        expect(result.domain.sesConfigurationSetName).toBe(
+          "opensend-domain-dom-repair",
+        );
+      }
+    } finally {
+      if (previousTopicArn === undefined) {
+        process.env.SES_EVENTS_SNS_TOPIC_ARN = "";
+      } else {
+        process.env.SES_EVENTS_SNS_TOPIC_ARN = previousTopicArn;
+      }
     }
   });
 
@@ -462,6 +587,7 @@ describe("domain service", () => {
         throw new Error("ses unavailable");
       },
       invalidateDomainCaches: vi.fn(),
+      syncDomainConfigurationSet: vi.fn(async () => "cfg-reconciled-domain"),
     });
 
     const result = await service.reconcileAllPendingVerifications();

--- a/tests/e2e/today-deliverability.spec.ts
+++ b/tests/e2e/today-deliverability.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "./fixtures/auth";
+
+test("today dashboard does not treat a config-set name alone as wired feedback", async ({
+  authenticatedPage: page,
+  e2eDb,
+  e2eRunId,
+  e2eTenant,
+}) => {
+  const unwiredDomain = `unwired-${e2eRunId}.e2e.opensend.test`;
+  const wiredDomain = `wired-${e2eRunId}.e2e.opensend.test`;
+
+  await e2eDb.query(
+    `insert into domains (
+       name, status, region, user_id, track_opens, ses_configuration_set_name
+     )
+     values
+       ($1, 'verified', 'us-east-1', $3, false, null),
+       ($2, 'verified', 'us-east-1', $3, true, $4)`,
+    [
+      unwiredDomain,
+      wiredDomain,
+      e2eTenant.user.id,
+      `opensend-domain-wired-${e2eRunId}`,
+    ],
+  );
+
+  const sentOnly = await e2eDb.query<{ id: string }>(
+    `insert into emails ("from", "to", subject, status, user_id, created_at)
+     values ($1, $2::jsonb, 'Unwired sent only', 'sent', $3, now())
+     returning id`,
+    [
+      `hi@${unwiredDomain}`,
+      JSON.stringify([`recipient@${e2eRunId}.e2e.opensend.test`]),
+      e2eTenant.user.id,
+    ],
+  );
+  const delivered = await e2eDb.query<{ id: string }>(
+    `insert into emails ("from", "to", subject, status, user_id, created_at)
+     values ($1, $2::jsonb, 'Wired delivered', 'sent', $3, now())
+     returning id`,
+    [
+      `hi@${wiredDomain}`,
+      JSON.stringify([`delivered@${e2eRunId}.e2e.opensend.test`]),
+      e2eTenant.user.id,
+    ],
+  );
+
+  await e2eDb.query(
+    `insert into email_events (email_id, source_id, type, payload, user_id, received_at)
+     values ($1, $2, 'delivered', '{}'::jsonb, $3, now())`,
+    [
+      delivered.rows[0]?.id,
+      `e2e-today-delivered-${e2eRunId}`,
+      e2eTenant.user.id,
+    ],
+  );
+
+  await page.goto("/today");
+
+  const reputationCard = page
+    .getByText("Reputation by domain")
+    .locator("xpath=ancestor::div[contains(@class, 'rounded-card')][1]");
+  const unwiredRow = reputationCard
+    .getByText(unwiredDomain, { exact: true })
+    .locator("xpath=ancestor::div[contains(@class, 'grid')][1]");
+  const wiredRow = reputationCard
+    .getByText(wiredDomain, { exact: true })
+    .locator("xpath=ancestor::div[contains(@class, 'grid')][1]");
+
+  await expect(page.getByText("Sent · 24h").locator("..")).toContainText("2");
+  const deliveredCard = page
+    .getByText("Delivered", { exact: true })
+    .locator("xpath=ancestor::div[contains(@class, 'rounded-card')][1]");
+  await expect(deliveredCard).toContainText("Not wired");
+  await expect(unwiredRow).toContainText("Not wired");
+  await expect(unwiredRow).toContainText("Off");
+  await expect(wiredRow).toContainText("Not wired");
+  await expect(page.getByText(sentOnly.rows[0]?.id ?? "")).toHaveCount(0);
+});
+
+test("today dashboard marks provider feedback unknown when recent sender domains exceed the live SES read cap", async ({
+  authenticatedPage: page,
+  e2eDb,
+  e2eRunId,
+  e2eTenant,
+}) => {
+  const domainSuffix = `${e2eRunId}.cap.e2e.opensend.test`;
+  const senderCount = 51;
+
+  await e2eDb.query(
+    `insert into domains (
+       name, status, region, user_id, track_opens, ses_configuration_set_name
+     )
+     select
+       'cap-' || g::text || '-' || $1,
+       'verified',
+       'us-east-1',
+       $2,
+       false,
+       null
+     from generate_series(1, $3) g`,
+    [domainSuffix, e2eTenant.user.id, senderCount],
+  );
+
+  await e2eDb.query(
+    `insert into emails ("from", "to", subject, status, user_id, created_at)
+     select
+       'hi@cap-' || g::text || '-' || $1,
+       $2::jsonb,
+       'Capped sender domain',
+       'sent',
+       $3,
+       now() - (g::text || ' seconds')::interval
+     from generate_series(1, $4) g`,
+    [
+      domainSuffix,
+      JSON.stringify([`recipient@${e2eRunId}.e2e.opensend.test`]),
+      e2eTenant.user.id,
+      senderCount,
+    ],
+  );
+
+  await page.goto("/today");
+
+  const deliveredCard = page
+    .getByText("Delivered", { exact: true })
+    .locator("xpath=ancestor::div[contains(@class, 'rounded-card')][1]");
+  await expect(deliveredCard).toContainText("Unknown");
+});

--- a/tests/email-provider-config-set.test.ts
+++ b/tests/email-provider-config-set.test.ts
@@ -74,4 +74,64 @@ describe("EmailProviderService.sendEmail with configurationSetName", () => {
     const callArg = MockSendEmailCommand.mock.calls[0][0];
     expect(callArg.ConfigurationSetName).toBeUndefined();
   });
+
+  it("stamps a trusted entity id header and SES message tag for simple sends", async () => {
+    mockSend.mockResolvedValueOnce({ MessageId: "msg-entity" });
+    const svc = new EmailProviderService();
+
+    await svc.sendEmail({
+      from: "sender@example.com",
+      to: ["recipient@example.com"],
+      subject: "Hello",
+      html: "<p>Hello</p>",
+      headers: {
+        "x-entity-id": "attacker-controlled",
+        "X-Customer-Header": "kept",
+      },
+      emailId: "550e8400-e29b-41d4-a716-446655440000",
+    });
+
+    const callArg = MockSendEmailCommand.mock.calls[0][0];
+    expect(callArg.EmailTags).toEqual([
+      {
+        Name: "X-Entity-ID",
+        Value: "550e8400-e29b-41d4-a716-446655440000",
+      },
+    ]);
+    expect(callArg.Content.Simple.Headers).toEqual([
+      { Name: "X-Customer-Header", Value: "kept" },
+      {
+        Name: "X-Entity-ID",
+        Value: "550e8400-e29b-41d4-a716-446655440000",
+      },
+    ]);
+  });
+
+  it("stamps a trusted entity id header and SES message tag for raw attachment sends", async () => {
+    mockSend.mockResolvedValueOnce({ MessageId: "msg-raw-entity" });
+    const svc = new EmailProviderService();
+
+    await svc.sendEmail({
+      from: "sender@example.com",
+      to: ["recipient@example.com"],
+      subject: "Hello",
+      html: "<p>Hello</p>",
+      headers: { "X-Entity-ID": "attacker-controlled" },
+      attachments: [{ filename: "hello.txt", content: "aGVsbG8=" }],
+      emailId: "550e8400-e29b-41d4-a716-446655440000",
+    });
+
+    const callArg = MockSendEmailCommand.mock.calls[0][0];
+    const rawMessage = new TextDecoder().decode(callArg.Content.Raw.Data);
+    expect(callArg.EmailTags).toEqual([
+      {
+        Name: "X-Entity-ID",
+        Value: "550e8400-e29b-41d4-a716-446655440000",
+      },
+    ]);
+    expect(rawMessage).toContain(
+      "X-Entity-ID: 550e8400-e29b-41d4-a716-446655440000",
+    );
+    expect(rawMessage).not.toContain("attacker-controlled");
+  });
 });

--- a/tests/ingester-ses-route.test.ts
+++ b/tests/ingester-ses-route.test.ts
@@ -18,11 +18,13 @@ const mockInvalidateDomainCaches = vi
   .mockResolvedValue(undefined);
 
 const mockCreateOrIgnoreDuplicate = vi.fn();
+const mockFindEmailById = vi.fn();
 const mockCreateInboundEmailIngestionService = vi.fn();
 const mockInboundProcess = vi.fn();
 const mockDomainReconcileAllPendingVerifications = vi.fn();
 const mockEnqueueDomainEvent = vi.fn();
 const mockWebhookList = vi.fn();
+const mockWebhookListForUserDispatch = vi.fn();
 const mockEnqueue = vi.fn();
 const mockDispatchDelivery = vi.fn();
 const mockPublishBackgroundJob = vi.fn();
@@ -31,6 +33,7 @@ const mockLogTelemetry = vi.fn();
 const mockRecordTelemetryError = vi.fn();
 const mockSuppressFromSesEvent = vi.fn();
 const mockS3Send = vi.fn();
+const SES_EVENTS_TOPIC_ARN = "arn:aws:sns:us-east-1:123456789012:ses-events";
 
 vi.mock("@aws-sdk/client-s3", () => ({
   GetObjectCommand: class MockGetObjectCommand {
@@ -125,6 +128,9 @@ vi.mock("@opensend/core", () => {
     emailEventRepo: {
       createOrIgnoreDuplicate: mockCreateOrIgnoreDuplicate,
     },
+    emailRepo: {
+      findById: mockFindEmailById,
+    },
     emitCloudWatchMetric: mockEmitCloudWatchMetric,
     enqueueDomainEvent: mockEnqueueDomainEvent,
     getTelemetryCarrier: (context: {
@@ -160,6 +166,7 @@ vi.mock("@opensend/core", () => {
     },
     webhookRepo: {
       listForDispatch: mockWebhookList,
+      listForUserDispatch: mockWebhookListForUserDispatch,
     },
   };
 });
@@ -255,7 +262,7 @@ function createSignedEnvelope(options?: {
   const base = {
     Type: messageType,
     MessageId: "sns-msg-1",
-    TopicArn: "arn:aws:sns:us-east-1:123456789012:ses-events",
+    TopicArn: SES_EVENTS_TOPIC_ARN,
     Message:
       messageType === "Notification"
         ? JSON.stringify(sesMessage)
@@ -311,6 +318,7 @@ describe("SES SNS ingestion route", () => {
     vi.resetModules();
     vi.clearAllMocks();
     vi.unstubAllEnvs();
+    vi.stubEnv("SES_EVENTS_SNS_TOPIC_ARN", SES_EVENTS_TOPIC_ARN);
 
     mockDomainReconcileAllPendingVerifications.mockResolvedValue({
       scanned: 0,
@@ -329,14 +337,19 @@ describe("SES SNS ingestion route", () => {
       status: "skipped",
       reason: "queue_url_missing",
     });
-    mockWebhookList.mockResolvedValue({
+    mockWebhookListForUserDispatch.mockResolvedValue({
       data: [
         {
           id: "hook-1",
+          userId: "user-1",
           status: "active",
           eventTypes: ["email.delivered"],
         },
       ],
+    });
+    mockFindEmailById.mockResolvedValue({
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      userId: "user-1",
     });
     mockEmitCloudWatchMetric.mockReset();
     mockLogTelemetry.mockReset();
@@ -656,10 +669,17 @@ describe("SES SNS ingestion route", () => {
     expect(response.status).toBe(200);
     expect(mockCreateOrIgnoreDuplicate).toHaveBeenCalledWith({
       emailId: "550e8400-e29b-41d4-a716-446655440000",
+      userId: "user-1",
       sourceId: "sns-msg-1",
       type: "delivered",
       payload: { smtpResponse: "250 ok" },
     });
+    expect(mockWebhookListForUserDispatch).toHaveBeenCalledWith({
+      userId: "user-1",
+      eventType: "email.delivered",
+      limit: 100,
+    });
+    expect(mockWebhookList).not.toHaveBeenCalled();
     expect(mockEnqueue).toHaveBeenCalledWith("hook-1", persistedEvent.id);
     expect(mockPublishBackgroundJob).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -681,6 +701,123 @@ describe("SES SNS ingestion route", () => {
     expect(mockDispatchDelivery).not.toHaveBeenCalled();
   });
 
+  it("queries SES webhook dispatch by event owner before applying the limit", async () => {
+    const persistedEvent = {
+      id: "evt-owner-hook",
+      emailId: "550e8400-e29b-41d4-a716-446655440000",
+      sourceId: "sns-msg-1",
+      type: "delivered",
+      payload: { smtpResponse: "250 ok" },
+    };
+    mockCreateOrIgnoreDuplicate.mockResolvedValue({
+      event: persistedEvent,
+      created: true,
+    });
+    mockWebhookList.mockResolvedValue({
+      data: Array.from({ length: 101 }, (_, index) => ({
+        id: `hook-other-${index}`,
+        userId: "other-user",
+        status: "active",
+        eventTypes: ["email.delivered"],
+      })),
+    });
+    mockWebhookListForUserDispatch.mockResolvedValue({
+      data: [
+        {
+          id: "hook-owner-after-global-limit",
+          userId: "user-1",
+          status: "active",
+          eventTypes: ["email.delivered"],
+        },
+      ],
+    });
+
+    const app = (await import("../packages/ingester/src/index")).default;
+    const envelope = createSignedEnvelope();
+
+    const response = await app.request("http://localhost/events/ses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-amz-sns-message-type": "Notification",
+      },
+      body: JSON.stringify(envelope),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockWebhookListForUserDispatch).toHaveBeenCalledWith({
+      userId: "user-1",
+      eventType: "email.delivered",
+      limit: 100,
+    });
+    expect(mockWebhookList).not.toHaveBeenCalled();
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      "hook-owner-after-global-limit",
+      persistedEvent.id,
+    );
+  });
+
+  it("rejects SES notifications from an unconfigured SNS topic before side effects", async () => {
+    const app = (await import("../packages/ingester/src/index")).default;
+    const envelope = createSignedEnvelope({
+      overrides: {
+        TopicArn: "arn:aws:sns:us-east-1:123456789012:attacker-topic",
+      },
+    });
+
+    const response = await app.request("http://localhost/events/ses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-amz-sns-message-type": "Notification",
+      },
+      body: JSON.stringify(envelope),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toContain("SES SNS topic is not allowed");
+    expect(mockFindEmailById).not.toHaveBeenCalled();
+    expect(mockCreateOrIgnoreDuplicate).not.toHaveBeenCalled();
+    expect(mockSuppressFromSesEvent).not.toHaveBeenCalled();
+    expect(mockEnqueue).not.toHaveBeenCalled();
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
+  });
+
+  it("rejects SES subscription confirmations from an unconfigured SNS topic before confirming", async () => {
+    const app = (await import("../packages/ingester/src/index")).default;
+    const envelope = createSignedEnvelope({
+      messageType: "SubscriptionConfirmation",
+      overrides: {
+        TopicArn: "arn:aws:sns:us-east-1:123456789012:attacker-topic",
+      },
+    });
+
+    const response = await app.request("http://localhost/events/ses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-amz-sns-message-type": "SubscriptionConfirmation",
+      },
+      body: JSON.stringify(envelope),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toContain("SES SNS topic is not allowed");
+    const fetchedUrls = vi
+      .mocked(fetch)
+      .mock.calls.map(([input]) =>
+        input instanceof Request ? input.url : String(input),
+      );
+    expect(fetchedUrls).not.toContain(
+      "https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription",
+    );
+    expect(mockFindEmailById).not.toHaveBeenCalled();
+    expect(mockCreateOrIgnoreDuplicate).not.toHaveBeenCalled();
+    expect(mockSuppressFromSesEvent).not.toHaveBeenCalled();
+    expect(mockEnqueue).not.toHaveBeenCalled();
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
+  });
+
   it("creates user-scoped suppressions for permanent bounce recipients", async () => {
     const persistedEvent = {
       id: "evt-bounce-1",
@@ -696,7 +833,7 @@ describe("SES SNS ingestion route", () => {
       event: persistedEvent,
       created: true,
     });
-    mockWebhookList.mockResolvedValue({ data: [] });
+    mockWebhookListForUserDispatch.mockResolvedValue({ data: [] });
     mockSuppressFromSesEvent.mockResolvedValue([{ id: "suppression-1" }]);
 
     const app = (await import("../packages/ingester/src/index")).default;
@@ -737,6 +874,109 @@ describe("SES SNS ingestion route", () => {
       sourceMessageId: "ses-msg-bounce-1",
       metadata: { bounceType: "Permanent" },
     });
+  });
+
+  it("acks stale SES events for unknown email ids without creating tenantless events", async () => {
+    mockFindEmailById.mockResolvedValue(null);
+
+    const app = (await import("../packages/ingester/src/index")).default;
+    const envelope = createSignedEnvelope();
+
+    const response = await app.request("http://localhost/events/ses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-amz-sns-message-type": "Notification",
+      },
+      body: JSON.stringify(envelope),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockCreateOrIgnoreDuplicate).not.toHaveBeenCalled();
+    expect(mockEnqueue).not.toHaveBeenCalled();
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
+    expect(mockLogTelemetry).toHaveBeenCalledWith(
+      "warn",
+      "ses.event.unknown_email_id",
+      expect.any(Object),
+      expect.objectContaining({
+        email_id: "550e8400-e29b-41d4-a716-446655440000",
+      }),
+    );
+  });
+
+  it("acks SES events for ownerless emails without creating tenantless events", async () => {
+    mockFindEmailById.mockResolvedValue({
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      userId: null,
+    });
+
+    const app = (await import("../packages/ingester/src/index")).default;
+    const envelope = createSignedEnvelope();
+
+    const response = await app.request("http://localhost/events/ses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-amz-sns-message-type": "Notification",
+      },
+      body: JSON.stringify(envelope),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockCreateOrIgnoreDuplicate).not.toHaveBeenCalled();
+    expect(mockEnqueue).not.toHaveBeenCalled();
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
+    expect(mockLogTelemetry).toHaveBeenCalledWith(
+      "warn",
+      "ses.event.email_missing_user_id",
+      expect.any(Object),
+      expect.objectContaining({
+        email_id: "550e8400-e29b-41d4-a716-446655440000",
+      }),
+    );
+  });
+
+  it("does not queue webhooks owned by a different user", async () => {
+    mockWebhookListForUserDispatch.mockResolvedValue({
+      data: [
+        {
+          id: "hook-other-user",
+          userId: "other-user",
+          status: "active",
+          eventTypes: ["email.delivered"],
+        },
+      ],
+    });
+    mockCreateOrIgnoreDuplicate.mockResolvedValue({
+      event: {
+        id: "evt-cross-tenant",
+        emailId: "550e8400-e29b-41d4-a716-446655440000",
+        sourceId: "sns-msg-1",
+        type: "delivered",
+        payload: { smtpResponse: "250 ok" },
+      },
+      created: true,
+    });
+
+    const app = (await import("../packages/ingester/src/index")).default;
+    const envelope = createSignedEnvelope();
+
+    const response = await app.request("http://localhost/events/ses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-amz-sns-message-type": "Notification",
+      },
+      body: JSON.stringify(envelope),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockCreateOrIgnoreDuplicate).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-1" }),
+    );
+    expect(mockEnqueue).not.toHaveBeenCalled();
+    expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
   });
 
   it("rejects invalid SNS signatures before touching persistence", async () => {
@@ -793,7 +1033,7 @@ describe("SES SNS ingestion route", () => {
     expect(mockEnqueue).not.toHaveBeenCalled();
     expect(mockDispatchDelivery).not.toHaveBeenCalled();
     expect(mockPublishBackgroundJob).not.toHaveBeenCalled();
-    expect(mockWebhookList).not.toHaveBeenCalled();
+    expect(mockWebhookListForUserDispatch).not.toHaveBeenCalled();
   });
 
   it("rejects malformed SES notifications with a 400", async () => {

--- a/tests/metrics-route.test.ts
+++ b/tests/metrics-route.test.ts
@@ -31,7 +31,7 @@ vi.mock("@/lib/cache/dashboard-aggregates", () => ({
     tagName: string | null;
     tagValue: string | null;
   }) =>
-    `dashboard-aggregate:v1:metrics:${userId}:${range}:${domain ?? "all"}:${eventType ?? "all"}:${tagName ?? "all"}:${tagValue ?? "all"}`,
+    `dashboard-aggregate:v2:metrics:${userId}:${range}:${domain ?? "all"}:${eventType ?? "all"}:${tagName ?? "all"}:${tagValue ?? "all"}`,
   readDashboardAggregateCache: mockReadDashboardAggregateCache,
   writeDashboardAggregateCache: mockWriteDashboardAggregateCache,
 }));
@@ -133,7 +133,7 @@ describe("metrics route adapter", () => {
     expect(mockWriteDashboardAggregateCache).not.toHaveBeenCalled();
     await expect(response.json()).resolves.toMatchObject({ totalEmails: 99 });
     expect(mockReadDashboardAggregateCache).toHaveBeenCalledWith(
-      "dashboard-aggregate:v1:metrics:user-1:last_7_days:example.com:delivered:campaign:launch",
+      "dashboard-aggregate:v2:metrics:user-1:last_7_days:example.com:delivered:campaign:launch",
     );
   });
 
@@ -173,7 +173,7 @@ describe("metrics route adapter", () => {
       millisecond: 999,
     });
     expect(mockWriteDashboardAggregateCache).toHaveBeenCalledWith(
-      "dashboard-aggregate:v1:metrics:user-1:last_7_days:example.com:opened:campaign:all",
+      "dashboard-aggregate:v2:metrics:user-1:last_7_days:example.com:opened:campaign:all",
       freshPayload,
       60,
     );

--- a/tests/queue-worker.test.ts
+++ b/tests/queue-worker.test.ts
@@ -200,6 +200,7 @@ describe("QueueWorker", () => {
         to: ["user@example.com"],
         attachments: [{ filename: "inline.txt", content: "aGVsbG8=" }],
         region: "us-east-1",
+        emailId: "email-1",
       }),
     );
     expect(mockUpdateEmail).toHaveBeenNthCalledWith(2, "email-1", {


### PR DESCRIPTION
## Summary
- wire Today/dashboard deliverability metrics to SES/SNS provider feedback instead of email status-only zeros
- add SES configuration-set event destination wiring, trusted X-Entity-ID stamping, ingester topic allowlisting, and provider-feedback repair preflight
- document deploy/repair flow and add focused unit + authenticated Playwright coverage

## Verification
- make check
- make test
- bun run test -- tests/dashboard-provider-feedback.test.ts tests/deploy.test.ts tests/deliverability-preflight.test.ts tests/ingester-ses-route.test.ts tests/dashboard-deliverability-state.test.ts tests/configuration-set-service.test.ts tests/domain-service.test.ts tests/domain-detail-service.test.ts tests/email-provider-config-set.test.ts tests/dashboard-aggregates-cache.test.ts tests/metrics-route.test.ts tests/core-email-event-repo.test.ts
- set -a; source ./.env; set +a; bunx playwright test tests/e2e/today-deliverability.spec.ts
- bash -n scripts/deploy.sh
- git diff --check

## UltraQA
- adversarial SNS wrong-topic/signature/malformed/duplicate/stale/tenant-scope cases passed
- provider-feedback fail-closed/no-cache-on-read-failure cases passed
- dashboard Not wired / Unknown / Off states passed

Note: this is merge-readiness QA; production/live SES repair and validation were not performed in this PR.