### PR TITLE
Complete Compose Redis and SMTP relay stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,9 +89,12 @@ GOOGLE_CLIENT_SECRET=
 # ─────────────────────────────────────────────────────────────────
 # Rate limiting + cache backend (recommended for staging/production)
 # ─────────────────────────────────────────────────────────────────
-# RATE_LIMIT_BACKEND=memory   # default for single-process dev
-# RATE_LIMIT_BACKEND=redis    # required for shared/staging/production
-# Use the TLS-enabled endpoint (rediss://...) when RATE_LIMIT_BACKEND=redis.
+# Outside Docker Compose, RATE_LIMIT_BACKEND defaults to disabled for single-process dev.
+# Docker Compose sets RATE_LIMIT_BACKEND=redis and REDIS_URL=redis://redis:6379 by default.
+# RATE_LIMIT_BACKEND=disabled # local single-process only; no API rate limiting
+# RATE_LIMIT_BACKEND=redis    # required for shared/staging/production and Compose
+# OPENSEND_APP_REPLICAS=1     # set >1 when running multiple app containers; warns unless backend=redis
+# Use the TLS-enabled endpoint (rediss://...) when RATE_LIMIT_BACKEND=redis outside Compose.
 # REDIS_URL backs:
 #   - Rate limiting (app, when RATE_LIMIT_BACKEND=redis)
 #   - API-key auth caching (app)
@@ -167,6 +170,16 @@ WEBHOOK_SECRET_ENCRYPTION_KEY=local-dev-webhook-secret-replace-before-production
 # right-most-Nth X-Forwarded-For entry is used as the client IP for rate
 # limiting. Set to 1 when behind a single proxy (ALB, Cloudflare).
 # TRUSTED_PROXY_HOPS=0
+
+# ─────────────────────────────────────────────────────────────────
+# SMTP relay profile (optional; Docker Compose only starts it with --profile smtp)
+# ─────────────────────────────────────────────────────────────────
+# docker compose --profile smtp up -d smtp-relay
+# SMTP_RELAY_PORT=2587
+# SMTP_RELAY_HOST=0.0.0.0
+# SMTP_RELAY_TLS_CERT_PATH=/run/secrets/smtp-cert.pem
+# SMTP_RELAY_TLS_KEY_PATH=/run/secrets/smtp-key.pem
+# SMTP_RELAY_MAX_MESSAGE_SIZE_BYTES=41943040
 
 # ─────────────────────────────────────────────────────────────────
 # Observability

--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ Compose starts:
 
 - `app`: Next.js dashboard and public API on `:3015`
 - `postgres`: local database
+- `redis`: shared rate limiting and cache coordination
 - `migrate`: one-shot schema migration runner
 - `ingester`: SES/SNS ingestion and workers on `:3016`
 - `scheduler`: scheduled job trigger sidecar
+- optional `smtp-relay`: SMTP compatibility service, only with `docker compose --profile smtp up -d smtp-relay`
 
 For real email delivery, add AWS SES credentials and verify a sending domain. For dashboard login, add Google OAuth credentials.
 
