### PR TITLE
Document root OpenAPI aliases

### DIFF
--- a/agent_docs/learnings/active/2026-06-08-issue-611-root-openapi-alias-contract.md
+++ b/agent_docs/learnings/active/2026-06-08-issue-611-root-openapi-alias-contract.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-08
+issue: "#611"
+type: pattern
+promoted_to: null
+---
+
+## Root OpenAPI aliases need an explicit runtime-backed allowlist
+
+Root-compatible OpenAPI paths should be documented only when runtime evidence exists in either `src/middleware.ts` rewrites or root App Router `route.ts` files. For collision paths like `/api-keys` and `/broadcasts`, collection aliases are middleware-gated so dashboard page GETs keep working; detail aliases can come from root route files where they exist.
+
+Keep pending roots such as automations, events, broadcast metrics, and contact relationship roots out of OpenAPI until a runtime route exists. A focused contract test should compare root operations against an explicit allowlist so implemented aliases cannot disappear and unsupported aliases cannot be advertised silently.

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -115,6 +115,30 @@ const emailIdPathParameter: ParameterObject = {
   schema: { type: "string", format: "uuid" },
 };
 
+const contactIdPathParameter: ParameterObject = {
+  name: "contact_id",
+  in: "path",
+  required: true,
+  description: "Contact ID or email address.",
+  schema: { type: "string" },
+};
+
+const audienceIdPathParameter: ParameterObject = {
+  name: "audience_id",
+  in: "path",
+  required: true,
+  description: "Audience ID.",
+  schema: { type: "string" },
+};
+
+const apiKeyIdPathParameter: ParameterObject = {
+  name: "id",
+  in: "path",
+  required: true,
+  description: "API key ID.",
+  schema: { type: "string" },
+};
+
 const templateIdOrAliasPathParameter: ParameterObject = {
   name: "id",
   in: "path",
@@ -4637,6 +4661,12 @@ export const openApiDocument = {
 } as const satisfies OpenApiDocument;
 
 const compatibilityAliases: Record<string, string> = {
+  "/segments": "/api/segments",
+  "/segments/{id}": "/api/segments/{id}",
+  "/segments/{id}/contacts": "/api/segments/{id}/contacts",
+  "/broadcasts": "/api/broadcasts",
+  "/broadcasts/{id}": "/api/broadcasts/{id}",
+  "/broadcasts/{id}/send": "/api/broadcasts/{id}/send",
   "/domains": "/api/domains",
   "/domains/{id}": "/api/domains/{id}",
   "/domains/{id}/verify": "/api/domains/{id}/verify",
@@ -4649,6 +4679,8 @@ const compatibilityAliases: Record<string, string> = {
   "/logs": "/api/logs",
   "/logs/{id}": "/api/logs/{id}",
   "/emails/{id}": "/api/emails/{id}",
+  "/emails/{id}/events": "/api/emails/{id}/events",
+  "/emails/{id}/trace": "/api/emails/{id}/trace",
   "/emails/{id}/attachments": "/api/emails/{id}/attachments",
   "/emails/{id}/attachments/{attachmentId}":
     "/api/emails/{id}/attachments/{attachmentId}",
@@ -4665,6 +4697,212 @@ for (const [aliasPath, canonicalPath] of Object.entries(compatibilityAliases)) {
   const canonicalPathItem = mutablePaths[canonicalPath];
   if (canonicalPathItem) mutablePaths[aliasPath] = canonicalPathItem;
 }
+
+function withAliasDetails(
+  operation: OperationObject,
+  overrides: Partial<OperationObject>,
+): OperationObject {
+  return { ...operation, ...overrides };
+}
+
+const canonicalApiKeysPath = mutablePaths["/api/api-keys"];
+if (canonicalApiKeysPath?.get && canonicalApiKeysPath.post) {
+  mutablePaths["/api-keys"] = {
+    get: withAliasDetails(canonicalApiKeysPath.get, {
+      summary: "List API keys",
+      description:
+        "Root-compatible API-key collection alias. Browser dashboard GET /api-keys remains a signed-in dashboard page; API-like requests are rewritten to /api/api-keys by OpenSend middleware.",
+      operationId: "listApiKeysAlias",
+    }),
+    post: withAliasDetails(canonicalApiKeysPath.post, {
+      summary: "Create an API key",
+      description:
+        "Root-compatible API-key collection alias rewritten to POST /api/api-keys by OpenSend middleware.",
+      operationId: "createApiKeyAlias",
+    }),
+  };
+}
+
+const canonicalApiKeyDetailPath = mutablePaths["/api/api-keys/{id}"];
+if (canonicalApiKeyDetailPath?.delete) {
+  mutablePaths["/api-keys/{id}"] = {
+    delete: withAliasDetails(canonicalApiKeyDetailPath.delete, {
+      summary: "Delete an API key",
+      description:
+        "Root-compatible API-key delete alias rewritten to DELETE /api/api-keys/{id} by OpenSend middleware. Root GET/PATCH detail aliases are not implemented.",
+      operationId: "deleteApiKeyAlias",
+      parameters: [apiKeyIdPathParameter],
+    }),
+  };
+}
+
+const canonicalContactsPath = mutablePaths["/api/contacts"];
+if (canonicalContactsPath?.get && canonicalContactsPath.post) {
+  mutablePaths["/contacts"] = {
+    get: withAliasDetails(canonicalContactsPath.get, {
+      summary: "List contacts",
+      description:
+        "Root-compatible contacts collection route implemented by src/app/contacts/route.ts.",
+      operationId: "listContactsAlias",
+    }),
+    post: withAliasDetails(canonicalContactsPath.post, {
+      summary: "Create a contact",
+      description:
+        "Root-compatible contacts collection route implemented by src/app/contacts/route.ts.",
+      operationId: "createContactAlias",
+    }),
+  };
+}
+
+const canonicalContactDetailPath = mutablePaths["/api/contacts/{id}"];
+if (
+  canonicalContactDetailPath?.get &&
+  canonicalContactDetailPath.patch &&
+  canonicalContactDetailPath.delete
+) {
+  mutablePaths["/contacts/{contact_id}"] = {
+    get: withAliasDetails(canonicalContactDetailPath.get, {
+      summary: "Retrieve a contact",
+      description:
+        "Root-compatible contact detail route implemented by src/app/contacts/[contact_id]/route.ts.",
+      operationId: "getContactAlias",
+      parameters: [contactIdPathParameter],
+    }),
+    patch: withAliasDetails(canonicalContactDetailPath.patch, {
+      summary: "Update a contact",
+      description:
+        "Root-compatible contact detail route implemented by src/app/contacts/[contact_id]/route.ts.",
+      operationId: "updateContactAlias",
+      parameters: [contactIdPathParameter],
+    }),
+    delete: withAliasDetails(canonicalContactDetailPath.delete, {
+      summary: "Delete a contact",
+      description:
+        "Root-compatible contact detail route implemented by src/app/contacts/[contact_id]/route.ts.",
+      operationId: "deleteContactAlias",
+      parameters: [contactIdPathParameter],
+    }),
+  };
+}
+
+const audienceSchema = {
+  type: "object",
+  properties: {
+    object: { type: "string" },
+    id: { type: "string" },
+    name: { type: "string" },
+    created_at: { type: "string", format: "date-time" },
+  },
+  required: ["object", "id", "name"],
+} satisfies JsonSchema;
+
+const audienceListSchema = {
+  type: "object",
+  properties: {
+    object: { type: "string" },
+    data: {
+      type: "array",
+      items: audienceSchema,
+    },
+    has_more: { type: "boolean" },
+  },
+  required: ["object", "data", "has_more"],
+} satisfies JsonSchema;
+
+const deleteAudienceResponseSchema = {
+  type: "object",
+  properties: {
+    object: { type: "string" },
+    id: { type: "string" },
+    deleted: { type: "boolean" },
+  },
+  required: ["object", "id", "deleted"],
+} satisfies JsonSchema;
+
+mutablePaths["/audiences"] = {
+  get: {
+    tags: ["Segments"],
+    summary: "List audiences",
+    description:
+      "Resend-compatible audience alias implemented by src/app/audiences/route.ts using OpenSend segment storage.",
+    operationId: "listAudiencesAlias",
+    security: bearerSecurity,
+    parameters: [
+      ...paginationParameters,
+      {
+        name: "search",
+        in: "query",
+        description: "Full-text search filter.",
+        schema: { type: "string" },
+      },
+    ],
+    responses: {
+      "200": {
+        description: "Audience list.",
+        content: jsonContent(audienceListSchema),
+      },
+      ...errorResponses,
+    },
+  },
+  post: {
+    tags: ["Segments"],
+    summary: "Create an audience",
+    description:
+      "Resend-compatible audience alias implemented by src/app/audiences/route.ts using OpenSend segment storage.",
+    operationId: "createAudienceAlias",
+    security: bearerSecurity,
+    requestBody: {
+      required: true,
+      content: jsonContent({
+        $ref: "#/components/schemas/CreateSegmentRequest",
+      }),
+    },
+    responses: {
+      "201": {
+        description: "Created audience.",
+        content: jsonContent(audienceSchema),
+      },
+      ...errorResponses,
+    },
+  },
+};
+
+mutablePaths["/audiences/{audience_id}"] = {
+  get: {
+    tags: ["Segments"],
+    summary: "Retrieve an audience",
+    description:
+      "Resend-compatible audience detail alias implemented by src/app/audiences/[audience_id]/route.ts using OpenSend segment storage.",
+    operationId: "getAudienceAlias",
+    security: bearerSecurity,
+    parameters: [audienceIdPathParameter],
+    responses: {
+      "200": {
+        description: "Audience detail.",
+        content: jsonContent(audienceSchema),
+      },
+      "404": { $ref: "#/components/responses/NotFound" },
+      ...errorResponses,
+    },
+  },
+  delete: {
+    tags: ["Segments"],
+    summary: "Delete an audience",
+    description:
+      "Resend-compatible audience detail alias implemented by src/app/audiences/[audience_id]/route.ts using OpenSend segment storage.",
+    operationId: "deleteAudienceAlias",
+    security: bearerSecurity,
+    parameters: [audienceIdPathParameter],
+    responses: {
+      "200": {
+        description: "Audience deleted.",
+        content: jsonContent(deleteAudienceResponseSchema),
+      },
+      "404": { $ref: "#/components/responses/NotFound" },
+      ...errorResponses,
+    },
+  },
+};
 
 const canonicalEmailsPath = mutablePaths["/api/emails"];
 const existingEmailsAliasPath = mutablePaths["/emails"];

--- a/tests/openapi-route.test.ts
+++ b/tests/openapi-route.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
+import { openApiDocument } from "@/lib/openapi";
 import type { NextRequest } from "next/server";
 import { describe, expect, it, vi } from "vitest";
 
@@ -13,6 +14,101 @@ function makeRequest(url: string, init?: RequestInit): NextRequest {
   const request = new Request(url, init) as Request & { nextUrl: URL };
   request.nextUrl = new URL(url);
   return request as unknown as NextRequest;
+}
+
+const httpMethods = ["delete", "get", "patch", "post", "put"] as const;
+
+const supportedRootAliasOperations = [
+  "DELETE /api-keys/{id}",
+  "DELETE /audiences/{audience_id}",
+  "DELETE /broadcasts/{id}",
+  "DELETE /contact-properties/{id}",
+  "DELETE /contacts/{contact_id}",
+  "DELETE /domains/{id}",
+  "DELETE /segments/{id}",
+  "DELETE /templates/{id}",
+  "DELETE /topics/{id}",
+  "DELETE /webhooks/{id}",
+  "GET /api-keys",
+  "GET /audiences",
+  "GET /audiences/{audience_id}",
+  "GET /broadcasts",
+  "GET /broadcasts/{id}",
+  "GET /contact-properties",
+  "GET /contact-properties/{id}",
+  "GET /contacts",
+  "GET /contacts/{contact_id}",
+  "GET /domains",
+  "GET /domains/{id}",
+  "GET /emails",
+  "GET /emails/receiving",
+  "GET /emails/receiving/{id}",
+  "GET /emails/receiving/{id}/attachments",
+  "GET /emails/receiving/{id}/attachments/{attachmentId}",
+  "GET /emails/{id}",
+  "GET /emails/{id}/attachments",
+  "GET /emails/{id}/attachments/{attachmentId}",
+  "GET /emails/{id}/events",
+  "GET /emails/{id}/trace",
+  "GET /logs",
+  "GET /logs/{id}",
+  "GET /segments",
+  "GET /segments/{id}",
+  "GET /segments/{id}/contacts",
+  "GET /templates",
+  "GET /templates/{id}",
+  "GET /topics",
+  "GET /topics/{id}",
+  "GET /webhooks",
+  "GET /webhooks/{id}",
+  "PATCH /broadcasts/{id}",
+  "PATCH /contact-properties/{id}",
+  "PATCH /contacts/{contact_id}",
+  "PATCH /domains/{id}",
+  "PATCH /emails/{id}",
+  "PATCH /templates/{id}",
+  "PATCH /topics/{id}",
+  "PATCH /webhooks/{id}",
+  "POST /api-keys",
+  "POST /audiences",
+  "POST /broadcasts",
+  "POST /broadcasts/{id}/send",
+  "POST /contact-properties",
+  "POST /contacts",
+  "POST /domains",
+  "POST /domains/{id}/verify",
+  "POST /emails",
+  "POST /emails/batch",
+  "POST /emails/{email_id}/cancel",
+  "POST /segments",
+  "POST /templates",
+  "POST /templates/{id}/duplicate",
+  "POST /templates/{id}/publish",
+  "POST /topics",
+  "POST /webhooks",
+] as const;
+
+const unsupportedRootAliasPaths = [
+  "/automations",
+  "/automations/{id}",
+  "/broadcasts/{id}/metrics",
+  "/contacts/{contact_id}/segments",
+  "/contacts/{contact_id}/segments/{segment_id}",
+  "/contacts/{contact_id}/topics",
+  "/domains/{id}/auto-configure",
+  "/events",
+  "/events/send",
+] as const;
+
+function rootOperationAllowlist() {
+  return Object.entries(openApiDocument.paths)
+    .filter(([pathKey]) => !pathKey.startsWith("/api/"))
+    .flatMap(([pathKey, pathItem]) =>
+      httpMethods
+        .filter((method) => method in pathItem)
+        .map((method) => `${method.toUpperCase()} ${pathKey}`),
+    )
+    .sort();
 }
 
 describe("GET /openapi.json", () => {
@@ -58,6 +154,17 @@ describe("GET /openapi.json", () => {
     );
     expect(serialized).not.toMatch(/sk_(live|test)_[A-Za-z0-9]+/);
     expect(serialized).not.toMatch(/os_(?!xxx)[A-Za-z0-9]{12,}/);
+  });
+
+  it("documents exactly the implemented root-compatible alias operations", () => {
+    expect(rootOperationAllowlist()).toEqual(supportedRootAliasOperations);
+    expect(new Set(rootOperationAllowlist()).size).toBe(
+      supportedRootAliasOperations.length,
+    );
+
+    for (const unsupportedPath of unsupportedRootAliasPaths) {
+      expect(openApiDocument.paths).not.toHaveProperty(unsupportedPath);
+    }
   });
 
   it("is not redirected by middleware without a dashboard session", async () => {


### PR DESCRIPTION
## Summary
- Documented implemented root-compatible OpenAPI aliases backed by runtime evidence in middleware/App Router routes: `/api-keys`, `/audiences`, `/contacts`, `/segments`, `/broadcasts`, plus implemented email events/trace aliases.
- Kept unsupported pending roots out of the contract (`/automations`, `/events`, broadcast metrics, contact relationship roots, domain auto-configure root alias).
- Added a Vitest OpenAPI contract allowlist so root alias operations cannot silently disappear or expand beyond implemented runtime support.

## Root OpenAPI counts
- Before: 25 root paths / 42 root operations.
- After: 39 root paths / 67 root operations.

## Test plan
- `bun run docs:generate` (no generated docs diff)
- `bun run test -- tests/openapi-route.test.ts`
- `make check && make test`

Closes #611
