### PR TITLE
Fix first-party docs examples and API payloads

### DIFF
--- a/public/docs/api-reference/contacts/add-contact-to-segment.md
+++ b/public/docs/api-reference/contacts/add-contact-to-segment.md
@@ -1,8 +1,8 @@
 # Add Contact to Segment
 
-Add a contact to a segment. This page documents the OpenSend-owned API contract for `POST /api/contacts/{id}/segments`.
+Add an existing contact to an existing segment. This page documents the OpenSend-owned API contract for `POST /api/contacts/{id}/segments/{segment_id}`.
 
-`POST /api/contacts/{id}/segments`
+`POST /api/contacts/{id}/segments/{segment_id}`
 
 ## Authentication
 
@@ -14,31 +14,32 @@ Authorization: Bearer os_YOUR_API_KEY
 
 ## When to use it
 
-Contact routes manage audience records for the authenticated tenant. Segment and topic relationship endpoints only affect the target contact and never expose another tenant's audience data. Attach the related resource to the target contact after validating both records belong to the caller.
+Use this route to attach one tenant-scoped contact to one tenant-scoped segment after both records already exist. The contact path parameter can be a contact ID or email where the contact route supports that lookup. The segment ID is always supplied in the path.
 
 ## Parameters
 
-Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+- `id` — contact ID or email for the authenticated tenant.
+- `segment_id` — segment ID for the authenticated tenant.
 
 ## Request example
 
-```json
-{
-  "email": "ada@example.com",
-  "firstName": "Ada",
-  "lastName": "Lovelace"
-}
+No JSON body is required.
+
+```http
+POST /api/contacts/520784e2-887d-4c25-b53c-4ad46ad38100/segments/78261eea-8f8b-4381-83c6-79fa7120f1cf
+Authorization: Bearer os_YOUR_API_KEY
 ```
 
 ## Response
 
-Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+Successful responses confirm the relationship mutation:
 
 ```json
 {
-  "id": "contact_123",
-  "email": "ada@example.com",
-  "subscribed": true
+  "object": "contact_segment",
+  "contact_id": "520784e2-887d-4c25-b53c-4ad46ad38100",
+  "segment_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+  "added": true
 }
 ```
 

--- a/public/docs/api-reference/contacts/delete-contact-segment.md
+++ b/public/docs/api-reference/contacts/delete-contact-segment.md
@@ -1,6 +1,6 @@
 # Delete Contact Segment
 
-Remove a contact from a segment. This page documents the OpenSend-owned API contract for `DELETE /api/contacts/{id}/segments/{segment_id}`.
+Remove an existing contact from an existing segment. This page documents the OpenSend-owned API contract for `DELETE /api/contacts/{id}/segments/{segment_id}`.
 
 `DELETE /api/contacts/{id}/segments/{segment_id}`
 
@@ -14,31 +14,32 @@ Authorization: Bearer os_YOUR_API_KEY
 
 ## When to use it
 
-Contact routes manage audience records for the authenticated tenant. Segment and topic relationship endpoints only affect the target contact and never expose another tenant's audience data. Delete or detach the target record for the authenticated tenant. Treat deletes as irreversible unless the resource-specific docs state otherwise.
+Use this route to detach one tenant-scoped contact from one tenant-scoped segment. It only changes the contact-to-segment relationship; it does not delete the contact or the segment resource.
 
 ## Parameters
 
-Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+- `id` — contact ID or email for the authenticated tenant.
+- `segment_id` — segment ID for the authenticated tenant.
 
 ## Request example
 
-```json
-{
-  "email": "ada@example.com",
-  "firstName": "Ada",
-  "lastName": "Lovelace"
-}
+No JSON body is required.
+
+```http
+DELETE /api/contacts/520784e2-887d-4c25-b53c-4ad46ad38100/segments/78261eea-8f8b-4381-83c6-79fa7120f1cf
+Authorization: Bearer os_YOUR_API_KEY
 ```
 
 ## Response
 
-Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+Successful responses confirm the relationship mutation:
 
 ```json
 {
-  "id": "contact_123",
-  "email": "ada@example.com",
-  "subscribed": true
+  "object": "contact_segment",
+  "contact_id": "520784e2-887d-4c25-b53c-4ad46ad38100",
+  "segment_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+  "deleted": true
 }
 ```
 

--- a/public/docs/api-reference/contacts/get-contact-topics.md
+++ b/public/docs/api-reference/contacts/get-contact-topics.md
@@ -14,21 +14,26 @@ Authorization: Bearer os_YOUR_API_KEY
 
 ## When to use it
 
-Contact routes manage audience records for the authenticated tenant. Segment and topic relationship endpoints only affect the target contact and never expose another tenant's audience data. Retrieve one tenant-scoped record by ID. A missing or cross-tenant ID returns not found instead of leaking ownership details.
+Use this route to inspect one contact's topic preference state. It returns topic subscription rows for the target contact and does not modify contact fields.
 
 ## Parameters
 
-`limit` and `after` may be used on collection routes when the route supports cursor pagination.
+- `id` — contact ID or email for the authenticated tenant.
 
 ## Response
 
-Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+Successful responses return topic preferences for the contact:
 
 ```json
 {
-  "id": "contact_123",
-  "email": "ada@example.com",
-  "subscribed": true
+  "object": "list",
+  "data": [
+    {
+      "id": "7a93a5b0-4f2d-4f8e-8e50-9f043c2fd710",
+      "name": "Product Updates",
+      "subscription": "opt_in"
+    }
+  ]
 }
 ```
 

--- a/public/docs/api-reference/contacts/list-contact-segments.md
+++ b/public/docs/api-reference/contacts/list-contact-segments.md
@@ -1,6 +1,6 @@
 # List Contact Segments
 
-List segments for a contact. This page documents the OpenSend-owned API contract for `GET /api/contacts/{id}/segments`.
+List segments assigned to a contact. This page documents the OpenSend-owned API contract for `GET /api/contacts/{id}/segments`.
 
 `GET /api/contacts/{id}/segments`
 
@@ -14,21 +14,27 @@ Authorization: Bearer os_YOUR_API_KEY
 
 ## When to use it
 
-Contact routes manage audience records for the authenticated tenant. Segment and topic relationship endpoints only affect the target contact and never expose another tenant's audience data. Return a tenant-scoped collection. Use pagination parameters when available instead of assuming a fixed result size.
+Use this route to inspect the segment memberships for one tenant-scoped contact. It does not create, update, or delete contact data.
 
 ## Parameters
 
-`limit` and `after` may be used on collection routes when the route supports cursor pagination.
+- `id` — contact ID or email for the authenticated tenant.
 
 ## Response
 
-Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+Successful responses return the contact's segment memberships:
 
 ```json
 {
-  "id": "contact_123",
-  "email": "ada@example.com",
-  "subscribed": true
+  "object": "list",
+  "data": [
+    {
+      "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+      "name": "Newsletter Subscribers",
+      "created_at": "2026-06-08T00:00:00.000Z"
+    }
+  ],
+  "has_more": false
 }
 ```
 

--- a/public/docs/api-reference/contacts/update-contact-topics.md
+++ b/public/docs/api-reference/contacts/update-contact-topics.md
@@ -14,31 +14,32 @@ Authorization: Bearer os_YOUR_API_KEY
 
 ## When to use it
 
-Contact routes manage audience records for the authenticated tenant. Segment and topic relationship endpoints only affect the target contact and never expose another tenant's audience data. Update the mutable fields for the target record. Fields not accepted by the API are ignored or rejected by route validation.
+Use this route to replace one contact's topic subscription preferences. It only updates topic relationship state; it does not update the contact's name, email, custom properties, or segment memberships.
 
 ## Parameters
 
-Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+- `id` — contact ID or email for the authenticated tenant.
 
 ## Request example
 
 ```json
 {
-  "email": "ada@example.com",
-  "firstName": "Ada",
-  "lastName": "Lovelace"
+  "topics": [
+    { "id": "7a93a5b0-4f2d-4f8e-8e50-9f043c2fd710", "subscription": "opt_in" },
+    { "id": "ab9b8b4e-b36d-44a1-8ff0-9971bb9aee4c", "subscription": "opt_out" }
+  ]
 }
 ```
 
 ## Response
 
-Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+Successful responses confirm the topic relationship update:
 
 ```json
 {
-  "id": "contact_123",
-  "email": "ada@example.com",
-  "subscribed": true
+  "object": "contact_topics",
+  "contact_id": "520784e2-887d-4c25-b53c-4ad46ad38100",
+  "updated": true
 }
 ```
 

--- a/public/docs/api-reference/events/list-events.md
+++ b/public/docs/api-reference/events/list-events.md
@@ -1,6 +1,6 @@
 # List Events
 
-List custom events. This page documents the OpenSend-owned API contract for `GET /api/events`.
+List custom events configured for automations. This page documents the OpenSend-owned API contract for `GET /api/events`.
 
 `GET /api/events`
 
@@ -14,28 +14,40 @@ Authorization: Bearer os_YOUR_API_KEY
 
 ## When to use it
 
-Event routes expose OpenSend automation events. Use them to inspect or send custom events that can trigger automations when your workspace has matching triggers configured. Return a tenant-scoped collection. Use pagination parameters when available instead of assuming a fixed result size.
+Use this route to inspect the custom event names and optional payload schemas that can trigger OpenSend automations for the authenticated tenant.
 
 ## Parameters
 
-`limit` and `after` may be used on collection routes when the route supports cursor pagination.
+`limit` and `after` may be used for cursor pagination.
 
 ## Response
 
-Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+Successful responses return a tenant-scoped list of custom event definitions:
 
 ```json
 {
+  "object": "list",
   "data": [
-    { "id": "event_123", "type": "user.signed_up" }
+    {
+      "object": "event",
+      "id": "41f2a3a9-6cb2-4c94-9ec6-f9be3f0ee4e8",
+      "name": "user.signed_up",
+      "schema": {
+        "properties": {
+          "plan": { "type": "string" }
+        }
+      },
+      "created_at": "2026-06-08T00:00:00.000Z",
+      "updated_at": "2026-06-08T00:00:00.000Z"
+    }
   ],
-  "hasMore": false
+  "has_more": false
 }
 ```
 
 ## Errors
 
-OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures.
 
 ## Self-hosting notes
 

--- a/public/docs/api-reference/events/send.md
+++ b/public/docs/api-reference/events/send.md
@@ -14,11 +14,16 @@ Authorization: Bearer os_YOUR_API_KEY
 
 ## When to use it
 
-Event routes expose OpenSend automation events. Use them to inspect or send custom events that can trigger automations when your workspace has matching triggers configured. Trigger delivery for an already-created resource. The route validates ownership and current state before queueing work.
+Use this route to deliver a custom event for exactly one contact. Provide either `contact_id`/`contactId` or `email`, plus an optional `payload` object. If the event has a stored schema, OpenSend validates `payload` before recording the delivery or resuming automations.
 
 ## Parameters
 
-Path parameters identify the tenant-scoped resource. JSON body fields are validated by the route before any database write.
+JSON body fields are validated before any database write. The route accepts:
+
+- `event` — custom event name.
+- `contact_id` or `contactId` — contact ID to associate with the event.
+- `email` — contact email to resolve instead of a contact ID.
+- `payload` — optional object passed to automations and schema validation.
 
 ## Request example
 