@@ -266,7 +268,7 @@ Full docs: [`packages/ruby-sdk/README.md`](./packages/ruby-sdk/README.md) and [`
 - Docker and Docker Compose
 - AWS account with SES access for real email delivery
 - Optional Cloudflare account for automatic DNS records
-- Optional Redis/SQS/EventBridge for production-grade rate limiting and background jobs
+- Redis (included in Docker Compose) plus optional SQS/EventBridge for production-grade background jobs
 
 ### Docker Compose
 
@@ -279,7 +281,7 @@ cp .env.example .env
 docker compose up -d
 ```
 
-The dashboard/API runs at **http://localhost:3015**. The ingester health endpoint is **http://localhost:3016/health**.
+The dashboard/API runs at **http://localhost:3015**. The ingester health endpoint is **http://localhost:3016/health**. Compose also starts Redis for shared rate limiting/cache coordination; the SMTP relay is available only when explicitly enabled with `docker compose --profile smtp up -d smtp-relay`.
 
 ### Production deployments
 
@@ -312,6 +314,7 @@ src/                 # Next.js app and public API routes
 packages/
 ├── core/            # Shared DB client, repositories, DTOs, webhook helpers
 ├── ingester/        # Production Hono ingester and workers, port 3016
+├── smtp-relay/      # Optional SMTP compatibility relay, profile-gated in Compose
 ├── sdk/             # TypeScript SDK
 ├── python-sdk/      # Python SDK
 ├── go-sdk/          # Go SDK
@@ -343,7 +346,7 @@ docs/                # Deployment, SDK, and operations docs
 | Billing for hosted cloud | Stripe                                          |
 | Ingester                 | Hono on Bun                                     |
 | Background jobs          | AWS SQS, EventBridge, scheduler sidecar         |
-| Cache/rate limit         | Redis                                           |
+| Cache/rate limit         | Redis (default in Docker Compose)              |
 | Tests                    | Vitest, Playwright                              |
 | Lint/format              | Biome                                           |
 
@@ -382,7 +385,7 @@ This repo is designed to be understandable to coding agents, but agent setup is 
 - [x] Built-in open/click analytics
 - [x] Additional webhook event types: opened, clicked, complained, delivery delayed
 - [x] Familiar audiences/contact API slices
-- [ ] SMTP relay support without AWS SES
+- [x] SMTP relay compatibility service for self-hosted deployments
 
 ## Contributing
 

--- a/agent_docs/learnings/active/2026-06-18-issue-644-compose-redis-rate-limit.md
+++ b/agent_docs/learnings/active/2026-06-18-issue-644-compose-redis-rate-limit.md
@@ -1,0 +1,23 @@
+---
+date: 2026-06-18
+issue: "#644"
+type: decision
+promoted_to: null
+---
+
+## Compose defaults Redis, but runtime still requires explicit Redis backend
+
+Docker Compose should be production-like for self-hosters: it starts Redis and
+sets the app to `RATE_LIMIT_BACKEND=redis` plus `REDIS_URL=redis://redis:6379`.
+The app and ingester wait for Redis health because the Compose defaults depend
+on shared Redis for rate limiting and cache coordination.
+
+Outside Compose, keep the runtime contract explicit. Unset
+`RATE_LIMIT_BACKEND` remains `disabled` for single-process local development,
+and `REDIS_URL` alone must not suppress startup warnings or enable rate
+limiting. Operators running more than one app replica should set
+`OPENSEND_APP_REPLICAS` and get warned unless `RATE_LIMIT_BACKEND=redis` is
+selected.
+
+Do not reintroduce a per-process/memory rate-limit backend as a quiet fallback;
+that repeats the original multi-instance safety bug.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,18 +11,25 @@
 #
 # What this brings up:
 #   - postgres   : Postgres 16 with the OpenSend schema, persisted in the named volume `pgdata`.
+#   - redis      : Shared Redis for Compose rate limiting and hot-path cache coordination.
 #   - migrate    : One-shot job that runs Drizzle migrations and exits.
 #   - app        : Next.js dashboard + REST API on http://localhost:${PORT:-3015}.
 #   - ingester   : Production Bun/Hono service that handles SES/SNS, Stripe, and scheduled-email
 #                  webhooks on http://localhost:${INGESTER_PORT:-3016}.
 #   - scheduler  : Durable short-interval driver for ingester /jobs/* scans.
 #
+# Optional profile:
+#   - smtp-relay : `docker compose --profile smtp up -d smtp-relay` publishes SMTP on ${SMTP_RELAY_PORT:-2587}.
 #
 # Optional overrides (all read from .env):
 #   - PORT                        : host port for the app (default 3015)
 #   - INGESTER_PORT               : host port for the ingester (default 3016)
 #   - POSTGRES_PORT               : host port for Postgres (default 5432)
 #   - POSTGRES_PASSWORD           : Postgres password (REQUIRED; set in .env before `docker compose up`)
+#   - REDIS_URL                   : Redis URL for app/ingester (default redis://redis:6379 in Compose)
+#   - RATE_LIMIT_BACKEND          : app rate-limit backend (default redis in Compose)
+#   - OPENSEND_APP_REPLICAS       : expected app replica count for startup warnings (default 1)
+#   - SMTP_RELAY_PORT             : host/container port for the smtp profile (default 2587)
 #   - BETTER_AUTH_SECRET          : required Better Auth session secret for app/ingester.
 #   - AWS_*                       : SES + S3 credentials. If unset, email sending is disabled.
 #   - BACKGROUND_JOBS_*           : SQS/EventBridge wiring for async send pipeline.
@@ -53,6 +60,21 @@ services:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U opensend"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  # Redis coordinates rate limiting across app replicas and backs hot-path caches.
+  # Compose uses plain redis:// on the private Docker network; managed production
+  # Redis should use a private TLS endpoint (rediss://...).
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--save", "60", "1", "--loglevel", "warning"]
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -90,6 +112,9 @@ services:
       BACKGROUND_JOBS_QUEUE_URL: ${BACKGROUND_JOBS_QUEUE_URL:-}
       BACKGROUND_JOBS_EVENT_BUS_NAME: ${BACKGROUND_JOBS_EVENT_BUS_NAME:-}
       BACKGROUND_JOBS_REQUIRE_QUEUE: ${BACKGROUND_JOBS_REQUIRE_QUEUE:-false}
+      RATE_LIMIT_BACKEND: ${RATE_LIMIT_BACKEND:-redis}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+      OPENSEND_APP_REPLICAS: ${OPENSEND_APP_REPLICAS:-1}
       WEBHOOK_SECRET_ENCRYPTION_KEY: ${WEBHOOK_SECRET_ENCRYPTION_KEY:?Set WEBHOOK_SECRET_ENCRYPTION_KEY in .env (local placeholder ok only for dev; generate a real secret for production)}
       INGESTER_HEALTH_URL: ${INGESTER_HEALTH_URL:-http://ingester:3016/health}
       S3_BUCKET_NAME: ${S3_BUCKET_NAME:-}
@@ -101,6 +126,8 @@ services:
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
     depends_on:
       postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
       migrate:
         condition: service_completed_successfully
@@ -147,11 +174,12 @@ services:
       STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-}
       BILLING_NOTIFICATION_FROM_EMAIL: ${BILLING_NOTIFICATION_FROM_EMAIL:-}
       STRIPE_OVERAGE_METER_EVENT_NAME: ${STRIPE_OVERAGE_METER_EVENT_NAME:-}
-      # Optional — required only for domain-cache invalidation. Uses the same
-      # Redis instance as the app. Leave unset for a basic local stack.
-      REDIS_URL: ${REDIS_URL:-}
+      # Uses the same Compose Redis as the app for domain-cache invalidation.
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379}
     depends_on:
       postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
       migrate:
         condition: service_completed_successfully
