### PR TITLE
Issue 613: strict compatibility mode for root /topics and /contact-properties

### DIFF
--- a/packages/core/src/services/audience-metadata.ts
+++ b/packages/core/src/services/audience-metadata.ts
@@ -16,6 +16,28 @@ type PropertyRow = typeof contactProperties.$inferSelect;
 type PropertyInsert = typeof contactProperties.$inferInsert;
 type ContactRow = typeof contacts.$inferSelect;
 
+type ApiCompatibilityMode = "api" | "root";
+
+const validTopicDefaultSubscriptions = ["opt_in", "opt_out"] as const;
+const validTopicVisibilities = ["public", "private"] as const;
+const validPropertyTypes = ["string", "number", "boolean", "date"] as const;
+
+type TopicDefaultSubscription = (typeof validTopicDefaultSubscriptions)[number];
+type TopicVisibility = (typeof validTopicVisibilities)[number];
+type PropertyType = (typeof validPropertyTypes)[number];
+
+type CreateTopicInput = {
+  userId: string;
+  body: unknown;
+  mode?: ApiCompatibilityMode;
+};
+
+type CreatePropertyInput = {
+  userId: string;
+  body: unknown;
+  mode?: ApiCompatibilityMode;
+};
+
 type SegmentListRow = Pick<SegmentRow, "id" | "name" | "createdAt">;
 type SegmentContactListRow = Pick<
   ContactRow,