@@ -26,26 +31,34 @@ Path parameters identify the tenant-scoped resource. JSON body fields are valida
 {
   "event": "user.signed_up",
   "email": "ada@example.com",
-  "properties": { "plan": "pro" }
+  "payload": { "plan": "pro" }
 }
 ```
 
 ## Response
 
-Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+Successful responses return `202 Accepted` with the event delivery and any automation runs created or resumed:
 
 ```json
 {
-  "data": [
-    { "id": "event_123", "type": "user.signed_up" }
-  ],
-  "hasMore": false
+  "object": "event_delivery",
+  "delivery": {
+    "object": "event_delivery",
+    "id": "2d66f2de-0d0e-4a2d-8e66-831e3522d124",
+    "event": "user.signed_up",
+    "contact_id": "520784e2-887d-4c25-b53c-4ad46ad38100",
+    "email": "ada@example.com",
+    "payload": { "plan": "pro" },
+    "received_at": "2026-06-08T00:00:00.000Z"
+  },
+  "resumed_runs": [],
+  "automation_runs": []
 }
 ```
 
 ## Errors
 
-OpenSend returns structured errors for missing authentication, validation failures, not-found resources, quota/rate-limit conditions, and unexpected server failures. Treat `404` as either missing or not owned by the caller.
+OpenSend returns structured errors for missing authentication, invalid JSON, validation failures, schema mismatches, quota/rate-limit conditions, and unexpected server failures.
 
 ## Self-hosting notes
 

--- a/public/docs/api-reference/segments/list-segment-contacts.md
+++ b/public/docs/api-reference/segments/list-segment-contacts.md
@@ -14,20 +14,32 @@ Authorization: Bearer os_YOUR_API_KEY
 
 ## When to use it
 
-Segment routes manage audience groupings. Segment membership is tenant-scoped and can be used by broadcasts, automations, and dashboard audience filters. Return a tenant-scoped collection. Use pagination parameters when available instead of assuming a fixed result size.
+Use this route to page through contacts assigned to one tenant-scoped segment. It validates the segment belongs to the caller before returning contact rows.
 
 ## Parameters
 
-`limit` and `after` may be used on collection routes when the route supports cursor pagination.
+- `id` — segment ID for the authenticated tenant.
+- `limit` — optional page size.
+- `after` — optional cursor from the previous page.
 
 ## Response
 
-Successful responses return JSON scoped to the authenticated tenant. A representative response shape is:
+Successful responses return a paginated contact list for the segment:
 
 ```json
 {
-  "id": "segment_123",
-  "name": "Product qualified leads"
+  "object": "list",
+  "data": [
+    {
+      "id": "520784e2-887d-4c25-b53c-4ad46ad38100",
+      "email": "ada@example.com",
+      "firstName": "Ada",
+      "lastName": "Lovelace",
+      "unsubscribed": false,
+      "created_at": "2026-06-08T00:00:00.000Z"
+    }
+  ],
+  "has_more": false
 }
 ```
 

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -53,13 +53,13 @@
 - [Get Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/get-contact-property.md): Retrieve one custom contact property definition.
 - [List Contact Properties](https://opensend.namuh.co/docs/api-reference/contact-properties/list-contact-properties.md): List custom contact properties available for segmentation and personalization.
 - [Update Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/update-contact-property.md): Update display metadata for a custom contact property.
-- [Add Contact to Segment](https://opensend.namuh.co/docs/api-reference/contacts/add-contact-to-segment.md): Add a contact to a segment. This page documents the OpenSend-owned API contract for POST /api/contacts/{id}/segments.
+- [Add Contact to Segment](https://opensend.namuh.co/docs/api-reference/contacts/add-contact-to-segment.md): Add an existing contact to an existing segment. This page documents the OpenSend-owned API contract for POST /api/contacts/{id}/segments/{segmentid}.
 - [Create Contact](https://opensend.namuh.co/docs/api-reference/contacts/create-contact.md): Create an audience contact. This page documents the OpenSend-owned API contract for POST /contacts.
-- [Delete Contact Segment](https://opensend.namuh.co/docs/api-reference/contacts/delete-contact-segment.md): Remove a contact from a segment. This page documents the OpenSend-owned API contract for DELETE /api/contacts/{id}/segments/{segmentid}.
+- [Delete Contact Segment](https://opensend.namuh.co/docs/api-reference/contacts/delete-contact-segment.md): Remove an existing contact from an existing segment. This page documents the OpenSend-owned API contract for DELETE /api/contacts/{id}/segments/{segmentid}.
 - [Delete Contact](https://opensend.namuh.co/docs/api-reference/contacts/delete-contact.md): Delete a contact. This page documents the OpenSend-owned API contract for DELETE /contacts/{contactid}.
 - [Retrieve Contact Topics](https://opensend.namuh.co/docs/api-reference/contacts/get-contact-topics.md): Get topic subscriptions for a contact. This page documents the OpenSend-owned API contract for GET /api/contacts/{id}/topics.
 - [Retrieve Contact](https://opensend.namuh.co/docs/api-reference/contacts/get-contact.md): Retrieve a contact by id or email where supported. This page documents the OpenSend-owned API contract for GET /contacts/{contactid}.
-- [List Contact Segments](https://opensend.namuh.co/docs/api-reference/contacts/list-contact-segments.md): List segments for a contact. This page documents the OpenSend-owned API contract for GET /api/contacts/{id}/segments.
+- [List Contact Segments](https://opensend.namuh.co/docs/api-reference/contacts/list-contact-segments.md): List segments assigned to a contact. This page documents the OpenSend-owned API contract for GET /api/contacts/{id}/segments.
 - [List Contacts](https://opensend.namuh.co/docs/api-reference/contacts/list-contacts.md): List contacts. This page documents the OpenSend-owned API contract for GET /contacts.
 - [Update Contact Topics](https://opensend.namuh.co/docs/api-reference/contacts/update-contact-topics.md): Update topic subscriptions for a contact. This page documents the OpenSend-owned API contract for PATCH /api/contacts/{id}/topics.
 - [Update Contact](https://opensend.namuh.co/docs/api-reference/contacts/update-contact.md): Update contact fields. This page documents the OpenSend-owned API contract for PATCH /contacts/{contactid}.
@@ -83,7 +83,7 @@
 - [Send Batch Emails](https://opensend.namuh.co/docs/api-reference/emails/send-batch-emails.md): Queue up to 100 emails in one request.
 - [Send Email](https://opensend.namuh.co/docs/api-reference/emails/send-email.md): Send one email through OpenSend.
 - [Update Scheduled Email](https://opensend.namuh.co/docs/api-reference/emails/update-email.md): Update a scheduled email before OpenSend sends it.
-- [List Events](https://opensend.namuh.co/docs/api-reference/events/list-events.md): List custom events. This page documents the OpenSend-owned API contract for GET /api/events.
+- [List Events](https://opensend.namuh.co/docs/api-reference/events/list-events.md): List custom events configured for automations. This page documents the OpenSend-owned API contract for GET /api/events.
 - [Send Custom Event](https://opensend.namuh.co/docs/api-reference/events/send.md): Send a custom event into OpenSend. This page documents the OpenSend-owned API contract for POST /api/events/send.
 - [List Logs](https://opensend.namuh.co/docs/api-reference/logs/list-logs.md): List API request logs for debugging delivery, auth, and integration behavior.
 - [Retrieve Log](https://opensend.namuh.co/docs/api-reference/logs/retrieve-log.md): Retrieve one API request log entry with request and response metadata.

--- a/public/docs/sdks.md
+++ b/public/docs/sdks.md
@@ -28,11 +28,11 @@ npm install opensend
 Send an email:
 
 ```ts
-import { Resend } from "opensend";
+import { Opensend } from "opensend";
 
-const resend = new Resend(process.env.OPENSEND_API_KEY);
+const opensend = new Opensend(process.env.OPENSEND_API_KEY);
 
