### PR TITLE
Prepare v1.0.0 release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# ABOUTME: Tag-triggered release workflow — version-sync gate + GitHub Release on `v*` tags.
+# ABOUTME: Tag-triggered release workflow — version-sync gate, GHCR images, curated GitHub Release.
 name: Release
 
 on:
@@ -8,64 +8,102 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  APP_IMAGE: ghcr.io/namuh-eng/opensend
+  INGESTER_IMAGE: ghcr.io/namuh-eng/opensend-ingester
 
 jobs:
   verify-version-sync:
     name: Verify Version Sync
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      tag: ${{ steps.release-meta.outputs.tag }}
+      version: ${{ steps.release-meta.outputs.version }}
+      release_notes: ${{ steps.release-meta.outputs.release_notes }}
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - name: Verify package versions match tag
+      - name: Verify package versions and curated release notes match tag
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: node tools/verify-release-version-sync.mjs --tag "$GITHUB_REF_NAME" --require-release-notes
+
+      - name: Export release metadata
+        id: release-meta
         env:
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
-          node --input-type=module <<'EOF'
-          import fs from 'node:fs';
-          import path from 'node:path';
+          version="${GITHUB_REF_NAME#v}"
+          release_notes="docs/release-notes/${GITHUB_REF_NAME}.md"
+          {
+            echo "tag=${GITHUB_REF_NAME}"
+            echo "version=${version}"
+            echo "release_notes=${release_notes}"
+          } >> "$GITHUB_OUTPUT"
 
-          const root = process.cwd();
-          const tag = process.env.GITHUB_REF_NAME ?? '';
-          const expected = tag.replace(/^v/, '');
+  build-and-push-images:
+    name: Build and Push Multi-arch Images
+    needs: [verify-version-sync]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
 
-          const synced = [
-            'package.json',
-            'packages/core/package.json',
-            'packages/ingester/package.json',
-          ];
+      - uses: docker/setup-qemu-action@v3
 
-          const problems = [];
+      - uses: docker/setup-buildx-action@v3
 
-          if (!/^v\d+\.\d+\.\d+(?:-[\w.]+)?$/.test(tag)) {
-            problems.push(`tag "${tag}" is not a valid semver vX.Y.Z(-suffix)`);
-          }
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
-          for (const rel of synced) {
-            const pkg = JSON.parse(fs.readFileSync(path.join(root, rel), 'utf-8'));
-            if (pkg.version !== expected) {
-              problems.push(`${rel} version (${pkg.version}) does not match tag (${expected})`);
-            }
-          }
+      - name: Build and push app image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          target: runner
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.APP_IMAGE }}:${{ needs.verify-version-sync.outputs.tag }}
+            ${{ env.APP_IMAGE }}:${{ needs.verify-version-sync.outputs.version }}
 
-          if (problems.length > 0) {
-            for (const p of problems) console.error(`[version-sync] ${p}`);
-            process.exit(1);
-          }
+      - name: Build and push ingester image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./packages/ingester/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.INGESTER_IMAGE }}:${{ needs.verify-version-sync.outputs.tag }}
+            ${{ env.INGESTER_IMAGE }}:${{ needs.verify-version-sync.outputs.version }}
 
-          console.log(`[version-sync] OK tag=${tag} root/core/ingester=${expected}`);
-          console.log('[version-sync] note: packages/sdk has an independent version cadence and is not gated here.');
-          EOF
+      - name: Verify pushed multi-arch manifests
+        env:
+          TAG: ${{ needs.verify-version-sync.outputs.tag }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "${APP_IMAGE}:${TAG}"
+          docker buildx imagetools inspect "${INGESTER_IMAGE}:${TAG}"
 
   publish-release:
     name: Publish GitHub Release
-    needs: [verify-version-sync]
+    needs: [verify-version-sync, build-and-push-images]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -76,13 +114,26 @@ jobs:
       - name: Create or update GitHub Release for tag
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ needs.verify-version-sync.outputs.tag }}
+          RELEASE_NOTES: ${{ needs.verify-version-sync.outputs.release_notes }}
+          TARGET_SHA: ${{ github.sha }}
         run: |
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release for $TAG already exists; leaving body untouched."
-            exit 0
+          set -euo pipefail
+          prerelease_flag=()
+          if [[ "$TAG" == *-* ]]; then
+            prerelease_flag=(--prerelease)
           fi
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --target main \
-            --generate-notes
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --title "$TAG" \
+              --target "$TARGET_SHA" \
+              --notes-file "$RELEASE_NOTES" \
+              "${prerelease_flag[@]}"
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --target "$TARGET_SHA" \
+              --notes-file "$RELEASE_NOTES" \
+              "${prerelease_flag[@]}"
+          fi

--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ Compose starts:
 
 ### v1.0.0 release artifacts
 
-The repository defaults to source-built Docker Compose so local evaluation works before a release image exists. The authorized `v1.0.0` tag workflow publishes pinned multi-arch GHCR images for production operators:
+The authorized `v1.0.0` tag workflow publishes pinned multi-arch GHCR images, and the default Compose file uses those exact tags for reproducible self-host deploys:
 
 - `ghcr.io/namuh-eng/opensend:v1.0.0` — app/API/dashboard
 - `ghcr.io/namuh-eng/opensend-ingester:v1.0.0` — ingester and scheduler bundle
 
-The workflow also publishes `:1.0.0` aliases and intentionally does not publish `:latest`. Use pinned tags in production, and keep the default Compose build path for local source evaluation. The release notes and runbook live in [`docs/release-notes/v1.0.0.md`](docs/release-notes/v1.0.0.md).
+The workflow also publishes `:1.0.0` aliases and intentionally does not publish `:latest`. For local source-build evaluation, run `docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build`. The release notes and runbook live in [`docs/release-notes/v1.0.0.md`](docs/release-notes/v1.0.0.md).
 
 For real email delivery, add AWS SES credentials and verify a sending domain. For dashboard login, add Google OAuth credentials.
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ Compose starts:
 - `scheduler`: scheduled job trigger sidecar
 - optional `smtp-relay`: SMTP compatibility service, only with `docker compose --profile smtp up -d smtp-relay`
 
