### PR TITLE
Release staging to main: SES custom MAIL FROM activation

### DIFF
--- a/packages/core/src/services/domain-providers.ts
+++ b/packages/core/src/services/domain-providers.ts
@@ -15,6 +15,7 @@ export type DomainIdentityProvider = {
   ): CreateDomainIdentityReturn;
   getDomainIdentity: typeof emailProvider.getDomainIdentity;
   deleteDomainIdentity: typeof emailProvider.deleteDomainIdentity;
+  setMailFromDomain: typeof emailProvider.setMailFromDomain;
 };
 
 export type DomainDnsCleanupRecord = {
@@ -75,6 +76,8 @@ export const domainIdentityProvider: DomainIdentityProvider = {
     emailProvider.getDomainIdentity(domain, options),
   deleteDomainIdentity: (domain, options) =>
     emailProvider.deleteDomainIdentity(domain, options),
+  setMailFromDomain: (domain, mailFromDomain, options) =>
+    emailProvider.setMailFromDomain(domain, mailFromDomain, options),
 };
 
 export const cloudflareDnsCleanupProvider: DomainDnsCleanupProvider = {

--- a/packages/core/src/services/domain.ts
+++ b/packages/core/src/services/domain.ts
@@ -225,9 +225,14 @@ export type DomainServiceDependencies = {
   getDomainIdentity?: (
     domain: string,
     options?: { region?: string },
-  ) => Promise<{ verified?: boolean }>;
+  ) => Promise<{ verified?: boolean; mailFromDomain?: string | null }>;
   deleteDomainIdentity?: (
     domain: string,
+    options?: { region?: string },
+  ) => Promise<void>;
+  setMailFromDomain?: (
+    domain: string,
+    mailFromDomain: string,
     options?: { region?: string },
   ) => Promise<void>;
   /**
@@ -370,6 +375,12 @@ export function createDomainService({
     domainIdentityProvider.getDomainIdentity(domain, options),
   deleteDomainIdentity = (domain: string, options?: { region?: string }) =>
     domainIdentityProvider.deleteDomainIdentity(domain, options),
+  setMailFromDomain = (
+    domain: string,
+    mailFromDomain: string,
+    options?: { region?: string },
+  ) =>
+    domainIdentityProvider.setMailFromDomain(domain, mailFromDomain, options),
   invalidateDomainCaches,
   syncDomainConfigurationSet = (input) =>
     configurationSetService.syncDomainConfigurationSet(input),
@@ -419,6 +430,37 @@ export function createDomainService({
         configErr,
       );
       return domain;
+    }
+  }
+
+  /**
+   * Point SES's MAIL FROM (envelope/bounce) domain at the return-path
+   * subdomain we already ask customers to add DNS records for, so SPF aligns
+   * with their domain. Without this call the records are decorative and every
+   * send goes out with MAIL FROM = amazonses.com (issue #650).
+   *
+   * Non-fatal by design: SES falls back to the default MAIL FROM on MX
+   * failure, so the worst case equals the previous behavior.
+   */
+  async function ensureMailFromAttributes(
+    domain: Pick<DomainRow, "id" | "name" | "region" | "customReturnPath">,
+    currentMailFromDomain?: string | null,
+  ): Promise<void> {
+    const desired = buildReturnPathRecordName(
+      domain.name,
+      domain.customReturnPath,
+    );
+    if (currentMailFromDomain === desired) return;
+
+    try {
+      await setMailFromDomain(domain.name, desired, {
+        region: domain.region ?? undefined,
+      });
+    } catch (mailFromErr) {
+      console.warn(
+        `Failed to set SES MAIL FROM for domain ${domain.id}:`,
+        mailFromErr,
+      );
     }
   }
 
@@ -482,6 +524,10 @@ export function createDomainService({
       const domainWithConfigSet =
         await syncAndPersistDomainConfigurationSet(row);
 
+      // Activate the custom MAIL FROM immediately so SES starts watching the
+      // return-path DNS records the customer is about to add.
+      await ensureMailFromAttributes(domainWithConfigSet);
+
       await invalidateDomainCaches({
         id: domainWithConfigSet.id,
         name: domainWithConfigSet.name,
@@ -516,6 +562,12 @@ export function createDomainService({
           (record, idx) => record.status !== recordsForUpdate[idx].status,
         );
       const statusChanged = domain.status !== nextStatus;
+
+      if (nextStatus === "verified") {
+        // Repair pass for identities that predate automatic MAIL FROM
+        // activation (or whose SES-side setting drifted).
+        await ensureMailFromAttributes(domain, identity.mailFromDomain);
+      }
 
       if (!statusChanged && !recordsChanged) {
         const repairedDomain =

--- a/packages/core/src/services/emailProvider.ts
+++ b/packages/core/src/services/emailProvider.ts
@@ -5,6 +5,7 @@ import {
   DeleteEmailIdentityCommand,
   GetEmailIdentityCommand,
   PutEmailIdentityDkimSigningAttributesCommand,
+  PutEmailIdentityMailFromAttributesCommand,
   SESv2Client,
   SendEmailCommand,
 } from "@aws-sdk/client-sesv2";
@@ -46,6 +47,10 @@ type EmailProviderGetDomainIdentityResult = {
   verified: boolean;
   dkimStatus: string;
   dkimTokens: string[];
+  /** Custom MAIL FROM domain configured on the identity, if any. */
+  mailFromDomain: string | null;
+  /** SES MAIL FROM state: PENDING | SUCCESS | FAILED | TEMPORARY_FAILURE | NOT_STARTED. */
+  mailFromStatus: string;
 };
 
 const hasAwsCredentials =
@@ -166,7 +171,13 @@ export class EmailProviderService {
     if (!domain) throw new Error("domain is required");
 
     if (useDevStub) {
-      return { verified: false, dkimStatus: "NOT_STARTED", dkimTokens: [] };
+      return {
+        verified: false,
+        dkimStatus: "NOT_STARTED",
+        dkimTokens: [],
+        mailFromDomain: null,
+        mailFromStatus: "NOT_STARTED",
+      };
     }
 
     const res = await this.getClient(options.region).send(
@@ -177,7 +188,39 @@ export class EmailProviderService {
       verified: res.VerifiedForSendingStatus ?? false,
       dkimStatus: res.DkimAttributes?.Status ?? "NOT_STARTED",
       dkimTokens: res.DkimAttributes?.Tokens ?? [],
+      mailFromDomain: res.MailFromAttributes?.MailFromDomain ?? null,
+      mailFromStatus:
+        res.MailFromAttributes?.MailFromDomainStatus ?? "NOT_STARTED",
     };
+  }
+
+  /**
+   * Point the identity's MAIL FROM (envelope/bounce) domain at the customer's
+   * return-path subdomain so SPF aligns with their domain. USE_DEFAULT_VALUE
+   * keeps mail flowing on amazonses.com if the MX record is missing or breaks.
+   */
+  async setMailFromDomain(
+    domain: string,
+    mailFromDomain: string,
+    options: { region?: string } = {},
+  ): Promise<void> {
+    if (!domain) throw new Error("domain is required");
+    if (!mailFromDomain) throw new Error("mailFromDomain is required");
+
+    if (useDevStub) {
+      console.log(
+        `[DEV] Would set SES MAIL FROM for ${domain} to ${mailFromDomain} in ${normalizeSesRegion(options.region)}`,
+      );
+      return;
+    }
+
+    await this.getClient(options.region).send(
+      new PutEmailIdentityMailFromAttributesCommand({
+        EmailIdentity: domain,
+        MailFromDomain: mailFromDomain,
+        BehaviorOnMxFailure: "USE_DEFAULT_VALUE",
+      }),
+    );
   }
 
   async deleteDomainIdentity(

--- a/tests/domain-service.test.ts
+++ b/tests/domain-service.test.ts
@@ -80,6 +80,9 @@ describe("domain service", () => {
         dkimPublicKey: "public-key",
         dkimPrivateKeyEnc: { ct: "ciphertext", iv: "iv" },
       });
+    const setMailFromDomain = vi
+      .spyOn(domainIdentityProvider, "setMailFromDomain")
+      .mockResolvedValue(undefined);
     const repository = createRepository({
       async create(data) {
         inserted.push(data);
@@ -114,8 +117,14 @@ describe("domain service", () => {
         status: "pending",
         ttl: "Auto",
       });
+      expect(setMailFromDomain).toHaveBeenCalledWith(
+        "example.com",
+        "send.example.com",
+        { region: "us-east-1" },
+      );
     } finally {
       createDomainIdentity.mockRestore();
+      setMailFromDomain.mockRestore();
     }
   });
 
@@ -146,9 +155,11 @@ describe("domain service", () => {
       },
     });
 
+    const setMailFromDomain = vi.fn(async () => undefined);
     const service = createDomainService({
       repository,
       createDomainIdentity,
+      setMailFromDomain,
       invalidateDomainCaches,
       syncDomainConfigurationSet: vi.fn(async () => "cfg-created-domain"),
     });
@@ -176,6 +187,12 @@ describe("domain service", () => {
       userId: "user-1",
       region: "eu-west-1",
     });
+    // Custom return path label drives the MAIL FROM subdomain.
+    expect(setMailFromDomain).toHaveBeenCalledWith(
+      "example.com",
+      "outbound.example.com",
+      { region: "eu-west-1" },
+    );
     expect(inserted[0]).toMatchObject({
       name: "example.com",
       region: "eu-west-1",
@@ -265,6 +282,7 @@ describe("domain service", () => {
       },
     });
     const service = createDomainService({
+      setMailFromDomain: vi.fn(async () => undefined),
       repository,
       createDomainIdentity: async () => ({ dkimTokens: [] }),
       invalidateDomainCaches: vi.fn(),
@@ -304,6 +322,7 @@ describe("domain service", () => {
   it("uses external API defaults when optional create fields are omitted", async () => {
     const inserted: DomainInsert[] = [];
     const service = createDomainService({
+      setMailFromDomain: vi.fn(async () => undefined),
       repository: createRepository({
         async create(data) {
           inserted.push(data);
@@ -394,6 +413,7 @@ describe("domain service", () => {
     });
 
     const service = createDomainService({
+      setMailFromDomain: vi.fn(async () => undefined),
       repository,
       getDomainIdentity,
       invalidateDomainCaches: vi.fn(),
@@ -453,6 +473,7 @@ describe("domain service", () => {
       },
     });
     const service = createDomainService({
+      setMailFromDomain: vi.fn(async () => undefined),
       repository,
       getDomainIdentity: async () => ({ verified: true }),
       invalidateDomainCaches: vi.fn(),
@@ -528,6 +549,7 @@ describe("domain service", () => {
       >();
 
     const service = createDomainService({
+      setMailFromDomain: vi.fn(async () => undefined),
       repository,
       getDomainIdentity: async () => ({ verified: false }),
       invalidateDomainCaches,
@@ -581,6 +603,7 @@ describe("domain service", () => {
     });
 
     const service = createDomainService({
+      setMailFromDomain: vi.fn(async () => undefined),
       repository,
       getDomainIdentity: async (name) => {
         if (name === "a.example") return { verified: true };
@@ -612,6 +635,7 @@ describe("domain service", () => {
       userId?: string | null;
     } | null = null;
     const service = createDomainService({
+      setMailFromDomain: vi.fn(async () => undefined),
       repository: createRepository({
         async list(options) {
           listOptions = options;
@@ -648,5 +672,75 @@ describe("domain service", () => {
       ],
       hasMore: true,
     });
+  });
+
+  it("reconcileVerification activates MAIL FROM on verified identities that lack it", async () => {
+    const setMailFromDomain = vi.fn(async () => undefined);
+    const service = createDomainService({
+      repository: createRepository({
+        async findById() {
+          return domainRow({ status: "pending" });
+        },
+      }),
+      getDomainIdentity: vi.fn(async () => ({
+        verified: true,
+        mailFromDomain: null,
+      })),
+      setMailFromDomain,
+      invalidateDomainCaches: vi.fn(),
+      syncDomainConfigurationSet: vi.fn(async () => "cfg-domain-1"),
+    });
+
+    await service.reconcileVerification("domain-1");
+
+    expect(setMailFromDomain).toHaveBeenCalledWith(
+      "example.com",
+      "send.example.com",
+      { region: "us-east-1" },
+    );
+  });
+
+  it("reconcileVerification skips MAIL FROM when SES already matches the return path", async () => {
+    const setMailFromDomain = vi.fn(async () => undefined);
+    const service = createDomainService({
+      repository: createRepository({
+        async findById() {
+          return domainRow({ status: "verified" });
+        },
+      }),
+      getDomainIdentity: vi.fn(async () => ({
+        verified: true,
+        mailFromDomain: "send.example.com",
+      })),
+      setMailFromDomain,
+      invalidateDomainCaches: vi.fn(),
+      syncDomainConfigurationSet: vi.fn(async () => "cfg-domain-1"),
+    });
+
+    await service.reconcileVerification("domain-1");
+
+    expect(setMailFromDomain).not.toHaveBeenCalled();
+  });
+
+  it("createDomain succeeds even when the MAIL FROM call fails (non-fatal)", async () => {
+    const service = createDomainService({
+      repository: createRepository(),
+      createDomainIdentity: vi.fn(async () => ({
+        dkimTokens: ["dkim-a"],
+        status: "PENDING",
+      })),
+      setMailFromDomain: vi.fn(async () => {
+        throw new Error("ses unavailable");
+      }),
+      invalidateDomainCaches: vi.fn(),
+      syncDomainConfigurationSet: vi.fn(async () => "cfg-created-domain"),
+    });
+
+    const result = await service.createDomain({
+      name: "example.com",
+      userId: "user-1",
+    });
+
+    expect(result.name).toBe("example.com");
   });
 });


### PR DESCRIPTION
## Release scope
Staging → main release for the MAIL FROM deliverability fix.

### Contents (vs main: 4 files, +194/−2)
- **#651 / closes #650** — Activate SES custom MAIL FROM when provisioning and verifying domains:
  - `createDomain` activates `send.<domain>` (or `custom_return_path`) in SES immediately
  - `reconcileVerification` repairs verified identities missing it (existing domains self-heal on next verify)
  - Non-fatal, `BehaviorOnMxFailure: USE_DEFAULT_VALUE` — worst case equals current behavior
  - `getDomainIdentity` exposes `mailFromDomain`/`mailFromStatus`
- Merge of `main` into the release branch (keeps the main-only learning file; no conflicts)

### Verification
- All 10 CI checks green on #651 (incl. migration-parity gate); full unit suite 1712 passed
- No migrations in this release — deploy's migrator step is a no-op
- Prod's existing domains already manually activated (see #650); this makes it automatic for future domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)