@@ -167,6 +195,33 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+
+  # Optional SMTP compatibility relay. It is profile-gated so the default
+  # Compose footprint remains app + ingester + scheduler + data services.
+  # Enable with: docker compose --profile smtp up -d smtp-relay
+  smtp-relay:
+    profiles: ["smtp"]
+    image: opensend-smtp-relay:local
+    build:
+      context: .
+      dockerfile: packages/smtp-relay/Dockerfile
+    restart: unless-stopped
+    ports:
+      - "${SMTP_RELAY_PORT:-2587}:${SMTP_RELAY_PORT:-2587}"
+    environment:
+      DATABASE_URL: postgresql://opensend:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env (see .env.example)}@postgres:5432/opensend
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+      BACKGROUND_JOBS_QUEUE_URL: ${BACKGROUND_JOBS_QUEUE_URL:-}
+      SMTP_RELAY_HOST: ${SMTP_RELAY_HOST:-0.0.0.0}
+      SMTP_RELAY_PORT: ${SMTP_RELAY_PORT:-2587}
+      SMTP_RELAY_TLS_CERT_PATH: ${SMTP_RELAY_TLS_CERT_PATH:-}
+      SMTP_RELAY_TLS_KEY_PATH: ${SMTP_RELAY_TLS_KEY_PATH:-}
+      SMTP_RELAY_MAX_MESSAGE_SIZE_BYTES: ${SMTP_RELAY_MAX_MESSAGE_SIZE_BYTES:-41943040}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
 
   # Durable local/self-host scheduler for ingester background scan endpoints.
   # It posts every ${INGESTER_SCHEDULER_INTERVAL_SECONDS:-60}s to:
@@ -189,3 +244,4 @@ services:
 
 volumes:
   pgdata:
+  redisdata:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -138,8 +138,9 @@ contributor-facing set; the table below adds the production-only entries.
 | `SES_INBOUND_BUCKET_NAME` | Optional raw MIME bucket allowlist for SES receipt-rule ingestion. Defaults to `S3_BUCKET_NAME`. |
 | `SES_INBOUND_RULE_SET_NAME` | Optional SES receipt rule set managed by the dashboard receiving toggle. Defaults to `opensend-inbound`. |
 | `INGESTER_SCHEDULER_INTERVAL_SECONDS` | Compose scheduler cadence for `/jobs/scheduled-emails`, `/jobs/webhooks`, `/jobs/domain-verify`, and `/jobs/billing-overage`. Default `60`; minimum `10`. |