+### v1.0.0 release artifacts
+
+The repository defaults to source-built Docker Compose so local evaluation works before a release image exists. The authorized `v1.0.0` tag workflow publishes pinned multi-arch GHCR images for production operators:
+
+- `ghcr.io/namuh-eng/opensend:v1.0.0` — app/API/dashboard
+- `ghcr.io/namuh-eng/opensend-ingester:v1.0.0` — ingester and scheduler bundle
+
+The workflow also publishes `:1.0.0` aliases and intentionally does not publish `:latest`. Use pinned tags in production, and keep the default Compose build path for local source evaluation. The release notes and runbook live in [`docs/release-notes/v1.0.0.md`](docs/release-notes/v1.0.0.md).
+
 For real email delivery, add AWS SES credentials and verify a sending domain. For dashboard login, add Google OAuth credentials.
 
 For local development without the full app container:

--- a/agent_docs/learnings/active/2026-06-18-issue-642-v1-release-pinned-images.md
+++ b/agent_docs/learnings/active/2026-06-18-issue-642-v1-release-pinned-images.md
@@ -1,0 +1,20 @@
+---
+date: 2026-06-18
+issue: "#642"
+type: decision
+promoted_to: null
+---
+
+## v1 release publishes pinned images, but default Compose stays source-built until images exist
+
+Issue #642 needs versioned app and ingester images plus pinned-image guidance, but
+this worker must not push the real `v1.0.0` tag or publish images. Switching the
+checked-in `docker-compose.yml` defaults to `ghcr.io/namuh-eng/opensend:v1.0.0`
+before the authorized tag runs would break fresh-clone evaluation because those
+images do not exist yet.
+
+Chosen path: prepare the tag workflow to publish multi-arch GHCR app and ingester
+images, document exact pinned image replacements in README/self-hosting/ingester
+deploy docs, and keep default Compose source-built. After Jaeyun/controller runs
+the real release and smoke-tests the images, maintainers can decide whether to
+flip Compose defaults or add a dedicated release Compose file.

