### PR TITLE
[codex] Improve receiving inbox UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 .omc/
 .omx/state/
 .omx/metrics.json
+.handoffs/
 # Track only QA/review-relevant logs; ignore noisy runtime hook logs.
 .omx/logs/*.jsonl
 !.omx/logs/omx-*.jsonl

--- a/agent_docs/architecture/2026-05-30-domain-verification-flow-explainer.html
+++ b/agent_docs/architecture/2026-05-30-domain-verification-flow-explainer.html
@@ -1,0 +1,295 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>OpenSend domain verification — what's broken in prod</title>
+<style>
+  :root {
+    --bg: #0b0f14;
+    --panel: #131923;
+    --border: #1f2937;
+    --text: #e5e7eb;
+    --muted: #9ca3af;
+    --green: #10b981;
+    --amber: #f59e0b;
+    --red: #ef4444;
+    --blue: #3b82f6;
+    --purple: #a78bfa;
+    --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; line-height: 1.55; }
+  main { max-width: 980px; margin: 0 auto; padding: 48px 32px 96px; }
+  h1 { font-size: 32px; margin: 0 0 8px; letter-spacing: -0.5px; }
+  h2 { font-size: 22px; margin: 56px 0 16px; padding-top: 24px; border-top: 1px solid var(--border); }
+  h3 { font-size: 16px; margin: 32px 0 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 1px; font-weight: 600; }
+  p { margin: 0 0 12px; }
+  code, .mono { font-family: var(--mono); font-size: 13px; background: rgba(255,255,255,0.06); padding: 2px 6px; border-radius: 4px; }
+  .lede { font-size: 17px; color: #cbd5e1; margin-bottom: 24px; }
+
+  .flow {
+    display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px;
+    margin: 24px 0; padding: 24px; background: var(--panel); border: 1px solid var(--border); border-radius: 12px;
+  }
+  .step {
+    background: rgba(255,255,255,0.03); border: 1px solid var(--border); border-radius: 8px;
+    padding: 14px 12px; font-size: 13px; position: relative;
+  }
+  .step strong { display: block; font-size: 14px; margin-bottom: 4px; color: var(--text); }
+  .step span { color: var(--muted); font-size: 12px; }
+
+  .arrow { position: absolute; right: -12px; top: 50%; transform: translateY(-50%); color: var(--muted); font-size: 14px; z-index: 1; }
+  .step:last-child .arrow { display: none; }
+
+  .box {
+    background: var(--panel); border: 1px solid var(--border); border-radius: 12px;
+    padding: 20px 24px; margin: 20px 0;
+  }
+  .bad { border-left: 4px solid var(--red); }
+  .good { border-left: 4px solid var(--green); }
+  .warn { border-left: 4px solid var(--amber); }
+  .info { border-left: 4px solid var(--blue); }
+
+  .pill {
+    display: inline-block; padding: 2px 10px; border-radius: 999px; font-size: 12px;
+    font-weight: 600; margin-right: 6px; vertical-align: middle;
+  }
+  .pill.fixed { background: rgba(16,185,129,0.15); color: var(--green); border: 1px solid var(--green); }
+  .pill.broken { background: rgba(239,68,68,0.15); color: var(--red); border: 1px solid var(--red); }
+  .pill.partial { background: rgba(245,158,11,0.15); color: var(--amber); border: 1px solid var(--amber); }
+
+  .diagram {
+    display: grid; gap: 0; margin: 24px 0;
+    background: var(--panel); border: 1px solid var(--border); border-radius: 12px;
+    padding: 28px; position: relative;
+  }
+  .actor-row { display: grid; grid-template-columns: 140px 1fr; gap: 16px; padding: 16px 0; border-bottom: 1px dashed var(--border); align-items: center; }
+  .actor-row:last-child { border-bottom: none; }
+  .actor {
+    font-weight: 600; color: var(--text); font-size: 14px;
+  }
+  .actor-sub { color: var(--muted); font-size: 12px; display: block; }
+  .messages { display: flex; flex-direction: column; gap: 8px; }
+  .msg { background: rgba(255,255,255,0.04); border: 1px solid var(--border); border-radius: 6px; padding: 8px 12px; font-size: 13px; }
+  .msg.broken-link { border: 1px dashed var(--red); color: #fca5a5; }
+  .msg.broken-link::before { content: "✗ "; color: var(--red); font-weight: 700; }
+  .msg.ok::before { content: "✓ "; color: var(--green); font-weight: 700; }
+
+  table {
+    width: 100%; border-collapse: collapse; margin: 16px 0;
+    background: var(--panel); border: 1px solid var(--border); border-radius: 8px; overflow: hidden;
+  }
+  th, td { padding: 12px 16px; text-align: left; font-size: 14px; border-bottom: 1px solid var(--border); }
+  th { background: rgba(255,255,255,0.03); color: var(--muted); font-weight: 600; text-transform: uppercase; font-size: 11px; letter-spacing: 0.5px; }
+  tr:last-child td { border-bottom: none; }
+
+  .timeline {
+    list-style: none; padding: 0; margin: 24px 0;
+    background: var(--panel); border: 1px solid var(--border); border-radius: 12px;
+  }
+  .timeline li {
+    padding: 16px 24px; border-bottom: 1px solid var(--border); display: grid; grid-template-columns: 80px 1fr; gap: 16px; align-items: start;
+  }
+  .timeline li:last-child { border-bottom: none; }
+  .time { color: var(--muted); font-family: var(--mono); font-size: 12px; padding-top: 2px; }
+  .what { font-size: 14px; }
+  .what em { color: var(--muted); font-style: normal; display: block; margin-top: 4px; font-size: 13px; }
+
+  .heart {
+    display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 6px; vertical-align: middle;
+  }
+  .heart.alive { background: var(--green); box-shadow: 0 0 0 0 rgba(16,185,129,0.5); animation: pulse 1.6s infinite; }
+  .heart.dead  { background: var(--red); }
+  @keyframes pulse {
+    0%   { box-shadow: 0 0 0 0 rgba(16,185,129,0.5); }
+    70%  { box-shadow: 0 0 0 8px rgba(16,185,129,0); }
+    100% { box-shadow: 0 0 0 0 rgba(16,185,129,0); }
+  }
+
+  .ascii { font-family: var(--mono); font-size: 12px; line-height: 1.4; background: rgba(0,0,0,0.3); padding: 16px; border-radius: 8px; border: 1px solid var(--border); overflow-x: auto; white-space: pre; color: #cbd5e1; }
+
+  .ratio-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; margin: 16px 0; }
+  .ratio-card { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
+  .ratio-card h4 { margin: 0 0 8px; font-size: 13px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
+  .ratio-card .num { font-size: 28px; font-weight: 700; font-family: var(--mono); }
+  .ratio-card.good .num { color: var(--green); }
+  .ratio-card.bad .num { color: var(--red); }
+</style>
+</head>
+<body>
+<main>
+  <h1>Why your domain stays "Pending" — the actual story</h1>
+  <p class="lede">You asked: <em>"what's the problem we're trying to solve?"</em>. This page walks through it. There are <strong>two</strong> bugs, not one. We shipped a fix for the first. The second is still broken — and now we can see it.</p>
+
+  <h2>1. The happy-path flow (what should happen)</h2>
+
+  <p>When you add a domain to OpenSend, here's the sequence that <em>should</em> turn it Verified within ~60 seconds of DNS propagation:</p>
+
+  <div class="flow">
+    <div class="step"><strong>1.</strong><span>You add a domain in dashboard</span><span class="arrow">→</span></div>
+    <div class="step"><strong>2.</strong><span>OpenSend tells AWS SES to track it</span><span class="arrow">→</span></div>
+    <div class="step"><strong>3.</strong><span>SES generates DNS records you need to add</span><span class="arrow">→</span></div>
+    <div class="step"><strong>4.</strong><span>You add records at your DNS provider</span><span class="arrow">→</span></div>
+    <div class="step"><strong>5.</strong><span>Status flips to "Verified"</span></div>
+  </div>
+
+  <p>The interesting part is step 5. SES doesn't push you a notification when it has verified a domain. <strong>You have to ask SES, every so often, "is this verified yet?"</strong> That's what the <em>scheduler</em> does — it's a small process that pings every 60 seconds.</p>
+
+  <div class="diagram">
+    <h3 style="margin-top:0">The verification loop, every 60s</h3>
+    <div class="actor-row">
+      <div class="actor">Scheduler<span class="actor-sub">runs every 60s</span></div>
+      <div class="messages">
+        <div class="msg ok">POST <code>/jobs/domain-verify</code> → Ingester</div>
+      </div>
+    </div>
+    <div class="actor-row">
+      <div class="actor">Ingester<span class="actor-sub">does the reconcile</span></div>
+      <div class="messages">
+        <div class="msg ok">Reads pending domains from Postgres</div>
+        <div class="msg ok">For each: asks SES "is this verified?"</div>
+        <div class="msg ok">If yes → updates Postgres status to "verified"</div>
+        <div class="msg ok">Tells Redis to forget the old cached "pending" value</div>
+      </div>
+    </div>
+    <div class="actor-row">
+      <div class="actor">Dashboard<span class="actor-sub">next time you refresh</span></div>
+      <div class="messages">
+        <div class="msg ok">Reads from Redis → MISS → reads fresh from Postgres → sees "verified"</div>
+      </div>
+    </div>
+  </div>
+
+  <h2>2. Bug #1 — the cache invalidation hole <span class="pill fixed">FIXED in #578</span></h2>
+
+  <div class="box bad">
+    <p><strong>The bug:</strong> the ingester DID update Postgres correctly. But it called a "tell Redis to forget" function that was secretly a no-op.</p>
+    <p>How that happened: the function was passed in as a dependency. The dependency had a default value of <code>async () =&gt; {}</code> — an empty function. When the ingester forgot to pass in the real one, it silently used the empty one. <strong>Cache never got cleared. Dashboard kept serving stale "Pending".</strong></p>
+  </div>
+
+  <h3>The fix in #578</h3>
+  <ol style="padding-left: 20px;">
+    <li>Made the "tell Redis to forget" dependency <strong>required</strong> — you can't construct the service without it. Code that forgets now fails to compile.</li>
+    <li>Deleted the global "convenience" instance that had the bug baked in.</li>
+    <li>Added a heartbeat table in Postgres — every time the scheduler runs a job, it writes "I'm alive" into a row.</li>
+    <li>Added a new endpoint <code>/api/health/scheduler</code> that reads those heartbeats and tells you which jobs aren't firing.</li>
+  </ol>
+
+  <p>That last point matters for Bug #2.</p>
+
+  <h2>2. Bug #2 — the scheduler doesn't exist in prod <span class="pill broken">STILL BROKEN</span></h2>
+
+  <div class="box bad">
+    <p><strong>This is the actual root cause of "domain stuck Pending 20+ min" you reported.</strong> Even with Bug #1 fixed, nothing has changed unless something is calling <code>/jobs/domain-verify</code> every 60s.</p>
+    <p>In docker-compose (for self-hosters) there's a tiny container called <code>scheduler</code> that does this. In your AWS production deploy, <strong>that container doesn't exist</strong>. Your ECS deploy script (<code>scripts/deploy.sh</code>) only deploys two services: the app and the ingester. No scheduler.</p>
+  </div>
+
+  <div class="diagram">
+    <h3 style="margin-top:0">What's actually running in prod right now</h3>
+    <div class="actor-row">
+      <div class="actor"><span class="heart dead"></span>Scheduler<span class="actor-sub">NOT DEPLOYED</span></div>
+      <div class="messages">
+        <div class="msg broken-link">(would POST /jobs/domain-verify every 60s)</div>
+        <div class="msg broken-link">(nothing is doing this in prod)</div>
+      </div>
+    </div>
+    <div class="actor-row">
+      <div class="actor"><span class="heart alive"></span>App<span class="actor-sub">ECS Fargate</span></div>
+      <div class="messages">
+        <div class="msg ok">Serves /api/* + dashboard</div>
+        <div class="msg ok">Reads from Redis cache</div>
+      </div>
+    </div>
+    <div class="actor-row">
+      <div class="actor"><span class="heart alive"></span>Ingester<span class="actor-sub">ECS Fargate</span></div>
+      <div class="messages">
+        <div class="msg ok">Receives SES SNS bounce/complaint webhooks</div>
+        <div class="msg ok">Has /jobs/* endpoints ready</div>
+        <div class="msg broken-link">...but nothing is calling them</div>
+      </div>
+    </div>
+  </div>
+
+  <h3>Live proof — your new health endpoint, hit right now</h3>
+  <div class="ascii">$ curl https://opensend.namuh.co/api/health/scheduler
+HTTP 503
+{
+  "scheduler": "missing",
+  "jobs": [
+    { "name": "scheduled-emails", "state": "missing", "last_seen_ms_ago": null, "interval_ms": null },
+    { "name": "webhooks",         "state": "missing", "last_seen_ms_ago": null, "interval_ms": null },
+    { "name": "domain-verify",    "state": "missing", "last_seen_ms_ago": null, "interval_ms": null }
+  ]
+}</div>
+  <p><strong>This is the diagnostic we built for ourselves.</strong> Before #578 deployed, you had no way to know the scheduler wasn't firing — you just saw "domain still pending" with no explanation. Now: HTTP 503 + a list saying exactly which jobs are missing. Bug #2 surfaces itself.</p>
+
+  <h2>3. Why we left Bug #2 unfixed (for now)</h2>
+
+  <p>Fixing it requires touching your AWS infrastructure (Terraform/CDK or ECS task definitions), not application code. That's a different repo and a different deploy path. The three PRs we just merged were code changes only — they fixed Bug #1 cleanly and exposed Bug #2 so you can see it.</p>
+
+  <h3>Three ways to fix Bug #2 (pick one)</h3>
+  <table>
+    <tr><th>Option</th><th>What it is</th><th>Effort</th></tr>
+    <tr>
+      <td><strong>EventBridge Scheduler rules</strong></td>
+      <td>AWS-native cron. Three rules, each POSTs to <code>events.opensend.namuh.co/jobs/&lt;name&gt;</code> every 60s with the bearer token.</td>
+      <td>~30 min in Terraform/CDK. Best long-term fit.</td>
+    </tr>
+    <tr>
+      <td><strong>ECS scheduler service</strong></td>
+      <td>Add a third ECS service running <code>bun /app/job-scheduler.js</code>. Mirrors how docker-compose works for self-hosters.</td>
+      <td>~1 hour. Closest to the existing setup.</td>
+    </tr>
+    <tr>
+      <td><strong>Sidecar container</strong></td>
+      <td>Add the scheduler as a sidecar container in the ingester ECS task definition. Same task as ingester, separate process inside it.</td>
+      <td>~20 min. Tightest coupling, smallest infra change.</td>
+    </tr>
+  </table>
+
+  <h2>4. Summary of what we shipped this session</h2>
+
+  <table>
+    <tr><th>PR</th><th>What it does</th><th>State</th></tr>
+    <tr>
+      <td><strong>#577</strong></td>
+      <td>Dashboard UI: meatball menu wired with Verify/Delete actions; DMARC moved under "Enable Sending" with better copy</td>
+      <td><span class="pill fixed">Merged + deployed</span></td>
+    </tr>
+    <tr>
+      <td><strong>#578</strong></td>
+      <td>Bug #1 fix: cache invalidation contract + scheduler heartbeat table + <code>/api/health/scheduler</code> diagnostic</td>
+      <td><span class="pill fixed">Merged + deployed</span></td>
+    </tr>
+    <tr>
+      <td><strong>#579</strong></td>
+      <td>Go CLI binary (<code>opensend version/health/domains/api-keys/logs/send/doctor</code>) + Bun-vs-Go worker benchmark proving the worker rewrite isn't justified</td>
+      <td><span class="pill fixed">Merged + deployed</span></td>
+    </tr>
+    <tr>
+      <td><strong>(not a PR)</strong></td>
+      <td>Bug #2: the scheduler is not deployed in prod. Needs an infra change.</td>
+      <td><span class="pill broken">Still broken — but visible now</span></td>
+    </tr>
+  </table>
+
+  <h2>5. Bonus: the Go benchmark result that ended the worker-migration question</h2>
+  <p>During this session we debated for ten rounds whether to rewrite the ingester worker in Go for performance. We then built a benchmark and ran it. The result:</p>
+  <div class="ratio-grid">
+    <div class="ratio-card good"><h4>JSON decode SES event</h4><div class="num">3.2× ↑</div>Bun is 3.2× faster than Go</div>
+    <div class="ratio-card good"><h4>HMAC-SHA256 sign</h4><div class="num">1.8× ↓</div>Go is 1.8× faster than Bun</div>
+    <div class="ratio-card"><h4>Fan out 1000 webhook POSTs</h4><div class="num">tie</div>Statistical dead heat — 41ms vs 41ms</div>
+    <div class="ratio-card"><h4>Verdict</h4><div class="num" style="font-size: 16px; line-height: 1.4;">Don't rewrite the worker</div>The real bottleneck is the network, not the runtime.</div>
+  </div>
+
+  <h2>Bottom line</h2>
+  <div class="box info">
+    <p><strong>You came in with one symptom (domain stuck Pending) and we found two distinct bugs causing it.</strong></p>
+    <p>Bug #1 (cache hole) — fixed and deployed.</p>
+    <p>Bug #2 (no scheduler in prod) — exposed by the new diagnostic; needs a 30-minute infra change to fix.</p>
+    <p>You also walked out with: a Go CLI binary, a deleted dead-code skeleton, a benchmark that settled a strategic argument, three learning docs, and an architectural learning about why optional-with-no-op-default DI fields are footguns.</p>
+  </div>
+</main>
+</body>
+</html>

--- a/agent_docs/learnings/active/2026-06-08-receiving-inbox-setup-ux-boundary.md
+++ b/agent_docs/learnings/active/2026-06-08-receiving-inbox-setup-ux-boundary.md
@@ -1,0 +1,18 @@
+---
+date: 2026-06-08
+issue: receiving-inbox-setup-ux-boundary
+type: decision
+promoted_to: null
+---
+
+# Receiving UI should lead with stored mail, then setup
+
+The dashboard `Emails > Receiving` mental model should start with received mail
+rows from `received_emails`. Domain receiving routes, catch-all rules, and
+forwarding controls are setup/configuration for the inbox, not the primary
+content of the page.
+
+Keep local mock inbox/config data development-only and clearly labeled. The real
+dashboard route should still fetch tenant-scoped `received_emails`, domains,
+routes, and forwarding rules, while the dev preview route can render the same
+component with empty props and `useDemoData` for fast visual review.

--- a/src/app/(dashboard)/dev/receiving-preview/page.tsx
+++ b/src/app/(dashboard)/dev/receiving-preview/page.tsx
@@ -1,0 +1,22 @@
+import { EmailsHeader } from "@/components/emails-header";
+import { ReceivingList } from "@/components/receiving-list";
+import { notFound } from "next/navigation";
+
+export default function ReceivingPreviewPage() {
+  if (process.env.NODE_ENV === "production") {
+    notFound();
+  }
+
+  return (
+    <div>
+      <EmailsHeader activeTab="receiving" />
+      <ReceivingList
+        domains={[]}
+        routes={[]}
+        forwardingRules={[]}
+        receivedEmails={[]}
+        useDemoData
+      />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/emails/receiving/page.tsx
+++ b/src/app/(dashboard)/emails/receiving/page.tsx
@@ -2,7 +2,7 @@ import { EmailsHeader } from "@/components/emails-header";
 import { ReceivingList } from "@/components/receiving-list";
 import { getServerSession } from "@/lib/api-auth";
 import { db } from "@/lib/db";
-import { domains, receivingRoutes } from "@/lib/db/schema";
+import { domains, receivedEmails, receivingRoutes } from "@/lib/db/schema";
 import { createForwardingRuleService } from "@opensend/core";
 import { desc, eq } from "drizzle-orm";
 import { redirect } from "next/navigation";
@@ -26,6 +26,27 @@ export default async function EmailsReceivingPage() {
     .from(receivingRoutes)
     .where(eq(receivingRoutes.userId, session.user.id))
     .orderBy(desc(receivingRoutes.createdAt));
+
+  const allReceivedEmails = await db
+    .select({
+      id: receivedEmails.id,
+      from: receivedEmails.from,
+      to: receivedEmails.to,
+      subject: receivedEmails.subject,
+      status: receivedEmails.status,
+      text: receivedEmails.text,
+      routeDecisions: receivedEmails.routeDecisions,
+      replyMatchStatus: receivedEmails.replyMatchStatus,
+      threadId: receivedEmails.threadId,
+      replyToEmailId: receivedEmails.replyToEmailId,
+      contactId: receivedEmails.contactId,
+      attachments: receivedEmails.attachments,
+      createdAt: receivedEmails.createdAt,
+    })
+    .from(receivedEmails)
+    .where(eq(receivedEmails.userId, session.user.id))
+    .orderBy(desc(receivedEmails.createdAt))
+    .limit(50);
 
   const data = allDomains.map((d) => ({
     id: d.id,
@@ -81,6 +102,21 @@ export default async function EmailsReceivingPage() {
         }
       : null,
   }));
+  const receivedEmailData = allReceivedEmails.map((email) => ({
+    id: email.id,
+    from: email.from,
+    to: email.to,
+    subject: email.subject,
+    status: email.status,
+    preview: email.text,
+    route_decisions: email.routeDecisions ?? [],
+    reply_match_status: email.replyMatchStatus,
+    thread_id: email.threadId,
+    reply_to_email_id: email.replyToEmailId,
+    contact_id: email.contactId,
+    attachment_count: email.attachments?.length ?? 0,
+    created_at: email.createdAt.toISOString(),
+  }));
 
   return (
     <div>
@@ -89,6 +125,8 @@ export default async function EmailsReceivingPage() {
         domains={data}
         routes={routeData}
         forwardingRules={forwardingRuleData}
+        receivedEmails={receivedEmailData}
+        useDemoData={process.env.NODE_ENV !== "production"}
       />
     </div>
   );

--- a/src/components/receiving-list.tsx
+++ b/src/components/receiving-list.tsx
@@ -1,6 +1,16 @@
 "use client";
 
+import { formatRelativeTime } from "@/components/emails-sending-data-table";
 import { StatusBadge } from "@/components/status-badge";
+import {
+  Forward,
+  Inbox,
+  Mail,
+  Paperclip,
+  Route,
+  Settings2,
+} from "lucide-react";
+import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 
 interface InboundDomain {
@@ -9,6 +19,7 @@ interface InboundDomain {
   status: "active" | "pending";
   createdAt: string;
   receivingEnabled: boolean;
+  demo?: boolean;
 }
 
 export interface ReceivingRouteItem {
@@ -19,6 +30,7 @@ export interface ReceivingRouteItem {
   local_part: string | null;
   target_local_part: string;
   target_address: string;
+  demo?: boolean;
 }
 
 export interface ForwardingRuleItem {
@@ -40,6 +52,34 @@ export interface ForwardingRuleItem {
     error_message: string | null;
     created_at: string;
   } | null;
+  demo?: boolean;
+}
+
+export type ReceivedRouteDecision = {
+  recipient: string;
+  status: "exact" | "alias" | "catch_all" | "unrouteable";
+  domainId?: string;
+  routeId?: string;
+  routeType?: "exact" | "alias" | "catch_all";
+  localPart?: string;
+  targetAddress?: string;
+};
+
+export interface ReceivedEmailItem {
+  id: string;
+  from: string;
+  to: string[];
+  subject: string;
+  status: string;
+  preview: string | null;
+  route_decisions: ReceivedRouteDecision[];
+  reply_match_status: string;
+  thread_id: string | null;
+  reply_to_email_id: string | null;
+  contact_id: string | null;
+  attachment_count: number;
+  created_at: string;
+  demo?: boolean;
 }
 
 type RouteFormState = {
@@ -63,6 +103,150 @@ const defaultForwardingForm: ForwardingFormState = {
   destinations: "",
   status: "active",
 };
+
+const demoDomains: InboundDomain[] = [
+  {
+    id: "demo-domain-inbound-opliora",
+    name: "inbound.opliora.com",
+    status: "active",
+    createdAt: "2026-06-08T06:10:00.000Z",
+    receivingEnabled: true,
+    demo: true,
+  },
+  {
+    id: "demo-domain-support-namuh",
+    name: "support.namuh.co",
+    status: "active",
+    createdAt: "2026-06-07T21:35:00.000Z",
+    receivingEnabled: true,
+    demo: true,
+  },
+];
+
+const demoRoutes: ReceivingRouteItem[] = [
+  {
+    id: "demo-route-catch-all",
+    domain_id: "demo-domain-inbound-opliora",
+    domain: "inbound.opliora.com",
+    type: "catch_all",
+    local_part: null,
+    target_local_part: "inbox",
+    target_address: "inbox@inbound.opliora.com",
+    demo: true,
+  },
+  {
+    id: "demo-route-support",
+    domain_id: "demo-domain-support-namuh",
+    domain: "support.namuh.co",
+    type: "exact",
+    local_part: "help",
+    target_local_part: "support",
+    target_address: "support@support.namuh.co",
+    demo: true,
+  },
+];
+
+const demoForwardingRules: ForwardingRuleItem[] = [
+  {
+    id: "demo-forwarding-ops",
+    domain_id: "demo-domain-inbound-opliora",
+    domain: "inbound.opliora.com",
+    route_id: "demo-route-catch-all",
+    route_target_address: "inbox@inbound.opliora.com",
+    destinations: ["ops@opliora.com", "founders@opliora.com"],
+    status: "active",
+    invalid_reason: null,
+    last_attempt: {
+      id: "demo-forwarding-attempt-1",
+      status: "queued",
+      reason: "forwarding_rule_active",
+      received_email_id: "demo-received-1",
+      forwarded_email_id: "demo-forwarded-1",
+      forwarded_email_status: "queued",
+      error_message: null,
+      created_at: "2026-06-08T08:18:00.000Z",
+    },
+    demo: true,
+  },
+];
+
+const demoReceivedEmails: ReceivedEmailItem[] = [
+  {
+    id: "demo-received-1",
+    from: "maya@customer.example",
+    to: ["hello@inbound.opliora.com"],
+    subject: "Can you confirm our onboarding window?",
+    status: "received",
+    preview:
+      "We are ready to start the workspace migration next week. Could you confirm the DNS and forwarding path before Friday?",
+    route_decisions: [
+      {
+        recipient: "hello@inbound.opliora.com",
+        status: "catch_all",
+        routeId: "demo-route-catch-all",
+        routeType: "catch_all",
+        targetAddress: "inbox@inbound.opliora.com",
+      },
+    ],
+    reply_match_status: "unmatched",
+    thread_id: null,
+    reply_to_email_id: null,
+    contact_id: null,
+    attachment_count: 1,
+    created_at: "2026-06-08T08:18:00.000Z",
+    demo: true,
+  },
+  {
+    id: "demo-received-2",
+    from: "alerts@aws.amazon.com",
+    to: ["help@support.namuh.co"],
+    subject: "SES receipt rule notification",
+    status: "received",
+    preview:
+      "Receipt rule processed the inbound message and stored the raw MIME object in the configured bucket.",
+    route_decisions: [
+      {
+        recipient: "help@support.namuh.co",
+        status: "exact",
+        routeId: "demo-route-support",
+        routeType: "exact",
+        targetAddress: "support@support.namuh.co",
+      },
+    ],
+    reply_match_status: "unmatched",
+    thread_id: null,
+    reply_to_email_id: null,
+    contact_id: null,
+    attachment_count: 0,
+    created_at: "2026-06-08T06:42:00.000Z",
+    demo: true,
+  },
+  {
+    id: "demo-received-3",
+    from: "alex@partner.example",
+    to: ["reply+demo-thread@inbound.opliora.com"],
+    subject: "Re: launch checklist",
+    status: "received",
+    preview:
+      "Looks good. We updated the launch copy and sent the test cases back over for review.",
+    route_decisions: [
+      {
+        recipient: "reply+demo-thread@inbound.opliora.com",
+        status: "catch_all",
+        routeId: "demo-route-catch-all",
+        routeType: "catch_all",
+        targetAddress: "inbox@inbound.opliora.com",
+      },
+    ],
+    reply_match_status: "matched",
+    thread_id: "demo-thread-1",
+    reply_to_email_id: "demo-outbound-1",
+    contact_id: "demo-contact-1",
+    attachment_count: 2,
+    created_at: "2026-06-07T23:10:00.000Z",
+    demo: true,
+  },
+];
 
 async function apiRequest<T>(input: string, init?: RequestInit): Promise<T> {
   const response = await fetch(input, init);
@@ -89,18 +273,78 @@ function typeLabel(type: ReceivingRouteItem["type"]): string {
   return type.charAt(0).toUpperCase() + type.slice(1);
 }
 
+function statusLabel(status: string): string {
+  return status
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function routeDecisionLabel(email: ReceivedEmailItem): string {
+  const decision = email.route_decisions[0];
+  if (!decision) return "Unrouted";
+  if (decision.status === "catch_all") return "Catch-all";
+  return statusLabel(decision.status);
+}
+
+function routeDecisionVariant(
+  email: ReceivedEmailItem,
+): "success" | "error" | "warning" | "info" | "default" {
+  const decision = email.route_decisions[0];
+  if (!decision) return "default";
+  if (decision.status === "unrouteable") return "error";
+  if (decision.status === "catch_all") return "info";
+  return "success";
+}
+
+function statusVariant(
+  status: string,
+): "success" | "error" | "warning" | "info" | "default" {
+  if (status === "received" || status === "processed") return "success";
+  if (status === "failed" || status === "unrouteable") return "error";
+  if (status === "pending") return "warning";
+  return "default";
+}
+
+function primaryRecipient(email: ReceivedEmailItem): string {
+  return email.to[0] ?? "";
+}
+
+function countActiveDomains(domains: InboundDomain[]): number {
+  return domains.filter(
+    (domain) => domain.status === "active" && domain.receivingEnabled,
+  ).length;
+}
+
+function countActiveForwardingRules(rules: ForwardingRuleItem[]): number {
+  return rules.filter((rule) => rule.status === "active").length;
+}
+
 export function ReceivingList({
   domains,
   routes: initialRoutes,
   forwardingRules: initialForwardingRules,
+  receivedEmails,
+  useDemoData = false,
 }: {
   domains: InboundDomain[];
   routes: ReceivingRouteItem[];
   forwardingRules: ForwardingRuleItem[];
+  receivedEmails?: ReceivedEmailItem[];
+  useDemoData?: boolean;
 }) {
-  const [routes, setRoutes] = useState(initialRoutes);
+  const useDemoInbox = useDemoData && (receivedEmails?.length ?? 0) === 0;
+  const useDemoConfig = useDemoData && domains.length === 0;
+  const displayedDomains = useDemoConfig ? demoDomains : domains;
+  const displayedReceivedEmails = useDemoInbox
+    ? demoReceivedEmails
+    : (receivedEmails ?? []);
+
+  const [routes, setRoutes] = useState(
+    useDemoConfig ? demoRoutes : initialRoutes,
+  );
   const [forwardingRules, setForwardingRules] = useState(
-    initialForwardingRules,
+    useDemoConfig ? demoForwardingRules : initialForwardingRules,
   );
   const [forms, setForms] = useState<Record<string, RouteFormState>>({});
   const [forwardingForms, setForwardingForms] = useState<
@@ -146,6 +390,8 @@ export function ReceivingList({
   };
 
   const createRoute = async (domainId: string) => {
+    const domain = displayedDomains.find((item) => item.id === domainId);
+    if (domain?.demo) return;
     const form = forms[domainId] ?? defaultForm;
     setError(null);
     setBusyId(domainId);
@@ -175,6 +421,7 @@ export function ReceivingList({
   };
 
   const createForwardingRule = async (route: ReceivingRouteItem) => {
+    if (route.demo) return;
     const form = forwardingForms[route.id] ?? defaultForwardingForm;
     const destinations = form.destinations
       .split(/[,\n]/)
@@ -213,6 +460,7 @@ export function ReceivingList({
     rule: ForwardingRuleItem,
     status: "active" | "disabled",
   ) => {
+    if (rule.demo) return;
     setError(null);
     setBusyId(`forward-${rule.id}`);
     try {
@@ -236,14 +484,15 @@ export function ReceivingList({
     }
   };
 
-  const deleteRoute = async (routeId: string) => {
+  const deleteRoute = async (route: ReceivingRouteItem) => {
+    if (route.demo) return;
     setError(null);
-    setBusyId(routeId);
+    setBusyId(route.id);
     try {
-      await apiRequest<{ id: string }>(`/api/receiving/routes/${routeId}`, {
+      await apiRequest<{ id: string }>(`/api/receiving/routes/${route.id}`, {
         method: "DELETE",
       });
-      setRoutes((current) => current.filter((route) => route.id !== routeId));
+      setRoutes((current) => current.filter((item) => item.id !== route.id));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to delete route");
     } finally {
@@ -252,297 +501,553 @@ export function ReceivingList({
   };
 
   return (
-    <div className="mt-8 space-y-6">
-      <div>
-        <h2 className="text-lg font-medium text-fg">Inbound Domains</h2>
-        <p className="mt-1 text-sm text-white/50">
-          Routes are evaluated in this order: exact address, alias, catch-all,
-          then unrouteable.
-        </p>
+    <div className="mt-6 space-y-8">
+      <section className="space-y-4">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <div className="mb-2 flex items-center gap-2 text-accent">
+              <Inbox aria-hidden className="h-4 w-4" />
+              <span className="mono text-[11px] uppercase tracking-[0.12em]">
+                Inbound mail
+              </span>
+            </div>
+            <h2 className="text-lg font-medium text-fg">Received inbox</h2>
+            <p className="mt-1 max-w-2xl text-sm leading-6 text-fg-3">
+              Messages stored after provider ingress, route matching, and tenant
+              ownership checks.
+            </p>
+          </div>
+          {useDemoInbox && <StatusBadge status="Demo data" variant="info" />}
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-3">
+          <Metric
+            icon={<Mail aria-hidden className="h-4 w-4" />}
+            label="Messages"
+            value={displayedReceivedEmails.length.toLocaleString()}
+          />
+          <Metric
+            icon={<Route aria-hidden className="h-4 w-4" />}
+            label="Active domains"
+            value={countActiveDomains(displayedDomains).toLocaleString()}
+          />
+          <Metric
+            icon={<Forward aria-hidden className="h-4 w-4" />}
+            label="Forwarding rules"
+            value={countActiveForwardingRules(forwardingRules).toLocaleString()}
+          />
+        </div>
+
+        <ReceivedInboxTable emails={displayedReceivedEmails} />
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <div className="mb-2 flex items-center gap-2 text-accent">
+              <Settings2 aria-hidden className="h-4 w-4" />
+              <span className="mono text-[11px] uppercase tracking-[0.12em]">
+                Setup
+              </span>
+            </div>
+            <h2 className="text-lg font-medium text-fg">
+              Receiving configuration
+            </h2>
+            <p className="mt-1 max-w-2xl text-sm leading-6 text-fg-3">
+              Domains decide where inbound mail can land. Routes decide which
+              local parts become stored messages and optional forwards.
+            </p>
+          </div>
+          {useDemoConfig && <StatusBadge status="Demo config" variant="info" />}
+        </div>
+
         {error && (
-          <p className="mt-2 text-sm text-red-400" role="alert">
+          <p className="text-sm text-red-400" role="alert">
             {error}
           </p>
         )}
+
+        <ReceivingConfigTable
+          busyId={busyId}
+          domains={displayedDomains}
+          forms={forms}
+          forwardingForms={forwardingForms}
+          forwardingRulesByRoute={forwardingRulesByRoute}
+          routesByDomain={routesByDomain}
+          createForwardingRule={createForwardingRule}
+          createRoute={createRoute}
+          deleteRoute={deleteRoute}
+          updateForm={updateForm}
+          updateForwardingForm={updateForwardingForm}
+          updateForwardingRuleStatus={updateForwardingRuleStatus}
+        />
+      </section>
+    </div>
+  );
+}
+
+function Metric({
+  icon,
+  label,
+  value,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="flex min-h-[70px] items-center justify-between rounded-md border border-line bg-bg-2 px-4 py-3">
+      <div>
+        <p className="mono text-[10.5px] uppercase tracking-[0.12em] text-fg-3">
+          {label}
+        </p>
+        <p className="mt-1 text-[22px] font-semibold text-fg">{value}</p>
       </div>
+      <div className="flex h-8 w-8 items-center justify-center rounded-md bg-black text-fg-2">
+        {icon}
+      </div>
+    </div>
+  );
+}
 
-      <div className="overflow-hidden rounded-lg border border-white/5 bg-black">
-        <table className="min-w-full divide-y divide-white/5">
-          <thead>
-            <tr>
-              <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-white/40">
-                Domain
-              </th>
-              <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-white/40">
-                Status
-              </th>
-              <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-white/40">
-                Routes
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-white/5">
-            {domains.map((domain) => {
-              const domainRoutes = routesByDomain.get(domain.id) ?? [];
-              const form = forms[domain.id] ?? defaultForm;
-              const ready =
-                domain.status === "active" && domain.receivingEnabled;
-              return (
-                <tr key={domain.id} className="align-top hover:bg-white/[0.02]">
-                  <td className="whitespace-nowrap px-6 py-4 text-sm text-fg">
-                    <div>{domain.name}</div>
-                    <div className="text-xs text-white/40">
-                      Added {new Date(domain.createdAt).toLocaleDateString()}
-                    </div>
-                  </td>
-                  <td className="whitespace-nowrap px-6 py-4 text-sm">
-                    <StatusBadge
-                      status={domain.status === "active" ? "active" : "pending"}
-                    />
-                    <div className="mt-2 text-xs text-white/40">
-                      Receiving{" "}
-                      {domain.receivingEnabled ? "enabled" : "disabled"}
-                    </div>
-                  </td>
-                  <td className="px-6 py-4 text-sm">
-                    <div className="space-y-2">
-                      {domainRoutes.map((route) => (
-                        <div
-                          key={route.id}
-                          className="rounded-md border border-white/10 px-3 py-2"
-                        >
-                          <div className="flex items-center justify-between gap-3">
-                            <div>
-                              <div className="font-mono text-xs text-fg">
-                                {routeLabel(route)} → {route.target_address}
-                              </div>
-                              <div className="text-xs text-white/40">
-                                {typeLabel(route.type)}
-                              </div>
-                            </div>
-                            <button
-                              type="button"
-                              className="text-xs text-red-300 hover:text-red-200 disabled:opacity-50"
-                              disabled={busyId === route.id}
-                              onClick={() => void deleteRoute(route.id)}
-                            >
-                              Delete
-                            </button>
-                          </div>
-                          {(() => {
-                            const forwardingRule = forwardingRulesByRoute.get(
-                              route.id,
-                            );
-                            const forwardingForm =
-                              forwardingForms[route.id] ??
-                              defaultForwardingForm;
-                            if (forwardingRule) {
-                              return (
-                                <div className="mt-3 rounded border border-white/5 bg-white/[0.02] p-3">
-                                  <div className="flex flex-wrap items-center justify-between gap-2">
-                                    <div>
-                                      <div className="text-xs font-medium text-fg">
-                                        Forwarding {forwardingRule.status}
-                                      </div>
-                                      <div className="text-xs text-white/40">
-                                        To{" "}
-                                        {forwardingRule.destinations.join(", ")}
-                                      </div>
-                                    </div>
-                                    <button
-                                      type="button"
-                                      className="rounded border border-white/10 px-2 py-1 text-xs text-fg hover:bg-white/5 disabled:opacity-50"
-                                      disabled={
-                                        busyId ===
-                                          `forward-${forwardingRule.id}` ||
-                                        forwardingRule.status === "invalid"
-                                      }
-                                      onClick={() =>
-                                        void updateForwardingRuleStatus(
-                                          forwardingRule,
-                                          forwardingRule.status === "active"
-                                            ? "disabled"
-                                            : "active",
-                                        )
-                                      }
-                                    >
-                                      {forwardingRule.status === "active"
-                                        ? "Disable"
-                                        : "Enable"}
-                                    </button>
-                                  </div>
-                                  {forwardingRule.invalid_reason && (
-                                    <div className="mt-1 text-xs text-yellow-300">
-                                      {forwardingRule.invalid_reason}
-                                    </div>
-                                  )}
-                                  {forwardingRule.last_attempt && (
-                                    <div className="mt-2 text-xs text-white/50">
-                                      Last forward:{" "}
-                                      <span className="text-fg">
-                                        {forwardingRule.last_attempt.status}
-                                      </span>{" "}
-                                      ({forwardingRule.last_attempt.reason})
-                                      {forwardingRule.last_attempt
-                                        .forwarded_email_status && (
-                                        <>
-                                          {" "}
-                                          · outbound{" "}
-                                          {
-                                            forwardingRule.last_attempt
-                                              .forwarded_email_status
-                                          }
-                                        </>
-                                      )}
-                                      {forwardingRule.last_attempt
-                                        .error_message && (
-                                        <div className="text-red-300">
-                                          {
-                                            forwardingRule.last_attempt
-                                              .error_message
-                                          }
-                                        </div>
-                                      )}
-                                    </div>
-                                  )}
-                                </div>
-                              );
-                            }
+function ReceivedInboxTable({ emails }: { emails: ReceivedEmailItem[] }) {
+  if (emails.length === 0) {
+    return (
+      <div className="rounded-lg border border-line bg-black px-6 py-14 text-center">
+        <h3 className="text-[16px] font-medium text-fg">
+          No received emails yet
+        </h3>
+        <p className="mx-auto mt-2 max-w-[430px] text-[13px] leading-6 text-fg-3">
+          Inbound messages appear here after the ingester stores a tenant-scoped
+          received email row.
+        </p>
+      </div>
+    );
+  }
 
-                            return (
-                              <div className="mt-3 grid gap-2 md:grid-cols-[1fr_120px_auto]">
-                                <input
-                                  aria-label={`Forwarding destinations for ${routeLabel(route)}`}
-                                  className="rounded-md border border-white/10 bg-black px-2 py-2 text-xs text-fg"
-                                  placeholder="forward@example.com, ops@example.com"
-                                  value={forwardingForm.destinations}
-                                  onChange={(event) =>
-                                    updateForwardingForm(
-                                      route.id,
-                                      (current) => ({
-                                        ...current,
-                                        destinations: event.target.value,
-                                      }),
-                                    )
-                                  }
-                                />
-                                <select
-                                  aria-label={`Forwarding status for ${routeLabel(route)}`}
-                                  className="rounded-md border border-white/10 bg-black px-2 py-2 text-xs text-fg"
-                                  value={forwardingForm.status}
-                                  onChange={(event) =>
-                                    updateForwardingForm(
-                                      route.id,
-                                      (current) => ({
-                                        ...current,
-                                        status: event.target
-                                          .value as ForwardingFormState["status"],
-                                      }),
-                                    )
-                                  }
-                                >
-                                  <option value="active">Active</option>
-                                  <option value="disabled">Disabled</option>
-                                </select>
-                                <button
-                                  type="button"
-                                  className="rounded-md border border-white/10 px-3 py-2 text-xs text-fg hover:bg-white/5 disabled:opacity-50"
-                                  disabled={busyId === `forward-${route.id}`}
-                                  onClick={() =>
-                                    void createForwardingRule(route)
-                                  }
-                                >
-                                  Add forwarding
-                                </button>
-                              </div>
-                            );
-                          })()}
-                        </div>
-                      ))}
-                      {domainRoutes.length === 0 && (
-                        <p className="text-xs text-white/40">
-                          No routes configured.
-                        </p>
+  return (
+    <div className="overflow-hidden rounded-lg border border-line bg-black">
+      <table className="w-full">
+        <thead>
+          <tr className="border-b border-line">
+            <th className="mono px-4 py-3 text-left text-[10.5px] uppercase tracking-[0.12em] text-fg-3">
+              From
+            </th>
+            <th className="mono px-4 py-3 text-left text-[10.5px] uppercase tracking-[0.12em] text-fg-3">
+              To
+            </th>
+            <th className="mono px-4 py-3 text-left text-[10.5px] uppercase tracking-[0.12em] text-fg-3">
+              Route
+            </th>
+            <th className="mono px-4 py-3 text-left text-[10.5px] uppercase tracking-[0.12em] text-fg-3">
+              Subject
+            </th>
+            <th className="mono px-4 py-3 text-left text-[10.5px] uppercase tracking-[0.12em] text-fg-3">
+              Received
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {emails.map((email) => (
+            <tr
+              key={email.id}
+              className="border-b border-line transition-colors last:border-b-0 hover:bg-bg-2"
+            >
+              <td className="px-4 py-3 text-[13.5px] text-fg">
+                <div className="flex min-w-[180px] items-center gap-2.5">
+                  <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-accent/15 text-[11px] font-semibold text-accent">
+                    {email.from.charAt(0).toUpperCase()}
+                  </div>
+                  <div className="min-w-0">
+                    <div className="truncate">{email.from}</div>
+                    <div className="mt-1 flex items-center gap-2">
+                      <StatusBadge
+                        status={statusLabel(email.status)}
+                        variant={statusVariant(email.status)}
+                      />
+                      {email.demo && (
+                        <span className="text-[11px] text-fg-3">Demo</span>
                       )}
                     </div>
-
-                    <div className="mt-4 grid gap-2 md:grid-cols-[140px_1fr_1fr_auto]">
-                      <select
-                        aria-label={`Route type for ${domain.name}`}
-                        className="rounded-md border border-white/10 bg-black px-2 py-2 text-xs text-fg"
-                        value={form.type}
-                        disabled={!ready}
-                        onChange={(event) =>
-                          updateForm(domain.id, (current) => ({
-                            ...current,
-                            type: event.target.value as RouteFormState["type"],
-                          }))
-                        }
-                      >
-                        <option value="exact">Exact</option>
-                        <option value="alias">Alias</option>
-                        <option value="catch_all">Catch-all</option>
-                      </select>
-                      <input
-                        className="rounded-md border border-white/10 bg-black px-2 py-2 text-xs text-fg disabled:opacity-50"
-                        placeholder="local part"
-                        value={form.localPart}
-                        disabled={!ready || form.type === "catch_all"}
-                        onChange={(event) =>
-                          updateForm(domain.id, (current) => ({
-                            ...current,
-                            localPart: event.target.value,
-                          }))
-                        }
-                      />
-                      <input
-                        className="rounded-md border border-white/10 bg-black px-2 py-2 text-xs text-fg disabled:opacity-50"
-                        placeholder={
-                          form.type === "exact"
-                            ? "target (optional)"
-                            : "target local part"
-                        }
-                        value={form.targetLocalPart}
-                        disabled={!ready}
-                        onChange={(event) =>
-                          updateForm(domain.id, (current) => ({
-                            ...current,
-                            targetLocalPart: event.target.value,
-                          }))
-                        }
-                      />
-                      <button
-                        type="button"
-                        className="rounded-md border border-white/10 px-3 py-2 text-xs text-fg hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-50"
-                        disabled={!ready || busyId === domain.id}
-                        onClick={() => void createRoute(domain.id)}
-                      >
-                        Add route
-                      </button>
+                  </div>
+                </div>
+              </td>
+              <td className="px-4 py-3 text-[13px] text-fg-2">
+                <div className="max-w-[220px] truncate">
+                  {primaryRecipient(email)}
+                </div>
+                {email.to.length > 1 && (
+                  <div className="mt-1 text-[12px] text-fg-3">
+                    +{email.to.length - 1} more
+                  </div>
+                )}
+              </td>
+              <td className="px-4 py-3">
+                <div className="flex flex-col gap-1">
+                  <StatusBadge
+                    status={routeDecisionLabel(email)}
+                    variant={routeDecisionVariant(email)}
+                  />
+                  {email.reply_match_status === "matched" && (
+                    <span className="text-[12px] text-fg-3">
+                      Thread matched
+                    </span>
+                  )}
+                </div>
+              </td>
+              <td className="px-4 py-3">
+                <div className="max-w-[360px]">
+                  <div className="truncate text-[13.5px] text-fg">
+                    {email.subject}
+                  </div>
+                  {email.preview && (
+                    <div className="mt-1 line-clamp-1 text-[12.5px] text-fg-3">
+                      {email.preview}
                     </div>
-                    {!ready && (
-                      <p className="mt-2 text-xs text-white/40">
-                        Verify the domain and enable receiving before adding
-                        routes.
-                      </p>
+                  )}
+                  {email.attachment_count > 0 && (
+                    <div className="mt-1 flex items-center gap-1 text-[12px] text-fg-3">
+                      <Paperclip aria-hidden className="h-3.5 w-3.5" />
+                      {email.attachment_count} attachment
+                      {email.attachment_count === 1 ? "" : "s"}
+                    </div>
+                  )}
+                </div>
+              </td>
+              <td
+                className="mono whitespace-nowrap px-4 py-3 text-[12px] text-fg-3"
+                title={new Date(email.created_at).toLocaleString()}
+              >
+                {formatRelativeTime(email.created_at)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ReceivingConfigTable({
+  busyId,
+  domains,
+  forms,
+  forwardingForms,
+  forwardingRulesByRoute,
+  routesByDomain,
+  createForwardingRule,
+  createRoute,
+  deleteRoute,
+  updateForm,
+  updateForwardingForm,
+  updateForwardingRuleStatus,
+}: {
+  busyId: string | null;
+  domains: InboundDomain[];
+  forms: Record<string, RouteFormState>;
+  forwardingForms: Record<string, ForwardingFormState>;
+  forwardingRulesByRoute: Map<string, ForwardingRuleItem>;
+  routesByDomain: Map<string, ReceivingRouteItem[]>;
+  createForwardingRule: (route: ReceivingRouteItem) => Promise<void>;
+  createRoute: (domainId: string) => Promise<void>;
+  deleteRoute: (route: ReceivingRouteItem) => Promise<void>;
+  updateForm: (
+    domainId: string,
+    updater: (form: RouteFormState) => RouteFormState,
+  ) => void;
+  updateForwardingForm: (
+    routeId: string,
+    updater: (form: ForwardingFormState) => ForwardingFormState,
+  ) => void;
+  updateForwardingRuleStatus: (
+    rule: ForwardingRuleItem,
+    status: "active" | "disabled",
+  ) => Promise<void>;
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-line bg-black">
+      <table className="min-w-full divide-y divide-line">
+        <thead>
+          <tr>
+            <th className="mono px-6 py-4 text-left text-[10.5px] uppercase tracking-[0.12em] text-fg-3">
+              Domain
+            </th>
+            <th className="mono px-6 py-4 text-left text-[10.5px] uppercase tracking-[0.12em] text-fg-3">
+              Status
+            </th>
+            <th className="mono px-6 py-4 text-left text-[10.5px] uppercase tracking-[0.12em] text-fg-3">
+              Routes
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-line">
+          {domains.map((domain) => {
+            const domainRoutes = routesByDomain.get(domain.id) ?? [];
+            const form = forms[domain.id] ?? defaultForm;
+            const ready = domain.status === "active" && domain.receivingEnabled;
+            const disabled = !ready || domain.demo;
+            return (
+              <tr key={domain.id} className="align-top hover:bg-bg-2">
+                <td className="whitespace-nowrap px-6 py-4 text-sm text-fg">
+                  <div className="flex items-center gap-2">
+                    <span>{domain.name}</span>
+                    {domain.demo && (
+                      <span className="text-[11px] text-fg-3">Demo</span>
                     )}
-                  </td>
-                </tr>
-              );
-            })}
-            {domains.length === 0 && (
-              <tr>
-                <td
-                  colSpan={3}
-                  className="px-6 py-12 text-center text-sm text-white/40"
-                >
-                  No inbound domains configured.
+                  </div>
+                  <div className="mt-1 text-xs text-fg-3">
+                    Added {new Date(domain.createdAt).toLocaleDateString()}
+                  </div>
+                </td>
+                <td className="whitespace-nowrap px-6 py-4 text-sm">
+                  <StatusBadge
+                    status={domain.status === "active" ? "active" : "pending"}
+                  />
+                  <div className="mt-2 text-xs text-fg-3">
+                    Receiving {domain.receivingEnabled ? "enabled" : "disabled"}
+                  </div>
+                </td>
+                <td className="px-6 py-4 text-sm">
+                  <div className="space-y-2">
+                    {domainRoutes.map((route) => (
+                      <RouteRow
+                        key={route.id}
+                        busyId={busyId}
+                        forwardingForm={
+                          forwardingForms[route.id] ?? defaultForwardingForm
+                        }
+                        forwardingRule={forwardingRulesByRoute.get(route.id)}
+                        route={route}
+                        createForwardingRule={createForwardingRule}
+                        deleteRoute={deleteRoute}
+                        updateForwardingForm={updateForwardingForm}
+                        updateForwardingRuleStatus={updateForwardingRuleStatus}
+                      />
+                    ))}
+                    {domainRoutes.length === 0 && (
+                      <p className="text-xs text-fg-3">No routes configured.</p>
+                    )}
+                  </div>
+
+                  <div className="mt-4 grid gap-2 md:grid-cols-[140px_1fr_1fr_auto]">
+                    <select
+                      aria-label={`Route type for ${domain.name}`}
+                      className="rounded-md border border-line bg-black px-2 py-2 text-xs text-fg disabled:opacity-50"
+                      value={form.type}
+                      disabled={disabled}
+                      onChange={(event) =>
+                        updateForm(domain.id, (current) => ({
+                          ...current,
+                          type: event.target.value as RouteFormState["type"],
+                        }))
+                      }
+                    >
+                      <option value="exact">Exact</option>
+                      <option value="alias">Alias</option>
+                      <option value="catch_all">Catch-all</option>
+                    </select>
+                    <input
+                      className="rounded-md border border-line bg-black px-2 py-2 text-xs text-fg disabled:opacity-50"
+                      placeholder="local part"
+                      value={form.localPart}
+                      disabled={disabled || form.type === "catch_all"}
+                      onChange={(event) =>
+                        updateForm(domain.id, (current) => ({
+                          ...current,
+                          localPart: event.target.value,
+                        }))
+                      }
+                    />
+                    <input
+                      className="rounded-md border border-line bg-black px-2 py-2 text-xs text-fg disabled:opacity-50"
+                      placeholder={
+                        form.type === "exact"
+                          ? "target (optional)"
+                          : "target local part"
+                      }
+                      value={form.targetLocalPart}
+                      disabled={disabled}
+                      onChange={(event) =>
+                        updateForm(domain.id, (current) => ({
+                          ...current,
+                          targetLocalPart: event.target.value,
+                        }))
+                      }
+                    />
+                    <button
+                      type="button"
+                      className="rounded-md border border-line px-3 py-2 text-xs text-fg hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-50"
+                      disabled={disabled || busyId === domain.id}
+                      onClick={() => void createRoute(domain.id)}
+                    >
+                      Add route
+                    </button>
+                  </div>
+                  {!ready && (
+                    <p className="mt-2 text-xs text-fg-3">
+                      Verify the domain and enable receiving before adding
+                      routes.
+                    </p>
+                  )}
                 </td>
               </tr>
-            )}
-          </tbody>
-        </table>
+            );
+          })}
+          {domains.length === 0 && (
+            <tr>
+              <td
+                colSpan={3}
+                className="px-6 py-12 text-center text-sm text-fg-3"
+              >
+                No inbound domains configured.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RouteRow({
+  busyId,
+  forwardingForm,
+  forwardingRule,
+  route,
+  createForwardingRule,
+  deleteRoute,
+  updateForwardingForm,
+  updateForwardingRuleStatus,
+}: {
+  busyId: string | null;
+  forwardingForm: ForwardingFormState;
+  forwardingRule?: ForwardingRuleItem;
+  route: ReceivingRouteItem;
+  createForwardingRule: (route: ReceivingRouteItem) => Promise<void>;
+  deleteRoute: (route: ReceivingRouteItem) => Promise<void>;
+  updateForwardingForm: (
+    routeId: string,
+    updater: (form: ForwardingFormState) => ForwardingFormState,
+  ) => void;
+  updateForwardingRuleStatus: (
+    rule: ForwardingRuleItem,
+    status: "active" | "disabled",
+  ) => Promise<void>;
+}) {
+  return (
+    <div className="rounded-md border border-line px-3 py-2">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <div className="font-mono text-xs text-fg">
+            {routeLabel(route)} -&gt; {route.target_address}
+          </div>
+          <div className="text-xs text-fg-3">{typeLabel(route.type)}</div>
+        </div>
+        <button
+          type="button"
+          className="text-xs text-red-300 hover:text-red-200 disabled:opacity-50"
+          disabled={busyId === route.id || route.demo}
+          onClick={() => void deleteRoute(route)}
+        >
+          Delete
+        </button>
       </div>
+
+      {forwardingRule ? (
+        <div className="mt-3 rounded border border-line bg-white/[0.02] p-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <div className="text-xs font-medium text-fg">
+                Forwarding {forwardingRule.status}
+              </div>
+              <div className="text-xs text-fg-3">
+                To {forwardingRule.destinations.join(", ")}
+              </div>
+            </div>
+            <button
+              type="button"
+              className="rounded border border-line px-2 py-1 text-xs text-fg hover:bg-white/5 disabled:opacity-50"
+              disabled={
+                busyId === `forward-${forwardingRule.id}` ||
+                forwardingRule.status === "invalid" ||
+                forwardingRule.demo
+              }
+              onClick={() =>
+                void updateForwardingRuleStatus(
+                  forwardingRule,
+                  forwardingRule.status === "active" ? "disabled" : "active",
+                )
+              }
+            >
+              {forwardingRule.status === "active" ? "Disable" : "Enable"}
+            </button>
+          </div>
+          {forwardingRule.invalid_reason && (
+            <div className="mt-1 text-xs text-yellow-300">
+              {forwardingRule.invalid_reason}
+            </div>
+          )}
+          {forwardingRule.last_attempt && (
+            <div className="mt-2 text-xs text-fg-3">
+              Last forward:{" "}
+              <span className="text-fg">
+                {forwardingRule.last_attempt.status}
+              </span>{" "}
+              ({forwardingRule.last_attempt.reason})
+              {forwardingRule.last_attempt.forwarded_email_status && (
+                <>
+                  {" "}
+                  outbound {forwardingRule.last_attempt.forwarded_email_status}
+                </>
+              )}
+              {forwardingRule.last_attempt.error_message && (
+                <div className="text-red-300">
+                  {forwardingRule.last_attempt.error_message}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="mt-3 grid gap-2 md:grid-cols-[1fr_120px_auto]">
+          <input
+            aria-label={`Forwarding destinations for ${routeLabel(route)}`}
+            className="rounded-md border border-line bg-black px-2 py-2 text-xs text-fg disabled:opacity-50"
+            placeholder="forward@example.com, ops@example.com"
+            value={forwardingForm.destinations}
+            disabled={route.demo}
+            onChange={(event) =>
+              updateForwardingForm(route.id, (current) => ({
+                ...current,
+                destinations: event.target.value,
+              }))
+            }
+          />
+          <select
+            aria-label={`Forwarding status for ${routeLabel(route)}`}
+            className="rounded-md border border-line bg-black px-2 py-2 text-xs text-fg disabled:opacity-50"
+            value={forwardingForm.status}
+            disabled={route.demo}
+            onChange={(event) =>
+              updateForwardingForm(route.id, (current) => ({
+                ...current,
+                status: event.target.value as ForwardingFormState["status"],
+              }))
+            }
+          >
+            <option value="active">Active</option>
+            <option value="disabled">Disabled</option>
+          </select>
+          <button
+            type="button"
+            className="rounded-md border border-line px-3 py-2 text-xs text-fg hover:bg-white/5 disabled:opacity-50"
+            disabled={busyId === `forward-${route.id}` || route.demo}
+            onClick={() => void createForwardingRule(route)}
+          >
+            Add forwarding
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/status-badge.tsx
+++ b/src/components/status-badge.tsx
@@ -16,7 +16,7 @@ export function StatusBadge({ status, variant = "default" }: StatusBadgeProps) {
 
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 rounded-md text-[12px] font-medium ${style}`}
+      className={`inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded-md text-[12px] font-medium ${style}`}
     >
       {status}
     </span>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -493,6 +493,9 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   const isPublicUnsubscribeRoute = pathname.startsWith("/unsubscribe/");
+  const isDevReceivingPreviewRoute =
+    process.env.NODE_ENV !== "production" &&
+    pathname === "/dev/receiving-preview";
 
   // Protect non-API page routes with session check. Resend-compatible send
   // aliases must bypass dashboard session redirects and use public API auth.
@@ -536,6 +539,7 @@ export async function middleware(request: NextRequest) {
       pathname === "/pricing" ||
       pathname.startsWith("/pricing/") ||
       pathname === "/status" ||
+      isDevReceivingPreviewRoute ||
       pathname.startsWith("/_next/") ||
       pathname.startsWith("/favicon")
     ) {

--- a/tests/middleware-rate-limit.test.ts
+++ b/tests/middleware-rate-limit.test.ts
@@ -47,6 +47,22 @@ describe("middleware rate limiting", () => {
     expect(response.headers.get("x-middleware-next")).toBe("1");
   });
 
+  it("allows the local receiving preview page without a dashboard session", async () => {
+    mockGetSessionCookie.mockReturnValue(null);
+    const { middleware } = await import("@/middleware");
+
+    const response = await middleware(
+      makeRequest("https://example.com/dev/receiving-preview", {
+        method: "GET",
+        headers: { accept: "text/html" },
+      }),
+    );
+
+    expect(mockGetSessionCookie).not.toHaveBeenCalled();
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+
   it("skips API rate limiting when RATE_LIMIT_BACKEND is disabled", async () => {
     const { middleware } = await import("@/middleware");
 

--- a/tests/receiving-list.test.tsx
+++ b/tests/receiving-list.test.tsx
@@ -1,0 +1,111 @@
+import { ReceivingList } from "@/components/receiving-list";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+afterEach(cleanup);
+
+const domain = {
+  id: "domain-1",
+  name: "inbound.example.com",
+  status: "active" as const,
+  createdAt: "2026-06-08T00:00:00.000Z",
+  receivingEnabled: true,
+};
+
+const route = {
+  id: "route-1",
+  domain_id: "domain-1",
+  domain: "inbound.example.com",
+  type: "exact" as const,
+  local_part: "support",
+  target_local_part: "support",
+  target_address: "support@inbound.example.com",
+};
+
+const receivedEmail = {
+  id: "received-1",
+  from: "customer@example.com",
+  to: ["support@inbound.example.com"],
+  subject: "Inbound support request",
+  status: "received",
+  preview: "Can you help us with the onboarding checklist?",
+  route_decisions: [
+    {
+      recipient: "support@inbound.example.com",
+      status: "exact" as const,
+      routeId: "route-1",
+      routeType: "exact" as const,
+      targetAddress: "support@inbound.example.com",
+    },
+  ],
+  reply_match_status: "unmatched",
+  thread_id: null,
+  reply_to_email_id: null,
+  contact_id: null,
+  attachment_count: 0,
+  created_at: "2026-06-08T00:05:00.000Z",
+};
+
+describe("ReceivingList", () => {
+  it("renders received emails as the primary surface before configuration", () => {
+    render(
+      <ReceivingList
+        domains={[domain]}
+        routes={[route]}
+        forwardingRules={[]}
+        receivedEmails={[receivedEmail]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Received inbox" }),
+    ).toBeDefined();
+    expect(screen.getByText("customer@example.com")).toBeDefined();
+    expect(screen.getByText("support@inbound.example.com")).toBeDefined();
+    expect(screen.getByText("Inbound support request")).toBeDefined();
+    expect(
+      screen.getByRole("heading", { name: "Receiving configuration" }),
+    ).toBeDefined();
+    expect(
+      screen.getByLabelText(
+        "Forwarding destinations for support@inbound.example.com",
+      ),
+    ).toBeDefined();
+  });
+
+  it("uses development demo data when the inbox and config are empty", () => {
+    render(
+      <ReceivingList
+        domains={[]}
+        routes={[]}
+        forwardingRules={[]}
+        receivedEmails={[]}
+        useDemoData
+      />,
+    );
+
+    expect(
+      screen.getByText("Can you confirm our onboarding window?"),
+    ).toBeDefined();
+    expect(screen.getByText("maya@customer.example")).toBeDefined();
+    expect(screen.getByText("inbound.opliora.com")).toBeDefined();
+    expect(screen.getByText("Demo data")).toBeDefined();
+    expect(screen.getByText("Demo config")).toBeDefined();
+  });
+
+  it("keeps production empty states free of demo rows", () => {
+    render(
+      <ReceivingList
+        domains={[]}
+        routes={[]}
+        forwardingRules={[]}
+        receivedEmails={[]}
+        useDemoData={false}
+      />,
+    );
+
+    expect(screen.getByText("No received emails yet")).toBeDefined();
+    expect(screen.getByText("No inbound domains configured.")).toBeDefined();
+    expect(screen.queryByText("maya@customer.example")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Improves the receiving inbox dashboard surface, including setup-state handling, preview ergonomics, and badge behavior.
- Adds a dev receiving preview page plus focused coverage for the receiving list and middleware rate-limit boundary.
- Preserves the receiving setup UX learning note and adds the domain verification production explainer under `agent_docs/architecture`.
- Ignores local `.handoffs/` agent state so transfer notes stay out of normal git status and Docker already excludes them.

## Why

The branch makes the receiving inbox page clearer for operators while keeping the implementation backed by focused tests. The documentation commit also keeps the domain verification scheduler/cache explanation as a durable repo artifact without committing local handoff state.

## Validation

- `make check && make test`
  - Typecheck passed
  - Biome passed
  - Vitest: 1617 passed, 10 skipped
- Push guardrails passed
  - change-scoped file check
  - full-project typecheck
  - changed-file Biome lint