-| `RATE_LIMIT_BACKEND` | `disabled` (single-process dev), or `redis` (production). |
-| `REDIS_URL` | TLS Redis endpoint, e.g. `rediss://default:<password>@<endpoint>:6379`. Used for rate limiting AND auth/domain metadata cache. |
+| `RATE_LIMIT_BACKEND` | `disabled` (single-process dev outside Compose), or `redis` (Compose/shared/staging/production). |
+| `REDIS_URL` | Redis endpoint. Compose defaults to `redis://redis:6379`; managed production should use a private TLS endpoint such as `rediss://default:<password>@<endpoint>:6379`. Used for rate limiting, auth/domain metadata cache, and ingester cache invalidation. |
+| `OPENSEND_APP_REPLICAS` | Expected app replica count. Set greater than `1` when load balancing app containers; startup checks warn unless `RATE_LIMIT_BACKEND=redis`. |
 | `CLOUDWATCH_METRICS_NAMESPACE` | Override the default `OpenSend` EMF metrics namespace. |
 
 ### AWS ECS deploy secret wiring
@@ -425,14 +426,12 @@ the dashboard works for development.
 
 API rate limiting is enforced by `src/middleware.ts`. There are two backends:
 
-- `RATE_LIMIT_BACKEND=disabled` — skip rate limiting entirely. Default. Safe
-  for single-process local dev only.
-- `RATE_LIMIT_BACKEND=redis` — use a shared Redis token bucket. Required for
-  any deployment with more than one app instance.
+- `RATE_LIMIT_BACKEND=disabled` — skip rate limiting entirely. Default outside Docker Compose. Safe for single-process local dev only.
+- `RATE_LIMIT_BACKEND=redis` — use a shared Redis token bucket. Default in Docker Compose and required for any deployment with more than one app instance.
 
-When `redis` is selected, `REDIS_URL` must point at a TLS endpoint
-(`rediss://...`). If Redis is unreachable, requests fail closed with HTTP 503
-rather than silently falling back to per-process memory.
+Compose starts Redis and wires the app/ingester to `redis://redis:6379`. Managed production deployments should use a private TLS endpoint (`rediss://...`). If Redis is selected for rate limiting but unreachable, requests fail closed with HTTP 503 rather than silently falling back to a per-process limiter. `REDIS_URL` alone does not enable rate limiting; `RATE_LIMIT_BACKEND=redis` is required.
+
+Set `OPENSEND_APP_REPLICAS` greater than `1` when a deployment can run multiple app containers. Startup checks warn when that multi-instance config is present without Redis-backed rate limiting.
 
 The same Redis is reused for hot-path metadata caching:
 
@@ -441,6 +440,16 @@ The same Redis is reused for hot-path metadata caching:
 - SES domain identity lookups by domain name (2 min TTL)
 
 Cache invalidation is automatic on create/update/delete/verify flows.
+
+## SMTP relay profile
+
+The repository includes `packages/smtp-relay`, a standalone Bun service that accepts SMTP AUTH with an OpenSend API key as the password and injects accepted messages into the normal send pipeline. It is available in Docker Compose only behind the explicit `smtp` profile:
+
+```bash
+docker compose --profile smtp up -d smtp-relay
+```
+
+The relay publishes `SMTP_RELAY_PORT` (default `2587`) and requires `DATABASE_URL`. `BACKGROUND_JOBS_QUEUE_URL` is optional for local evaluation but should match the app/ingester queue in production. Accepted SMTP messages only enter the normal delivery worker path when `BACKGROUND_JOBS_QUEUE_URL` is configured; without a queue URL, rows can be accepted for local evaluation but delivery is skipped until the queue contract is wired. Configure `SMTP_RELAY_TLS_CERT_PATH` and `SMTP_RELAY_TLS_KEY_PATH` before exposing STARTTLS publicly.
 
 ## Splitting the ingester service
 

--- a/packages/smtp-relay/README.md
+++ b/packages/smtp-relay/README.md
@@ -40,6 +40,22 @@ DATABASE_URL=postgres://... bun packages/smtp-relay/src/index.ts
 
 ## Running with Docker
 