--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
     },
     "packages/core": {
       "name": "@opensend/core",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.1019.0",
         "lru-cache": "^11.0.0",
@@ -72,7 +72,7 @@
     },
     "packages/ingester": {
       "name": "@opensend/ingester",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@opensend/core": "workspace:*",
         "redis": "^5.12.1",

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,30 @@
+# Local source-build override for OpenSend development/evaluation.
+#
+# Default `docker compose up -d` uses pinned release images for app, ingester,
+# and scheduler. Use this file only when you intentionally want to build the app
+# and ingester from the checked-out source tree:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
+#
+# The optional smtp-relay and one-shot migrator are already build-local in the
+# base Compose file because v1.0.0 does not publish separate relay or migrator
+# images.
+
+services:
+  app:
+    image: opensend:local
+    build:
+      context: .
+      target: runner
+
+  ingester:
+    image: opensend-ingester:local
+    build:
+      context: .
+      dockerfile: packages/ingester/Dockerfile
+
+  scheduler:
+    image: opensend-ingester:local
+    build:
+      context: .
+      dockerfile: packages/ingester/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,14 @@
 #
 # To wipe the local database and start fresh:
 #   docker compose down -v
+#
+# Release images:
+#   This file builds from source by default so local evaluation works from a fresh clone.
+#   After the authorized v1.0.0 release publishes images, production operators can
+#   replace the app build block with `image: ghcr.io/namuh-eng/opensend:v1.0.0`
+#   and use `image: ghcr.io/namuh-eng/opensend-ingester:v1.0.0` for ingester
+#   and scheduler while keeping the same environment, ports, health checks, and
+#   dependencies. Run migrations before rolling app or ingester containers.
 
 name: opensend-staging
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,12 +43,13 @@
 #   docker compose down -v
 #
 # Release images:
-#   This file builds from source by default so local evaluation works from a fresh clone.
-#   After the authorized v1.0.0 release publishes images, production operators can
-#   replace the app build block with `image: ghcr.io/namuh-eng/opensend:v1.0.0`
-#   and use `image: ghcr.io/namuh-eng/opensend-ingester:v1.0.0` for ingester
-#   and scheduler while keeping the same environment, ports, health checks, and
-#   dependencies. Run migrations before rolling app or ingester containers.
+#   Default Compose pins the v1.0.0 app and ingester GHCR images so self-hosters
+#   get reproducible deploys instead of local source builds. For local source
+#   evaluation, use the explicit override:
+#     docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
+#   The migrator and optional smtp-relay still build locally because the release
+#   workflow does not publish separate migrator or SMTP relay images. Run
+#   migrations before rolling app or ingester containers.
 
 name: opensend-staging
 
@@ -102,10 +103,10 @@ services:
 
   # Next.js dashboard and REST API. Container listens on 8080; published to ${PORT:-3015}
   # on the host. AWS_* and CLOUDFLARE_* are optional — leave unset for a basic local stack.
+  # Default self-host deploys use the pinned v1.0.0 GHCR image. Use
+  # docker-compose.local.yml when you intentionally want to build app code locally.
   app:
-    build:
-      context: .
-      target: runner
+    image: ghcr.io/namuh-eng/opensend:v1.0.0
     restart: unless-stopped
     ports:
       - "${PORT:-3015}:8080"
@@ -152,10 +153,7 @@ services:
   #   http://<host>:${INGESTER_PORT:-3016}/webhooks/stripe
   # Set BACKGROUND_WORKER_POLL=true to enable the SQS long-poll loop in this container.
   ingester:
-    image: opensend-ingester:local
-    build:
-      context: .
-      dockerfile: packages/ingester/Dockerfile
+    image: ghcr.io/namuh-eng/opensend-ingester:v1.0.0
     restart: unless-stopped
     ports:
       - "${INGESTER_PORT:-3016}:3016"
@@ -207,6 +205,8 @@ services:
   # Optional SMTP compatibility relay. It is profile-gated so the default
   # Compose footprint remains app + ingester + scheduler + data services.
   # Enable with: docker compose --profile smtp up -d smtp-relay
+  # No official SMTP relay image is published in v1.0.0, so this profile remains
+  # build-local until a future release workflow publishes a relay image.
   smtp-relay:
     profiles: ["smtp"]
     image: opensend-smtp-relay:local
@@ -239,7 +239,7 @@ services:
   #   - /jobs/billing-overage
   # The scheduler sends Authorization: Bearer <INGESTER_JOB_TOKEN>.
   scheduler:
-    image: opensend-ingester:local
+    image: ghcr.io/namuh-eng/opensend-ingester:v1.0.0
     restart: unless-stopped
     command: ["bun", "/app/job-scheduler.js"]
     environment:

--- a/docs/ingester-deploy.md
+++ b/docs/ingester-deploy.md
@@ -39,18 +39,20 @@ and SQS:
 
 | Service | Image source | Public host (example) | Port |
 | --- | --- | --- | --- |
-| App | `ghcr.io/namuh-eng/opensend:v1.0.0` after the authorized v1.0.0 release; otherwise build the root `Dockerfile` `runner` target into your registry | `app.yourdomain.com` and `api.app.yourdomain.com` | `8080` |
-| Ingester | `ghcr.io/namuh-eng/opensend-ingester:v1.0.0` after the authorized v1.0.0 release; otherwise build `packages/ingester/Dockerfile` into your registry | `events.app.yourdomain.com` | `3016` |
+| App | `ghcr.io/namuh-eng/opensend:v1.0.0`; use `docker-compose.local.yml` or your own registry tag when building from source | `app.yourdomain.com` and `api.app.yourdomain.com` | `8080` |
+| Ingester | `ghcr.io/namuh-eng/opensend-ingester:v1.0.0`; scheduler uses the same image with `bun /app/job-scheduler.js` | `events.app.yourdomain.com` | `3016` |
 
 If your platform has host-based routing (AWS ALB, GCP Load Balancer, Cloudflare
 Spectrum), point each hostname at its target service. The events host has to
 be reachable from the public internet so SES SNS can deliver to it.
 
 The GitHub release workflow publishes the official app and ingester images on
-`v*` tags. The ingester process only consumes the image at runtime; it does not
-publish Docker images. The workflow publishes `:v1.0.0` and `:1.0.0` tags and
-intentionally does not publish `:latest`, so production deployments should pin
-the exact release tag they have validated.
+`v*` tags. The default `docker-compose.yml` pins those app, ingester, and
+scheduler tags for reproducible self-host deploys. The ingester process only
+consumes the image at runtime; it does not publish Docker images. The workflow
+publishes `:v1.0.0` and `:1.0.0` tags and intentionally does not publish
+`:latest`, so production deployments should pin the exact release tag they have
+validated.
 
 For forks, private registries, or pre-release validation, build images yourself.
 Use `linux/amd64` for amd64 production targets even from M-chip Macs, or include

--- a/docs/ingester-deploy.md
+++ b/docs/ingester-deploy.md
@@ -39,34 +39,48 @@ and SQS:
 
 | Service | Image source | Public host (example) | Port |
 | --- | --- | --- | --- |
-| App | `Dockerfile` (default target) | `app.yourdomain.com` and `api.app.yourdomain.com` | `8080` |
-| Ingester | `packages/ingester/Dockerfile` | `events.app.yourdomain.com` | `3016` |
+| App | `ghcr.io/namuh-eng/opensend:v1.0.0` after the authorized v1.0.0 release; otherwise build the root `Dockerfile` `runner` target into your registry | `app.yourdomain.com` and `api.app.yourdomain.com` | `8080` |
+| Ingester | `ghcr.io/namuh-eng/opensend-ingester:v1.0.0` after the authorized v1.0.0 release; otherwise build `packages/ingester/Dockerfile` into your registry | `events.app.yourdomain.com` | `3016` |
 
 If your platform has host-based routing (AWS ALB, GCP Load Balancer, Cloudflare
 Spectrum), point each hostname at its target service. The events host has to
 be reachable from the public internet so SES SNS can deliver to it.
 
-Build images for `linux/amd64` even from M-chip Macs:
+The GitHub release workflow publishes the official app and ingester images on
+`v*` tags. The ingester process only consumes the image at runtime; it does not
+publish Docker images. The workflow publishes `:v1.0.0` and `:1.0.0` tags and
+intentionally does not publish `:latest`, so production deployments should pin
+the exact release tag they have validated.
+
+For forks, private registries, or pre-release validation, build images yourself.
+Use `linux/amd64` for amd64 production targets even from M-chip Macs, or include
+both supported release platforms when you need a multi-arch manifest:
 
 ```bash
-docker buildx build --platform linux/amd64 \
-  -t yourorg/opensend-app:latest --push .
+docker buildx build --platform linux/amd64,linux/arm64 \
+  --target runner \
+  -t yourorg/opensend-app:v1.0.0 --push .
 
-docker buildx build --platform linux/amd64 \
+docker buildx build --platform linux/amd64,linux/arm64 \
   -f packages/ingester/Dockerfile \
-  -t yourorg/opensend-ingester:latest --push .
+  -t yourorg/opensend-ingester:v1.0.0 --push .
+
+docker buildx imagetools inspect yourorg/opensend-app:v1.0.0
+docker buildx imagetools inspect yourorg/opensend-ingester:v1.0.0
 ```
 
 Run a one-shot migrator container against the production `DATABASE_URL`
 **before** redeploying the app or ingester when the change includes schema
-migrations:
+migrations. The v1.0.0 release workflow does not publish a separate migrator
+image, so build the root Dockerfile `migrator` target into your registry when
+your platform needs an image-only migration job:
 
 ```bash
 docker buildx build --platform linux/amd64 --target migrator \
-  -t yourorg/opensend-migrator:latest --push .
+  -t yourorg/opensend-migrator:v1.0.0 --push .
 
 # Run once against production DB
-docker run --rm --env DATABASE_URL=... yourorg/opensend-migrator:latest
+docker run --rm --env DATABASE_URL=... yourorg/opensend-migrator:v1.0.0
 ```
 
 ## Background job worker

--- a/docs/release-notes/v1.0.0.md
+++ b/docs/release-notes/v1.0.0.md
@@ -1,0 +1,132 @@
+# OpenSend v1.0.0 release notes
+
+> **Release gate:** this file prepares the curated body for the first formal
+> OpenSend release. This PR does not publish the `v1.0.0` tag, create the real
+> GitHub Release, or push Docker images. Those actions remain a
+> Jaeyun/controller-authorized release gate after the repo-side changes merge.
+
+## Highlights
+
+OpenSend v1.0.0 is the first formal self-hostable release of the email platform:
+
+- Next.js dashboard and REST API for transactional email, domains, API keys,
+  audiences, broadcasts, automations, templates, logs, suppressions, receiving,
+  billing surfaces, and operational settings.
+- Standalone Bun/Hono ingester for SES/SNS feedback, inbound receiving events,
+  scheduled jobs, webhook retries, domain verification scans, billing overage
+  scans, and queue-backed email workers.
+- Docker Compose reference stack with Postgres, Redis, one-shot migrations, app,
+  ingester, scheduler, and an optional SMTP relay profile.
+- First-party SDK and API docs for TypeScript plus in-repo Python, Go, Ruby,
+  PHP, JVM, MCP, SMTP, and REST integration guidance at their current maturity.
+- Production-oriented guardrails for migrations, Redis-backed rate limiting,
+  webhook secret encryption, SES deliverability feedback, SQS background jobs,
+  and zero-phone-home self-hosting defaults.
+
+## Version and image artifacts
+
+The release workflow verifies these package versions against the pushed tag:
+
+- `package.json` — `1.0.0`
+- `packages/core/package.json` — `1.0.0`
+- `packages/ingester/package.json` — `1.0.0`
+
+Language SDK package registries are intentionally not published as part of this
+release. SDK packages and examples that still show pre-1.0 versions keep their
+own release cadence until their registry publishing work is complete.
+
+When an authorized maintainer pushes `v1.0.0`, the release workflow publishes
+multi-arch GHCR images for `linux/amd64` and `linux/arm64`:
+
+- App/API/dashboard: `ghcr.io/namuh-eng/opensend:v1.0.0`
+- App/API/dashboard alias: `ghcr.io/namuh-eng/opensend:1.0.0`
+- Ingester/scheduler: `ghcr.io/namuh-eng/opensend-ingester:v1.0.0`
+- Ingester/scheduler alias: `ghcr.io/namuh-eng/opensend-ingester:1.0.0`
+
+No `latest` tag is published by the release workflow. Operators should pin the
+exact version tag they have validated.
+
+## Upgrade notes
+
+1. Back up the production database before upgrading.
+2. Run committed Drizzle migrations before deploying app or ingester code that
+   expects new columns.
+3. Replace local `.env.example` placeholders before any shared or production
+   deployment: `BETTER_AUTH_SECRET`, `INGESTER_JOB_TOKEN`, and
+   `WEBHOOK_SECRET_ENCRYPTION_KEY` must be real generated secrets.
+4. Use Redis-backed rate limiting for shared, staging, production, or
+   multi-replica app deployments: set `RATE_LIMIT_BACKEND=redis` and point
+   `REDIS_URL` at a shared Redis endpoint.
+5. Point SES/SNS and inbound receiving callbacks at the ingester service, not
+   the Next.js app URL.
+6. Keep the scheduler and ingester on the same `INGESTER_JOB_TOKEN` so `/jobs/*`
+   scans can run.
+7. For production pinned-image deploys, run a migrator image built from the
+   root Dockerfile `migrator` target before rolling the app and ingester.
+
+## Known limitations and caveats
+
+- OpenSend Cloud billing surfaces are present, but self-hosted deployments keep
+  `BILLING_BACKEND` unset or `disabled` unless they intentionally wire Stripe.
+- SDK registries outside the TypeScript package are at different maturity levels
+  and are not part of this v1.0.0 release publication gate.
+- The reference `docker-compose.yml` remains source-built by default so local
+  evaluation works before the release images exist. Production operators can pin
+  the GHCR image tags documented above, or forks can keep building into their
+  own registry.
+- The release workflow publishes app and ingester images. It does not publish a
+  separate migrator image tag; build the root Dockerfile `migrator` target for
+  platforms that require an image-only migration job.
+- Multi-arch release images must be smoke-tested after publication before they
+  are advertised as production-ready for a specific environment.
+
+## Human release gate and runbook
+
+Only a Jaeyun/controller-authorized maintainer should run the real release:
+
+1. Merge the implementation PR into `staging` and complete the normal staging QA
+   path.
+2. Promote the verified release commit through the approved staging-to-main gate.
+3. From the approved release commit, push the real tag:
+
+   ```bash
+   git tag -a v1.0.0 -m "OpenSend v1.0.0"
+   git push origin v1.0.0
+   ```
+
+4. Watch the `Release` GitHub Actions run. It must pass version sync, build and
+   push both multi-arch images, inspect the pushed manifests, and only then
+   create or update the GitHub Release with this curated body.
+5. Inspect the published manifests:
+
+   ```bash
+   docker buildx imagetools inspect ghcr.io/namuh-eng/opensend:v1.0.0
+   docker buildx imagetools inspect ghcr.io/namuh-eng/opensend-ingester:v1.0.0
+   ```
+
+6. Smoke-test pinned images in a throwaway environment:
+
+   ```bash
+   docker run --rm ghcr.io/namuh-eng/opensend:v1.0.0 bun --version
+   docker run --rm ghcr.io/namuh-eng/opensend-ingester:v1.0.0 bun --version
+   ```
+
+   Then boot a Compose or platform-specific staging stack with the pinned app and
+   ingester tags, run migrations, confirm `GET /api/health`, confirm ingester
+   `/health`, and send a real SES-backed message if credentials are available.
+
+7. Leave #642 open until the real tag, GitHub Release, and GHCR images exist and
+   have been smoke-tested.
+
+## RC and dry-run path
+
+This PR uses local no-publish validation for the workflow and release metadata.
+If maintainers want a real GitHub Actions RC rehearsal, create a temporary RC
+version commit where the gated packages are set to `1.0.0-rc.1`, add a matching
+`docs/release-notes/v1.0.0-rc.1.md`, and push `v1.0.0-rc.1`. The version gate
+requires prerelease package versions to exactly match prerelease tags; a
+`v1.0.0-rc.1` tag intentionally fails against packages set to `1.0.0`.
+
+Do not push `v1.0.0`, create the final GitHub Release, or publish final images
+from worker lanes. The final release remains a human/controller authorization
+step.

--- a/docs/release-notes/v1.0.0.md
+++ b/docs/release-notes/v1.0.0.md
@@ -70,13 +70,14 @@ exact version tag they have validated.
   `BILLING_BACKEND` unset or `disabled` unless they intentionally wire Stripe.
 - SDK registries outside the TypeScript package are at different maturity levels
   and are not part of this v1.0.0 release publication gate.
-- The reference `docker-compose.yml` remains source-built by default so local
-  evaluation works before the release images exist. Production operators can pin
-  the GHCR image tags documented above, or forks can keep building into their
-  own registry.
+- The reference `docker-compose.yml` pins the v1.0.0 app, ingester, and
+  scheduler GHCR image tags by default for reproducible self-host deploys. Use
+  `docker-compose.local.yml` only when intentionally building app and ingester
+  from the checked-out source tree.
 - The release workflow publishes app and ingester images. It does not publish a
-  separate migrator image tag; build the root Dockerfile `migrator` target for
-  platforms that require an image-only migration job.
+  separate migrator or SMTP relay image tag; the Compose migrator and optional
+  SMTP relay profile remain build-local unless you publish those images to your
+  own registry.
 - Multi-arch release images must be smoke-tested after publication before they
   are advertised as production-ready for a specific environment.
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -13,6 +13,7 @@ there. This document is for production deployments.
 - [Deployment options](#deployment-options)
 - [Requirements](#requirements)
 - [Quickstart: Docker Compose](#quickstart-docker-compose)
+- [Release images and pinned deploys](#release-images-and-pinned-deploys)
 - [Environment variables](#environment-variables)
 - [Database](#database)
 - [AWS SES](#aws-ses)
@@ -45,6 +46,34 @@ The Dockerfile in this repo is multi-stage and builds three artifacts:
 
 You can run all three on the same machine via Docker Compose, or split them
 across separate services on a container platform.
+
+## Release images and pinned deploys
+
+Local Docker Compose remains source-built by default so `docker compose up -d`
+works from a fresh clone before any release images exist. For production, prefer
+immutable image tags after an authorized release publishes them to GHCR:
+
+| Service | Release image | Notes |
+| --- | --- | --- |
+| App/API/dashboard | `ghcr.io/namuh-eng/opensend:v1.0.0` | Built from the root `Dockerfile` `runner` target. |
+| Ingester | `ghcr.io/namuh-eng/opensend-ingester:v1.0.0` | Built from `packages/ingester/Dockerfile`. |
+| Scheduler | `ghcr.io/namuh-eng/opensend-ingester:v1.0.0` | Same image as the ingester, with `command: ["bun", "/app/job-scheduler.js"]`. |
+
+The release workflow also publishes `:1.0.0` aliases and intentionally does not
+publish `:latest`. The workflow publishes images; the ingester service only
+consumes the image at runtime.
+
+To pin a Compose-style production deployment after the real release images are
+published, replace the `app` service `build:` block with
+`image: ghcr.io/namuh-eng/opensend:v1.0.0`, replace the `ingester` and
+`scheduler` image values with `ghcr.io/namuh-eng/opensend-ingester:v1.0.0`, and
+keep the same environment, ports, health checks, and dependencies. Run the
+migrator before rolling the app and ingester; build the root Dockerfile
+`migrator` target into your registry if your platform needs an image-only
+migration job.
+
+Forks and private deployments can still build their own images with `docker
+buildx` and pin those registry tags instead.
 
 ## Requirements
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -49,9 +49,8 @@ across separate services on a container platform.
 
 ## Release images and pinned deploys
 
-Local Docker Compose remains source-built by default so `docker compose up -d`
-works from a fresh clone before any release images exist. For production, prefer
-immutable image tags after an authorized release publishes them to GHCR:
+Default Docker Compose uses pinned release images for reproducible self-host
+deploys. The authorized `v1.0.0` workflow publishes these immutable GHCR tags:
 
 | Service | Release image | Notes |
 | --- | --- | --- |
@@ -63,17 +62,20 @@ The release workflow also publishes `:1.0.0` aliases and intentionally does not
 publish `:latest`. The workflow publishes images; the ingester service only
 consumes the image at runtime.
 
-To pin a Compose-style production deployment after the real release images are
-published, replace the `app` service `build:` block with
-`image: ghcr.io/namuh-eng/opensend:v1.0.0`, replace the `ingester` and
-`scheduler` image values with `ghcr.io/namuh-eng/opensend-ingester:v1.0.0`, and
-keep the same environment, ports, health checks, and dependencies. Run the
-migrator before rolling the app and ingester; build the root Dockerfile
-`migrator` target into your registry if your platform needs an image-only
-migration job.
+`docker-compose.yml` pins those app, ingester, and scheduler tags by default.
+Use the explicit local override when you intentionally want to build from the
+checked-out source tree:
 
-Forks and private deployments can still build their own images with `docker
-buildx` and pin those registry tags instead.
+```bash
+docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
+```
+
+The one-shot `migrate` job and optional `smtp-relay` profile still build from
+source because v1.0.0 does not publish separate migrator or SMTP relay images.
+Run the migrator before rolling the app and ingester; build the root Dockerfile
+`migrator` target into your registry if your platform needs an image-only
+migration job. Forks and private deployments can still build their own images
+with `docker buildx` and pin those registry tags instead.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensend-monorepo",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "packageManager": "bun@1.3.8",
   "workspaces": ["packages/*", "services/*"],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensend/core",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/ingester/package.json
+++ b/packages/ingester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensend/ingester",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/public/docs/ingester-deploy.md
+++ b/public/docs/ingester-deploy.md
@@ -2,6 +2,19 @@
 
 Deploy the standalone ingester and queue worker. Provider callbacks should target the ingester service, not the Next.js app URL.
 
+## Release images
+
+After an authorized OpenSend release publishes images, production deployments should pin exact GHCR tags:
+
+- App/API/dashboard: `ghcr.io/namuh-eng/opensend:v1.0.0`
+- Ingester and scheduler: `ghcr.io/namuh-eng/opensend-ingester:v1.0.0`
+
+The release workflow publishes these images for `linux/amd64` and `linux/arm64` and also publishes `:1.0.0` aliases. It intentionally does not publish `:latest`. The ingester process consumes the image at runtime; it does not publish images.
+
+Forks and private deployments can build the same artifacts into their own registry with `docker buildx build --platform linux/amd64,linux/arm64 --target runner .` for the app and `docker buildx build --platform linux/amd64,linux/arm64 -f packages/ingester/Dockerfile .` for the ingester. Inspect pushed manifests before advertising a multi-arch image.
+
+Run migrations before rolling app or ingester containers. If your platform needs a migrator image, build the root Dockerfile `migrator` target into your own registry.
+
 ## Endpoints
 
 - `POST /events/ses` — SES/SNS sending lifecycle notifications for delivered, bounced, complained, opened, and clicked events.

--- a/public/docs/ingester-deploy.md
+++ b/public/docs/ingester-deploy.md
@@ -9,7 +9,7 @@ After an authorized OpenSend release publishes images, production deployments sh
 - App/API/dashboard: `ghcr.io/namuh-eng/opensend:v1.0.0`
 - Ingester and scheduler: `ghcr.io/namuh-eng/opensend-ingester:v1.0.0`
 
-The release workflow publishes these images for `linux/amd64` and `linux/arm64` and also publishes `:1.0.0` aliases. It intentionally does not publish `:latest`. The ingester process consumes the image at runtime; it does not publish images.
+The release workflow publishes these images for `linux/amd64` and `linux/arm64` and also publishes `:1.0.0` aliases. It intentionally does not publish `:latest`. The default `docker-compose.yml` pins the app, ingester, and scheduler tags for reproducible self-host deploys. The ingester process consumes the image at runtime; it does not publish images.
 
 Forks and private deployments can build the same artifacts into their own registry with `docker buildx build --platform linux/amd64,linux/arm64 --target runner .` for the app and `docker buildx build --platform linux/amd64,linux/arm64 -f packages/ingester/Dockerfile .` for the ingester. Inspect pushed manifests before advertising a multi-arch image.
 

--- a/public/docs/self-hosting.md
+++ b/public/docs/self-hosting.md
@@ -20,7 +20,7 @@ Production deployments can run these as separate services on ECS, Fly, Railway, 
 
 ## Release images and pinned deploys
 
-The default Compose file builds from source so local evaluation works from a fresh clone. After an authorized OpenSend release publishes images, production operators should pin exact GHCR tags instead of using a moving tag:
+The default Compose file uses pinned release images for reproducible self-host deploys. The authorized v1.0.0 workflow publishes these exact GHCR tags instead of a moving tag:
 
 | Service | Release image | Notes |
 | --- | --- | --- |
@@ -30,7 +30,7 @@ The default Compose file builds from source so local evaluation works from a fre
 
 The release workflow publishes the images; the ingester service consumes the published image and does not publish images itself. The workflow also publishes `:1.0.0` aliases and intentionally does not publish `:latest`.
 
-For Compose-style production deployments, replace the source `build:` block on `app` with `image: ghcr.io/namuh-eng/opensend:v1.0.0`, use `image: ghcr.io/namuh-eng/opensend-ingester:v1.0.0` for `ingester` and `scheduler`, and keep the same environment, ports, dependencies, and health checks. Run migrations before rolling app or ingester containers; if your platform requires a migrator image, build the root Dockerfile `migrator` target into your own registry.
+`docker-compose.yml` pins those app, ingester, and scheduler tags by default. Use `docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build` when you intentionally want to build app and ingester from the checked-out source tree. The one-shot migrator and optional SMTP relay profile still build locally because v1.0.0 does not publish separate migrator or relay images. Run migrations before rolling app or ingester containers; if your platform requires a migrator image, build the root Dockerfile `migrator` target into your own registry.
 
 ## Quick start
 

--- a/public/docs/self-hosting.md
+++ b/public/docs/self-hosting.md
@@ -18,6 +18,20 @@ Docker Compose starts the same service boundaries used by production deployments
 
 Production deployments can run these as separate services on ECS, Fly, Railway, Cloud Run, Kubernetes, or a single VM. Keep app traffic pointed at the Next.js service, and point SES/SNS event webhooks at the ingester.
 
+## Release images and pinned deploys
+
+The default Compose file builds from source so local evaluation works from a fresh clone. After an authorized OpenSend release publishes images, production operators should pin exact GHCR tags instead of using a moving tag:
+
+| Service | Release image | Notes |
+| --- | --- | --- |
+| App/API/dashboard | `ghcr.io/namuh-eng/opensend:v1.0.0` | Built from the root Dockerfile runner target. |
+| Ingester | `ghcr.io/namuh-eng/opensend-ingester:v1.0.0` | Handles SES/SNS, inbound events, workers, and job endpoints. |
+| Scheduler | `ghcr.io/namuh-eng/opensend-ingester:v1.0.0` | Same image, started with `bun /app/job-scheduler.js`. |
+
+The release workflow publishes the images; the ingester service consumes the published image and does not publish images itself. The workflow also publishes `:1.0.0` aliases and intentionally does not publish `:latest`.
+
+For Compose-style production deployments, replace the source `build:` block on `app` with `image: ghcr.io/namuh-eng/opensend:v1.0.0`, use `image: ghcr.io/namuh-eng/opensend-ingester:v1.0.0` for `ingester` and `scheduler`, and keep the same environment, ports, dependencies, and health checks. Run migrations before rolling app or ingester containers; if your platform requires a migrator image, build the root Dockerfile `migrator` target into your own registry.
+
 ## Quick start
 
 ```bash

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -7,6 +7,17 @@ import { describe, expect, it } from "vitest";
 
 const root = join(__dirname, "..");
 
+function serviceBlock(compose: string, serviceName: string): string {
+  const escapedServiceName = serviceName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = compose.match(
+    new RegExp(
+      `\\n  ${escapedServiceName}:\\n[\\s\\S]*?(?=\\n  [a-zA-Z0-9_-]+:\\n|\\nvolumes:\\n|$)`,
+    ),
+  );
+  expect(match).not.toBeNull();
+  return match?.[0] ?? "";
+}
+
 describe("deploy-001: ECS Fargate deployment configuration", () => {
   it("next.config.js has standalone output for Docker deployment", () => {
     const config = readFileSync(join(root, "next.config.js"), "utf-8");
@@ -178,12 +189,41 @@ describe("deploy-001: ECS Fargate deployment configuration", () => {
     expect(ignore).toContain(".next");
   });
 
-  it("docker-compose includes a dedicated ingester service with a healthcheck", () => {
+  it("docker-compose pins release images for app, ingester, and scheduler by default", () => {
     const compose = readFileSync(join(root, "docker-compose.yml"), "utf-8");
-    expect(compose).toContain("ingester:");
-    expect(compose).toContain("dockerfile: packages/ingester/Dockerfile");
-    expect(compose).toContain("INGESTER_PORT:-3016");
-    expect(compose).toContain("http://127.0.0.1:3016/health");
+    const app = serviceBlock(compose, "app");
+    const ingester = serviceBlock(compose, "ingester");
+    const scheduler = serviceBlock(compose, "scheduler");
+
+    expect(app).toContain("image: ghcr.io/namuh-eng/opensend:v1.0.0");
+    expect(app).not.toContain("build:");
+    expect(ingester).toContain(
+      "image: ghcr.io/namuh-eng/opensend-ingester:v1.0.0",
+    );
+    expect(ingester).not.toContain("build:");
+    expect(ingester).toContain("INGESTER_PORT:-3016");
+    expect(ingester).toContain("http://127.0.0.1:3016/health");
+    expect(scheduler).toContain(
+      "image: ghcr.io/namuh-eng/opensend-ingester:v1.0.0",
+    );
+    expect(scheduler).toContain('command: ["bun", "/app/job-scheduler.js"]');
+  });
+
+  it("docker-compose local override builds the app and ingester from source", () => {
+    const override = readFileSync(
+      join(root, "docker-compose.local.yml"),
+      "utf-8",
+    );
+    const app = serviceBlock(override, "app");
+    const ingester = serviceBlock(override, "ingester");
+    const scheduler = serviceBlock(override, "scheduler");
+
+    expect(app).toContain("image: opensend:local");
+    expect(app).toContain("target: runner");
+    expect(ingester).toContain("image: opensend-ingester:local");
+    expect(ingester).toContain("dockerfile: packages/ingester/Dockerfile");
+    expect(scheduler).toContain("image: opensend-ingester:local");
+    expect(scheduler).toContain("dockerfile: packages/ingester/Dockerfile");
   });
 
   it("docker-compose wires Redis-backed rate limiting by default", () => {

--- a/tests/release-version-sync.test.ts
+++ b/tests/release-version-sync.test.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = path.resolve("tools/verify-release-version-sync.mjs");
+
+function writePackageJson(repoRoot: string, relPath: string, version: string) {
+  const fullPath = path.join(repoRoot, relPath);
+  mkdirSync(path.dirname(fullPath), { recursive: true });
+  writeFileSync(
+    fullPath,
+    `${JSON.stringify({ name: relPath, version }, null, 2)}\n`,
+  );
+}
+
+function makeFixture(version: string, releaseNoteTag = "v1.0.0") {
+  const repoRoot = mkdtempSync(path.join(tmpdir(), "opensend-release-sync-"));
+  writePackageJson(repoRoot, "package.json", version);
+  writePackageJson(repoRoot, "packages/core/package.json", version);
+  writePackageJson(repoRoot, "packages/ingester/package.json", version);
+  const notesDir = path.join(repoRoot, "docs/release-notes");
+  mkdirSync(notesDir, { recursive: true });
+  writeFileSync(
+    path.join(notesDir, `${releaseNoteTag}.md`),
+    "# Release notes\n",
+  );
+  return repoRoot;
+}
+
+function runVersionCheck(repoRoot: string, tag: string) {
+  return execFileSync(
+    "node",
+    [
+      scriptPath,
+      "--repo-root",
+      repoRoot,
+      "--tag",
+      tag,
+      "--require-release-notes",
+    ],
+    { encoding: "utf8" },
+  );
+}
+
+describe("verify-release-version-sync", () => {
+  it("accepts a stable v1.0.0 tag when gated package versions and notes match", () => {
+    const output = runVersionCheck(makeFixture("1.0.0"), "v1.0.0");
+
+    expect(output).toContain("root/core/ingester=1.0.0");
+    expect(output).toContain("release notes=docs/release-notes/v1.0.0.md");
+  });
+
+  it("rejects mismatched stable tags", () => {
+    const repoRoot = makeFixture("1.0.0", "v1.0.1");
+
+    expect(() => runVersionCheck(repoRoot, "v1.0.1")).toThrow(
+      /does not match tag \(1\.0\.1\)/,
+    );
+  });
+
+  it("requires prerelease tags to match prerelease package versions exactly", () => {
+    expect(() => runVersionCheck(makeFixture("1.0.0"), "v1.0.0-rc.1")).toThrow(
+      /does not match tag \(1\.0\.0-rc\.1\)/,
+    );
+
+    const output = runVersionCheck(
+      makeFixture("1.0.0-rc.1", "v1.0.0-rc.1"),
+      "v1.0.0-rc.1",
+    );
+    expect(output).toContain("root/core/ingester=1.0.0-rc.1");
+  });
+});

--- a/tools/verify-release-version-sync.mjs
+++ b/tools/verify-release-version-sync.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+export const SYNCED_PACKAGE_FILES = [
+  "package.json",
+  "packages/core/package.json",
+  "packages/ingester/package.json",
+];
+
+const TAG_PATTERN = /^v(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/;
+
+export function parseReleaseTag(tag) {
+  const match = TAG_PATTERN.exec(tag);
+  if (!match) {
+    return {
+      ok: false,
+      version: null,
+      problem: `tag "${tag}" is not a valid semver vX.Y.Z or vX.Y.Z-prerelease tag`,
+    };
+  }
+
+  return { ok: true, version: match[1], problem: null };
+}
+
+export function releaseNotesPathForTag(repoRoot, tag) {
+  return path.join(repoRoot, "docs", "release-notes", `${tag}.md`);
+}
+
+export function verifyReleaseVersionSync({
+  repoRoot,
+  tag,
+  requireReleaseNotes = false,
+}) {
+  const parsed = parseReleaseTag(tag);
+  const problems = [];
+
+  if (!parsed.ok || parsed.version === null) {
+    problems.push(parsed.problem ?? `invalid tag "${tag}"`);
+  }
+
+  const expected = parsed.version ?? tag.replace(/^v/, "");
+
+  for (const rel of SYNCED_PACKAGE_FILES) {
+    const pkgPath = path.join(repoRoot, rel);
+    let pkg;
+    try {
+      pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      problems.push(`${rel} could not be read as JSON: ${message}`);
+      continue;
+    }
+
+    if (pkg.version !== expected) {
+      problems.push(
+        `${rel} version (${pkg.version ?? "missing"}) does not match tag (${expected})`,
+      );
+    }
+  }
+
+  const releaseNotesPath = releaseNotesPathForTag(repoRoot, tag);
+  if (requireReleaseNotes && !fs.existsSync(releaseNotesPath)) {
+    problems.push(
+      `release notes file is missing for ${tag}: ${path.relative(repoRoot, releaseNotesPath)}`,
+    );
+  }
+
+  return {
+    ok: problems.length === 0,
+    tag,
+    expectedVersion: expected,
+    syncedPackageFiles: SYNCED_PACKAGE_FILES,
+    releaseNotesPath,
+    problems,
+  };
+}
+
+function parseArgs(argv) {
+  const options = {
+    repoRoot: process.cwd(),
+    tag: process.env.GITHUB_REF_NAME ?? "",
+    requireReleaseNotes: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--repo-root") {
+      options.repoRoot = argv[++i] ?? options.repoRoot;
+    } else if (arg === "--tag") {
+      options.tag = argv[++i] ?? options.tag;
+    } else if (arg === "--require-release-notes") {
+      options.requireReleaseNotes = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const result = verifyReleaseVersionSync(options);
+
+    if (!result.ok) {
+      for (const problem of result.problems) {
+        console.error(`[version-sync] ${problem}`);
+      }
+      process.exit(1);
+    }
+
+    console.log(
+      `[version-sync] OK tag=${result.tag} root/core/ingester=${result.expectedVersion}`,
+    );
+    console.log(
+      "[version-sync] note: SDKs and other workspace packages keep independent release cadences and are not gated here.",
+    );
+    if (options.requireReleaseNotes) {
+      console.log(
+        `[version-sync] release notes=${path.relative(options.repoRoot, result.releaseNotesPath)}`,
+      );
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[version-sync] ${message}`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary

Refs #642.

Prepares the repo-side v1.0.0 release package without publishing the real release/tag/images:

- syncs root, `@opensend/core`, and `@opensend/ingester` versions to `1.0.0` and updates `bun.lock`
- adds a reusable release version/notes gate plus Vitest coverage for stable and prerelease semantics
- updates `.github/workflows/release.yml` so tag releases:
  - verify package versions and curated release notes
  - build/push multi-arch GHCR app + ingester images
  - inspect pushed manifests
  - create/update the GitHub Release only after image publication succeeds
- adds curated `docs/release-notes/v1.0.0.md` with upgrade notes, limitations, RC/dry-run guidance, and the human-gated release runbook
- pins default `docker-compose.yml` app, ingester, and scheduler services to the versioned GHCR images, and adds `docker-compose.local.yml` as the explicit source-build/local-development override

## Release gate caveat

This PR intentionally does **not** push `v1.0.0`, create the real GitHub Release, or publish GHCR images. Final #642 closure still requires Jaeyun/controller authorization to push the real tag and verify the workflow/image smoke checks.

## Validation

- `bun install --ignore-scripts`
- `bun install --frozen-lockfile --ignore-scripts`
- `bun run docs:generate`
- `node tools/verify-release-version-sync.mjs --tag v1.0.0 --require-release-notes`
- Expected-failure checks for `v1.0.1` and `v1.0.0-rc.1` against stable package versions
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "YAML OK #{f}" }' .github/workflows/release.yml docker-compose.yml`
- `docker compose --env-file .env.example config`
- `git diff --check`
- `bunx vitest run tests/release-version-sync.test.ts`
- `make check`
- `make test`
- no-push Docker builds:
  - `docker buildx build --platform linux/amd64 --target runner .`
  - `docker buildx build --platform linux/amd64 -f packages/ingester/Dockerfile .`
  - `docker buildx build --platform linux/amd64 --target migrator .`
- review-fix validation after pinning default Compose images (`b28f0f0`):
  - `git diff --check`
  - `docker compose --env-file .env.example config --quiet`
  - `docker compose --env-file .env.example -f docker-compose.yml -f docker-compose.local.yml config --quiet`
  - `bun run docs:generate`
  - `bun run docs:check`
  - `bunx vitest run tests/release-version-sync.test.ts`
  - push guardrails: `node scripts/check-changed-files.mjs`, full-project typecheck, changed-file Biome lint

## Notes

- The app Docker build emitted the existing Docker warning about build-time `BETTER_AUTH_SECRET`; no real secret was used.
- Local Docker needed an isolated config to avoid the macOS keychain credential-helper issue; all builds were no-push.