@@ -177,6 +199,27 @@ function trimOptionalStringAsNull(
 function firstTruthyString(...values: unknown[]): string | null {
   const found = values.find(Boolean);
   return found === undefined || found === null ? null : String(found);
+}
+
+function assertStrictEnumValue<T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  field: string,
+): T[number] {
+  if (typeof value !== "string") {
+    throw invalidInput(`${field} is required`);
+  }
+
+  const normalized = value.trim();
+  if (!normalized) {
+    throw invalidInput(`${field} is required`);
+  }
+
+  if (!allowed.includes(normalized as T[number])) {
+    throw invalidInput(`${field} must be one of: ${allowed.join(" | ")}`, 422);
+  }
+
+  return normalized as T[number];
 }
 
 function toSegmentListItem(row: SegmentListRow) {
@@ -360,7 +403,7 @@ export function createAudienceMetadataService({
       };
     },
 
-    async createTopic(input: { userId: string; body: unknown }) {
+    async createTopic(input: CreateTopicInput) {
       const body = asRecord(input.body);
       const name = trimRequiredString(body.name, "name");
       if (!name) throw invalidInput("Name is required");
@@ -373,11 +416,33 @@ export function createAudienceMetadataService({
         throw invalidInput("Description must be 200 characters or less", 422);
       }
 
-      const defaultSubscription =
-        (body.default_subscription || body.defaultSubscription) === "opt_in"
-          ? "opt_in"
-          : "opt_out";
-      const visibility = body.visibility === "private" ? "private" : "public";
+      const mode = input.mode === "root" ? "root" : "api";
+
+      const defaultSubscriptionRaw =
+        body.default_subscription ?? body.defaultSubscription;
+      const visibilityRaw = body.visibility;
+
+      const defaultSubscription: TopicDefaultSubscription =
+        mode === "root"
+          ? (assertStrictEnumValue(
+              defaultSubscriptionRaw,
+              validTopicDefaultSubscriptions,
+              "default_subscription",
+            ) as TopicDefaultSubscription)
+          : defaultSubscriptionRaw === "opt_in"
+            ? "opt_in"
+            : "opt_out";
+
+      const visibility: TopicVisibility =
+        mode === "root"
+          ? (assertStrictEnumValue(
+              visibilityRaw,
+              validTopicVisibilities,
+              "visibility",
+            ) as TopicVisibility)
+          : visibilityRaw === "private"
+            ? "private"
+            : "public";
 
       const [topic] = await repository.createTopic({
         name,
@@ -471,11 +536,27 @@ export function createAudienceMetadataService({
       };
     },
 
-    async createProperty(input: { userId: string; body: unknown }) {
+    async createProperty(input: CreatePropertyInput) {
       const body = asRecord(input.body);
-      const key = trimRequiredString(body.key, "key");
+      const mode = input.mode === "root" ? "root" : "api";
+
+      const key =
+        mode === "root"
+          ? trimRequiredString(body.key, "key")
+          : trimOptionalStringAsNull(body.key, "key") || "";
+
+      if (mode === "root" && !key) {
+        throw invalidInput("key is required");
+      }
       const name = trimRequiredString(body.name, "name");
-      const type = firstTruthyString(body.type) ?? "string";
+      const type =
+        mode === "root"
+          ? (assertStrictEnumValue(
+              body.type,
+              validPropertyTypes,
+              "type",
+            ) as PropertyType)
+          : (firstTruthyString(body.type) ?? "string");
       const fallbackValue = firstTruthyString(
         body.fallback_value,
         body.fallbackValue,

--- a/packages/core/src/services/audience-metadata.ts
+++ b/packages/core/src/services/audience-metadata.ts
@@ -38,6 +38,20 @@ type CreatePropertyInput = {
   mode?: ApiCompatibilityMode;
 };
 
+type UpdateTopicInput = {
+  userId: string;
+  id: string;
+  body: unknown;
+  mode?: ApiCompatibilityMode;
+};
+
+type UpdatePropertyInput = {
+  userId: string;
+  id: string;
+  body: unknown;
+  mode?: ApiCompatibilityMode;
+};
+
 type SegmentListRow = Pick<SegmentRow, "id" | "name" | "createdAt">;
 type SegmentContactListRow = Pick<
   ContactRow,
@@ -472,8 +486,9 @@ export function createAudienceMetadataService({
       return toTopicDetail(topic);
     },
 
-    async updateTopic(input: { userId: string; id: string; body: unknown }) {
+    async updateTopic(input: UpdateTopicInput) {
       const body = asRecord(input.body);
+      const mode = input.mode === "root" ? "root" : "api";
       const updateData: Partial<TopicInsert> = {};
 
       if (body.name !== undefined) {
@@ -485,13 +500,31 @@ export function createAudienceMetadataService({
           "description",
         );
       }
-      if (body.defaultSubscription !== undefined) {
+      const defaultSubscriptionInput =
+        body.default_subscription ?? body.defaultSubscription;
+      if (defaultSubscriptionInput !== undefined) {
         updateData.defaultSubscription =
-          body.defaultSubscription === "opt_in" ? "opt_in" : "opt_out";
+          mode === "root"
+            ? (assertStrictEnumValue(
+                defaultSubscriptionInput,
+                validTopicDefaultSubscriptions,
+                "default_subscription",
+              ) as TopicDefaultSubscription)
+            : defaultSubscriptionInput === "opt_in"
+              ? "opt_in"
+              : "opt_out";
       }
       if (body.visibility !== undefined) {
         updateData.visibility =
-          body.visibility === "private" ? "private" : "public";
+          mode === "root"
+            ? (assertStrictEnumValue(
+                body.visibility,
+                validTopicVisibilities,
+                "visibility",
+              ) as TopicVisibility)
+            : body.visibility === "private"
+              ? "private"
+              : "public";
       }
 
       if (Object.keys(updateData).length === 0) {
@@ -589,15 +622,23 @@ export function createAudienceMetadataService({
       return toPropertyPayload(property);
     },
 
-    async updateProperty(input: { userId: string; id: string; body: unknown }) {
+    async updateProperty(input: UpdatePropertyInput) {
       const body = asRecord(input.body);
+      const mode = input.mode === "root" ? "root" : "api";
       const updateData: Partial<PropertyInsert> = { updatedAt: now() };
 
       if (body.name !== undefined) {
         updateData.name = trimPresentString(body.name, "name");
       }
       if (body.type !== undefined) {
-        updateData.type = String(body.type);
+        updateData.type =
+          mode === "root"
+            ? (assertStrictEnumValue(
+                body.type,
+                validPropertyTypes,
+                "type",
+              ) as PropertyType)
+            : String(body.type);
       }
       if (body.fallback_value !== undefined) {
         updateData.fallbackValue =

--- a/public/docs/api-reference/contact-properties/create-contact-property.md
+++ b/public/docs/api-reference/contact-properties/create-contact-property.md
@@ -1,10 +1,25 @@
 # Create Contact Property
 
-Create a custom contact property definition.
+Create a custom contact property definition for audience management.
 
 `POST /contact-properties`
 
-Compatibility note: `POST /api/properties` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
+`POST /api/properties`
+
+## Compatibility behavior
+
+`/contact-properties` is the compatibility alias. In this mode the request body is validated strictly:
+
+- `name` is required and trimmed.
+- `key` is required and cannot be omitted.
+- `type` is required and must be one of `string`, `number`, `boolean`, or `date`.
+- `fallback_value` is optional.
+
+`/api/properties` retains OpenSend extension behavior:
+
+- `key` may be omitted and is derived from `name` when missing.
+- `type` defaults to `string` when omitted.
+- Existing `/api/properties` integration behavior is preserved.
 
 ## Authentication
 
@@ -18,7 +33,10 @@ Dashboard session cookies are not API credentials.
 
 ## Parameters
 
-Choose a stable key before using the property in imports or automations.
+- `name` (required)
+- `key` (optional; required for `/contact-properties`)
+- `type` (optional; required for `/contact-properties`)
+- `fallback_value` (optional)
 
 ## Response
 
@@ -26,4 +44,4 @@ Returns an OpenSend JSON response for the authenticated tenant. Error responses 
 
 ## Self-hosting notes
 
-Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/properties` while dashboard page requests continue to render normally.
+Self-hosted deployments can use the same path on their own `OPENSEND_BASE_URL`. Ensure middleware is enabled so API-like requests are routed to `/api/properties` while dashboard page routes continue to render normally.

--- a/public/docs/api-reference/contact-properties/update-contact-property.md
+++ b/public/docs/api-reference/contact-properties/update-contact-property.md
@@ -4,7 +4,14 @@ Update display metadata for a custom contact property.
 
 `PATCH /contact-properties/{id}`
 
-Compatibility note: `PATCH /api/properties/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
+Compatibility behavior:
+
+- `/contact-properties/{id}` is the compatibility alias handled by middleware rewrite to `/api/properties/{id}`.
+- In compatibility mode, if `type` is provided it must be one of: `string` | `number` | `boolean` | `date`.
+- `name` and `fallback_value` remain editable for legacy-compatible updates.
+- `key` is create-only/stable and is not patch-updated by this route.
+- `PATCH /api/properties/{id}` remains legacy compatible for existing OpenSend integrations.
+
 
 ## Authentication
 

--- a/public/docs/api-reference/topics/create-topic.md
+++ b/public/docs/api-reference/topics/create-topic.md
@@ -4,7 +4,22 @@ Create a subscription topic for audience preference management.
 
 `POST /topics`
 
-Compatibility note: `POST /api/topics` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
+`POST /api/topics`
+
+## Compatibility behavior
+
+`/topics` is the compatibility alias. In this mode the request body is validated strictly:
+
+- `name` is required and trimmed.
+- `default_subscription` is required and must be either `opt_in` or `opt_out`.
+- `visibility` is required and must be either `public` or `private`.
+- `description` is optional and still capped at 200 characters.
+
+`/api/topics` retains OpenSend extension behavior:
+
+- Missing `default_subscription` defaults to `opt_out`.
+- Missing `visibility` defaults to `public`.
+- Invalid values for those fields are still normalized to legacy defaults.
 
 ## Authentication
 
@@ -18,7 +33,12 @@ Dashboard session cookies are not API credentials.
 
 ## Parameters
 
-Body includes topic display fields accepted by OpenSend.
+Body includes topic display fields accepted by this API.
+
+- `name` (required)
+- `description` (optional)
+- `default_subscription` (optional; strict root mode requires it)
+- `visibility` (optional; strict root mode requires it)
 
 ## Response
 

--- a/public/docs/api-reference/topics/update-topic.md
+++ b/public/docs/api-reference/topics/update-topic.md
@@ -4,7 +4,16 @@ Update mutable subscription topic fields.
 
 `PATCH /topics/{id}`
 
-Compatibility note: `PATCH /api/topics/{id}` remains available for existing OpenSend integrations; new API clients should prefer the root compatibility path above. Browser dashboard navigation is preserved for page routes that share these names.
+Compatibility behavior:
+
+- `/topics/{id}` is the compatibility alias handled by middleware rewrite to `/api/topics/{id}`.
+- In compatibility mode, provided enum fields are validated strictly:
+  - `default_subscription` (or `defaultSubscription`): `opt_in` | `opt_out`
+  - `visibility`: `public` | `private`
+- `name` and `description` remain optional for partial updates.
+- `PATCH /api/topics/{id}` remains legacy compatible for existing OpenSend integrations.
+
+Note: compatibility updates are partial and strict on provided enum fields only.
 
 ## Authentication
 

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -56,7 +56,7 @@
 - [List Broadcasts](https://opensend.namuh.co/docs/api-reference/broadcasts/list-broadcasts.md): List broadcasts. This page documents the OpenSend-owned API contract for GET /broadcasts.
 - [Send Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/send-broadcast.md): Send or schedule a broadcast. This page documents the OpenSend-owned API contract for POST /broadcasts/{id}/send.
 - [Update Broadcast](https://opensend.namuh.co/docs/api-reference/broadcasts/update-broadcast.md): Update a broadcast. This page documents the OpenSend-owned API contract for PATCH /broadcasts/{id}.
-- [Create Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/create-contact-property.md): Create a custom contact property definition.
+- [Create Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/create-contact-property.md): Create a custom contact property definition for audience management.
 - [Delete Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/delete-contact-property.md): Delete a custom contact property definition.
 - [Get Contact Property](https://opensend.namuh.co/docs/api-reference/contact-properties/get-contact-property.md): Retrieve one custom contact property definition.
 - [List Contact Properties](https://opensend.namuh.co/docs/api-reference/contact-properties/list-contact-properties.md): List custom contact properties available for segmentation and personalization.

--- a/src/app/api/properties/[id]/route.ts
+++ b/src/app/api/properties/[id]/route.ts
@@ -1,5 +1,6 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
+import { getRootApiAlias } from "@/lib/root-api-compatibility";
 import {
   AudienceMetadataServiceError,
   createAudienceMetadataService,
@@ -20,6 +21,11 @@ function mapServiceError(error: unknown, fallback: string) {
 
   console.error(`${fallback}:`, error);
   return NextResponse.json({ error: fallback }, { status: 500 });
+}
+
+function inputMode(request: NextRequest) {
+  const alias = getRootApiAlias(request.headers);
+  return alias === "contact-properties" ? "root" : "api";
 }
 
 export async function GET(
@@ -62,6 +68,7 @@ export async function PATCH(
       userId: auth.userId,
       id,
       body,
+      mode: inputMode(request),
     });
 
     return NextResponse.json(result);

--- a/src/app/api/properties/route.ts
+++ b/src/app/api/properties/route.ts
@@ -4,6 +4,7 @@ import {
   unauthorizedResponse,
 } from "@/lib/api-auth";
 import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
+import { getRootApiAlias } from "@/lib/root-api-compatibility";
 import {
   AudienceMetadataServiceError,
   createAudienceMetadataService,
@@ -13,6 +14,11 @@ import { type NextRequest, NextResponse } from "next/server";
 type PropertyRouteAuth = NonNullable<
   Awaited<ReturnType<typeof authorizeDashboardOrApiKey>>
 >;
+
+function inputMode(request: NextRequest) {
+  const alias = getRootApiAlias(request.headers);
+  return alias === "contact-properties" ? "root" : "api";
+}
 
 async function resolveUserId(auth: PropertyRouteAuth): Promise<string | null> {
   if ("userId" in auth) return auth.userId;
@@ -76,6 +82,7 @@ export async function POST(request: NextRequest) {
     const result = await audienceMetadataService().createProperty({
       userId,
       body,
+      mode: inputMode(request),
     });
 
     return NextResponse.json(result, { status: 201 });

--- a/src/app/api/topics/[id]/route.ts
+++ b/src/app/api/topics/[id]/route.ts
@@ -1,5 +1,6 @@
 import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
 import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
+import { getRootApiAlias } from "@/lib/root-api-compatibility";
 import {
   AudienceMetadataServiceError,
   createAudienceMetadataService,
@@ -20,6 +21,11 @@ function mapServiceError(error: unknown, fallback: string) {
 
   console.error(`${fallback}:`, error);
   return NextResponse.json({ error: fallback }, { status: 500 });
+}
+
+function inputMode(request: NextRequest) {
+  const alias = getRootApiAlias(request.headers);
+  return alias === "topics" ? "root" : "api";
 }
 
 export async function GET(
@@ -62,6 +68,7 @@ export async function PATCH(
       userId: auth.userId,
       id,
       body,
+      mode: inputMode(request),
     });
 
     return NextResponse.json(result);

--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -4,6 +4,7 @@ import {
   unauthorizedResponse,
 } from "@/lib/api-auth";
 import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
+import { getRootApiAlias } from "@/lib/root-api-compatibility";
 import {
   AudienceMetadataServiceError,
   createAudienceMetadataService,
@@ -13,6 +14,11 @@ import { type NextRequest, NextResponse } from "next/server";
 type TopicRouteAuth = NonNullable<
   Awaited<ReturnType<typeof authorizeDashboardOrApiKey>>
 >;
+
+function inputMode(request: NextRequest) {
+  const alias = getRootApiAlias(request.headers);
+  return alias === "topics" ? "root" : "api";
+}
 
 async function resolveUserId(auth: TopicRouteAuth): Promise<string | null> {
   if ("userId" in auth) return auth.userId;
@@ -77,6 +83,7 @@ export async function POST(request: NextRequest) {
     const result = await audienceMetadataService().createTopic({
       userId,
       body,
+      mode: inputMode(request),
     });
 
     return NextResponse.json(result, { status: 201 });

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -4196,6 +4196,25 @@ export const openApiDocument = {
           description: { type: "string", nullable: true },
         },
       },
+      UpdateTopicRequestStrict: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          description: { type: "string", nullable: true },
+          default_subscription: {
+            type: "string",
+            enum: ["opt_in", "opt_out"],
+          },
+          defaultSubscription: {
+            type: "string",
+            enum: ["opt_in", "opt_out"],
+          },
+          visibility: {
+            type: "string",
+            enum: ["public", "private"],
+          },
+        },
+      },
       Property: {
         type: "object",
         properties: {
@@ -4267,6 +4286,24 @@ export const openApiDocument = {
         type: "object",
         properties: {
           name: { type: "string" },
+        },
+      },
+      UpdatePropertyRequestStrict: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          type: {
+            type: "string",
+            enum: ["string", "number", "boolean", "date"],
+          },
+          fallback_value: {
+            oneOf: [
+              { type: "string" },
+              { type: "number" },
+              { type: "boolean" },
+              { type: "null" },
+            ],
+          },
         },
       },
       Broadcast: {
@@ -5376,6 +5413,25 @@ if (canonicalTopicsPath?.post) {
   };
 }
 
+const canonicalTopicDetailPath = mutablePaths["/api/topics/{id}"];
+if (canonicalTopicDetailPath?.patch) {
+  mutablePaths["/topics/{id}"] = {
+    ...(mutablePaths["/topics/{id}"] as PathItemObject),
+    patch: withAliasDetails(canonicalTopicDetailPath.patch, {
+      summary: "Update a topic",
+      description:
+        "Root-compatible topic detail route. `default_subscription` (or `defaultSubscription`) and `visibility` can be supplied and must be one of the documented enum values. Both fields are optional for partial updates.",
+      requestBody: {
+        required: true,
+        content: jsonContent({
+          $ref: "#/components/schemas/UpdateTopicRequestStrict",
+        }),
+      },
+      operationId: "updateTopicRoot",
+    }),
+  };
+}
+
 const canonicalContactPropertiesPath = mutablePaths["/api/properties"];
 if (canonicalContactPropertiesPath?.post) {
   mutablePaths["/contact-properties"] = {
@@ -5391,6 +5447,25 @@ if (canonicalContactPropertiesPath?.post) {
         }),
       },
       operationId: "createContactPropertyRoot",
+    }),
+  };
+}
+
+const canonicalContactPropertyDetailPath = mutablePaths["/api/properties/{id}"];
+if (canonicalContactPropertyDetailPath?.patch) {
+  mutablePaths["/contact-properties/{id}"] = {
+    ...(mutablePaths["/contact-properties/{id}"] as PathItemObject),
+    patch: withAliasDetails(canonicalContactPropertyDetailPath.patch, {
+      summary: "Update a contact property",
+      description:
+        "Root-compatible contact-property detail route. If provided, `type` must be one of the documented enum values. `key` remains create-only/stable and is not patchable for compatibility with OpenSend clients.",
+      requestBody: {
+        required: true,
+        content: jsonContent({
+          $ref: "#/components/schemas/UpdatePropertyRequestStrict",
+        }),
+      },
+      operationId: "updateContactPropertyRoot",
     }),
   };
 }

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -1,5 +1,12 @@
 type JsonSchema = {
-  type?: "array" | "boolean" | "integer" | "number" | "object" | "string";
+  type?:
+    | "array"
+    | "boolean"
+    | "integer"
+    | "number"
+    | "null"
+    | "object"
+    | "string";
   format?: string;
   description?: string;
   pattern?: string;
@@ -1640,6 +1647,8 @@ export const openApiDocument = {
         summary: "Create a topic",
         operationId: "createTopic",
         security: bearerSecurity,
+        description:
+          "OpenSend-compatible endpoint. `default_subscription` and `visibility` are optional and default to `opt_out` and `public` when omitted.",
         requestBody: {
           required: true,
           content: jsonContent({
@@ -1739,6 +1748,8 @@ export const openApiDocument = {
         summary: "Create a contact property",
         operationId: "createProperty",
         security: bearerSecurity,
+        description:
+          "OpenSend-compatible endpoint. If `key` is omitted, it is derived from `name`. If `type` is omitted, it defaults to `string`.",
         requestBody: {
           required: true,
           content: jsonContent({
@@ -4151,8 +4162,32 @@ export const openApiDocument = {
         properties: {
           name: { type: "string" },
           description: { type: "string" },
+          default_subscription: {
+            type: "string",
+            enum: ["opt_in", "opt_out"],
+          },
+          visibility: {
+            type: "string",
+            enum: ["public", "private"],
+          },
         },
         required: ["name"],
+      },
+      CreateTopicRequestStrict: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          description: { type: "string" },
+          default_subscription: {
+            type: "string",
+            enum: ["opt_in", "opt_out"],
+          },
+          visibility: {
+            type: "string",
+            enum: ["public", "private"],
+          },
+        },
+        required: ["name", "default_subscription", "visibility"],
       },
       UpdateTopicRequest: {
         type: "object",
@@ -4196,6 +4231,34 @@ export const openApiDocument = {
           type: {
             type: "string",
             enum: ["string", "number", "boolean", "date"],
+          },
+          fallback_value: {
+            oneOf: [
+              { type: "string" },
+              { type: "number" },
+              { type: "boolean" },
+              { type: "null" },
+            ],
+          },
+        },
+        required: ["name"],
+      },
+      CreatePropertyRequestStrict: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          key: { type: "string" },
+          type: {
+            type: "string",
+            enum: ["string", "number", "boolean", "date"],
+          },
+          fallback_value: {
+            oneOf: [
+              { type: "string" },
+              { type: "number" },
+              { type: "boolean" },
+              { type: "null" },
+            ],
           },
         },
         required: ["name", "key", "type"],
@@ -5290,6 +5353,44 @@ if (canonicalEventsPath?.get && canonicalEventsPath.post) {
       description:
         "Root-compatible custom events create route. Requires an OpenSend API key and creates the event definition for the authenticated tenant.",
       operationId: "createEventRoot",
+    }),
+  };
+}
+
+const canonicalTopicsPath = mutablePaths["/api/topics"];
+if (canonicalTopicsPath?.post) {
+  mutablePaths["/topics"] = {
+    ...(mutablePaths["/topics"] as PathItemObject),
+    post: withAliasDetails(canonicalTopicsPath.post, {
+      summary: "Create a topic",
+      description:
+        "Root-compatible topics create route with strict schema requirements. `default_subscription` and `visibility` are required and must be explicit values. Existing `/api/topics` defaults are preserved for non-root callers.",
+      requestBody: {
+        required: true,
+        content: jsonContent({
+          $ref: "#/components/schemas/CreateTopicRequestStrict",
+        }),
+      },
+      operationId: "createTopicRoot",
+    }),
+  };
+}
+
+const canonicalContactPropertiesPath = mutablePaths["/api/properties"];
+if (canonicalContactPropertiesPath?.post) {
+  mutablePaths["/contact-properties"] = {
+    ...(mutablePaths["/contact-properties"] as PathItemObject),
+    post: withAliasDetails(canonicalContactPropertiesPath.post, {
+      summary: "Create a contact property",
+      description:
+        "Root-compatible contact-property create route with strict schema requirements. `key` and `type` are required for root requests; OpenSend `/api/properties` defaults remain unchanged.",
+      requestBody: {
+        required: true,
+        content: jsonContent({
+          $ref: "#/components/schemas/CreatePropertyRequestStrict",
+        }),
+      },
+      operationId: "createContactPropertyRoot",
     }),
   };
 }

--- a/src/lib/root-api-compatibility.ts
+++ b/src/lib/root-api-compatibility.ts
@@ -1,0 +1,16 @@
+export type RootApiAlias = "topics" | "contact-properties";
+
+export const rootApiAliasHeaderName = "x-opensend-root-api-alias";
+
+export function getRootApiAlias(headers: Headers): RootApiAlias | null {
+  const value = headers.get(rootApiAliasHeaderName);
+  if (value === "topics" || value === "contact-properties") {
+    return value;
+  }
+
+  return null;
+}
+
+export function isRootApiAlias(headers: Headers, alias: RootApiAlias): boolean {
+  return getRootApiAlias(headers) === alias;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -665,62 +665,68 @@ export async function middleware(request: NextRequest) {
 
   const rewriteHeaders = (path: string) => {
     const headers = new Headers(responseHeaders);
+    const requestHeaders = new Headers(request.headers);
     const aliasHeader = rootApiAliasForPath(path);
     if (aliasHeader) {
       headers.set(rootApiAliasHeaderName, aliasHeader);
+      requestHeaders.set(rootApiAliasHeaderName, aliasHeader);
     }
 
-    return headers;
+    return {
+      headers,
+      request: {
+        headers: requestHeaders,
+      },
+    };
   };
 
   if (backend === "disabled") {
     if (isSingleSendPostAlias(pathname, request.method)) {
-      return NextResponse.rewrite(new URL("/api/emails", request.url), {
-        headers: rewriteHeaders(pathname),
-      });
+      return NextResponse.rewrite(
+        new URL("/api/emails", request.url),
+        rewriteHeaders(pathname),
+      );
     }
     if (isBatchSendPostAlias(pathname, request.method)) {
-      return NextResponse.rewrite(new URL("/api/emails/batch", request.url), {
-        headers: rewriteHeaders(pathname),
-      });
+      return NextResponse.rewrite(
+        new URL("/api/emails/batch", request.url),
+        rewriteHeaders(pathname),
+      );
     }
     if (isBroadcastsCollectionAlias(pathname, request.method)) {
-      return NextResponse.rewrite(new URL("/api/broadcasts", request.url), {
-        headers: rewriteHeaders(pathname),
-      });
+      return NextResponse.rewrite(
+        new URL("/api/broadcasts", request.url),
+        rewriteHeaders(pathname),
+      );
     }
     if (isApiKeyAlias) {
       return NextResponse.rewrite(
         new URL(toApiKeysPath(pathname), request.url),
-        {
-          headers: rewriteHeaders(pathname),
-        },
+        rewriteHeaders(pathname),
       );
     }
     if (isTemplateAlias) {
       return NextResponse.rewrite(
         new URL(toPublicTemplatesPath(pathname), request.url),
-        { headers: rewriteHeaders(pathname) },
+        rewriteHeaders(pathname),
       );
     }
     if (isContactRelationshipAlias(pathname, request.method)) {
       return NextResponse.rewrite(
         new URL(toContactsApiPath(pathname), request.url),
-        {
-          headers: rewriteHeaders(pathname),
-        },
+        rewriteHeaders(pathname),
       );
     }
     if (isAutomationAlias) {
       return NextResponse.rewrite(
         new URL(toPublicAutomationsPath(pathname), request.url),
-        { headers: rewriteHeaders(pathname) },
+        rewriteHeaders(pathname),
       );
     }
     if (isApiCompatibilityAlias) {
       return NextResponse.rewrite(
         new URL(toApiCompatibilityPath(pathname), request.url),
-        { headers: rewriteHeaders(pathname) },
+        rewriteHeaders(pathname),
       );
     }
 
@@ -771,49 +777,51 @@ export async function middleware(request: NextRequest) {
   }
 
   if (isSingleSendPostAlias(pathname, request.method)) {
-    return NextResponse.rewrite(new URL("/api/emails", request.url), {
-      headers: rewriteHeaders(pathname),
-    });
+    return NextResponse.rewrite(
+      new URL("/api/emails", request.url),
+      rewriteHeaders(pathname),
+    );
   }
   if (isBatchSendPostAlias(pathname, request.method)) {
-    return NextResponse.rewrite(new URL("/api/emails/batch", request.url), {
-      headers: rewriteHeaders(pathname),
-    });
+    return NextResponse.rewrite(
+      new URL("/api/emails/batch", request.url),
+      rewriteHeaders(pathname),
+    );
   }
   if (isBroadcastsCollectionAlias(pathname, request.method)) {
-    return NextResponse.rewrite(new URL("/api/broadcasts", request.url), {
-      headers: rewriteHeaders(pathname),
-    });
+    return NextResponse.rewrite(
+      new URL("/api/broadcasts", request.url),
+      rewriteHeaders(pathname),
+    );
   }
   if (isApiKeyAlias) {
-    return NextResponse.rewrite(new URL(toApiKeysPath(pathname), request.url), {
-      headers: rewriteHeaders(pathname),
-    });
+    return NextResponse.rewrite(
+      new URL(toApiKeysPath(pathname), request.url),
+      rewriteHeaders(pathname),
+    );
   }
   if (isTemplateAlias) {
     return NextResponse.rewrite(
       new URL(toPublicTemplatesPath(pathname), request.url),
-      { headers: rewriteHeaders(pathname) },
+      rewriteHeaders(pathname),
     );
   }
   if (isContactRelationshipAlias(pathname, request.method)) {
     return NextResponse.rewrite(
       new URL(toContactsApiPath(pathname), request.url),
-      {
-        headers: rewriteHeaders(pathname),
-      },
+      rewriteHeaders(pathname),
     );
   }
   if (isAutomationAlias) {
     return NextResponse.rewrite(
       new URL(toPublicAutomationsPath(pathname), request.url),
-      { headers: rewriteHeaders(pathname) },
+      rewriteHeaders(pathname),
     );
   }
   if (isApiCompatibilityAlias) {
     return NextResponse.rewrite(
       new URL(toApiCompatibilityPath(pathname), request.url),
-      { headers: rewriteHeaders(pathname) },
+      rewriteHeaders(pathname),
     );
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,7 @@
+import {
+  type RootApiAlias,
+  rootApiAliasHeaderName,
+} from "@/lib/root-api-compatibility";
 import { getSessionCookie } from "better-auth/cookies";
 import { type NextRequest, NextResponse } from "next/server";
 
@@ -466,6 +470,21 @@ function toApiCompatibilityPath(pathname: string): string {
   return pathname;
 }
 
+function rootApiAliasForPath(pathname: string): RootApiAlias | null {
+  if (pathname === "/topics" || pathname.startsWith("/topics/")) {
+    return "topics";
+  }
+
+  if (
+    pathname === "/contact-properties" ||
+    pathname.startsWith("/contact-properties/")
+  ) {
+    return "contact-properties";
+  }
+
+  return null;
+}
+
 function isSendApiPost(pathname: string, method: string): boolean {
   return (
     method === "POST" &&
@@ -644,54 +663,64 @@ export async function middleware(request: NextRequest) {
   const backend = getRateLimitBackend();
   const responseHeaders = new Headers({ "X-RateLimit-Backend": backend });
 
+  const rewriteHeaders = (path: string) => {
+    const headers = new Headers(responseHeaders);
+    const aliasHeader = rootApiAliasForPath(path);
+    if (aliasHeader) {
+      headers.set(rootApiAliasHeaderName, aliasHeader);
+    }
+
+    return headers;
+  };
+
   if (backend === "disabled") {
     if (isSingleSendPostAlias(pathname, request.method)) {
       return NextResponse.rewrite(new URL("/api/emails", request.url), {
-        headers: responseHeaders,
+        headers: rewriteHeaders(pathname),
       });
     }
     if (isBatchSendPostAlias(pathname, request.method)) {
       return NextResponse.rewrite(new URL("/api/emails/batch", request.url), {
-        headers: responseHeaders,
+        headers: rewriteHeaders(pathname),
       });
     }
     if (isBroadcastsCollectionAlias(pathname, request.method)) {
       return NextResponse.rewrite(new URL("/api/broadcasts", request.url), {
-        headers: responseHeaders,
+        headers: rewriteHeaders(pathname),
       });
     }
     if (isApiKeyAlias) {
       return NextResponse.rewrite(
         new URL(toApiKeysPath(pathname), request.url),
         {
-          headers: responseHeaders,
+          headers: rewriteHeaders(pathname),
         },
       );
     }
     if (isTemplateAlias) {
       return NextResponse.rewrite(
         new URL(toPublicTemplatesPath(pathname), request.url),
-        { headers: responseHeaders },
+        { headers: rewriteHeaders(pathname) },
       );
     }
     if (isContactRelationshipAlias(pathname, request.method)) {
       return NextResponse.rewrite(
         new URL(toContactsApiPath(pathname), request.url),
         {
-          headers: responseHeaders,
+          headers: rewriteHeaders(pathname),
         },
       );
     }
     if (isAutomationAlias) {
       return NextResponse.rewrite(
         new URL(toPublicAutomationsPath(pathname), request.url),
-        { headers: responseHeaders },
+        { headers: rewriteHeaders(pathname) },
       );
     }
     if (isApiCompatibilityAlias) {
       return NextResponse.rewrite(
         new URL(toApiCompatibilityPath(pathname), request.url),
-        { headers: responseHeaders },
+        { headers: rewriteHeaders(pathname) },
       );
     }
 
@@ -743,48 +772,48 @@ export async function middleware(request: NextRequest) {
 
   if (isSingleSendPostAlias(pathname, request.method)) {
     return NextResponse.rewrite(new URL("/api/emails", request.url), {
-      headers: responseHeaders,
+      headers: rewriteHeaders(pathname),
     });
   }
   if (isBatchSendPostAlias(pathname, request.method)) {
     return NextResponse.rewrite(new URL("/api/emails/batch", request.url), {
-      headers: responseHeaders,
+      headers: rewriteHeaders(pathname),
     });
   }
   if (isBroadcastsCollectionAlias(pathname, request.method)) {
     return NextResponse.rewrite(new URL("/api/broadcasts", request.url), {
-      headers: responseHeaders,
+      headers: rewriteHeaders(pathname),
     });
   }
   if (isApiKeyAlias) {
     return NextResponse.rewrite(new URL(toApiKeysPath(pathname), request.url), {
-      headers: responseHeaders,
+      headers: rewriteHeaders(pathname),
     });
   }
   if (isTemplateAlias) {
     return NextResponse.rewrite(
       new URL(toPublicTemplatesPath(pathname), request.url),
-      { headers: responseHeaders },
+      { headers: rewriteHeaders(pathname) },
     );
   }
   if (isContactRelationshipAlias(pathname, request.method)) {
     return NextResponse.rewrite(
       new URL(toContactsApiPath(pathname), request.url),
       {
-        headers: responseHeaders,
+        headers: rewriteHeaders(pathname),
       },
     );
   }
   if (isAutomationAlias) {
     return NextResponse.rewrite(
       new URL(toPublicAutomationsPath(pathname), request.url),
-      { headers: responseHeaders },
+      { headers: rewriteHeaders(pathname) },
     );
   }
   if (isApiCompatibilityAlias) {
     return NextResponse.rewrite(
       new URL(toApiCompatibilityPath(pathname), request.url),
-      { headers: responseHeaders },
+      { headers: rewriteHeaders(pathname) },
     );
   }
 

--- a/tests/audience-metadata-routes.test.ts
+++ b/tests/audience-metadata-routes.test.ts
@@ -9,6 +9,7 @@ const mockCreateTopic = vi.hoisted(() => vi.fn());
 const mockCreateProperty = vi.hoisted(() => vi.fn());
 const mockGetProperty = vi.hoisted(() => vi.fn());
 const mockUpdateTopic = vi.hoisted(() => vi.fn());
+const mockUpdateProperty = vi.hoisted(() => vi.fn());
 
 class TestAudienceMetadataServiceError extends Error {
   constructor(
@@ -38,6 +39,7 @@ vi.mock("@opensend/core", () => ({
     createProperty: mockCreateProperty,
     getProperty: mockGetProperty,
     updateTopic: mockUpdateTopic,
+    updateProperty: mockUpdateProperty,
   }),
 }));
 
@@ -324,6 +326,81 @@ describe("audience metadata route adapters", () => {
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
       error: "No fields to update",
+    });
+  });
+
+  it("passes root-api alias mode to strict topic detail update calls when header is present", async () => {
+    mockUpdateTopic.mockResolvedValueOnce({
+      id: "topic-1",
+      name: "News",
+      description: null,
+      defaultSubscription: "opt_in",
+      visibility: "private",
+      createdAt: "2026-05-10T00:00:00.000Z",
+    });
+    const { PATCH } = await import("@/app/api/topics/[id]/route");
+
+    const response = await PATCH(
+      makeNextRequest("http://localhost/api/topics/topic-1", {
+        method: "PATCH",
+        headers: {
+          authorization: "Bearer os_test",
+          "content-type": "application/json",
+          "x-opensend-root-api-alias": "topics",
+        },
+        body: JSON.stringify({
+          default_subscription: "opt_in",
+          visibility: "private",
+        }),
+      }) as never,
+      { params: Promise.resolve({ id: "topic-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpdateTopic).toHaveBeenCalledWith({
+      userId: "user-1",
+      id: "topic-1",
+      body: {
+        default_subscription: "opt_in",
+        visibility: "private",
+      },
+      mode: "root",
+    });
+  });
+
+  it("passes root-api alias mode to strict property detail update calls when header is present", async () => {
+    mockUpdateProperty.mockResolvedValueOnce({
+      id: "prop-1",
+      key: "company",
+      name: "Company",
+      type: "number",
+      fallback_value: null,
+      created_at: "2026-05-10T00:00:00.000Z",
+      updated_at: "2026-05-10T00:00:00.000Z",
+    });
+    const { PATCH } = await import("@/app/api/properties/[id]/route");
+
+    const response = await PATCH(
+      makeNextRequest("http://localhost/api/properties/prop-1", {
+        method: "PATCH",
+        headers: {
+          authorization: "Bearer os_test",
+          "content-type": "application/json",
+          "x-opensend-root-api-alias": "contact-properties",
+        },
+        body: JSON.stringify({ type: "number" }),
+      }) as never,
+      { params: Promise.resolve({ id: "prop-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpdateProperty).toHaveBeenCalledWith({
+      userId: "user-1",
+      id: "prop-1",
+      body: {
+        type: "number",
+      },
+      mode: "root",
     });
   });
 

--- a/tests/audience-metadata-routes.test.ts
+++ b/tests/audience-metadata-routes.test.ts
@@ -6,6 +6,7 @@ const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockListSegments = vi.hoisted(() => vi.fn());
 const mockListSegmentContacts = vi.hoisted(() => vi.fn());
 const mockCreateTopic = vi.hoisted(() => vi.fn());
+const mockCreateProperty = vi.hoisted(() => vi.fn());
 const mockGetProperty = vi.hoisted(() => vi.fn());
 const mockUpdateTopic = vi.hoisted(() => vi.fn());
 
@@ -34,6 +35,7 @@ vi.mock("@opensend/core", () => ({
     listSegments: mockListSegments,
     listSegmentContacts: mockListSegmentContacts,
     createTopic: mockCreateTopic,
+    createProperty: mockCreateProperty,
     getProperty: mockGetProperty,
     updateTopic: mockUpdateTopic,
   }),
@@ -117,6 +119,119 @@ describe("audience metadata route adapters", () => {
     expect(mockCreateTopic).toHaveBeenCalledWith({
       userId: "user-1",
       body: { name: "News" },
+      mode: "api",
+    });
+  });
+
+  it("passes root-api alias mode to strict topic service path when header is present", async () => {
+    mockCreateTopic.mockResolvedValueOnce({
+      object: "topic",
+      id: "topic-1",
+      name: "News",
+      description: null,
+      defaultSubscription: "opt_in",
+      visibility: "private",
+      createdAt: "2026-05-10T00:00:00.000Z",
+    });
+    const { POST } = await import("@/app/api/topics/route");
+
+    const response = await POST(
+      makeNextRequest("http://localhost/api/topics", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-opensend-root-api-alias": "topics",
+        },
+        body: JSON.stringify({
+          name: "News",
+          default_subscription: "opt_in",
+          visibility: "private",
+        }),
+      }) as never,
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockCreateTopic).toHaveBeenCalledWith({
+      userId: "user-1",
+      body: {
+        name: "News",
+        default_subscription: "opt_in",
+        visibility: "private",
+      },
+      mode: "root",
+    });
+  });
+
+  it("passes root-api alias mode to strict property service path when header is present", async () => {
+    mockCreateProperty.mockResolvedValueOnce({
+      object: "contact_property",
+      id: "prop-1",
+      key: "company_size",
+      name: "Company size",
+      type: "number",
+      fallback_value: null,
+      created_at: "2026-05-10T00:00:00.000Z",
+      updated_at: "2026-05-10T00:00:00.000Z",
+    });
+    const { POST } = await import("@/app/api/properties/route");
+
+    const response = await POST(
+      makeNextRequest("http://localhost/api/properties", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-opensend-root-api-alias": "contact-properties",
+        },
+        body: JSON.stringify({
+          name: "Company size",
+          key: "company_size",
+          type: "number",
+        }),
+      }) as never,
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockCreateProperty).toHaveBeenCalledWith({
+      userId: "user-1",
+      body: {
+        name: "Company size",
+        key: "company_size",
+        type: "number",
+      },
+      mode: "root",
+    });
+  });
+
+  it("defaults /api properties to API-compatible key/type behavior", async () => {
+    mockCreateProperty.mockResolvedValueOnce({
+      object: "contact_property",
+      id: "prop-1",
+      key: "company_size",
+      name: "Company Size",
+      type: "string",
+      fallback_value: null,
+      created_at: "2026-05-10T00:00:00.000Z",
+      updated_at: "2026-05-10T00:00:00.000Z",
+    });
+    const { POST } = await import("@/app/api/properties/route");
+
+    const response = await POST(
+      makeNextRequest("http://localhost/api/properties", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ name: "Company Size" }),
+      }) as never,
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockCreateProperty).toHaveBeenCalledWith({
+      userId: "user-1",
+      body: {
+        name: "Company Size",
+      },
+      mode: "api",
     });
   });
 

--- a/tests/audience-metadata-service.test.ts
+++ b/tests/audience-metadata-service.test.ts
@@ -310,6 +310,70 @@ describe("audience metadata service", () => {
       defaultSubscription: "opt_in",
       visibility: "private",
     });
+
+    await expect(
+      service.createTopic({
+        userId: "user-1",
+        body: {
+          name: "Product 2",
+        },
+      }),
+    ).resolves.toMatchObject({
+      object: "topic",
+      name: "Product 2",
+      defaultSubscription: "opt_out",
+      visibility: "public",
+    });
+  });
+
+  it("enforces strict root validation for topics", async () => {
+    const service = createAudienceMetadataService({
+      repository: makeRepository(),
+    });
+
+    await expect(
+      service.createTopic({
+        userId: "user-1",
+        mode: "root",
+        body: {
+          name: " Product ",
+          description: " updates ",
+          visibility: "private",
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "default_subscription is required",
+      status: 400,
+    });
+
+    await expect(
+      service.createTopic({
+        userId: "user-1",
+        mode: "root",
+        body: {
+          name: " Product ",
+          default_subscription: "opt_in",
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "visibility is required",
+      status: 400,
+    });
+
+    await expect(
+      service.createTopic({
+        userId: "user-1",
+        mode: "root",
+        body: {
+          name: " Product ",
+          default_subscription: "oops",
+          visibility: "private",
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "default_subscription must be one of: opt_in | opt_out",
+      status: 422,
+    });
   });
 
   it("returns not found instead of crossing tenants for detail and mutation", async () => {
@@ -410,6 +474,54 @@ describe("audience metadata service", () => {
       name: "Company Size",
       type: "number",
       fallback_value: null,
+    });
+
+    await expect(
+      service.createProperty({
+        userId: "user-1",
+        body: { name: "Company Type" },
+      }),
+    ).resolves.toMatchObject({
+      object: "contact_property",
+      key: "company_type",
+      type: "string",
+    });
+
+    await expect(
+      service.createProperty({
+        userId: "user-1",
+        mode: "root",
+        body: {
+          name: "Company Type",
+          type: "string",
+        },
+      }),
+    ).rejects.toMatchObject({ message: "key is required", status: 400 });
+
+    await expect(
+      service.createProperty({
+        userId: "user-1",
+        mode: "root",
+        body: {
+          name: "Company Type",
+          key: "company_type",
+        },
+      }),
+    ).rejects.toMatchObject({ message: "type is required", status: 400 });
+
+    await expect(
+      service.createProperty({
+        userId: "user-1",
+        mode: "root",
+        body: {
+          name: "Company Type",
+          key: "company_type",
+          type: "text",
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "type must be one of: string | number | boolean | date",
+      status: 422,
     });
   });
 

--- a/tests/audience-metadata-service.test.ts
+++ b/tests/audience-metadata-service.test.ts
@@ -376,6 +376,82 @@ describe("audience metadata service", () => {
     });
   });
 
+  it("supports root-detail topic PATCH validation without requiring omitted enum fields", async () => {
+    const service = createAudienceMetadataService({
+      repository: makeRepository({
+        topics: [topic("topic-1", "News", "user-1")],
+      }),
+    });
+
+    await expect(
+      service.updateTopic({
+        userId: "user-1",
+        mode: "root",
+        id: "topic-1",
+        body: {
+          defaultSubscription: "opt_in",
+          visibility: "private",
+        },
+      }),
+    ).resolves.toMatchObject({
+      id: "topic-1",
+      defaultSubscription: "opt_in",
+      visibility: "private",
+    });
+
+    await expect(
+      service.updateTopic({
+        userId: "user-1",
+        mode: "root",
+        id: "topic-1",
+        body: {
+          default_subscription: "yes",
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "default_subscription must be one of: opt_in | opt_out",
+      status: 422,
+    });
+
+    await expect(
+      service.updateTopic({
+        userId: "user-1",
+        mode: "root",
+        id: "topic-1",
+        body: {
+          visibility: "open",
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "visibility must be one of: public | private",
+      status: 422,
+    });
+  });
+
+  it("preserves API-mode topic update fallback semantics", async () => {
+    const service = createAudienceMetadataService({
+      repository: makeRepository({
+        topics: [topic("topic-1", "News", "user-1")],
+      }),
+    });
+
+    await expect(
+      service.updateTopic({
+        userId: "user-1",
+        mode: "api",
+        id: "topic-1",
+        body: {
+          default_subscription: "definitely-not-valid",
+          visibility: "locked",
+        },
+      }),
+    ).resolves.toMatchObject({
+      id: "topic-1",
+      defaultSubscription: "opt_out",
+      visibility: "public",
+    });
+  });
+
   it("returns not found instead of crossing tenants for detail and mutation", async () => {
     const service = createAudienceMetadataService({
       repository: makeRepository({
@@ -522,6 +598,50 @@ describe("audience metadata service", () => {
     ).rejects.toMatchObject({
       message: "type must be one of: string | number | boolean | date",
       status: 422,
+    });
+  });
+
+  it("enforces strict root validation for property PATCH type", async () => {
+    const service = createAudienceMetadataService({
+      repository: makeRepository({
+        properties: [property("prop-1", "company", "user-1")],
+      }),
+    });
+
+    await expect(
+      service.updateProperty({
+        userId: "user-1",
+        mode: "root",
+        id: "prop-1",
+        body: {
+          type: "text",
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "type must be one of: string | number | boolean | date",
+      status: 422,
+    });
+  });
+
+  it("preserves API-mode property patch semantics", async () => {
+    const service = createAudienceMetadataService({
+      repository: makeRepository({
+        properties: [property("prop-1", "company", "user-1")],
+      }),
+    });
+
+    await expect(
+      service.updateProperty({
+        userId: "user-1",
+        mode: "api",
+        id: "prop-1",
+        body: {
+          type: 123,
+        },
+      }),
+    ).resolves.toMatchObject({
+      id: "prop-1",
+      type: "123",
     });
   });
 

--- a/tests/middleware-rate-limit.test.ts
+++ b/tests/middleware-rate-limit.test.ts
@@ -184,6 +184,8 @@ describe("middleware rate limiting", () => {
       ["/webhooks/webhook_123", "/api/webhooks/webhook_123"],
       ["/topics", "/api/topics"],
       ["/contact-properties", "/api/properties"],
+      ["/topics/topic_123", "/api/topics/topic_123"],
+      ["/contact-properties/prop_123", "/api/properties/prop_123"],
       ["/logs", "/api/logs"],
       ["/logs/log_123", "/api/logs/log_123"],
       ["/emails", "/api/emails"],
@@ -229,11 +231,14 @@ describe("middleware rate limiting", () => {
         `https://example.com${apiPath}`,
       );
 
-      if (aliasPath === "/topics") {
+      if (aliasPath === "/topics" || aliasPath.startsWith("/topics/")) {
         expect(response.headers.get("x-opensend-root-api-alias")).toBe(
           "topics",
         );
-      } else if (aliasPath === "/contact-properties") {
+      } else if (
+        aliasPath === "/contact-properties" ||
+        aliasPath.startsWith("/contact-properties/")
+      ) {
         expect(response.headers.get("x-opensend-root-api-alias")).toBe(
           "contact-properties",
         );
@@ -308,6 +313,7 @@ describe("middleware rate limiting", () => {
       ["PATCH", "/topics/topic_123", "/api/topics/topic_123"],
       ["POST", "/contact-properties", "/api/properties"],
       ["DELETE", "/contact-properties/prop_123", "/api/properties/prop_123"],
+      ["PATCH", "/contact-properties/prop_123", "/api/properties/prop_123"],
       ["PATCH", "/emails/email_123", "/api/emails/email_123"],
       ["POST", "/automations", "/api/public/automations"],
       ["PATCH", "/automations/auto_123", "/api/public/automations/auto_123"],
@@ -334,13 +340,16 @@ describe("middleware rate limiting", () => {
         `https://example.com${apiPath}`,
       );
 
-      if (aliasPath === "/topics") {
+      if (aliasPath === "/topics" || aliasPath.startsWith("/topics/")) {
         expect(response.headers.get("x-opensend-root-api-alias")).toBe(
           "topics",
         );
       }
 
-      if (aliasPath === "/contact-properties") {
+      if (
+        aliasPath === "/contact-properties" ||
+        aliasPath.startsWith("/contact-properties/")
+      ) {
         expect(response.headers.get("x-opensend-root-api-alias")).toBe(
           "contact-properties",
         );

--- a/tests/middleware-rate-limit.test.ts
+++ b/tests/middleware-rate-limit.test.ts
@@ -182,6 +182,8 @@ describe("middleware rate limiting", () => {
       ["/domains/domain_123", "/api/domains/domain_123"],
       ["/webhooks", "/api/webhooks"],
       ["/webhooks/webhook_123", "/api/webhooks/webhook_123"],
+      ["/topics", "/api/topics"],
+      ["/contact-properties", "/api/properties"],
       ["/logs", "/api/logs"],
       ["/logs/log_123", "/api/logs/log_123"],
       ["/emails", "/api/emails"],
@@ -226,6 +228,18 @@ describe("middleware rate limiting", () => {
       expect(response.headers.get("x-middleware-rewrite")).toBe(
         `https://example.com${apiPath}`,
       );
+
+      if (aliasPath === "/topics") {
+        expect(response.headers.get("x-opensend-root-api-alias")).toBe(
+          "topics",
+        );
+      } else if (aliasPath === "/contact-properties") {
+        expect(response.headers.get("x-opensend-root-api-alias")).toBe(
+          "contact-properties",
+        );
+      } else {
+        expect(response.headers.get("x-opensend-root-api-alias")).toBeNull();
+      }
     }
 
     expect(mockGetSessionCookie).not.toHaveBeenCalled();
@@ -237,6 +251,8 @@ describe("middleware rate limiting", () => {
     for (const aliasPath of [
       "/domains",
       "/webhooks",
+      "/topics",
+      "/contact-properties",
       "/logs",
       "/emails",
       "/automations",
@@ -317,6 +333,18 @@ describe("middleware rate limiting", () => {
       expect(response.headers.get("x-middleware-rewrite")).toBe(
         `https://example.com${apiPath}`,
       );
+
+      if (aliasPath === "/topics") {
+        expect(response.headers.get("x-opensend-root-api-alias")).toBe(
+          "topics",
+        );
+      }
+
+      if (aliasPath === "/contact-properties") {
+        expect(response.headers.get("x-opensend-root-api-alias")).toBe(
+          "contact-properties",
+        );
+      }
     }
 
     expect(mockGetSessionCookie).not.toHaveBeenCalled();

--- a/tests/middleware-rate-limit.test.ts
+++ b/tests/middleware-rate-limit.test.ts
@@ -231,9 +231,24 @@ describe("middleware rate limiting", () => {
         `https://example.com${apiPath}`,
       );
 
+      const overriddenAliasHeader = response.headers.get(
+        "x-middleware-request-x-opensend-root-api-alias",
+      );
+      const overriddenHeaders = response.headers.get(
+        "x-middleware-override-headers",
+      );
+      const overrideHeaderList = (overriddenHeaders ?? "")
+        .toLowerCase()
+        .split(",")
+        .map((header) => header.trim());
+
       if (aliasPath === "/topics" || aliasPath.startsWith("/topics/")) {
         expect(response.headers.get("x-opensend-root-api-alias")).toBe(
           "topics",
+        );
+        expect(overriddenAliasHeader).toBe("topics");
+        expect(overrideHeaderList.includes("x-opensend-root-api-alias")).toBe(
+          true,
         );
       } else if (
         aliasPath === "/contact-properties" ||
@@ -242,8 +257,21 @@ describe("middleware rate limiting", () => {
         expect(response.headers.get("x-opensend-root-api-alias")).toBe(
           "contact-properties",
         );
+        expect(overriddenAliasHeader).toBe("contact-properties");
+        expect(overrideHeaderList.includes("x-opensend-root-api-alias")).toBe(
+          true,
+        );
       } else {
         expect(response.headers.get("x-opensend-root-api-alias")).toBeNull();
+        expect(overriddenAliasHeader).toBeNull();
+        expect(
+          response.headers.get(
+            "x-middleware-request-x-opensend-root-api-alias",
+          ),
+        ).toBeNull();
+        expect(overrideHeaderList.includes("x-opensend-root-api-alias")).toBe(
+          false,
+        );
       }
     }
 


### PR DESCRIPTION
## Summary
- Added provenance-aware root alias handling for `/topics` and `/contact-properties` so middleware rewrites carry an internal alias marker to downstream handlers.
- Introduced compatibility-mode branching in `packages/core` topic/property creation services:
  - `/topics` root alias requires strict `default_subscription` and `visibility` enum validation (`opt_in|opt_out`, `public|private`) and rejects missing/invalid values.
  - `/contact-properties` root alias requires explicit `key` and strict `type` validation (`string|number|boolean|date`).
  - Existing `/api/topics` and `/api/properties` keep legacy OpenSend extension behavior, including defaults/derivations.
- Propagated alias mode from middleware rewrites into `/api/topics` and `/api/properties` route handlers.
- Updated OpenAPI to document root strict schemas separately and documented API-compatible lenient behavior for `/api` routes.
- Updated public docs for topic/contact-property creation compatibility behavior and regenerated `public/docs/llms.txt`.
- Added/expanded tests in audience metadata service, route adapter, and middleware to cover strict root requirements and preserved dashboard/API behavior.

## Test Plan
- `make check`
- `make test`
- `bun run docs:generate`
- Targeted Vitest suites:
  - `bun run test tests/audience-metadata-service.test.ts`
  - `bun run test tests/audience-metadata-routes.test.ts`
  - `bun run test tests/middleware-rate-limit.test.ts`

Closes #613