+The repository `docker-compose.yml` exposes the relay behind the explicit
+`smtp` profile so it does not run in the default stack:
+
+```bash
+docker compose --profile smtp up -d smtp-relay
+```
+
+Set `SMTP_RELAY_PORT` to change the published/listen port. Configure TLS paths
+only when the referenced certificate/key files are mounted into the relay
+container. Accepted SMTP messages only enter the normal delivery worker path
+when `BACKGROUND_JOBS_QUEUE_URL` is configured; without a queue URL, rows can
+be accepted for local evaluation but delivery is skipped until the queue
+contract is wired.
+
+For a standalone image:
+
 ```bash
 docker build \
   --platform linux/amd64 \

--- a/public/docs/security.md
+++ b/public/docs/security.md
@@ -39,14 +39,15 @@ Use unique 32+ character secrets for `INGESTER_JOB_TOKEN` and `INGESTER_INBOUND_
 
 ## Rate limiting
 
-API rate limiting is enforced in Next.js middleware. Local single-process evaluation can use the default memory behavior. Shared and production deployments should use Redis:
+API rate limiting is enforced in Next.js middleware. Outside Docker Compose, an unset backend is treated as `disabled` for single-process local development. Shared, production, and multi-replica deployments should use Redis:
 
 ```env
 RATE_LIMIT_BACKEND=redis
 REDIS_URL=rediss://default:<password>@your-cache-endpoint:6379
+OPENSEND_APP_REPLICAS=2
 ```
 
-When Redis-backed rate limiting is selected, keep Redis private to the runtime network and use TLS endpoints.
+The reference Docker Compose stack starts Redis and defaults the app to `RATE_LIMIT_BACKEND=redis`. For other deployments, `REDIS_URL` alone does not enable rate limiting; set `RATE_LIMIT_BACKEND=redis` explicitly. Keep Redis private to the runtime network and use TLS endpoints for managed production Redis.
 
 ## Secret management
 

--- a/public/docs/self-hosting.md
+++ b/public/docs/self-hosting.md
@@ -10,9 +10,11 @@ Docker Compose starts the same service boundaries used by production deployments
 
 - `app`: Next.js dashboard and public API on port `3015`.
 - `postgres`: OpenSend application database.
+- `redis`: shared rate limiting and cache coordination for the Compose stack.
 - `migrate`: one-shot Drizzle migration runner.
 - `ingester`: SES/SNS event receiver and background worker on port `3016`.
 - `scheduler`: sidecar that triggers ingester `/jobs/*` scans.
+- `smtp-relay`: optional SMTP compatibility service, started only with the `smtp` profile.
 
 Production deployments can run these as separate services on ECS, Fly, Railway, Cloud Run, Kubernetes, or a single VM. Keep app traffic pointed at the Next.js service, and point SES/SNS event webhooks at the ingester.
 
@@ -65,7 +67,7 @@ Production values to plan before real traffic:
 | Background jobs | `BACKGROUND_JOBS_QUEUE_URL`, `BACKGROUND_JOBS_REQUIRE_QUEUE=true`, `BACKGROUND_WORKER_POLL=true` on the ingester |
 | Scheduler auth | `INGESTER_JOB_TOKEN`, `INGESTER_SCHEDULER_INTERVAL_SECONDS` |
 | Inbound receiving | `INGESTER_INBOUND_TOKEN` when `/events/inbound` is exposed, plus `SES_INBOUND_SNS_TOPIC_ARN` and `S3_BUCKET_NAME` or `SES_INBOUND_BUCKET_NAME` for SES receipt-rule ingestion |
-| Rate limiting/cache | `RATE_LIMIT_BACKEND=redis`, `REDIS_URL` |
+| Rate limiting/cache | `RATE_LIMIT_BACKEND=redis`, `REDIS_URL`, `OPENSEND_APP_REPLICAS` |
 | Secret encryption | `WEBHOOK_SECRET_ENCRYPTION_KEY`, optional `INTEGRATION_SECRET_ENCRYPTION_KEY`, optional DKIM encryption key variables |
 | Observability | Sentry, PostHog, CloudWatch, or OTel variables you explicitly configure |
 
@@ -105,14 +107,29 @@ Local evaluation can run without SQS; rows are still persisted, but production d
 
 ## Rate limiting and cache
 
