### PR TITLE
Wire up Import CSV button in audience dashboard

### DIFF
--- a/src/components/audience-layout.tsx
+++ b/src/components/audience-layout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AddContactModal } from "@/components/add-contact-modal";
+import { ImportCsvModal } from "@/components/import-csv-modal";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
@@ -25,6 +26,7 @@ export function AudienceLayout({ stats, children }: AudienceLayoutProps) {
   const pathname = usePathname();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [addModalOpen, setAddModalOpen] = useState(false);
+  const [importModalOpen, setImportModalOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
 
@@ -88,7 +90,10 @@ export function AudienceLayout({ stats, children }: AudienceLayoutProps) {
               <button
                 type="button"
                 className="w-full text-left px-3 py-2 text-[13px] text-fg hover:bg-white/10 transition-colors"
-                onClick={() => setDropdownOpen(false)}
+                onClick={() => {
+                  setDropdownOpen(false);
+                  setImportModalOpen(true);
+                }}
               >
                 Import CSV
               </button>
@@ -159,6 +164,11 @@ export function AudienceLayout({ stats, children }: AudienceLayoutProps) {
       <AddContactModal
         open={addModalOpen}
         onClose={() => setAddModalOpen(false)}
+        onSuccess={() => router.refresh()}
+      />
+      <ImportCsvModal
+        open={importModalOpen}
+        onClose={() => setImportModalOpen(false)}
         onSuccess={() => router.refresh()}
       />
     </div>

--- a/src/components/import-csv-modal.tsx
+++ b/src/components/import-csv-modal.tsx
@@ -1,0 +1,529 @@
+"use client";
+
+import {
+  KNOWN_FIELD_KEYS,
+  SKIP_SENTINEL,
+  buildMapping,
+  parseCsvHeaders,
+} from "@/lib/csv-import";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface Segment {
+  id: string;
+  name: string;
+}
+
+function isSegment(value: unknown): value is Segment {
+  if (typeof value !== "object" || value === null) return false;
+  const m = value as Record<string, unknown>;
+  return typeof m.id === "string" && typeof m.name === "string";
+}
+
+function extractSegments(payload: unknown): Segment[] {
+  if (Array.isArray(payload)) return payload.filter(isSegment);
+  if (typeof payload !== "object" || payload === null) return [];
+  const m = payload as Record<string, unknown>;
+  return Array.isArray(m.data) ? m.data.filter(isSegment) : [];
+}
+
+const CONTACT_IMPORT_MAX_BYTES = 10 * 1024 * 1024;
+const ALLOWED_MIME = new Set([
+  "text/csv",
+  "application/csv",
+  "application/vnd.ms-excel",
+]);
+
+interface ImportCsvModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+type Step = "pick" | "map" | "success";
+
+export function ImportCsvModal({
+  open,
+  onClose,
+  onSuccess,
+}: ImportCsvModalProps) {
+  const [step, setStep] = useState<Step>("pick");
+  const [file, setFile] = useState<File | null>(null);
+  const [headers, setHeaders] = useState<string[]>([]);
+  const [assignments, setAssignments] = useState<Record<string, string>>({});
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [segments, setSegments] = useState<Segment[]>([]);
+  const [selectedSegment, setSelectedSegment] = useState<Segment | null>(null);
+  const [segmentSearch, setSegmentSearch] = useState("");
+  const [segmentDropdownOpen, setSegmentDropdownOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [createdCount, setCreatedCount] = useState<number>(0);
+
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const segmentRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const fetchSegments = useCallback(async () => {
+    try {
+      const apiKey =
+        typeof window !== "undefined"
+          ? (localStorage?.getItem?.("api_key") ?? null)
+          : null;
+      const headers: Record<string, string> = {};
+      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+      const res = await fetch("/api/segments", { headers });
+      if (res.ok) {
+        const data = await res.json();
+        setSegments(extractSegments(data));
+      }
+    } catch {
+      // ignore — segment picker is optional
+    }
+  }, []);
+
+  // Reset state when modal opens
+  useEffect(() => {
+    if (open) {
+      setStep("pick");
+      setFile(null);
+      setHeaders([]);
+      setAssignments({});
+      setFileError(null);
+      setSubmitError(null);
+      setSelectedSegment(null);
+      setSegmentSearch("");
+      setCreatedCount(0);
+      fetchSegments();
+    }
+  }, [open, fetchSegments]);
+
+  // Escape to close
+  useEffect(() => {
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    if (open) document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [open, onClose]);
+
+  // Click-outside for segment dropdown
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        segmentRef.current &&
+        !segmentRef.current.contains(e.target as Node)
+      ) {
+        setSegmentDropdownOpen(false);
+      }
+    }
+    if (segmentDropdownOpen)
+      document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [segmentDropdownOpen]);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const picked = e.target.files?.[0];
+    if (!picked) return;
+
+    setFileError(null);
+
+    // Size check
+    if (picked.size > CONTACT_IMPORT_MAX_BYTES) {
+      setFileError("File exceeds 10 MB limit. Please choose a smaller file.");
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    // Type check
+    const mime = picked.type?.toLowerCase().split(";")[0]?.trim() ?? "";
+    const hasCsvExt = picked.name.toLowerCase().endsWith(".csv");
+    if (mime && !ALLOWED_MIME.has(mime) && !hasCsvExt) {
+      setFileError("Unsupported file type. Please upload a .csv file.");
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    try {
+      const cols = await parseCsvHeaders(picked);
+      if (cols.length === 0) {
+        setFileError(
+          "Could not detect any column headers. Check that the file is not empty.",
+        );
+        return;
+      }
+      setFile(picked);
+      setHeaders(cols);
+      // Pre-assign columns whose names exactly match known field keys
+      const autoAssign: Record<string, string> = {};
+      for (const col of cols) {
+        const match = KNOWN_FIELD_KEYS.find((k) => k === col.toLowerCase());
+        autoAssign[col] = match ?? SKIP_SENTINEL;
+      }
+      setAssignments(autoAssign);
+      setStep("map");
+    } catch {
+      setFileError("Failed to read the CSV file. Please try again.");
+    }
+  };
+
+  const emailMapped = Object.values(assignments).includes("email");
+
+  const handleSubmit = async () => {
+    if (!file) return;
+
+    const apiKey =
+      typeof window !== "undefined"
+        ? (localStorage?.getItem?.("api_key") ?? null)
+        : null;
+    if (!apiKey) {
+      setSubmitError(
+        "No API key found. Add a full-access API key in Settings first.",
+      );
+      return;
+    }
+
+    let mapping: Record<string, string>;
+    try {
+      mapping = buildMapping(assignments);
+    } catch (err) {
+      setSubmitError(
+        err instanceof Error ? err.message : "Invalid column mapping.",
+      );
+      return;
+    }
+
+    setSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("mapping", JSON.stringify(mapping));
+      if (selectedSegment) {
+        formData.append("segment_id", selectedSegment.id);
+      }
+
+      const res = await fetch("/api/contacts/import", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${apiKey}` },
+        body: formData,
+      });
+
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        throw new Error(body.error ?? `Server error ${res.status}`);
+      }
+
+      const result = (await res.json()) as { created_count?: number };
+      setCreatedCount(result.created_count ?? 0);
+      setStep("success");
+      onSuccess();
+    } catch (err) {
+      setSubmitError(
+        err instanceof Error ? err.message : "Import failed. Please try again.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const filteredSegments = segments.filter(
+    (s) =>
+      s.name.toLowerCase().includes(segmentSearch.toLowerCase()) &&
+      s.id !== selectedSegment?.id,
+  );
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={(e) => {
+        if (e.target === overlayRef.current) onClose();
+      }}
+      onKeyDown={() => {}}
+    >
+      <div className="w-full max-w-lg bg-bg-card border border-line rounded-lg shadow-xl">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-line">
+          <h2 className="text-[16px] font-semibold text-fg">Import CSV</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1 rounded hover:bg-white/[0.14] text-fg-2 hover:text-fg transition-colors"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M18 6L6 18" />
+              <path d="M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-4 space-y-4">
+          {/* Step: pick file */}
+          {step === "pick" && (
+            <div>
+              <label
+                htmlFor="csv-file-input"
+                className="block text-[13px] font-medium text-fg mb-1.5"
+              >
+                CSV file
+              </label>
+              <input
+                id="csv-file-input"
+                ref={fileInputRef}
+                type="file"
+                accept=".csv,text/csv,application/csv,application/vnd.ms-excel"
+                onChange={handleFileChange}
+                className="w-full text-[13px] text-fg file:mr-3 file:py-1.5 file:px-3 file:rounded file:border file:border-line file:bg-transparent file:text-[13px] file:text-fg-2 file:cursor-pointer hover:file:text-fg file:transition-colors"
+              />
+              <p className="mt-1.5 text-[12px] text-fg-2">
+                Max 10 MB. The first row must contain column headers.
+              </p>
+              {fileError && (
+                <p className="mt-2 text-[12px] text-red-400" role="alert">
+                  {fileError}
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Step: map columns */}
+          {step === "map" && (
+            <>
+              <div>
+                <p className="text-[13px] text-fg-2 mb-3">
+                  Map CSV columns to contact fields. At least one column must be
+                  mapped to{" "}
+                  <span className="font-medium text-fg">Email address</span>.
+                </p>
+                <div className="space-y-2">
+                  {headers.map((col) => (
+                    <div
+                      key={col}
+                      className="flex items-center gap-3 text-[13px]"
+                    >
+                      <span className="w-1/2 truncate text-fg font-mono text-[12px] px-2 py-1.5 bg-white/5 border border-line rounded">
+                        {col}
+                      </span>
+                      <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className="text-fg-2 shrink-0"
+                        aria-hidden="true"
+                      >
+                        <path d="M5 12h14" />
+                        <path d="M12 19l7-7-7-7" />
+                      </svg>
+                      <select
+                        aria-label={`Map column ${col} to contact field`}
+                        value={assignments[col] ?? SKIP_SENTINEL}
+                        onChange={(e) =>
+                          setAssignments((prev) => ({
+                            ...prev,
+                            [col]: e.target.value,
+                          }))
+                        }
+                        className="w-1/2 h-8 px-2 text-[13px] bg-transparent border border-line rounded text-fg outline-none focus:border-line-3"
+                      >
+                        <option value={SKIP_SENTINEL}>— skip —</option>
+                        <option value="email">Email address</option>
+                        <option value="first_name">First name</option>
+                        <option value="last_name">Last name</option>
+                      </select>
+                    </div>
+                  ))}
+                </div>
+                {!emailMapped && (
+                  <p className="mt-2 text-[12px] text-amber-400">
+                    Map one column to Email address to enable import.
+                  </p>
+                )}
+              </div>
+
+              {/* Segment (optional) */}
+              <div>
+                <label
+                  htmlFor="import-csv-segment-search"
+                  className="block text-[13px] font-medium text-fg mb-1.5"
+                >
+                  Add to segment{" "}
+                  <span className="font-normal text-fg-2">(optional)</span>
+                </label>
+                <div ref={segmentRef} className="relative">
+                  {selectedSegment && (
+                    <div className="flex flex-wrap gap-1.5 mb-1.5">
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 text-[12px] bg-white/10 border border-line rounded text-fg">
+                        {selectedSegment.name}
+                        <button
+                          type="button"
+                          onClick={() => setSelectedSegment(null)}
+                          className="text-fg-2 hover:text-fg"
+                        >
+                          <svg
+                            width="12"
+                            height="12"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            aria-hidden="true"
+                          >
+                            <path d="M18 6L6 18" />
+                            <path d="M6 6l12 12" />
+                          </svg>
+                        </button>
+                      </span>
+                    </div>
+                  )}
+                  {!selectedSegment && (
+                    <input
+                      id="import-csv-segment-search"
+                      type="text"
+                      value={segmentSearch}
+                      onChange={(e) => {
+                        setSegmentSearch(e.target.value);
+                        setSegmentDropdownOpen(true);
+                      }}
+                      onFocus={() => setSegmentDropdownOpen(true)}
+                      placeholder="Search segments..."
+                      className="w-full h-9 px-3 text-[13px] bg-transparent border border-line rounded-md text-fg placeholder-[#666] outline-none focus:border-line-3"
+                    />
+                  )}
+                  {segmentDropdownOpen && filteredSegments.length > 0 && (
+                    <div className="absolute top-full left-0 right-0 mt-1 max-h-40 overflow-y-auto bg-bg-2 border border-line rounded-md shadow-lg z-50">
+                      {filteredSegments.map((s) => (
+                        <button
+                          key={s.id}
+                          type="button"
+                          onClick={() => {
+                            setSelectedSegment(s);
+                            setSegmentSearch("");
+                            setSegmentDropdownOpen(false);
+                          }}
+                          className="w-full text-left px-3 py-2 text-[13px] text-fg hover:bg-white/10 transition-colors"
+                        >
+                          {s.name}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {submitError && (
+                <p className="text-[12px] text-red-400" role="alert">
+                  {submitError}
+                </p>
+              )}
+
+              <p className="text-[12px] text-fg-2">
+                File: <span className="font-medium text-fg">{file?.name}</span>
+                {file && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setStep("pick");
+                      setFile(null);
+                      setHeaders([]);
+                      setAssignments({});
+                      setFileError(null);
+                      setSubmitError(null);
+                      if (fileInputRef.current) fileInputRef.current.value = "";
+                    }}
+                    className="ml-2 text-fg-2 underline hover:text-fg transition-colors"
+                  >
+                    Change
+                  </button>
+                )}
+              </p>
+            </>
+          )}
+
+          {/* Step: success */}
+          {step === "success" && (
+            <div className="py-4 text-center space-y-2">
+              <svg
+                width="32"
+                height="32"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="mx-auto text-green-400"
+                aria-hidden="true"
+              >
+                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+                <polyline points="22 4 12 14.01 9 11.01" />
+              </svg>
+              <p className="text-[15px] font-semibold text-fg">
+                Import complete
+              </p>
+              <p className="text-[13px] text-fg-2">
+                Imported{" "}
+                <span className="font-medium text-fg">{createdCount}</span>{" "}
+                contact{createdCount !== 1 ? "s" : ""}.
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 px-6 py-4 border-t border-line">
+          {step === "success" ? (
+            <button
+              type="button"
+              onClick={onClose}
+              className="btn btn-primary btn-sm"
+            >
+              Done
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-3 py-1.5 text-[13px] font-medium text-fg-2 border border-line rounded-md hover:text-fg hover:border-line-3 transition-colors"
+              >
+                Cancel
+              </button>
+              {step === "map" && (
+                <button
+                  type="button"
+                  onClick={handleSubmit}
+                  disabled={submitting || !emailMapped}
+                  className="btn btn-primary btn-sm disabled:opacity-50"
+                >
+                  {submitting ? "Importing..." : "Import"}
+                </button>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/csv-import.ts
+++ b/src/lib/csv-import.ts
@@ -1,0 +1,51 @@
+import Papa from "papaparse";
+
+/**
+ * Reads only the header row of a CSV file using PapaParse preview mode.
+ * O(first-row) on the client — does not load the full file into memory.
+ */
+export function parseCsvHeaders(file: File): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    Papa.parse(file, {
+      preview: 1,
+      header: true,
+      skipEmptyLines: true,
+      complete(results) {
+        const fields = results.meta.fields ?? [];
+        resolve(fields);
+      },
+      error(err) {
+        reject(new Error(err.message));
+      },
+    });
+  });
+}
+
+export const SKIP_SENTINEL = "— skip —";
+
+export const KNOWN_FIELD_KEYS = ["email", "first_name", "last_name"] as const;
+export type KnownFieldKey = (typeof KNOWN_FIELD_KEYS)[number];
+
+/**
+ * Converts a UI assignment map (csvColumn → fieldKey | SKIP_SENTINEL) into
+ * the mapping object expected by POST /api/contacts/import.
+ * Throws if no column is assigned to "email".
+ */
+export function buildMapping(
+  assignments: Record<string, string>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  let hasEmail = false;
+
+  for (const [col, fieldKey] of Object.entries(assignments)) {
+    if (fieldKey === SKIP_SENTINEL || fieldKey === "") continue;
+    result[col] = fieldKey;
+    if (fieldKey === "email") hasEmail = true;
+  }
+
+  if (!hasEmail) {
+    throw new Error("At least one column must be mapped to 'email'.");
+  }
+
+  return result;
+}

--- a/tests/csv-import-helpers.test.ts
+++ b/tests/csv-import-helpers.test.ts
@@ -1,0 +1,135 @@
+import { SKIP_SENTINEL, buildMapping, parseCsvHeaders } from "@/lib/csv-import";
+import Papa from "papaparse";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// buildMapping
+// ---------------------------------------------------------------------------
+
+describe("buildMapping", () => {
+  it("returns mapping for valid assignments", () => {
+    const result = buildMapping({
+      Email: "email",
+      "First Name": "first_name",
+      "Last Name": "last_name",
+    });
+    expect(result).toEqual({
+      Email: "email",
+      "First Name": "first_name",
+      "Last Name": "last_name",
+    });
+  });
+
+  it("throws when no column is mapped to email", () => {
+    expect(() =>
+      buildMapping({
+        Name: "first_name",
+        Phone: "last_name",
+      }),
+    ).toThrow("email");
+  });
+
+  it("omits skip-sentinel entries from the result", () => {
+    const result = buildMapping({
+      Email: "email",
+      Notes: SKIP_SENTINEL,
+      Phone: "",
+    });
+    expect(result).toEqual({ Email: "email" });
+    expect(Object.keys(result)).not.toContain("Notes");
+    expect(Object.keys(result)).not.toContain("Phone");
+  });
+
+  it("throws on empty assignments", () => {
+    expect(() => buildMapping({})).toThrow();
+  });
+
+  it("accepts a single email-only mapping", () => {
+    expect(buildMapping({ address: "email" })).toEqual({ address: "email" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseCsvHeaders — tested by mocking PapaParse
+// ---------------------------------------------------------------------------
+
+/** Minimal shape of the config object parseCsvHeaders passes to Papa.parse. */
+interface MockPapaConfig {
+  preview?: number;
+  header?: boolean;
+  skipEmptyLines?: boolean;
+  complete?: (results: {
+    meta: { fields?: string[] } & Record<string, unknown>;
+    data: unknown[];
+  }) => void;
+  error?: (err: { message: string }) => void;
+}
+
+describe("parseCsvHeaders", () => {
+  // A single spy instance is reused across tests to avoid the
+  // "Cannot redefine property" error from multiple vi.spyOn calls.
+  // biome-ignore lint/suspicious/noExplicitAny: spy typing — intentional
+  let parseSpy: ReturnType<typeof vi.spyOn<any, any>>;
+
+  beforeEach(() => {
+    parseSpy = vi.spyOn(Papa, "parse");
+  });
+
+  afterEach(() => {
+    parseSpy.mockRestore();
+  });
+
+  it("resolves with the header field names", async () => {
+    parseSpy.mockImplementation((...args: unknown[]) => {
+      const config = args[1] as MockPapaConfig | undefined;
+      config?.complete?.({
+        meta: { fields: ["email", "first_name", "last_name"] },
+        data: [],
+      });
+    });
+
+    const file = new File(
+      ["email,first_name,last_name\na@b.com,A,B"],
+      "test.csv",
+      { type: "text/csv" },
+    );
+    const headers = await parseCsvHeaders(file);
+    expect(headers).toEqual(["email", "first_name", "last_name"]);
+  });
+
+  it("calls PapaParse with preview: 1 and header: true", async () => {
+    parseSpy.mockImplementation((...args: unknown[]) => {
+      const config = args[1] as MockPapaConfig | undefined;
+      config?.complete?.({ meta: { fields: ["col"] }, data: [] });
+    });
+
+    const file = new File(["col\nval"], "x.csv", { type: "text/csv" });
+    await parseCsvHeaders(file);
+
+    expect(parseSpy).toHaveBeenCalledWith(
+      file,
+      expect.objectContaining({ preview: 1, header: true }),
+    );
+  });
+
+  it("rejects when PapaParse reports an error", async () => {
+    parseSpy.mockImplementation((...args: unknown[]) => {
+      const config = args[1] as MockPapaConfig | undefined;
+      config?.error?.({ message: "parse failure" });
+    });
+
+    const file = new File(["bad"], "bad.csv", { type: "text/csv" });
+    await expect(parseCsvHeaders(file)).rejects.toThrow("parse failure");
+  });
+
+  it("resolves with empty array when meta.fields is absent", async () => {
+    parseSpy.mockImplementation((...args: unknown[]) => {
+      const config = args[1] as MockPapaConfig | undefined;
+      config?.complete?.({ meta: {}, data: [] });
+    });
+
+    const file = new File([""], "empty.csv", { type: "text/csv" });
+    const headers = await parseCsvHeaders(file);
+    expect(headers).toEqual([]);
+  });
+});

--- a/tests/e2e/import-csv-modal.spec.ts
+++ b/tests/e2e/import-csv-modal.spec.ts
@@ -1,0 +1,200 @@
+import path from "node:path";
+import { expect, test } from "./fixtures/auth";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Absolute path to the shared CSV fixture. */
+const FIXTURE_CSV = path.join(
+  import.meta.dirname,
+  "../fixtures/contacts-sample.csv",
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Import CSV modal", () => {
+  test("opens modal from Import CSV dropdown item", async ({
+    authenticatedPage: page,
+  }) => {
+    const pageErrors: string[] = [];
+    page.on("pageerror", (err) => pageErrors.push(err.message));
+
+    await page.goto("/audience");
+
+    await page.getByRole("button", { name: /add contacts/i }).click();
+    await page.getByText("Import CSV").click();
+
+    await expect(
+      page.getByRole("heading", { name: "Import CSV" }),
+    ).toBeVisible();
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("closes modal with Cancel button", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/audience");
+
+    await page.getByRole("button", { name: /add contacts/i }).click();
+    await page.getByText("Import CSV").click();
+
+    await expect(
+      page.getByRole("heading", { name: "Import CSV" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Cancel" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Import CSV" }),
+    ).not.toBeVisible();
+  });
+
+  test("closes modal with X button", async ({ authenticatedPage: page }) => {
+    await page.goto("/audience");
+
+    await page.getByRole("button", { name: /add contacts/i }).click();
+    await page.getByText("Import CSV").click();
+
+    await expect(
+      page.getByRole("heading", { name: "Import CSV" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: /close/i }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Import CSV" }),
+    ).not.toBeVisible();
+  });
+
+  test("shows column mapping UI after selecting a CSV file", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/audience");
+
+    await page.getByRole("button", { name: /add contacts/i }).click();
+    await page.getByText("Import CSV").click();
+
+    await page.getByLabel("CSV file").setInputFiles(FIXTURE_CSV);
+
+    // Mapping step should appear with column headers detected
+    await expect(
+      page.getByText(/map csv columns/i, { exact: false }),
+    ).toBeVisible();
+    await expect(page.getByText("email")).toBeVisible();
+    await expect(page.getByText("first_name")).toBeVisible();
+  });
+
+  test("Import button is disabled until email column is mapped", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/audience");
+
+    await page.getByRole("button", { name: /add contacts/i }).click();
+    await page.getByText("Import CSV").click();
+
+    await page.getByLabel("CSV file").setInputFiles(FIXTURE_CSV);
+
+    // Wait for mapping step
+    await expect(page.getByRole("button", { name: "Import" })).toBeVisible();
+
+    // Clear the auto-assigned email mapping
+    const emailSelect = page
+      .locator("select")
+      .filter({ hasText: /email address/i })
+      .first();
+    await emailSelect.selectOption("— skip —");
+
+    await expect(page.getByRole("button", { name: "Import" })).toBeDisabled();
+  });
+
+  test("happy path: imports contacts from CSV and shows success", async ({
+    authenticatedPage: page,
+    e2eDb,
+    e2eRunId,
+    e2eTenant,
+  }) => {
+    await page.goto("/audience");
+
+    await page.getByRole("button", { name: /add contacts/i }).click();
+    await page.getByText("Import CSV").click();
+
+    await page.getByLabel("CSV file").setInputFiles(FIXTURE_CSV);
+
+    // Wait for mapping step
+    await expect(page.getByRole("button", { name: "Import" })).toBeVisible();
+
+    // email column should be auto-mapped (fixture header is "email")
+    await expect(
+      page.getByRole("button", { name: "Import" }),
+    ).not.toBeDisabled();
+
+    await page.getByRole("button", { name: "Import" }).click();
+
+    // Success step
+    await expect(page.getByText(/import complete/i)).toBeVisible();
+    await expect(page.getByText(/imported/i)).toBeVisible();
+
+    // Close
+    await page.getByRole("button", { name: "Done" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Import CSV" }),
+    ).not.toBeVisible();
+
+    // Verify at least one of the fixture emails landed in the DB
+    const { rows } = await e2eDb.query<{ email: string }>(
+      `select email from contacts where email like '%@${e2eRunId}.e2e.opensend.test' and user_id = $1`,
+      [e2eTenant.user.id],
+    );
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  test("shows file type error for non-CSV files without making a network request", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/audience");
+
+    await page.getByRole("button", { name: /add contacts/i }).click();
+    await page.getByText("Import CSV").click();
+
+    // Upload a plain-text file disguised as something else
+    await page.getByLabel("CSV file").setInputFiles({
+      name: "contacts.txt",
+      mimeType: "text/plain",
+      buffer: Buffer.from("email\nfoo@bar.com"),
+    });
+
+    // Error shown, still on pick step (no mapping UI)
+    await expect(
+      page.getByText(/unsupported file type/i, { exact: false }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Import" }),
+    ).not.toBeVisible();
+  });
+
+  test("shows size error for files larger than 10 MB", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/audience");
+
+    await page.getByRole("button", { name: /add contacts/i }).click();
+    await page.getByText("Import CSV").click();
+
+    const oversizedBuffer = Buffer.alloc(11 * 1024 * 1024, "a");
+    await page.getByLabel("CSV file").setInputFiles({
+      name: "big.csv",
+      mimeType: "text/csv",
+      buffer: oversizedBuffer,
+    });
+
+    await expect(
+      page.getByText(/10 mb limit/i, { exact: false }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Import" }),
+    ).not.toBeVisible();
+  });
+});

--- a/tests/fixtures/contacts-sample.csv
+++ b/tests/fixtures/contacts-sample.csv
@@ -1,0 +1,4 @@
+email,first_name,last_name
+alice@e2erunid.e2e.opensend.test,Alice,Example
+bob@e2erunid.e2e.opensend.test,Bob,Example
+carol@e2erunid.e2e.opensend.test,Carol,Example


### PR DESCRIPTION
## What
Makes the **Import CSV** dropdown item in the audience header functional. It was previously a dead stub that only closed the dropdown, even though the backend `POST /api/contacts/import` (multipart file + column mapping + optional segment) was already fully implemented.

## How
A 3-step import modal (pick file → map columns → success):
- `parseCsvHeaders()` reads **only the header row** client-side via PapaParse `preview:1` to populate the mapping dropdowns (no full-file load in the browser)
- `buildMapping()` converts the UI column→field assignments into the API mapping shape, requiring at least one column mapped to `email`
- Client-side file size (10MB) and CSV mime/extension validation before any network request, mirroring the server checks
- Reuses the existing `add-contact-modal` pattern (localStorage api_key Bearer auth, `/api/segments` autocomplete, overlay/escape/click-outside)

## Tests
- **Vitest**: 9 unit cases for the pure helpers (`buildMapping`, `parseCsvHeaders`)
- **Playwright E2E**: open → map → happy-path import with DB assertion, plus type/size error and email-required gating paths

## Reviewed
Independently reviewed; typecheck + Biome + unit tests pass. Server-side import endpoint unchanged.

## Follow-ups (not in this PR)
- Per-row skipped-count reporting (rows with no email are silently skipped server-side)
- Custom-property column mapping (backend supports it; UI currently offers email/first/last only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)