### PR TITLE
docs: label JVM and PHP SDK support surfaces

### DIFF
--- a/packages/jvm-sdk/README.md
+++ b/packages/jvm-sdk/README.md
@@ -2,6 +2,22 @@
 
 First-party Java/Kotlin-compatible SDK for OpenSend. This v1 staging slice is intentionally narrow and handwritten so it stays reviewable while OpenSend's OpenAPI/client-generation story matures.
 
+## Support level
+
+This is a **partial, blocking-only JVM SDK**. Before copying examples, note
+that this package currently wraps only:
+
+- `emails`: send, batch send, list, retrieve, cancel
+- `contacts`: create, list, retrieve, update, delete
+- `domains`: create, list, retrieve, update, verify, delete
+- `suppressions`: create, list, retrieve, delete
+
+Other public OpenSend resources, including API keys, broadcasts, segments,
+topics, templates, webhooks, logs, contact properties, events, automations,
+receiving, dedicated IPs, and unsubscribe-page settings, are available through
+the REST API and `/openapi.json`, but they are **not** exposed by this JVM
+package yet.
+
 ## Install from this repository
 
 ```bash
@@ -28,14 +44,17 @@ The SDK is **blocking-only** in this first slice. It uses Java's `java.net.http.
 
 ## Supported API surface
 
-This package only exposes routes implemented in this repository:
+This package only exposes routes implemented in this repository and listed above:
 
 - `emails`: send, batch send, list, retrieve, cancel
 - `contacts`: create, list, retrieve, update, delete
 - `domains`: create, list, retrieve, update, verify, delete
 - `suppressions`: create, list, retrieve, delete
 
-Use the REST API or another first-party SDK for resources not listed here.
+Use the REST API or another first-party SDK for resources not listed here. Do
+not assume a route in `/openapi.json` has a corresponding JVM method until it
+appears in this README and in
+`packages/jvm-sdk/src/main/java/com/opensend/resources`.
 
 ## Java
 

--- a/packages/jvm-sdk/examples/java/PlainJvmExample.java
+++ b/packages/jvm-sdk/examples/java/PlainJvmExample.java
@@ -5,6 +5,10 @@ import com.opensend.models.EmailResponse;
 import com.opensend.models.SendEmailRequest;
 import java.util.List;
 
