### PR TITLE
Feat/import csv dashboard

### DIFF
--- a/src/app/api/contacts/import/route.ts
+++ b/src/app/api/contacts/import/route.ts
@@ -1,8 +1,25 @@
-import { unauthorizedResponse, validateApiKey } from "@/lib/api-auth";
-import { requireFullAccessApiKey } from "@/lib/api-key-permissions";
+import {
+  authorizeDashboardOrApiKey,
+  getServerSession,
+  unauthorizedResponse,
+} from "@/lib/api-auth";
+import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
 import { createContactOperationsService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 import Papa from "papaparse";
+
+type ImportRouteAuth = NonNullable<
+  Awaited<ReturnType<typeof authorizeDashboardOrApiKey>>
+>;
+
+// Dashboard callers authenticate with a Better Auth session cookie; API
+// callers send a full-access Bearer key. Mirror /api/contacts so the
+// in-dashboard Import CSV modal works without a localStorage api_key.
+async function resolveUserId(auth: ImportRouteAuth): Promise<string | null> {
+  if ("userId" in auth) return auth.userId;
+  const session = await getServerSession();
+  return session?.user?.id ?? null;
+}
 
 const CONTACT_IMPORT_MAX_BYTES = 10 * 1024 * 1024;
 const CONTACT_IMPORT_ALLOWED_MIME = new Set([
@@ -16,12 +33,14 @@ function contactOperationsService() {
 }
 
 export async function POST(request: NextRequest) {
-  const auth = await validateApiKey(request.headers.get("authorization"));
+  const auth = await authorizeDashboardOrApiKey(
+    request.headers.get("authorization"),
+  );
   if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessApiKey(auth);
+  const permissionError = requireFullAccessForApiKeyCaller(auth);
   if (permissionError) return permissionError;
-  if (!auth.userId) return unauthorizedResponse();
-  const userId = auth.userId;
+  const userId = await resolveUserId(auth);
+  if (!userId) return unauthorizedResponse();
 
   try {
     const formData = await request.formData();

--- a/src/app/api/contacts/import/route.ts
+++ b/src/app/api/contacts/import/route.ts
@@ -56,9 +56,16 @@ export async function POST(request: NextRequest) {
 
     const mapping = JSON.parse(mappingStr || "{}") as Record<string, string>;
     const text = await file.text();
-    const parseResult = Papa.parse(text, {
+    // Strip leading blank / comma-only junk rows (e.g. a `,,,,,,` row some
+    // exporters prepend) so header:true uses the REAL header row. PapaParse's
+    // `skipEmptyLines: "greedy"` does not skip a comma-only *header* row, so we
+    // must remove it first. transformHeader trims so the keys match the trimmed
+    // names the client mapper shows in parseCsvHeaders.
+    const normalized = text.replace(/^(?:[\s,]*\r?\n)+/, "");
+    const parseResult = Papa.parse(normalized, {
       header: true,
-      skipEmptyLines: true,
+      skipEmptyLines: "greedy",
+      transformHeader: (h) => h.trim(),
     });
     const rows = parseResult.data as Record<string, string>[];
 

--- a/src/app/api/contacts/import/route.ts
+++ b/src/app/api/contacts/import/route.ts
@@ -1,25 +1,7 @@
-import {
-  authorizeDashboardOrApiKey,
-  getServerSession,
-  unauthorizedResponse,
-} from "@/lib/api-auth";
-import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
+import { getServerSession, unauthorizedResponse } from "@/lib/api-auth";
 import { createContactOperationsService } from "@opensend/core";
 import { type NextRequest, NextResponse } from "next/server";
 import Papa from "papaparse";
-
-type ImportRouteAuth = NonNullable<
-  Awaited<ReturnType<typeof authorizeDashboardOrApiKey>>
->;
-
-// Dashboard callers authenticate with a Better Auth session cookie; API
-// callers send a full-access Bearer key. Mirror /api/contacts so the
-// in-dashboard Import CSV modal works without a localStorage api_key.
-async function resolveUserId(auth: ImportRouteAuth): Promise<string | null> {
-  if ("userId" in auth) return auth.userId;
-  const session = await getServerSession();
-  return session?.user?.id ?? null;
-}
 
 const CONTACT_IMPORT_MAX_BYTES = 10 * 1024 * 1024;
 const CONTACT_IMPORT_ALLOWED_MIME = new Set([
@@ -33,13 +15,12 @@ function contactOperationsService() {
 }
 
 export async function POST(request: NextRequest) {
-  const auth = await authorizeDashboardOrApiKey(
-    request.headers.get("authorization"),
-  );
-  if (!auth) return unauthorizedResponse();
-  const permissionError = requireFullAccessForApiKeyCaller(auth);
-  if (permissionError) return permissionError;
-  const userId = await resolveUserId(auth);
+  // CSV file import is a dashboard-only feature, mirroring Resend: CSV upload
+  // lives in the dashboard, while programmatic callers add contacts via the
+  // JSON endpoints (POST /api/contacts, /api/contacts/bulk). Require an
+  // authenticated dashboard session; there is no Bearer-key path here.
+  const session = await getServerSession();
+  const userId = session?.user?.id;
   if (!userId) return unauthorizedResponse();
 
   try {

--- a/src/components/import-csv-modal.tsx
+++ b/src/components/import-csv-modal.tsx
@@ -171,13 +171,6 @@ export function ImportCsvModal({
   const handleSubmit = async () => {
     if (!file) return;
 
-    // Dashboard users authenticate via the Better Auth session cookie; an
-    // api_key in localStorage is only attached as a Bearer token when present.
-    const apiKey =
-      typeof window !== "undefined"
-        ? (localStorage?.getItem?.("api_key") ?? null)
-        : null;
-
     let mapping: Record<string, string>;
     try {
       mapping = buildMapping(assignments);
@@ -199,12 +192,10 @@ export function ImportCsvModal({
         formData.append("segment_id", selectedSegment.id);
       }
 
-      const headers: Record<string, string> = {};
-      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
-
+      // Same-origin request: the browser sends the dashboard session cookie
+      // automatically, so no Authorization header is needed.
       const res = await fetch("/api/contacts/import", {
         method: "POST",
-        headers,
         body: formData,
       });
 

--- a/src/components/import-csv-modal.tsx
+++ b/src/components/import-csv-modal.tsx
@@ -171,16 +171,12 @@ export function ImportCsvModal({
   const handleSubmit = async () => {
     if (!file) return;
 
+    // Dashboard users authenticate via the Better Auth session cookie; an
+    // api_key in localStorage is only attached as a Bearer token when present.
     const apiKey =
       typeof window !== "undefined"
         ? (localStorage?.getItem?.("api_key") ?? null)
         : null;
-    if (!apiKey) {
-      setSubmitError(
-        "No API key found. Add a full-access API key in Settings first.",
-      );
-      return;
-    }
 
     let mapping: Record<string, string>;
     try {
@@ -203,9 +199,12 @@ export function ImportCsvModal({
         formData.append("segment_id", selectedSegment.id);
       }
 
+      const headers: Record<string, string> = {};
+      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
       const res = await fetch("/api/contacts/import", {
         method: "POST",
-        headers: { Authorization: `Bearer ${apiKey}` },
+        headers,
         body: formData,
       });
 

--- a/src/components/import-csv-modal.tsx
+++ b/src/components/import-csv-modal.tsx
@@ -26,6 +26,24 @@ function extractSegments(payload: unknown): Segment[] {
   return Array.isArray(m.data) ? m.data.filter(isSegment) : [];
 }
 
+interface PropertyOption {
+  key: string;
+  name: string;
+}
+
+function isProperty(value: unknown): value is PropertyOption {
+  if (typeof value !== "object" || value === null) return false;
+  const m = value as Record<string, unknown>;
+  return typeof m.key === "string" && typeof m.name === "string";
+}
+
+function extractProperties(payload: unknown): PropertyOption[] {
+  if (Array.isArray(payload)) return payload.filter(isProperty);
+  if (typeof payload !== "object" || payload === null) return [];
+  const m = payload as Record<string, unknown>;
+  return Array.isArray(m.data) ? m.data.filter(isProperty) : [];
+}
+
 const CONTACT_IMPORT_MAX_BYTES = 10 * 1024 * 1024;
 const ALLOWED_MIME = new Set([
   "text/csv",
@@ -52,6 +70,7 @@ export function ImportCsvModal({
   const [assignments, setAssignments] = useState<Record<string, string>>({});
   const [fileError, setFileError] = useState<string | null>(null);
   const [segments, setSegments] = useState<Segment[]>([]);
+  const [properties, setProperties] = useState<PropertyOption[]>([]);
   const [selectedSegment, setSelectedSegment] = useState<Segment | null>(null);
   const [segmentSearch, setSegmentSearch] = useState("");
   const [segmentDropdownOpen, setSegmentDropdownOpen] = useState(false);
@@ -81,6 +100,19 @@ export function ImportCsvModal({
     }
   }, []);
 
+  const fetchProperties = useCallback(async () => {
+    try {
+      // Same-origin: the dashboard session cookie authenticates the request.
+      const res = await fetch("/api/properties");
+      if (res.ok) {
+        const data = await res.json();
+        setProperties(extractProperties(data));
+      }
+    } catch {
+      // ignore — custom-property options are optional
+    }
+  }, []);
+
   // Reset state when modal opens
   useEffect(() => {
     if (open) {
@@ -94,8 +126,9 @@ export function ImportCsvModal({
       setSegmentSearch("");
       setCreatedCount(0);
       fetchSegments();
+      fetchProperties();
     }
-  }, [open, fetchSegments]);
+  }, [open, fetchSegments, fetchProperties]);
 
   // Escape to close
   useEffect(() => {
@@ -153,11 +186,14 @@ export function ImportCsvModal({
       }
       setFile(picked);
       setHeaders(cols);
-      // Pre-assign columns whose names exactly match known field keys
+      // Pre-assign columns whose names match a known field or a defined
+      // custom property key; everything else defaults to skip.
       const autoAssign: Record<string, string> = {};
       for (const col of cols) {
-        const match = KNOWN_FIELD_KEYS.find((k) => k === col.toLowerCase());
-        autoAssign[col] = match ?? SKIP_SENTINEL;
+        const lower = col.toLowerCase();
+        const known = KNOWN_FIELD_KEYS.find((k) => k === lower);
+        const prop = properties.find((p) => p.key.toLowerCase() === lower);
+        autoAssign[col] = known ?? prop?.key ?? SKIP_SENTINEL;
       }
       setAssignments(autoAssign);
       setStep("map");
@@ -341,6 +377,21 @@ export function ImportCsvModal({
                         <option value="email">Email address</option>
                         <option value="first_name">First name</option>
                         <option value="last_name">Last name</option>
+                        {properties.length > 0 && (
+                          <optgroup label="Custom properties">
+                            {properties.map((p) => (
+                              <option key={p.key} value={p.key}>
+                                {p.name}
+                              </option>
+                            ))}
+                          </optgroup>
+                        )}
+                        {!KNOWN_FIELD_KEYS.includes(
+                          col.toLowerCase() as (typeof KNOWN_FIELD_KEYS)[number],
+                        ) &&
+                          !properties.some((p) => p.key === col) && (
+                            <option value={col}>New property: “{col}”</option>
+                          )}
                       </select>
                     </div>
                   ))}

--- a/src/lib/csv-import.ts
+++ b/src/lib/csv-import.ts
@@ -1,18 +1,29 @@
 import Papa from "papaparse";
 
 /**
- * Reads only the header row of a CSV file using PapaParse preview mode.
- * O(first-row) on the client — does not load the full file into memory.
+ * Reads only the first few rows of a CSV file using PapaParse preview mode —
+ * does not load the full file into memory.
+ *
+ * Uses `skipEmptyLines: "greedy"` so comma-only junk rows (e.g. a leading
+ * `,,,,,,` exported by some tools) are skipped and the real header row is
+ * used. `preview` is > 1 because greedy-skipped rows still count toward the
+ * preview budget, so preview: 1 would return nothing when a junk row leads.
+ * Parses without `header` so we read the raw header cells directly, trim
+ * them, and drop blank columns (trailing `,,,,`) — otherwise PapaParse
+ * surfaces them as nameless `_1`, `_2`, … columns in the mapping UI.
  */
 export function parseCsvHeaders(file: File): Promise<string[]> {
   return new Promise((resolve, reject) => {
-    Papa.parse(file, {
-      preview: 1,
-      header: true,
-      skipEmptyLines: true,
+    Papa.parse<string[]>(file, {
+      preview: 5,
+      header: false,
+      skipEmptyLines: "greedy",
       complete(results) {
-        const fields = results.meta.fields ?? [];
-        resolve(fields);
+        const firstRow = (results.data[0] as string[] | undefined) ?? [];
+        const headers = firstRow
+          .map((cell) => (typeof cell === "string" ? cell.trim() : ""))
+          .filter((cell) => cell.length > 0);
+        resolve(headers);
       },
       error(err) {
         reject(new Error(err.message));

--- a/tests/contact-operations-routes.test.ts
+++ b/tests/contact-operations-routes.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockValidateApiKey = vi.hoisted(() => vi.fn());
+const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockBulkAction = vi.hoisted(() => vi.fn());
 const mockImportContacts = vi.hoisted(() => vi.fn());
 const mockListContactTopics = vi.hoisted(() => vi.fn());
@@ -27,13 +28,10 @@ function makeRequest(url: string, init?: RequestInit) {
 }
 
 vi.mock("@/lib/api-auth", () => ({
+  // The bulk route still authenticates with a Bearer API key.
   validateApiKey: mockValidateApiKey,
-  // The import route authenticates with authorizeDashboardOrApiKey (session
-  // cookie OR Bearer key). Delegate to the same mock so API-key test setups
-  // continue to drive auth; a real session path returns null here.
-  authorizeDashboardOrApiKey: (header: string | null | undefined) =>
-    mockValidateApiKey(header),
-  getServerSession: vi.fn(async () => null),
+  // The CSV import route is dashboard-session-only.
+  getServerSession: mockGetServerSession,
   unauthorizedResponse: () =>
     Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
 }));
@@ -41,13 +39,6 @@ vi.mock("@/lib/api-auth", () => ({
 vi.mock("@/lib/api-key-permissions", () => ({
   requireFullAccessApiKey: (auth: { permission?: string }) =>
     auth.permission === "full_access"
-      ? null
-      : Response.json({ error: "Forbidden" }, { status: 403 }),
-  requireFullAccessForApiKeyCaller: (auth: {
-    permission?: string;
-    dashboard?: true;
-  }) =>
-    auth.dashboard || auth.permission === "full_access"
       ? null
       : Response.json({ error: "Forbidden" }, { status: 403 }),
 }));
@@ -72,6 +63,8 @@ describe("contact operations route adapters", () => {
       domain: null,
       userId: "user-1",
     });
+    // CSV import resolves the user from the dashboard session.
+    mockGetServerSession.mockResolvedValue({ user: { id: "user-1" } });
   });
 
   it("keeps /api/contacts/bulk auth in the route and delegates body/user to the service", async () => {

--- a/tests/contact-operations-routes.test.ts
+++ b/tests/contact-operations-routes.test.ts
@@ -191,6 +191,43 @@ describe("contact operations route adapters", () => {
     });
   });
 
+  it("strips a leading comma-only junk row so rows key off the real header", async () => {
+    mockImportContacts.mockResolvedValueOnce({
+      object: "import",
+      created_count: 1,
+      ids: ["contact-1"],
+    });
+    // Mirrors the real export bug: a blank `,,,,,,` row precedes the header
+    // and there are trailing empty columns.
+    const csv =
+      ",,,,,,\r\nid,email,created_at,,,,\r\n3,weswong@gmail.com,2026-03-23\r\n";
+    const formData = {
+      get: (key: string) => {
+        if (key === "file") return { text: async () => csv };
+        if (key === "mapping") return JSON.stringify({ email: "email" });
+        return null;
+      },
+    };
+
+    const route = await import("@/app/api/contacts/import/route");
+    const response = await route.POST({
+      headers: new Headers({ authorization: "Bearer key" }),
+      formData: async () => formData,
+    } as never);
+
+    expect(response.status).toBe(200);
+    const callArg = mockImportContacts.mock.calls[0]?.[0] as {
+      rows: Record<string, string>[];
+    };
+    // The junk row is gone (one real data row), keyed by the real header.
+    expect(callArg.rows).toHaveLength(1);
+    expect(callArg.rows[0]).toMatchObject({
+      id: "3",
+      email: "weswong@gmail.com",
+      created_at: "2026-03-23",
+    });
+  });
+
   it("returns the legacy import 400 before delegating when no file is provided", async () => {
     const route = await import("@/app/api/contacts/import/route");
     const response = await route.POST({

--- a/tests/contact-operations-routes.test.ts
+++ b/tests/contact-operations-routes.test.ts
@@ -28,6 +28,12 @@ function makeRequest(url: string, init?: RequestInit) {
 
 vi.mock("@/lib/api-auth", () => ({
   validateApiKey: mockValidateApiKey,
+  // The import route authenticates with authorizeDashboardOrApiKey (session
+  // cookie OR Bearer key). Delegate to the same mock so API-key test setups
+  // continue to drive auth; a real session path returns null here.
+  authorizeDashboardOrApiKey: (header: string | null | undefined) =>
+    mockValidateApiKey(header),
+  getServerSession: vi.fn(async () => null),
   unauthorizedResponse: () =>
     Response.json({ error: "Missing or invalid API key" }, { status: 401 }),
 }));
@@ -35,6 +41,13 @@ vi.mock("@/lib/api-auth", () => ({
 vi.mock("@/lib/api-key-permissions", () => ({
   requireFullAccessApiKey: (auth: { permission?: string }) =>
     auth.permission === "full_access"
+      ? null
+      : Response.json({ error: "Forbidden" }, { status: 403 }),
+  requireFullAccessForApiKeyCaller: (auth: {
+    permission?: string;
+    dashboard?: true;
+  }) =>
+    auth.dashboard || auth.permission === "full_access"
       ? null
       : Response.json({ error: "Forbidden" }, { status: 403 }),
 }));

--- a/tests/contact-tenant-isolation.test.ts
+++ b/tests/contact-tenant-isolation.test.ts
@@ -511,6 +511,9 @@ describe("contact API tenant isolation", () => {
   });
 
   it("stamps imported contacts with the caller user", async () => {
+    // CSV import is dashboard-session-only: the caller user comes from the
+    // authenticated session, not a Bearer key.
+    mockGetServerSession.mockResolvedValue({ user: { id: "user-b" } });
     mockContactOperationsService.importContacts.mockResolvedValueOnce({
       object: "import",
       created_count: 1,
@@ -528,7 +531,7 @@ describe("contact API tenant isolation", () => {
 
     const route = await import("@/app/api/contacts/import/route");
     const response = await route.POST({
-      headers: new Headers({ authorization: "Bearer user-b-key" }),
+      headers: new Headers(),
       formData: async () => formData,
     } as never);
 

--- a/tests/csv-import-helpers.test.ts
+++ b/tests/csv-import-helpers.test.ts
@@ -47,6 +47,20 @@ describe("buildMapping", () => {
   it("accepts a single email-only mapping", () => {
     expect(buildMapping({ address: "email" })).toEqual({ address: "email" });
   });
+
+  it("passes custom-property keys through unchanged", () => {
+    // Any non-standard target key is forwarded verbatim; the server stores it
+    // as a custom property. This is how the modal's "New property" / defined
+    // property options reach the import endpoint.
+    expect(
+      buildMapping({
+        Email: "email",
+        id: "id",
+        Created: "created_at",
+        Notes: SKIP_SENTINEL,
+      }),
+    ).toEqual({ Email: "email", id: "id", Created: "created_at" });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -57,11 +71,8 @@ describe("buildMapping", () => {
 interface MockPapaConfig {
   preview?: number;
   header?: boolean;
-  skipEmptyLines?: boolean;
-  complete?: (results: {
-    meta: { fields?: string[] } & Record<string, unknown>;
-    data: unknown[];
-  }) => void;
+  skipEmptyLines?: boolean | "greedy";
+  complete?: (results: { data: unknown[] }) => void;
   error?: (err: { message: string }) => void;
 }
 
@@ -79,13 +90,10 @@ describe("parseCsvHeaders", () => {
     parseSpy.mockRestore();
   });
 
-  it("resolves with the header field names", async () => {
+  it("resolves with the header cells from the first parsed row", async () => {
     parseSpy.mockImplementation((...args: unknown[]) => {
       const config = args[1] as MockPapaConfig | undefined;
-      config?.complete?.({
-        meta: { fields: ["email", "first_name", "last_name"] },
-        data: [],
-      });
+      config?.complete?.({ data: [["email", "first_name", "last_name"]] });
     });
 
     const file = new File(
@@ -97,10 +105,10 @@ describe("parseCsvHeaders", () => {
     expect(headers).toEqual(["email", "first_name", "last_name"]);
   });
 
-  it("calls PapaParse with preview: 1 and header: true", async () => {
+  it("parses raw rows with greedy skipEmptyLines so junk rows are dropped", async () => {
     parseSpy.mockImplementation((...args: unknown[]) => {
       const config = args[1] as MockPapaConfig | undefined;
-      config?.complete?.({ meta: { fields: ["col"] }, data: [] });
+      config?.complete?.({ data: [["col"]] });
     });
 
     const file = new File(["col\nval"], "x.csv", { type: "text/csv" });
@@ -108,8 +116,27 @@ describe("parseCsvHeaders", () => {
 
     expect(parseSpy).toHaveBeenCalledWith(
       file,
-      expect.objectContaining({ preview: 1, header: true }),
+      expect.objectContaining({
+        preview: 5,
+        header: false,
+        skipEmptyLines: "greedy",
+      }),
     );
+  });
+
+  it("trims headers and drops blank columns (leading junk row + trailing empties)", async () => {
+    // Simulates a CSV whose first non-empty row is `id,email,created_at,,,,`
+    // after greedy skip dropped a leading `,,,,,,` row.
+    parseSpy.mockImplementation((...args: unknown[]) => {
+      const config = args[1] as MockPapaConfig | undefined;
+      config?.complete?.({
+        data: [["id", " email ", "created_at", "", "  ", ""]],
+      });
+    });
+
+    const file = new File(["..."], "messy.csv", { type: "text/csv" });
+    const headers = await parseCsvHeaders(file);
+    expect(headers).toEqual(["id", "email", "created_at"]);
   });
 
   it("rejects when PapaParse reports an error", async () => {
@@ -122,14 +149,36 @@ describe("parseCsvHeaders", () => {
     await expect(parseCsvHeaders(file)).rejects.toThrow("parse failure");
   });
 
-  it("resolves with empty array when meta.fields is absent", async () => {
+  it("resolves with empty array when there is no parsed row", async () => {
     parseSpy.mockImplementation((...args: unknown[]) => {
       const config = args[1] as MockPapaConfig | undefined;
-      config?.complete?.({ meta: {}, data: [] });
+      config?.complete?.({ data: [] });
     });
 
     const file = new File([""], "empty.csv", { type: "text/csv" });
     const headers = await parseCsvHeaders(file);
     expect(headers).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: real PapaParse against the exact malformed shape that produced
+// blank/`_1`..`_6` columns in the import UI (leading comma-only row + trailing
+// empty columns). Uses the real parser (no spy) on a string to avoid relying
+// on a DOM FileReader in the test environment.
+// ---------------------------------------------------------------------------
+
+describe("PapaParse greedy header parsing (integration)", () => {
+  it("skips a comma-only leading row and yields the trimmed real header", () => {
+    const csv = ",,,,,,\r\nid,email,created_at,,,,\r\n3,a@b.com,2026-03-23\r\n";
+    const result = Papa.parse<string[]>(csv, {
+      preview: 5,
+      header: false,
+      skipEmptyLines: "greedy",
+    });
+    const headers = (result.data[0] ?? [])
+      .map((cell) => cell.trim())
+      .filter((cell) => cell.length > 0);
+    expect(headers).toEqual(["id", "email", "created_at"]);
   });
 });

--- a/tests/e2e/import-csv-modal.spec.ts
+++ b/tests/e2e/import-csv-modal.spec.ts
@@ -1,15 +1,15 @@
-import path from "node:path";
 import { expect, test } from "./fixtures/auth";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Absolute path to the shared CSV fixture. */
-const FIXTURE_CSV = path.join(
-  import.meta.dirname,
-  "../fixtures/contacts-sample.csv",
-);
+/**
+ * Path to the shared CSV fixture, relative to the repo root. Playwright's
+ * setInputFiles resolves relative paths against the cwd (the project root
+ * when running `bunx playwright test`).
+ */
+const FIXTURE_CSV = "tests/fixtures/contacts-sample.csv";
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -79,12 +79,14 @@ test.describe("Import CSV modal", () => {
 
     await page.getByLabel("CSV file").setInputFiles(FIXTURE_CSV);
 
-    // Mapping step should appear with column headers detected
+    // Mapping step should appear with the CSV column headers detected.
+    // Use exact matches so the column-name cells are not confused with the
+    // "Email address" select options or the "Emails" nav item.
     await expect(
       page.getByText(/map csv columns/i, { exact: false }),
     ).toBeVisible();
-    await expect(page.getByText("email")).toBeVisible();
-    await expect(page.getByText("first_name")).toBeVisible();
+    await expect(page.getByText("email", { exact: true })).toBeVisible();
+    await expect(page.getByText("first_name", { exact: true })).toBeVisible();
   });
 
   test("Import button is disabled until email column is mapped", async ({
@@ -113,7 +115,6 @@ test.describe("Import CSV modal", () => {
   test("happy path: imports contacts from CSV and shows success", async ({
     authenticatedPage: page,
     e2eDb,
-    e2eRunId,
     e2eTenant,
   }) => {
     await page.goto("/audience");
@@ -143,12 +144,20 @@ test.describe("Import CSV modal", () => {
       page.getByRole("heading", { name: "Import CSV" }),
     ).not.toBeVisible();
 
-    // Verify at least one of the fixture emails landed in the DB
+    // Verify all three fixture contacts landed in the DB under this tenant.
+    // The fixture uses a static @e2erunid.e2e.opensend.test domain; cleanup
+    // removes them via the user_id prefix regardless of the email domain.
     const { rows } = await e2eDb.query<{ email: string }>(
-      `select email from contacts where email like '%@${e2eRunId}.e2e.opensend.test' and user_id = $1`,
+      `select email from contacts
+       where user_id = $1 and email like '%@e2erunid.e2e.opensend.test'
+       order by email`,
       [e2eTenant.user.id],
     );
-    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.map((r) => r.email)).toEqual([
+      "alice@e2erunid.e2e.opensend.test",
+      "bob@e2erunid.e2e.opensend.test",
+      "carol@e2erunid.e2e.opensend.test",
+    ]);
   });
 
   test("shows file type error for non-CSV files without making a network request", async ({

--- a/tests/e2e/import-csv-modal.spec.ts
+++ b/tests/e2e/import-csv-modal.spec.ts
@@ -11,6 +11,9 @@ import { expect, test } from "./fixtures/auth";
  */
 const FIXTURE_CSV = "tests/fixtures/contacts-sample.csv";
 
+/** Fixture with a non-standard `plan` column for custom-property mapping. */
+const FIXTURE_WITH_PROPERTY = "tests/fixtures/contacts-with-property.csv";
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -205,5 +208,39 @@ test.describe("Import CSV modal", () => {
     await expect(
       page.getByRole("button", { name: "Import" }),
     ).not.toBeVisible();
+  });
+
+  test("maps a non-standard column to a custom property", async ({
+    authenticatedPage: page,
+    e2eDb,
+    e2eTenant,
+  }) => {
+    await page.goto("/audience");
+
+    await page.getByRole("button", { name: /add contacts/i }).click();
+    await page.getByText("Import CSV").click();
+
+    await page.getByLabel("CSV file").setInputFiles(FIXTURE_WITH_PROPERTY);
+
+    // The `plan` column is not a standard field, so it offers a
+    // "New property" option keyed by the column name.
+    await page
+      .getByLabel("Map column plan to contact field")
+      .selectOption("plan");
+
+    await page.getByRole("button", { name: "Import" }).click();
+    await expect(page.getByText(/import complete/i)).toBeVisible();
+    await page.getByRole("button", { name: "Done" }).click();
+
+    // The custom property is stored on the contact's custom_properties JSON.
+    const { rows } = await e2eDb.query<{
+      custom_properties: Record<string, string> | null;
+    }>(
+      `select custom_properties from contacts
+       where user_id = $1 and email = 'dave@e2erunid.e2e.opensend.test'`,
+      [e2eTenant.user.id],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.custom_properties).toMatchObject({ plan: "pro" });
   });
 });

--- a/tests/fixtures/contacts-with-property.csv
+++ b/tests/fixtures/contacts-with-property.csv
@@ -1,0 +1,2 @@
+email,plan
+dave@e2erunid.e2e.opensend.test,pro


### PR DESCRIPTION
## Summary

## Why

## Validation

- [ ] `make check`
- [ ] `make test`
- [ ] `bun run docs:generate` if public docs changed
- [ ] `bun run docs:check` if public docs changed
- [ ] Scenario or E2E proof for user-facing/auth/API/persistence-sensitive work
- [ ] Not applicable because:

## Screenshots or recordings

Add for dashboard, docs, or visual changes.

## Security, tenant, and env impact

- New or changed env vars:
- Secrets touched:
- Tenant isolation or auth impact:
- Migration impact:
- Webhook/API compatibility impact:

## Docs

- [ ] README updated if the first-run or product story changed
- [ ] `public/docs/**/*.md` updated for public docs changes
- [ ] `/docs/llms.txt` regenerated when public docs changed