-const { data, error } = await resend.emails.send({
+const { data, error } = await opensend.emails.send({
   from: "OpenSend <onboarding@updates.example.com>",
   to: ["user@example.com"],
   subject: "Hello from OpenSend",

--- a/public/docs/send-with-aws-lambda.md
+++ b/public/docs/send-with-aws-lambda.md
@@ -14,9 +14,9 @@ Set `OPENSEND_BASE_URL` to your self-hosted app URL if you are not using OpenSen
 ## TypeScript handler
 
 ```ts
-import { Resend } from "opensend";
+import { Opensend } from "opensend";
 
-const resend = new Resend(process.env.OPENSEND_API_KEY, {
+const opensend = new Opensend(process.env.OPENSEND_API_KEY, {
   baseUrl: process.env.OPENSEND_BASE_URL,
 });
 
@@ -29,7 +29,7 @@ export async function handler(event: Event) {
     return { statusCode: 400, body: JSON.stringify({ error: "email is required" }) };
   }
 
-  const { data, error } = await resend.emails.send(
+  const { data, error } = await opensend.emails.send(
     {
       from: "OpenSend <onboarding@updates.example.com>",
       to: event.email,

--- a/public/docs/send-with-bun.md
+++ b/public/docs/send-with-bun.md
@@ -21,13 +21,13 @@ export OPENSEND_BASE_URL="http://localhost:3015"
 Create `send.ts`:
 
 ```ts
-import { Resend } from "opensend";
+import { Opensend } from "opensend";
 
-const resend = new Resend(Bun.env.OPENSEND_API_KEY, {
+const opensend = new Opensend(Bun.env.OPENSEND_API_KEY, {
   baseUrl: Bun.env.OPENSEND_BASE_URL,
 });
 
-const { data, error } = await resend.emails.send({
+const { data, error } = await opensend.emails.send({
   from: "OpenSend <onboarding@updates.example.com>",
   to: "user@example.com",
   subject: "Hello from Bun",
@@ -51,9 +51,9 @@ bun run send.ts
 ## Bun HTTP server
 
 ```ts
-import { Resend } from "opensend";
+import { Opensend } from "opensend";
 
-const resend = new Resend(Bun.env.OPENSEND_API_KEY, {
+const opensend = new Opensend(Bun.env.OPENSEND_API_KEY, {
   baseUrl: Bun.env.OPENSEND_BASE_URL,
 });
 
@@ -69,7 +69,7 @@ Bun.serve({
       return Response.json({ error: "email is required" }, { status: 400 });
     }
 
-    const { data, error } = await resend.emails.send({
+    const { data, error } = await opensend.emails.send({
       from: "OpenSend <onboarding@updates.example.com>",
       to: email,
       subject: "Welcome",

--- a/public/docs/send-with-express.md
+++ b/public/docs/send-with-express.md
@@ -21,12 +21,12 @@ export OPENSEND_BASE_URL="http://localhost:3015"
 
 ```ts
 import express from "express";
-import { Resend } from "opensend";
+import { Opensend } from "opensend";
 
 const app = express();
 app.use(express.json());
 
-const resend = new Resend(process.env.OPENSEND_API_KEY, {
+const opensend = new Opensend(process.env.OPENSEND_API_KEY, {
   baseUrl: process.env.OPENSEND_BASE_URL,
 });
 
@@ -41,7 +41,7 @@ app.post("/send", async (req, res) => {
     return;
   }
 
-  const { data, error } = await resend.emails.send({
+  const { data, error } = await opensend.emails.send({
     from: "OpenSend <onboarding@updates.example.com>",
     to: email,
     subject: "Hello from Express",
@@ -98,7 +98,7 @@ See [Verify webhook requests](./webhooks/verify-webhooks-requests.md) for the si
 When Express receives a duplicate upstream request, use idempotency keys:
 
 ```ts
-await resend.emails.send(payload, {
+await opensend.emails.send(payload, {
   idempotencyKey: `signup-${userId}`,
 });
 ```

--- a/public/docs/send-with-hono.md
+++ b/public/docs/send-with-hono.md
@@ -10,11 +10,11 @@ npm install hono opensend
 
 ```ts
 import { Hono } from "hono";
-import { Resend } from "opensend";
+import { Opensend } from "opensend";
 
 const app = new Hono();
 
-const resend = new Resend(process.env.OPENSEND_API_KEY, {
+const opensend = new Opensend(process.env.OPENSEND_API_KEY, {
   baseUrl: process.env.OPENSEND_BASE_URL,
 });
 
@@ -24,7 +24,7 @@ app.post("/send", async (c) => {
     return c.json({ error: "email is required" }, 400);
   }
 
-  const { data, error } = await resend.emails.send({
+  const { data, error } = await opensend.emails.send({
     from: "OpenSend <onboarding@updates.example.com>",
     to: body.email,
     subject: "Hello from Hono",

--- a/public/docs/send-with-nextjs.md
+++ b/public/docs/send-with-nextjs.md
@@ -23,9 +23,9 @@ Do not use `NEXT_PUBLIC_OPENSEND_API_KEY`.
 Create `app/api/send/route.ts`:
 
 ```ts
-import { Resend } from "opensend";
+import { Opensend } from "opensend";
 
-const resend = new Resend(process.env.OPENSEND_API_KEY, {
+const opensend = new Opensend(process.env.OPENSEND_API_KEY, {
   baseUrl: process.env.OPENSEND_BASE_URL,
 });
 
@@ -40,7 +40,7 @@ export async function POST(request: Request) {
     return Response.json({ error: "email is required" }, { status: 400 });
   }
 
-  const { data, error } = await resend.emails.send({
+  const { data, error } = await opensend.emails.send({
     from: "OpenSend <onboarding@updates.example.com>",
     to: body.email,
     subject: "Welcome",
@@ -63,9 +63,9 @@ export async function POST(request: Request) {
 ```ts
 "use server";
 
-import { Resend } from "opensend";
+import { Opensend } from "opensend";
 
-const resend = new Resend(process.env.OPENSEND_API_KEY, {
+const opensend = new Opensend(process.env.OPENSEND_API_KEY, {
   baseUrl: process.env.OPENSEND_BASE_URL,
 });
 
@@ -73,7 +73,7 @@ export async function sendInvite(formData: FormData) {
   const email = String(formData.get("email") ?? "");
   if (!email) return { ok: false, error: "email is required" };
 
-  const { data, error } = await resend.emails.send({
+  const { data, error } = await opensend.emails.send({
     from: "OpenSend <onboarding@updates.example.com>",
     to: email,
     subject: "You are invited",
@@ -95,7 +95,7 @@ npm install react react-dom @react-email/components
 
 ```tsx
 import { Html, Text } from "@react-email/components";
-import { Resend } from "opensend";
+import { Opensend } from "opensend";
 
 function InviteEmail({ workspace }: { workspace: string }) {
   return (
@@ -105,9 +105,9 @@ function InviteEmail({ workspace }: { workspace: string }) {
   );
 }
 
-const resend = new Resend(process.env.OPENSEND_API_KEY);
+const opensend = new Opensend(process.env.OPENSEND_API_KEY);
 
-await resend.emails.send({
+await opensend.emails.send({
   from: "OpenSend <onboarding@updates.example.com>",
   to: "user@example.com",
   subject: "Workspace invite",

--- a/public/docs/send-with-nodejs.md
+++ b/public/docs/send-with-nodejs.md
@@ -23,13 +23,13 @@ Do not prefix the key with `NEXT_PUBLIC_`, `VITE_`, or any client-side exposure 
 ## Send one email
 
 ```ts
-import { Resend } from "opensend";
+import { Opensend } from "opensend";
 
-const resend = new Resend(process.env.OPENSEND_API_KEY, {
+const opensend = new Opensend(process.env.OPENSEND_API_KEY, {
   baseUrl: process.env.OPENSEND_BASE_URL,
 });
 
-const { data, error } = await resend.emails.send({
+const { data, error } = await opensend.emails.send({
   from: "OpenSend <onboarding@updates.example.com>",
   to: ["user@example.com"],
   subject: "Hello from Node.js",
@@ -52,7 +52,7 @@ When `OPENSEND_BASE_URL` is absent, the SDK targets OpenSend Cloud at `https://o
 Use an idempotency key when a worker may retry after a timeout or crash. OpenSend stores idempotency decisions for 24 hours.
 
 ```ts
-await resend.emails.send(
+await opensend.emails.send(
   {
     from: "OpenSend <onboarding@updates.example.com>",
     to: "user@example.com",
@@ -73,7 +73,7 @@ npm install opensend react react-dom @react-email/components
 
 ```tsx
 import { Html, Text } from "@react-email/components";
-import { Resend } from "opensend";
+import { Opensend } from "opensend";
 
 function WelcomeEmail({ name }: { name: string }) {
   return (
@@ -83,9 +83,9 @@ function WelcomeEmail({ name }: { name: string }) {
   );
 }
 
-const resend = new Resend(process.env.OPENSEND_API_KEY);
+const opensend = new Opensend(process.env.OPENSEND_API_KEY);
 
-await resend.emails.send({
+await opensend.emails.send({
   from: "OpenSend <onboarding@updates.example.com>",
   to: "user@example.com",
   subject: "Welcome",
@@ -98,7 +98,7 @@ If `react-dom/server` is missing or rendering throws, the SDK returns a `react_r
 ## Batch sends
 
 ```ts
-const { data, error } = await resend.emails.sendBatch([
+const { data, error } = await opensend.emails.sendBatch([
   {
     from: "OpenSend <onboarding@updates.example.com>",
     to: "a@example.com",

--- a/public/docs/send-with-railway.md
+++ b/public/docs/send-with-railway.md
@@ -16,14 +16,14 @@ If you self-host OpenSend on Railway, set `OPENSEND_BASE_URL` to your OpenSend a
 ## Node.js service example
 
 ```ts
-import { Resend } from "opensend";
+import { Opensend } from "opensend";
 
-const resend = new Resend(process.env.OPENSEND_API_KEY, {
+const opensend = new Opensend(process.env.OPENSEND_API_KEY, {
   baseUrl: process.env.OPENSEND_BASE_URL,
 });
 
 export async function sendWelcome(email: string) {
-  const { data, error } = await resend.emails.send({
+  const { data, error } = await opensend.emails.send({
     from: "OpenSend <onboarding@updates.example.com>",
     to: email,
     subject: "Welcome",

--- a/public/docs/send-with-vercel.md
+++ b/public/docs/send-with-vercel.md
@@ -20,9 +20,9 @@ The [Next.js guide](./send-with-nextjs.md) is the recommended starting point. It
 ## Standalone serverless function
 
 ```ts
-import { Resend } from "opensend";
+import { Opensend } from "opensend";
 
-const resend = new Resend(process.env.OPENSEND_API_KEY, {
+const opensend = new Opensend(process.env.OPENSEND_API_KEY, {
   baseUrl: process.env.OPENSEND_BASE_URL,
 });
 
@@ -32,7 +32,7 @@ export async function POST(request: Request) {
     return Response.json({ error: "email is required" }, { status: 400 });
   }
 
-  const { data, error } = await resend.emails.send({
+  const { data, error } = await opensend.emails.send({
     from: "OpenSend <onboarding@updates.example.com>",
     to: email,
     subject: "Hello from Vercel",

--- a/src/components/api-code-drawer.tsx
+++ b/src/components/api-code-drawer.tsx
@@ -43,17 +43,17 @@ const EMAIL_SECTIONS: ApiCodeSection[] = [
   {
     title: "Send Email",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.emails.send({
+const { data, error } = await opensend.emails.send({
   from: 'you@example.com',
   to: ['user@gmail.com'],
   subject: 'Hello World',
   html: '<p>Congrats on sending your <strong>first email</strong>!</p>',
 }, { idempotencyKey: 'welcome-user-123' });`,
-      curl: `curl -X POST https://api.example.com/emails \\
+      curl: `curl -X POST https://opensend.namuh.co/emails \\
   -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -H "Idempotency-Key: welcome-user-123" \\
@@ -68,11 +68,11 @@ const { data, error } = await resend.emails.send({
   {
     title: "Send Batch Emails",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.batch.send([
+const { data, error } = await opensend.batch.send([
   {
     from: 'you@example.com',
     to: ['user1@gmail.com'],
@@ -86,7 +86,7 @@ const { data, error } = await resend.batch.send([
     html: '<p>Hello User 2</p>',
   },
 ], { idempotencyKey: 'batch-campaign-123' });`,
-      curl: `curl -X POST https://api.example.com/emails/batch \\
+      curl: `curl -X POST https://opensend.namuh.co/emails/batch \\
   -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -H "Idempotency-Key: batch-campaign-123" \\
@@ -109,29 +109,29 @@ const { data, error } = await resend.batch.send([
   {
     title: "Retrieve Email",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.emails.get(
+const { data, error } = await opensend.emails.get(
   '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794'
 );`,
-      curl: `curl -X GET https://api.example.com/emails/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794 \\
+      curl: `curl -X GET https://opensend.namuh.co/emails/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794 \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
     title: "Update Email",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.emails.update({
+const { data, error } = await opensend.emails.update({
   id: '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794',
   scheduledAt: '2024-08-05T11:52:01.858Z',
 });`,
-      curl: `curl -X PATCH https://api.example.com/emails/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794 \\
+      curl: `curl -X PATCH https://opensend.namuh.co/emails/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794 \\
   -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -145,14 +145,14 @@ const DOMAIN_SECTIONS: ApiCodeSection[] = [
   {
     title: "Add Domain",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.domains.create({
+const { data, error } = await opensend.domains.create({
   name: 'example.com',
 });`,
-      curl: `curl -X POST https://api.example.com/domains \\
+      curl: `curl -X POST https://opensend.namuh.co/domains \\
   -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{"name": "example.com"}'`,
@@ -161,44 +161,44 @@ const { data, error } = await resend.domains.create({
   {
     title: "Retrieve Domain",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.domains.get(
+const { data, error } = await opensend.domains.get(
   'd91cd9bd-1176-453e-8fc1-35364d380206'
 );`,
-      curl: `curl -X GET https://api.example.com/domains/d91cd9bd-1176-453e-8fc1-35364d380206 \\
+      curl: `curl -X GET https://opensend.namuh.co/domains/d91cd9bd-1176-453e-8fc1-35364d380206 \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
     title: "Verify Domain",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.domains.verify(
+const { data, error } = await opensend.domains.verify(
   'd91cd9bd-1176-453e-8fc1-35364d380206'
 );`,
-      curl: `curl -X POST https://api.example.com/domains/d91cd9bd-1176-453e-8fc1-35364d380206/verify \\
+      curl: `curl -X POST https://opensend.namuh.co/domains/d91cd9bd-1176-453e-8fc1-35364d380206/verify \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
     title: "Update Domain",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.domains.update({
+const { data, error } = await opensend.domains.update({
   id: 'd91cd9bd-1176-453e-8fc1-35364d380206',
   openTracking: true,
   clickTracking: true,
 });`,
-      curl: `curl -X PATCH https://api.example.com/domains/d91cd9bd-1176-453e-8fc1-35364d380206 \\
+      curl: `curl -X PATCH https://opensend.namuh.co/domains/d91cd9bd-1176-453e-8fc1-35364d380206 \\
   -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -210,26 +210,26 @@ const { data, error } = await resend.domains.update({
   {
     title: "List Domains",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.domains.list();`,
-      curl: `curl -X GET https://api.example.com/domains \\
+const { data, error } = await opensend.domains.list();`,
+      curl: `curl -X GET https://opensend.namuh.co/domains \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
     title: "Delete Domain",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.domains.remove(
+const { data, error } = await opensend.domains.remove(
   'd91cd9bd-1176-453e-8fc1-35364d380206'
 );`,
-      curl: `curl -X DELETE https://api.example.com/domains/d91cd9bd-1176-453e-8fc1-35364d380206 \\
+      curl: `curl -X DELETE https://opensend.namuh.co/domains/d91cd9bd-1176-453e-8fc1-35364d380206 \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
@@ -239,15 +239,15 @@ const WEBHOOK_SECTIONS: ApiCodeSection[] = [
   {
     title: "Create Webhook",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.webhooks.create({
+const { data, error } = await opensend.webhooks.create({
   endpoint: 'https://example.com/webhooks',
   events: ['email.sent', 'email.delivered', 'email.bounced'],
 });`,
-      curl: `curl -X POST https://api.example.com/webhooks \\
+      curl: `curl -X POST https://opensend.namuh.co/webhooks \\
   -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -259,26 +259,26 @@ const { data, error } = await resend.webhooks.create({
   {
     title: "List Webhooks",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.webhooks.list();`,
-      curl: `curl -X GET https://api.example.com/webhooks \\
+const { data, error } = await opensend.webhooks.list();`,
+      curl: `curl -X GET https://opensend.namuh.co/webhooks \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
     title: "Remove Webhook",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.webhooks.remove(
+const { data, error } = await opensend.webhooks.remove(
   'wh_123456789'
 );`,
-      curl: `curl -X DELETE https://api.example.com/webhooks/wh_123456789 \\
+      curl: `curl -X DELETE https://opensend.namuh.co/webhooks/wh_123456789 \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
@@ -288,15 +288,15 @@ const API_KEY_SECTIONS: ApiCodeSection[] = [
   {
     title: "Create API Key",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.apiKeys.create({
+const { data, error } = await opensend.apiKeys.create({
   name: 'Production',
   permission: 'full_access',
 });`,
-      curl: `curl -X POST https://api.example.com/api-keys \\
+      curl: `curl -X POST https://opensend.namuh.co/api-keys \\
   -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -308,26 +308,26 @@ const { data, error } = await resend.apiKeys.create({
   {
     title: "List API Keys",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.apiKeys.list();`,
-      curl: `curl -X GET https://api.example.com/api-keys \\
+const { data, error } = await opensend.apiKeys.list();`,
+      curl: `curl -X GET https://opensend.namuh.co/api-keys \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
     title: "Remove API Key",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.apiKeys.remove(
+const { data, error } = await opensend.apiKeys.remove(
   'key_123456789'
 );`,
-      curl: `curl -X DELETE https://api.example.com/api-keys/key_123456789 \\
+      curl: `curl -X DELETE https://opensend.namuh.co/api-keys/key_123456789 \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
@@ -337,18 +337,18 @@ const CONTACT_SECTIONS: ApiCodeSection[] = [
   {
     title: "Create Contact",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.contacts.create({
+const { data, error } = await opensend.contacts.create({
   email: 'user@example.com',
   firstName: 'John',
   lastName: 'Doe',
   unsubscribed: false,
   segmentId: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
 });`,
-      curl: `curl -X POST https://api.example.com/contacts \\
+      curl: `curl -X POST https://opensend.namuh.co/contacts \\
   -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -363,29 +363,29 @@ const { data, error } = await resend.contacts.create({
   {
     title: "List Contacts",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.contacts.list({
+const { data, error } = await opensend.contacts.list({
   segmentId: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
 });`,
-      curl: `curl -X GET "https://api.example.com/contacts?segmentId=78261eea-8f8b-4381-83c6-79fa7120f1cf" \\
+      curl: `curl -X GET "https://opensend.namuh.co/contacts?segmentId=78261eea-8f8b-4381-83c6-79fa7120f1cf" \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
     title: "Remove Contact",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.contacts.remove({
+const { data, error } = await opensend.contacts.remove({
   id: '520784e2-887d-4c25-b53c-4ad46ad38100',
   segmentId: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
 });`,
-      curl: `curl -X DELETE "https://api.example.com/contacts/520784e2-887d-4c25-b53c-4ad46ad38100?segmentId=78261eea-8f8b-4381-83c6-79fa7120f1cf" \\
+      curl: `curl -X DELETE "https://opensend.namuh.co/contacts/520784e2-887d-4c25-b53c-4ad46ad38100?segmentId=78261eea-8f8b-4381-83c6-79fa7120f1cf" \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
@@ -395,17 +395,17 @@ const BROADCAST_SECTIONS: ApiCodeSection[] = [
   {
     title: "Create Broadcast",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.broadcasts.create({
+const { data, error } = await opensend.broadcasts.create({
   segmentId: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
   from: 'you@example.com',
   subject: 'Hello World',
   html: '<p>Hello subscribers!</p>',
 });`,
-      curl: `curl -X POST https://api.example.com/broadcasts \\
+      curl: `curl -X POST https://opensend.namuh.co/broadcasts \\
   -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -419,26 +419,26 @@ const { data, error } = await resend.broadcasts.create({
   {
     title: "Send Broadcast",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.broadcasts.send(
+const { data, error } = await opensend.broadcasts.send(
   '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794'
 );`,
-      curl: `curl -X POST https://api.example.com/broadcasts/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794/send \\
+      curl: `curl -X POST https://opensend.namuh.co/broadcasts/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794/send \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
     title: "List Broadcasts",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.broadcasts.list();`,
-      curl: `curl -X GET https://api.example.com/broadcasts \\
+const { data, error } = await opensend.broadcasts.list();`,
+      curl: `curl -X GET https://opensend.namuh.co/broadcasts \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
@@ -448,15 +448,15 @@ const TEMPLATE_SECTIONS: ApiCodeSection[] = [
   {
     title: "Create Template",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.templates.create({
+const { data, error } = await opensend.templates.create({
   name: 'Welcome Email',
   html: '<p>Welcome {{name}}!</p>',
 });`,
-      curl: `curl -X POST https://api.example.com/templates \\
+      curl: `curl -X POST https://opensend.namuh.co/templates \\
   -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -468,26 +468,26 @@ const { data, error } = await resend.templates.create({
   {
     title: "List Templates",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.templates.list();`,
-      curl: `curl -X GET https://api.example.com/templates \\
+const { data, error } = await opensend.templates.list();`,
+      curl: `curl -X GET https://opensend.namuh.co/templates \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
     title: "Remove Template",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.templates.remove(
+const { data, error } = await opensend.templates.remove(
   'tmpl_123456789'
 );`,
-      curl: `curl -X DELETE https://api.example.com/templates/tmpl_123456789 \\
+      curl: `curl -X DELETE https://opensend.namuh.co/templates/tmpl_123456789 \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
@@ -497,14 +497,14 @@ const SEGMENT_SECTIONS: ApiCodeSection[] = [
   {
     title: "Create Segment",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.segments.create({
+const { data, error } = await opensend.segments.create({
   name: 'Newsletter Subscribers',
 });`,
-      curl: `curl -X POST https://api.example.com/segments \\
+      curl: `curl -X POST https://opensend.namuh.co/segments \\
   -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{"name": "Newsletter Subscribers"}'`,
@@ -513,26 +513,26 @@ const { data, error } = await resend.segments.create({
   {
     title: "List Segments",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.segments.list();`,
-      curl: `curl -X GET https://api.example.com/segments \\
+const { data, error } = await opensend.segments.list();`,
+      curl: `curl -X GET https://opensend.namuh.co/segments \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
     title: "Remove Segment",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.segments.remove(
+const { data, error } = await opensend.segments.remove(
   '78261eea-8f8b-4381-83c6-79fa7120f1cf'
 );`,
-      curl: `curl -X DELETE https://api.example.com/segments/78261eea-8f8b-4381-83c6-79fa7120f1cf \\
+      curl: `curl -X DELETE https://opensend.namuh.co/segments/78261eea-8f8b-4381-83c6-79fa7120f1cf \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
@@ -542,14 +542,14 @@ const TOPIC_SECTIONS: ApiCodeSection[] = [
   {
     title: "Create Topic",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.topics.create({
+const { data, error } = await opensend.topics.create({
   name: 'Product Updates',
 });`,
-      curl: `curl -X POST https://api.example.com/topics \\
+      curl: `curl -X POST https://opensend.namuh.co/topics \\
   -H "Authorization: Bearer os_123456789" \\
   -H "Content-Type: application/json" \\
   -d '{"name": "Product Updates"}'`,
@@ -558,26 +558,26 @@ const { data, error } = await resend.topics.create({
   {
     title: "List Topics",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.topics.list();`,
-      curl: `curl -X GET https://api.example.com/topics \\
+const { data, error } = await opensend.topics.list();`,
+      curl: `curl -X GET https://opensend.namuh.co/topics \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },
   {
     title: "Remove Topic",
     code: {
-      nodejs: `import { Resend } from 'resend';
+      nodejs: `import { Opensend } from 'opensend';
 
-const resend = new Resend('os_123456789');
+const opensend = new Opensend('os_123456789');
 
-const { data, error } = await resend.topics.remove(
+const { data, error } = await opensend.topics.remove(
   'topic_123456789'
 );`,
-      curl: `curl -X DELETE https://api.example.com/topics/topic_123456789 \\
+      curl: `curl -X DELETE https://opensend.namuh.co/topics/topic_123456789 \\
   -H "Authorization: Bearer os_123456789"`,
     },
   },

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -3607,16 +3607,17 @@ export const openApiDocument = {
       ContactTopicList: {
         type: "object",
         properties: {
-          object: { type: "string" },
+          object: { type: "string", enum: ["list"] },
           data: {
             type: "array",
             items: {
               type: "object",
               properties: {
-                topic_id: { type: "string", format: "uuid" },
-                subscribed: { type: "boolean" },
+                id: { type: "string", format: "uuid" },
+                name: { type: "string" },
+                subscription: { type: "string", enum: ["opt_in", "opt_out"] },
               },
-              required: ["topic_id", "subscribed"],
+              required: ["id", "name", "subscription"],
             },
           },
         },
@@ -3625,19 +3626,19 @@ export const openApiDocument = {
       UpdateContactTopicsRequest: {
         type: "object",
         properties: {
-          subscriptions: {
+          topics: {
             type: "array",
             items: {
               type: "object",
               properties: {
-                topic_id: { type: "string", format: "uuid" },
-                subscribed: { type: "boolean" },
+                id: { type: "string", format: "uuid" },
+                subscription: { type: "string", enum: ["opt_in", "opt_out"] },
               },
-              required: ["topic_id", "subscribed"],
+              required: ["id", "subscription"],
             },
           },
         },
-        required: ["subscriptions"],
+        required: ["topics"],
       },
       BulkContactRequest: {
         type: "object",
@@ -4431,9 +4432,42 @@ export const openApiDocument = {
       SendCustomEventResponse: {
         type: "object",
         properties: {
-          accepted: { type: "boolean" },
-          runs_resumed: { type: "integer" },
+          object: { type: "string", enum: ["event_delivery"] },
+          delivery: { $ref: "#/components/schemas/CustomEventDelivery" },
+          resumed_runs: {
+            type: "array",
+            items: { $ref: "#/components/schemas/AutomationRun" },
+          },
+          automation_runs: {
+            type: "array",
+            items: { $ref: "#/components/schemas/AutomationRun" },
+          },
         },
+        required: ["object", "delivery", "resumed_runs", "automation_runs"],
+      },
+      CustomEventDelivery: {
+        type: "object",
+        properties: {
+          object: { type: "string", enum: ["event_delivery"] },
+          id: { type: "string", format: "uuid" },
+          event: { type: "string" },
+          contact_id: { type: "string", format: "uuid", nullable: true },
+          email: { type: "string", format: "email", nullable: true },
+          payload: {
+            type: "object",
+            additionalProperties: true,
+          },
+          received_at: { type: "string", format: "date-time" },
+        },
+        required: [
+          "object",
+          "id",
+          "event",
+          "contact_id",
+          "email",
+          "payload",
+          "received_at",
+        ],
       },
       ErrorEnvelope: {
         type: "object",

--- a/tests/api-code-drawer.test.ts
+++ b/tests/api-code-drawer.test.ts
@@ -83,7 +83,9 @@ describe("API Code Drawer", () => {
         (s: ApiCodeSection) => s.title === "Send Email",
       );
       expect(sendEmail).toBeDefined();
-      expect(sendEmail?.code.nodejs).toContain("Resend");
+      expect(sendEmail?.code.nodejs).toContain("Opensend");
+      expect(sendEmail?.code.nodejs).toContain("from 'opensend'");
+      expect(sendEmail?.code.nodejs).not.toContain("from 'resend'");
     });
 
     it("cURL code uses proper HTTP methods", () => {
@@ -94,6 +96,8 @@ describe("API Code Drawer", () => {
       expect(sendEmail).toBeDefined();
       expect(sendEmail?.code.curl).toContain("curl");
       expect(sendEmail?.code.curl).toContain("/emails");
+      expect(sendEmail?.code.curl).toContain("https://opensend.namuh.co");
+      expect(sendEmail?.code.curl).not.toContain("https://api.example.com");
     });
   });
 

--- a/tests/docs-content.test.ts
+++ b/tests/docs-content.test.ts
@@ -177,6 +177,62 @@ describe("docs content shell", () => {
     expect(sdks).not.toMatch(/Java SDK|\\.NET SDK|Rust SDK/);
   });
 
+  it("keeps public SDK examples OpenSend-owned", () => {
+    const checkedRoots = [
+      path.join(process.cwd(), "public/docs"),
+      path.join(process.cwd(), "src/components"),
+    ];
+
+    for (const root of checkedRoots) {
+      for (const file of listTextFiles(root)) {
+        const content = readFileSync(file, "utf8");
+        expect(content, file).not.toMatch(/from ["']resend["']/i);
+        expect(content, file).not.toMatch(/require\(["']resend["']\)/i);
+        expect(content, file).not.toMatch(/import\(["']resend["']\)/i);
+        expect(content, file).not.toMatch(
+          /import \{\s*Resend\s*\} from ["']opensend["']/i,
+        );
+        expect(content, file).not.toMatch(/new Resend\(/);
+        expect(content, file).not.toContain("https://api.example.com");
+      }
+    }
+  });
+
+  it("keeps custom event and contact relationship examples route-specific", () => {
+    const docsRoot = path.join(process.cwd(), "public/docs");
+    const eventSend = readFileSync(
+      path.join(docsRoot, "api-reference/events/send.md"),
+      "utf8",
+    );
+    expect(eventSend).toContain('"payload": { "plan": "pro" }');
+    expect(eventSend).not.toContain('"properties": { "plan": "pro" }');
+    expect(eventSend).toContain('"object": "event_delivery"');
+
+    const addSegment = readFileSync(
+      path.join(docsRoot, "api-reference/contacts/add-contact-to-segment.md"),
+      "utf8",
+    );
+    expect(addSegment).toContain("No JSON body is required.");
+    expect(addSegment).toContain('"object": "contact_segment"');
+    expect(addSegment).toContain('"added": true');
+    expect(addSegment).not.toContain('"firstName": "Ada"');
+
+    const deleteSegment = readFileSync(
+      path.join(docsRoot, "api-reference/contacts/delete-contact-segment.md"),
+      "utf8",
+    );
+    expect(deleteSegment).toContain('"deleted": true');
+    expect(deleteSegment).not.toContain('"firstName": "Ada"');
+
+    const updateTopics = readFileSync(
+      path.join(docsRoot, "api-reference/contacts/update-contact-topics.md"),
+      "utf8",
+    );
+    expect(updateTopics).toContain('"topics": [');
+    expect(updateTopics).toContain('"object": "contact_topics"');
+    expect(updateTopics).not.toContain('"email": "ada@example.com"');
+  });
+
   it("documents implemented dashboard product areas with caveats", () => {
     const docsRoot = path.join(process.cwd(), "public/docs");
     const requiredDashboardDocs = [

--- a/tests/e2e/api-code-drawer.spec.ts
+++ b/tests/e2e/api-code-drawer.spec.ts
@@ -33,7 +33,7 @@ test.describe("API Code Drawer", () => {
     ).toBeVisible();
 
     // Verify Node.js code is shown
-    await expect(drawer.locator("code").first()).toContainText("Resend");
+    await expect(drawer.locator("code").first()).toContainText("Opensend");
 
     // Switch to cURL tab
     const curlTab = page.getByTestId("lang-tab-curl");


### PR DESCRIPTION
## Summary
- Replaces public drawer/framework SDK examples with first-party `opensend` package usage via the `Opensend` client and OpenSend-hosted base URLs.
- Corrects custom event send/list examples and public OpenAPI schemas to use the current `payload`/event-delivery contracts.
- Rewrites contact segment/topic relationship docs with route-specific request/response examples and adds docs-content guards against competitor package/example regressions.

Closes #614

## Changes
- **Public examples**: updates API drawer and public SDK/framework docs from compatibility-style `Resend` snippets to OpenSend-owned `Opensend` snippets.
- **API docs**: aligns custom event send/list docs plus contact segment/topic relationship docs with current route/service shapes.
- **OpenAPI/docs index**: updates matching OpenAPI schemas and regenerates `public/docs/llms.txt`.
- **Tests**: extends docs/content and drawer tests to guard package imports, stale base URLs, and route-specific examples.

## How to Test
- [x] `./.scratch/issue-614-docs-guard.sh` (local ignored scenario guard)
- [x] `bun run docs:generate`
- [x] `bun run docs:check`
- [x] `bun run test -- tests/docs-content.test.ts tests/api-code-drawer.test.ts`
- [x] `make check && make test`

## Notes
- Public migration-note prose that explicitly mentions the `Resend` compatibility alias remains; copy/paste examples now use the first-party `Opensend` client name.