-Single-process local evaluation can use the default memory behavior. Shared or production deployments should use Redis:
+The Docker Compose stack starts Redis and sets the app to use Redis-backed rate limiting by default:
 
 ```env
 RATE_LIMIT_BACKEND=redis
-REDIS_URL=rediss://default:<password>@your-cache-endpoint:6379
+REDIS_URL=redis://redis:6379
+OPENSEND_APP_REPLICAS=1
 ```
 
-Redis backs API rate limiting plus hot-path auth and domain metadata caches. Use a TLS endpoint and keep it private to your runtime network.
+Outside Compose, an unset `RATE_LIMIT_BACKEND` is treated as `disabled` so single-process local development does not unexpectedly require Redis. Any shared, staging, production, or multi-replica deployment should set `RATE_LIMIT_BACKEND=redis` and point `REDIS_URL` at a shared Redis endpoint. Use `rediss://...` for managed production Redis and keep it private to your runtime network.
+
+Set `OPENSEND_APP_REPLICAS` to the number of app containers you expect to run. Startup checks warn when this value is greater than `1` and Redis-backed rate limiting is not enabled. `REDIS_URL` alone does not enable rate limiting; `RATE_LIMIT_BACKEND=redis` is required.
+
+Redis backs API rate limiting plus hot-path auth/domain metadata caches and ingester domain-cache invalidation. If Redis is selected for rate limiting but unavailable, API requests fail closed with HTTP 503 instead of silently downgrading to a per-process limiter.
+
+## SMTP relay profile
+
+The SMTP relay is available in the reference Compose file but is not part of the default footprint. Enable it only when an application must submit mail over SMTP:
+
+```bash
+docker compose --profile smtp up -d smtp-relay
+```
+
+By default the relay publishes port `2587` and authenticates with OpenSend API keys as SMTP passwords. It requires the same Postgres database as the app. `BACKGROUND_JOBS_QUEUE_URL` is optional for local evaluation but should match the app/ingester queue in production. Accepted SMTP messages only enter the normal delivery worker path when `BACKGROUND_JOBS_QUEUE_URL` is configured; without a queue URL, rows can be accepted for local evaluation but delivery is skipped until the queue contract is wired. Configure `SMTP_RELAY_TLS_CERT_PATH` and `SMTP_RELAY_TLS_KEY_PATH` before advertising STARTTLS on a public relay.
 
 ## Privacy and telemetry
 
@@ -130,6 +147,8 @@ Before sending real production traffic:
 6. If using receiving, confirm the inbound SNS topic reaches `/events/inbound/ses-s3` and SES can write raw MIME to the configured bucket.
 7. Confirm scheduled jobs run with the same `INGESTER_JOB_TOKEN` configured on the scheduler and ingester.
 8. Confirm rate limiting, queue, integration encryption, and secret-manager variables are set for shared deployments.
+9. If scaling app containers beyond one, set `OPENSEND_APP_REPLICAS` and verify all replicas share the same Redis.
+10. If enabling SMTP, start the `smtp` profile and send a message through port `2587` with an OpenSend API key as the password.
 
 Useful local checks:
 

--- a/public/docs/send-with-smtp.md
+++ b/public/docs/send-with-smtp.md
@@ -91,6 +91,11 @@ The relay is a standalone Bun service in `packages/smtp-relay/`. Run it
 alongside the main app or as a separate container:
 
 ```bash
+# Docker Compose profile
+docker compose --profile smtp up -d smtp-relay
+```
+
+```bash
 # Standalone
 DATABASE_URL=postgres://... \
 BACKGROUND_JOBS_QUEUE_URL=https://sqs... \
@@ -111,8 +116,7 @@ docker run --rm \
   opensend-smtp-relay
 ```
 
-See `packages/smtp-relay/README.md` for the full list of environment variables
-and STARTTLS configuration.
+The Compose profile uses the same Postgres database as the app, publishes `SMTP_RELAY_PORT` (default `2587`), and is not started by default. Accepted SMTP messages only enter the normal delivery worker path when `BACKGROUND_JOBS_QUEUE_URL` is configured; without a queue URL, rows can be accepted for local evaluation but delivery is skipped until the queue contract is wired. See `packages/smtp-relay/README.md` for the full list of environment variables and STARTTLS configuration.
 
 ## Limitations
 

--- a/src/lib/startup-checks.ts
+++ b/src/lib/startup-checks.ts
@@ -101,18 +101,44 @@ function requireIntegrationSecretKey(logger: Logger): void {
   }
 }
 
