### PR TITLE
chore(deploy): remove local images after push to bound runner disk

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -102,6 +102,12 @@ build_and_push() {
 
   docker "${args[@]}"
   ok "  pushed ${image}"
+
+  # Drop the local copy now that it lives in ECR. These images are never run
+  # locally (migrations + deploys go through `aws ecs run-task`), so leaving the
+  # tagged build behind just leaks disk on the shared self-hosted Mac mini
+  # runner every deploy. Best-effort: never fail the deploy over cleanup.
+  docker image rm -f "${image}" >/dev/null 2>&1 || true
 }
 
 app_task_definition() {


### PR DESCRIPTION
## Why
The shared Mac mini self-hosted runner (forever / opensend / exponential all share **one** Docker daemon) keeps filling its disk. `build_and_push()` pushes each image (app / migrator / ingester / scheduler) to ECR but leaves the **local tagged copy** behind. `docker image prune` only reaps *dangling* images, so these tagged builds leak disk on every deploy.

## Fix
Delete each image **right after push** inside `build_and_push()` — one line covers all four images. Safe because images are never run locally (migrations + deploys go through `aws ecs run-task`, line ~777). Best-effort (`|| true`).

Mirrors the same fix already merged in `forever-agent#420` (verified working on a live deploy).

## Validation
- `bash -n scripts/deploy.sh` ✅

## Heads-up
This workflow deploys on **every** push to `main`, so **merging will trigger a deploy** — expected and safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)