### PR TITLE
Raise overage rate to $0.85 per 1,000 emails

### DIFF
--- a/src/components/landing/pricing-page.tsx
+++ b/src/components/landing/pricing-page.tsx
@@ -20,7 +20,7 @@ const SELF_HOST_URL = `${GITHUB_URL}#self-host`;
 const FAQ: Array<[string, string]> = [
   [
     "What happens if I exceed my quota?",
-    "You get a soft warning at 80% and a notification at 100%. Sends are not blocked — overage is billed at $0.40 per 1,000 emails until you upgrade.",
+    "You get a soft warning at 80% and a notification at 100%. Sends are not blocked — overage is billed at $0.85 per 1,000 emails until you upgrade.",
   ],
   [
     "Do I have to use AWS SES?",


### PR DESCRIPTION
Bumps the quota-overage rate from **$0.40** to **$0.85 per 1,000 emails** in the pricing FAQ.

## Why
Positioning: at $0.85 we're at near-parity with Resend ($0.90/1k), so overage stops being a price play and the differentiator becomes product/quality — deliberately *not* a cheaper Resend clone.

## Scope
- Pricing FAQ copy only (`pricing-page.tsx`). Overage is not yet enforced server-side — metered billing tracked in #656, whose spec is updated to $0.85 to match.

No tests assert the rate string; `make check` clean.