+function getConfiguredAppReplicas(): number {
+  const raw = process.env.OPENSEND_APP_REPLICAS?.trim();
+  if (!raw) return 1;
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return 1;
+  return parsed;
+}
+
 function warnIfRateLimitDisabled(logger: Logger): void {
-  if (!isProd()) return;
-  const backend = (process.env.RATE_LIMIT_BACKEND ?? "").toLowerCase();
+  const backend = (process.env.RATE_LIMIT_BACKEND ?? "").trim().toLowerCase();
   if (backend === "redis") return;
-  if (backend === "" && process.env.REDIS_URL) return;
-  logger.warn(
-    {
-      event: "security.rate_limit.disabled_in_production",
-      backend: backend || "disabled",
-    },
-    "Rate limiting backend is disabled in production — set REDIS_URL or RATE_LIMIT_BACKEND=redis",
-  );
+
+  const appReplicas = getConfiguredAppReplicas();
+  const backendLabel = backend || "disabled";
+
+  if (isProd()) {
+    logger.warn(
+      {
+        event: "security.rate_limit.disabled_in_production",
+        backend: backendLabel,
+        appReplicas,
+      },
+      "Rate limiting backend is disabled in production — set RATE_LIMIT_BACKEND=redis and REDIS_URL to a shared Redis endpoint",
+    );
+    return;
+  }
+
+  if (appReplicas > 1) {
+    logger.warn(
+      {
+        event: "security.rate_limit.disabled_in_multi_instance",
+        backend: backendLabel,
+        appReplicas,
+      },
+      "Multiple app replicas are configured without Redis-backed rate limiting — set RATE_LIMIT_BACKEND=redis and REDIS_URL to a shared Redis endpoint",
+    );
+  }
 }
 
 function requirePostgresPassword(logger: Logger): void {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -186,6 +186,31 @@ describe("deploy-001: ECS Fargate deployment configuration", () => {
     expect(compose).toContain("http://127.0.0.1:3016/health");
   });
 
+  it("docker-compose wires Redis-backed rate limiting by default", () => {
+    const compose = readFileSync(join(root, "docker-compose.yml"), "utf-8");
+    expect(compose).toContain("redis:");
+    expect(compose).toContain("image: redis:7-alpine");
+    expect(compose).toContain("REDIS_URL: ${REDIS_URL:-redis://redis:6379}");
+    expect(compose).toContain(
+      "RATE_LIMIT_BACKEND: ${RATE_LIMIT_BACKEND:-redis}",
+    );
+    expect(compose).toContain(
+      "OPENSEND_APP_REPLICAS: ${OPENSEND_APP_REPLICAS:-1}",
+    );
+    expect(compose).toContain("redisdata:");
+  });
+
+  it("docker-compose keeps the SMTP relay behind an explicit profile", () => {
+    const compose = readFileSync(join(root, "docker-compose.yml"), "utf-8");
+    expect(compose).toContain("smtp-relay:");
+    expect(compose).toContain('profiles: ["smtp"]');
+    expect(compose).toContain("dockerfile: packages/smtp-relay/Dockerfile");
+    expect(compose).toContain(
+      '"${SMTP_RELAY_PORT:-2587}:${SMTP_RELAY_PORT:-2587}"',
+    );
+    expect(compose).not.toContain("smtp-relay:\n    image:");
+  });
+
   it("ingester Dockerfile builds a standalone server bundle", () => {
     const dockerfile = readFileSync(
       join(root, "packages", "ingester", "Dockerfile"),

--- a/tests/security-startup-checks.test.ts
+++ b/tests/security-startup-checks.test.ts
@@ -32,6 +32,7 @@ const ENV_KEYS = [
   "WEBHOOK_SECRET_ENCRYPTION_KEY",
   "RATE_LIMIT_BACKEND",
   "REDIS_URL",
+  "OPENSEND_APP_REPLICAS",
   "DATABASE_URL",
   "POSTGRES_PASSWORD_ENFORCE_CHANGE",
 ];
@@ -83,7 +84,7 @@ describe("startup-checks", () => {
     ).toBe(true);
   });
 
-  it("does not warn about rate limit when REDIS_URL set", () => {
+  it("warns in production when only REDIS_URL is set without redis backend", () => {
     vi.stubEnv("NODE_ENV", "production");
     process.env.BETTER_AUTH_SECRET = "x".repeat(32);
     process.env.WEBHOOK_SECRET_ENCRYPTION_KEY = "x".repeat(32);
@@ -93,6 +94,49 @@ describe("startup-checks", () => {
     expect(
       logs.some(
         (l) => l.data.event === "security.rate_limit.disabled_in_production",
+      ),
+    ).toBe(true);
+  });
+
+  it("warns for multiple app replicas outside production when redis backend is disabled", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    process.env.WEBHOOK_SECRET_ENCRYPTION_KEY = "x".repeat(32);
+    process.env.OPENSEND_APP_REPLICAS = "2";
+    const { logs, logger } = makeLogger();
+    runStartupChecks(logger);
+    expect(
+      logs.some(
+        (l) =>
+          l.data.event === "security.rate_limit.disabled_in_multi_instance" &&
+          l.data.appReplicas === 2,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not warn for multiple app replicas when redis backend is selected", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    process.env.WEBHOOK_SECRET_ENCRYPTION_KEY = "x".repeat(32);
+    process.env.OPENSEND_APP_REPLICAS = "2";
+    process.env.RATE_LIMIT_BACKEND = "redis";
+    process.env.REDIS_URL = "redis://localhost:6379";
+    const { logs, logger } = makeLogger();
+    runStartupChecks(logger);
+    expect(
+      logs.some((l) =>
+        String(l.data.event ?? "").startsWith("security.rate_limit."),
+      ),
+    ).toBe(false);
+  });
+
+  it("treats malformed OPENSEND_APP_REPLICAS as a single local app", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    process.env.WEBHOOK_SECRET_ENCRYPTION_KEY = "x".repeat(32);
+    process.env.OPENSEND_APP_REPLICAS = "not-a-number";
+    const { logs, logger } = makeLogger();
+    runStartupChecks(logger);
+    expect(
+      logs.some((l) =>
+        String(l.data.event ?? "").startsWith("security.rate_limit."),
       ),
     ).toBe(false);
   });


### PR DESCRIPTION
## Summary
- Add Redis to the default Docker Compose topology with persistence/healthcheck, and wire the Compose app/ingester to `redis://redis:6379`.
- Default Compose app rate limiting to `RATE_LIMIT_BACKEND=redis`, while preserving non-Compose single-process behavior where unset backend remains disabled.
- Add startup warnings for production or multi-replica (`OPENSEND_APP_REPLICAS>1`) configs that are not using Redis-backed rate limiting.
- Add the existing `packages/smtp-relay` service behind the explicit `smtp` Compose profile with honest queue/TLS caveats.
- Update self-hosting/security/SMTP docs and README guidance for single-instance → multi-instance graduation.

Closes #644

## Validation
- `bun run docs:generate` — indexed 216 markdown docs.
- `git diff --check` — pass.
- `docker compose --env-file .env.example config --quiet` — pass.
- `docker compose --env-file .env.example config --services` — default services: `postgres`, `migrate`, `redis`, `app`, `ingester`, `scheduler`.
- `docker compose --env-file .env.example --profile smtp config --quiet` — pass.
- `docker compose --env-file .env.example --profile smtp config --services` — includes `smtp-relay`.
- `bun run test tests/security-startup-checks.test.ts tests/deploy.test.ts` — 32 passed.
- `make check && make test` — TypeCheck passed; Biome checked 805 files; Vitest 212 files passed / 3 skipped, 1737 tests passed / 10 skipped.
- Push hook: change-scoped guardrails passed; full-project typecheck passed; changed-file Biome passed.

## Review / QA evidence
- `$ralplan` consensus gate completed: Architect APPROVE, Critic APPROVE (`.omx/plans/issue-644-ralplan-handoff.json`).
- `$ultraqa` report completed (`.omx/reports/issue-644-ultraqa.md`): Compose config/profile checks, targeted startup/deploy tests, full validation, and docs drift checks passed.
- Independent `code-reviewer`: APPROVE, 0 issues.
- Independent `architect`: CLEAR; only advisory caveat is that `OPENSEND_APP_REPLICAS` is an operator-provided hint, not runtime topology discovery.

## Caveats
- Did not run `docker compose up`; validation used deterministic `docker compose config` and service-list checks.
- Did not run browser/E2E proof; this change is Compose/runtime/docs/test coverage, not a UI flow.
- SMTP relay remains profile-gated and requires queue wiring for real delivery; docs call this out explicitly.
