### PR TITLE
[codex] Fix Today dashboard quickstart and metrics

### DIFF
--- a/src/app/(dashboard)/today/page.tsx
+++ b/src/app/(dashboard)/today/page.tsx
@@ -18,7 +18,9 @@ import {
 } from "@/lib/dashboard-provider-feedback";
 import { db } from "@/lib/db";
 import { domains, emailEvents, emails } from "@/lib/db/schema";
+import { getTodayApiBaseUrl } from "@/lib/today-dashboard";
 import { desc, eq, sql } from "drizzle-orm";
+import { headers } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
@@ -251,6 +253,7 @@ async function loadRecentSenderDomains(
 async function loadDomainReputation(
   userId: string,
 ): Promise<DomainReputationRow[]> {
+  const since = new Date(Date.now() - 24 * HOUR_MS);
   try {
     const result = await db.execute(sql`
       SELECT
@@ -266,6 +269,7 @@ async function loadDomainReputation(
       FROM ${domains} d
       LEFT JOIN ${emails} e
         ON e.user_id = d.user_id
+       AND e.created_at >= ${since}
        AND (
          lower(e.from) LIKE '%@' || lower(d.name)
          OR lower(e.from) LIKE '%@' || lower(d.name) || '>'
@@ -350,12 +354,6 @@ function relativeTime(d: Date | string): string {
   return `${Math.floor(ms / 86_400_000)}d`;
 }
 
-function getApiBaseUrl(): string {
-  const raw = process.env.NEXT_PUBLIC_APP_URL?.trim();
-  if (!raw) return "https://your-opensend-host";
-  return raw.replace(/\/$/, "");
-}
-
 export default async function TodayPage() {
   const session = await getServerSession();
   if (!session) redirect("/auth");
@@ -418,6 +416,7 @@ export default async function TodayPage() {
   const openedSpark = hourly.map((h) => h.opened);
   const bouncedSpark = hourly.map((h) => h.bounced);
   const chartMax = Math.max(1, ...sentSpark);
+  const chartTotal = hourly.reduce((sum, bucket) => sum + bucket.sent, 0);
   const deliveryState = getProviderFeedbackMetricState({
     total: stats.total,
     providerFeedbackWired,
@@ -430,7 +429,8 @@ export default async function TodayPage() {
   const deliveryStateLabel = dashboardMetricStateLabel(deliveryState);
   const openStateLabel = dashboardMetricStateLabel(openState);
 
-  const apiBase = getApiBaseUrl();
+  const requestHeaders = await headers();
+  const apiBase = getTodayApiBaseUrl(requestHeaders);
   const apiSendUrl = `${apiBase}/emails`;
   const fromExample = domainRows[0]?.name
     ? `hi@${domainRows[0].name}`
@@ -510,6 +510,7 @@ export default async function TodayPage() {
             <SectionHeader
               kicker="// send volume · last 24h"
               title="Hourly sends"
+              sub="Accepted sends grouped by hour, with opens and bounces overlaid when tracking or provider feedback exists."
               action={
                 <div className="mono flex gap-3.5 text-[11.5px] text-fg-3">
                   <span className="inline-flex items-center gap-1.5">
@@ -527,10 +528,20 @@ export default async function TodayPage() {
                 </div>
               }
             />
-            <div className="mt-3 flex h-[180px] items-end gap-1.5">
+            <div className="mono mt-3 flex items-center justify-between text-[11px] text-fg-4">
+              <span>24h ago</span>
+              <span>
+                {chartTotal.toLocaleString()} send
+                {chartTotal === 1 ? "" : "s"} · peak {chartMax.toLocaleString()}
+                /hr
+              </span>
+              <span>now</span>
+            </div>
+            <div className="mt-2 flex h-[180px] items-end gap-1.5 border-b border-line/70 pb-1">
               {hourly.map((h, i) => {
                 const sentH = (h.sent / chartMax) * 100;
                 const openH = (h.opened / chartMax) * 100;
+                const bounceH = (h.bounced / chartMax) * 100;
                 return (
                   <div
                     // biome-ignore lint/suspicious/noArrayIndexKey: hour buckets are stable ordinals
@@ -544,6 +555,10 @@ export default async function TodayPage() {
                     <div
                       className="w-full rounded-sm bg-violet/60"
                       style={{ height: `${openH * 0.45}%` }}
+                    />
+                    <div
+                      className="w-full rounded-sm bg-red/70"
+                      style={{ height: `${bounceH * 0.45}%` }}
                     />
                   </div>
                 );
@@ -608,6 +623,7 @@ export default async function TodayPage() {
             <SectionHeader
               kicker="// deliverability"
               title="Reputation by domain"
+              sub="Last-24h provider feedback from accepted sends and SES/SNS lifecycle events."
               action={
                 <Link
                   href="/domains"

--- a/src/lib/today-dashboard.ts
+++ b/src/lib/today-dashboard.ts
@@ -1,0 +1,33 @@
+type HeaderReader = Pick<Headers, "get">;
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function envUrl(): string | null {
+  const raw =
+    process.env.NEXT_PUBLIC_APP_URL?.trim() ||
+    process.env.APP_URL?.trim() ||
+    process.env.BETTER_AUTH_URL?.trim() ||
+    "";
+  return raw ? stripTrailingSlash(raw) : null;
+}
+
+export function getTodayApiBaseUrl(headers?: HeaderReader): string {
+  const configured = envUrl();
+  if (configured) return configured;
+
+  const host =
+    headers?.get("x-forwarded-host")?.split(",")[0]?.trim() ||
+    headers?.get("host")?.trim() ||
+    "";
+  if (!host) return "http://localhost:3015";
+
+  const proto =
+    headers?.get("x-forwarded-proto")?.split(",")[0]?.trim() ||
+    (host.startsWith("localhost") || host.startsWith("127.0.0.1")
+      ? "http"
+      : "https");
+
+  return `${proto}://${host}`;
+}

--- a/tests/today-dashboard.test.ts
+++ b/tests/today-dashboard.test.ts
@@ -1,0 +1,56 @@
+import { getTodayApiBaseUrl } from "@/lib/today-dashboard";
+import { afterEach, describe, expect, it } from "vitest";
+
+function makeHeaders(values: Record<string, string>): Headers {
+  return new Headers(values);
+}
+
+const envKeys = ["NEXT_PUBLIC_APP_URL", "APP_URL", "BETTER_AUTH_URL"] as const;
+const originalEnv = Object.fromEntries(
+  envKeys.map((key) => [key, process.env[key]]),
+) as Record<(typeof envKeys)[number], string | undefined>;
+
+function setEnv(key: (typeof envKeys)[number], value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+describe("today dashboard helpers", () => {
+  afterEach(() => {
+    for (const key of envKeys) {
+      setEnv(key, originalEnv[key]);
+    }
+  });
+
+  it("uses the configured public app URL for quick-start API examples", () => {
+    setEnv("NEXT_PUBLIC_APP_URL", "https://mail.example.com/");
+
+    expect(getTodayApiBaseUrl()).toBe("https://mail.example.com");
+  });
+
+  it("falls back to the current forwarded request host", () => {
+    setEnv("NEXT_PUBLIC_APP_URL", "");
+    setEnv("APP_URL", "");
+    setEnv("BETTER_AUTH_URL", "");
+
+    expect(
+      getTodayApiBaseUrl(
+        makeHeaders({
+          "x-forwarded-host": "selfhost.example.com",
+          "x-forwarded-proto": "https",
+        }),
+      ),
+    ).toBe("https://selfhost.example.com");
+  });
+
+  it("uses localhost when no configured or request host is available", () => {
+    setEnv("NEXT_PUBLIC_APP_URL", "");
+    setEnv("APP_URL", "");
+    setEnv("BETTER_AUTH_URL", "");
+
+    expect(getTodayApiBaseUrl()).toBe("http://localhost:3015");
+  });
+});


### PR DESCRIPTION
## What changed

- Replaced the Today quick-start URL placeholder fallback with a resolver that uses `NEXT_PUBLIC_APP_URL`, `APP_URL`, `BETTER_AUTH_URL`, or the current request host before falling back to local dev.
- Clarified the Hourly sends card with last-24h context, total/peak labels, and rendered the bounce series that the legend already advertised.
- Scoped Reputation by domain counts to the same last-24h window as the Today page and labeled the section as provider-feedback backed.
- Added focused regression tests for the quick-start base URL resolver.

## Why

The Today page could show `https://your-opensend-host/emails` when the public app URL env was missing, which looked like a hardcoded production endpoint. The send-volume and domain reputation panels were also ambiguous: Hourly sends lacked enough context, and domain reputation was described as a Today surface while using all-time send counts.

## Validation

- `bun test tests/today-dashboard.test.ts tests/dashboard-deliverability-state.test.ts`
- `bun run typecheck`
- `bunx biome check 'src/app/(dashboard)/today/page.tsx' src/lib/today-dashboard.ts tests/today-dashboard.test.ts`
- Push guardrails also ran `node scripts/check-changed-files.mjs`, full-project typecheck, and changed-file Biome successfully.