### PR TITLE
[codex] Use OpenSend API key prefix

### DIFF
--- a/agent_docs/learnings/active/2026-06-08-api-key-runtime-prefix.md
+++ b/agent_docs/learnings/active/2026-06-08-api-key-runtime-prefix.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-08
+issue: null
+type: decision
+promoted_to: null
+---
+
+## API-key runtime generation now uses the OpenSend prefix
+
+Runtime-created API keys should use `os_...` from `packages/core/src/services/apiKeys.ts`. The older issue #427 boundary intentionally left runtime generation as `re_...` while docs/examples moved to `os_...`; that boundary is superseded for newly created keys.
+
+Existing `re_...` keys remain valid because API-key auth hashes the full raw token and performs a database lookup without prefix enforcement.

--- a/packages/core/src/services/apiKeys.ts
+++ b/packages/core/src/services/apiKeys.ts
@@ -113,7 +113,7 @@ export type ApiKeyServiceDependencies = {
 };
 
 function defaultGenerateRawKey(): string {
-  return `re_${randomUUID().replace(/-/g, "")}`;
+  return `os_${randomUUID().replace(/-/g, "")}`;
 }
 
 function hashApiKey(rawKey: string): string {

--- a/tests/api-key-service.test.ts
+++ b/tests/api-key-service.test.ts
@@ -53,6 +53,19 @@ function createRepository(overrides: Partial<ApiKeyRepository> = {}) {
 }
 
 describe("api key service", () => {
+  it("generates OpenSend-prefixed API keys by default", async () => {
+    const service = createApiKeyService({
+      repository: createRepository(),
+    });
+
+    const result = await service.createApiKey({
+      name: "Default prefix",
+      userId: "user-1",
+    });
+
+    expect(result.token).toMatch(/^os_[a-f0-9]{32}$/);
+  });
+
   it("creates an API key with trimmed name, hashed token, preview, and cache invalidation", async () => {
     let inserted: ApiKeyInsert | null = null;
     const invalidateAuthCache = vi.fn<(_: string) => Promise<void>>();


### PR DESCRIPTION
## Summary
- Change runtime API-key generation from `re_...` to `os_...`.
- Add a regression test that exercises the default generator instead of an injected key.
- Record the updated runtime-prefix decision in `agent_docs/learnings/active/`.

## Root Cause
OpenSend docs and examples had already standardized on `os_...`, but `packages/core/src/services/apiKeys.ts` still generated `re_...` by default from the older Resend-compatible runtime contract.

## Validation
- `bun test tests/api-key-service.test.ts`
- `make check`
- `make test`
- `bun .scratch/verify-api-key-runtime-prefix.ts` against the real configured database; the scratch script created a temporary user/key, verified the `os_...` token and stored preview, validated auth lookup, then cleaned up.

## Compatibility
Existing `re_...` keys remain valid because auth hashes the full raw token and looks up the stored hash without prefix enforcement.