+// Support level: the JVM SDK is currently a partial, blocking client for
+// emails, contacts, domains, and suppressions. Use the REST API and
+// /openapi.json for other OpenSend resources until JVM resource clients are
+// added.
 final class PlainJvmExample {
   private PlainJvmExample() {}
 

--- a/packages/jvm-sdk/examples/java/SpringBootMailService.java
+++ b/packages/jvm-sdk/examples/java/SpringBootMailService.java
@@ -4,6 +4,10 @@ import com.opensend.models.EmailResponse;
 import com.opensend.models.SendEmailRequest;
 import java.util.List;
 
+// Support level: the JVM SDK is currently a partial, blocking client for
+// emails, contacts, domains, and suppressions. Use the REST API and
+// /openapi.json for other OpenSend resources until JVM resource clients are
+// added.
 final class SpringBootMailService {
   private final OpenSend openSend;
 

--- a/packages/jvm-sdk/examples/kotlin/SendEmailExample.kt
+++ b/packages/jvm-sdk/examples/kotlin/SendEmailExample.kt
@@ -3,6 +3,10 @@ import com.opensend.OpenSend
 import com.opensend.RequestOptions
 import com.opensend.models.SendEmailRequest
 
+// Support level: the JVM SDK is currently a partial, blocking client for
+// emails, contacts, domains, and suppressions. Use the REST API and
+// /openapi.json for other OpenSend resources until JVM resource clients are
+// added.
 fun sendWelcomeEmail() {
     val client = OpenSend.builder(System.getenv("OPENSEND_API_KEY"))
         .baseUrl(System.getenv("OPENSEND_BASE_URL") ?: OpenSend.DEFAULT_BASE_URL)

--- a/packages/php-sdk/README.md
+++ b/packages/php-sdk/README.md
@@ -2,6 +2,23 @@
 
 First-party PHP SDK for OpenSend. This initial v1 slice focuses on the core send-email path and shared HTTP/error plumbing that future resource clients can reuse.
 
+## Support level
+
+This is a **partial, send-only PHP SDK**. Before copying examples, note that
+this package currently exposes only:
+
+- `client->emails->send(...)` for `POST /emails`
+- request options for idempotency keys
+- typed send request/response objects
+- typed OpenSend API error envelopes
+
+It does **not** yet expose PHP clients for email reads, batch sends, contacts,
+domains, suppressions, API keys, broadcasts, audiences, segments, topics,
+templates, webhooks, logs, contact properties, events, automations, receiving,
+dedicated IPs, or unsubscribe-page settings. Use the REST API and
+`/openapi.json` for those resources until matching PHP resource clients are
+added.
+
 ## Install
 
 Install from this repository until Packagist publishing is enabled:

--- a/packages/php-sdk/examples/send-email.php
+++ b/packages/php-sdk/examples/send-email.php
@@ -8,6 +8,11 @@ use OpenSend\Client;
 use OpenSend\Errors\ApiException;
 use OpenSend\ValueObjects\RequestOptions;
 
+// Support level: the PHP SDK is currently send-only. This example uses the
+// implemented client->emails->send(...) method for POST /emails. Use the REST
+// API and /openapi.json for other OpenSend resources until PHP resource clients
+// are added.
+
 $apiKey = getenv('OPENSEND_API_KEY');
 if (!is_string($apiKey) || trim($apiKey) === '') {
     fwrite(STDERR, "Set OPENSEND_API_KEY before running this example.\n");

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -2,7 +2,7 @@
 
 ## Docs
 
-- [Official SDKs](https://opensend.namuh.co/docs/sdks.md): OpenSend ships first-party SDKs for the languages most teams use to send mail from production services. All SDKs target OpenSend Cloud by default at https://opensend.namuh.co and can point at a self-hosted deployment by setting a base URL.
+- [Official SDKs](https://opensend.namuh.co/docs/sdks.md): OpenSend ships first-party SDKs for the languages most teams use to send mail from production services. All SDKs target OpenSend Cloud by default at https://opensend.namuh.co and can point at a self-hosted deployment by setting a base URL. The Java/Kotlin and PHP packages are intentionally partial today; their supported resources are listed below before any copyable examples.
 - [Examples](https://opensend.namuh.co/docs/examples.md): Example application patterns for OpenSend. Start with the SDK or framework guide that matches your runtime, then adapt the sender domain, base URL, and secret storage to your deployment.
 - [Send emails with Node.js](https://opensend.namuh.co/docs/send-with-nodejs.md): Use the TypeScript SDK from Node.js server code. This guide works for plain Node services, background workers, queues, and CLIs.
 - [Send emails with Bun](https://opensend.namuh.co/docs/send-with-bun.md): Bun projects can use the same opensend TypeScript SDK as Node.js projects. This is useful for Bun APIs, queue workers, scripts, and the OpenSend monorepo itself.
@@ -18,7 +18,7 @@
 - [Send emails with Flask](https://opensend.namuh.co/docs/send-with-flask.md): Use the Python SDK from Flask routes, CLI commands, or background workers.
 - [Send emails with Django](https://opensend.namuh.co/docs/send-with-django.md): Use the Python SDK from Django views, management commands, or background jobs.
 - [Send emails with Go](https://opensend.namuh.co/docs/send-with-go.md): Send email from Go with the first-party OpenSend Go SDK.
-- [Send emails with Java and Kotlin](https://opensend.namuh.co/docs/send-with-java.md): Use the first-party OpenSend JVM SDK from plain Java, Kotlin, Spring Boot services, workers, and command-line applications. The package lives in this repository at packages/jvm-sdk while registry publishing is prepared.
+- [Send emails with Java and Kotlin](https://opensend.namuh.co/docs/send-with-java.md): Use the first-party OpenSend JVM SDK from plain Java, Kotlin, Spring Boot services, workers, and command-line applications. The package lives in this repository at packages/jvm-sdk while registry publishing is prepared. This is a partial, blocking-only SDK for emails, contacts, domains, and suppressions; use the REST API and /openapi.json for other resources.
 - [Send emails with Ruby](https://opensend.namuh.co/docs/send-with-ruby.md): Send email from Ruby with the first-party OpenSend Ruby SDK. It works in Rails, Sinatra, Ruby scripts, and background jobs.
 - [Send emails with Rails](https://opensend.namuh.co/docs/send-with-rails.md): Use the Ruby SDK from Rails controllers, jobs, mailer adapters, or service objects.
 - [Send emails with Sinatra](https://opensend.namuh.co/docs/send-with-sinatra.md): Use the Ruby SDK from Sinatra routes or background jobs.
@@ -31,7 +31,7 @@
 - [React Email Skill](https://opensend.namuh.co/docs/react-email-skill.md): Build HTML email with React components.
 - [Email Best Practices Skill](https://opensend.namuh.co/docs/email-best-practices-skill.md): Guardrails for production email systems.
 - [Custom Event Schemas](https://opensend.namuh.co/docs/custom-event-schemas.md): Define and validate custom event payloads.
-- [Send emails with PHP](https://opensend.namuh.co/docs/send-with-php.md): Send email from PHP with the first-party OpenSend PHP SDK. This first SDK slice supports the core single-email send path, idempotency keys, typed request/response objects, and typed OpenSend API errors.
+- [Send emails with PHP](https://opensend.namuh.co/docs/send-with-php.md): Send email from PHP with the first-party OpenSend PHP SDK. This first SDK slice is send-only: it supports the single-email send method, idempotency keys, typed request/response objects, and typed OpenSend API errors, but not other OpenSend resources yet.
 - [Introduction](https://opensend.namuh.co/docs/api-reference/introduction.md): Core concepts for the OpenSend API.
 - [Authentication](https://opensend.namuh.co/docs/api-reference/authentication.md): How API key authentication works in OpenSend.
 - [Pagination](https://opensend.namuh.co/docs/api-reference/pagination.md): OpenSend collection endpoints use cursor-style pagination where the route supports it. The API keeps pagination deliberately simple so self-hosted deployments and generated clients can share the same contract.

--- a/public/docs/sdks.md
+++ b/public/docs/sdks.md
@@ -1,6 +1,6 @@
 # Official SDKs
 
-OpenSend ships first-party SDKs for the languages most teams use to send mail from production services. All SDKs target OpenSend Cloud by default at `https://opensend.namuh.co` and can point at a self-hosted deployment by setting a base URL.
+OpenSend ships first-party SDKs for the languages most teams use to send mail from production services. All SDKs target OpenSend Cloud by default at `https://opensend.namuh.co` and can point at a self-hosted deployment by setting a base URL. The Java/Kotlin and PHP packages are intentionally partial today; their supported resources are listed below before any copyable examples.
 
 Use an OpenSend API key that starts with `os_`. Keep keys in server-side environment variables and never expose them to browser JavaScript, mobile apps, or public repositories.
 
@@ -16,6 +16,27 @@ Use an OpenSend API key that starts with `os_`. Keep keys in server-side environ
 | PHP | `packages/php-sdk` / future `opensend/opensend-php` Composer package | PHP services, Laravel/Symfony apps, workers | First-party send-email slice; install from the repo until Packagist publishing is enabled |
 | SMTP relay | `@opensend/smtp-relay` service | Apps that only speak SMTP | Self-hosted relay service |
 | Other languages | `/openapi.json` | Generated clients | Generate from the OpenAPI contract |
+
+## Partial SDK surfaces
+
+Each SDK has its own package-specific surface. The JVM and PHP packages are
+narrower than the full REST API and should be treated as explicit slices:
+
+- **Java / Kotlin (`packages/jvm-sdk`)**: blocking-only client for emails,
+  contacts, domains, and suppressions. It does not expose JVM methods for API
+  keys, broadcasts, audiences, segments, topics, templates, webhooks, logs,
+  contact properties, events, automations, receiving, dedicated IPs, or
+  unsubscribe-page settings yet.
+- **PHP (`packages/php-sdk`)**: send-only client for
+  `client->emails->send(...)`, idempotency options, typed send
+  payloads/responses, and typed OpenSend API errors. It does not expose PHP
+  resource clients for reads, batch sends, contacts, domains, suppressions, API
+  keys, broadcasts, audiences, segments, topics, templates, webhooks, logs,
+  contact properties, events, automations, receiving, dedicated IPs, or
+  unsubscribe-page settings yet.
+
+Use `/openapi.json` and the REST API docs for resources not listed in a package
+README. Do not assume every OpenAPI path has a handwritten JVM or PHP method.
 
 ## TypeScript and JavaScript
 
@@ -141,6 +162,11 @@ func main() {
 
 ## Java and Kotlin
 
+**Support level:** partial, blocking-only SDK. This package currently supports
+implemented email, contact, domain, and suppression routes only. Use the REST
+API and `/openapi.json` for other resources until matching JVM resource clients
+are added.
+
 Install from this repository until Maven publishing is complete:
 
 ```bash
@@ -173,7 +199,7 @@ EmailResponse email = client.emails().send(
 System.out.println(email.id());
 ```
 
-The JVM SDK is blocking-only in this first slice and supports implemented email, contact, domain, and suppression routes. It exposes `ApiException` for OpenSend error envelopes plus rate-limit headers. See [Send emails with Java and Kotlin](./send-with-java.md) for Kotlin and Spring Boot examples.
+The JVM SDK exposes `ApiException` for OpenSend error envelopes plus rate-limit headers. See [Send emails with Java and Kotlin](./send-with-java.md) for Kotlin and Spring Boot examples.
 
 ## Ruby
 
@@ -212,6 +238,12 @@ The Ruby package also exports `Resend` as a compatibility alias for migration-or
 
 
 ## PHP
+
+**Support level:** partial, send-only SDK. This package currently supports
+`client->emails->send(...)` for `POST /emails`, idempotency options, typed send
+payloads/responses, and typed OpenSend API errors only. Use the REST API and
+`/openapi.json` for other resources until matching PHP resource clients are
+added.
 
 Install from this repository until Packagist publishing is complete:
 

--- a/public/docs/send-with-java.md
+++ b/public/docs/send-with-java.md
@@ -1,8 +1,21 @@
 # Send emails with Java and Kotlin
 
-Use the first-party OpenSend JVM SDK from plain Java, Kotlin, Spring Boot services, workers, and command-line applications. The package lives in this repository at `packages/jvm-sdk` while registry publishing is prepared.
+Use the first-party OpenSend JVM SDK from plain Java, Kotlin, Spring Boot services, workers, and command-line applications. The package lives in this repository at `packages/jvm-sdk` while registry publishing is prepared. This is a partial, blocking-only SDK for emails, contacts, domains, and suppressions; use the REST API and `/openapi.json` for other resources.
 
 The JVM SDK targets OpenSend Cloud by default at `https://opensend.namuh.co` and can point at self-hosted OpenSend by setting `OPENSEND_BASE_URL`.
+
+## Support level
+
+This JVM package is intentionally narrower than the full OpenSend REST API. It currently wraps:
+
+- `emails`: `POST /emails`, `POST /emails/batch`, `GET /api/emails`, `GET /api/emails/{id}`, `POST /emails/{id}/cancel`
+- `contacts`: `POST /contacts`, `GET /contacts`, `GET /contacts/{id}`, `PATCH /contacts/{id}`, `DELETE /contacts/{id}`
+- `domains`: `POST /api/domains`, `GET /api/domains`, `GET /api/domains/{id}`, `PATCH /api/domains/{id}`, `POST /api/domains/{id}/verify`, `DELETE /api/domains/{id}`
+- `suppressions`: `POST /api/suppressions`, `GET /api/suppressions`, `GET /api/suppressions/{email}`, `DELETE /api/suppressions/{email}`
+
+It does not expose JVM methods for API keys, broadcasts, audiences, segments,
+topics, templates, webhooks, logs, contact properties, events, automations,
+receiving, dedicated IPs, or unsubscribe-page settings yet.
 
 ## Install from the repository
 

--- a/public/docs/send-with-php.md
+++ b/public/docs/send-with-php.md
@@ -1,6 +1,16 @@
 # Send emails with PHP
 
-Send email from PHP with the first-party OpenSend PHP SDK. This first SDK slice supports the core single-email send path, idempotency keys, typed request/response objects, and typed OpenSend API errors.
+Send email from PHP with the first-party OpenSend PHP SDK. This first SDK slice is send-only: it supports the single-email send method, idempotency keys, typed request/response objects, and typed OpenSend API errors, but not other OpenSend resources yet.
+
+## Support level
+
+This PHP package is intentionally narrower than the full OpenSend REST API. It currently wraps only `POST /emails` through `client->emails->send(...)`.
+
+It does not expose PHP clients for email reads, batch sends, contacts, domains,
+suppressions, API keys, broadcasts, audiences, segments, topics, templates,
+webhooks, logs, contact properties, events, automations, receiving, dedicated
+IPs, or unsubscribe-page settings yet. Use the REST API and `/openapi.json` for
+those resources until matching PHP resource clients are added.
 
 ## Install
 


### PR DESCRIPTION
## Summary

Refs #617

Chosen path: **clearly label partial support** for the JVM and PHP SDKs instead of expanding handwritten clients in this PR.

This keeps the public docs truthful while OpenSend's OpenAPI/client-generation path continues to stabilize:

- Adds visible support-level callouts to JVM and PHP SDK READMEs before install/example sections.
- Adds support-level comments directly in JVM/PHP example files before copyable send code.
- Updates `/docs/sdks`, `send-with-java.md`, and `send-with-php.md` so users see the JVM/PHP limitations before copying examples.
- Regenerates `public/docs/llms.txt` so the LLM docs index carries the same partial-support warnings.
- Fixes the generated PHP guide summary so the LLM index does not mangle the PHP `client->emails->send(...)` call shape into a nonexistent method name.

## Validation

Passed:

- `bun run docs:generate` → `Indexed 193 markdown docs in public/docs/llms.txt`
- `bun run docs:check` → `Docs quality check passed for 193 pages.`
- `git diff --check`
- `make check && make test`
  - TypeCheck passed
  - Biome lint/format passed
  - Vitest: `201 passed | 3 skipped`, `1616 passed | 10 skipped`
- Push guardrails:
  - `scripts/check-changed-files.mjs`
  - full-project typecheck passed
  - changed-file Biome passed

Package-local SDK checks attempted but blocked by missing local toolchains in this worktree environment:

- `mvn test` → `zsh:1: command not found: mvn`; `java -version` reported no Java Runtime.
- `composer install --no-interaction && composer test` → `zsh:1: command not found: composer`; `php` not found.

Review evidence:

- Independent `codex exec review --uncommitted` found one P2 in `public/docs/llms.txt` where generated text advertised `client-emails-send(...)`; fixed by changing the PHP guide summary and regenerating docs.
- A second final recheck was unavailable/too slow after the fix and was stopped per controller instruction; repo verification above passed after the fix.
