### PR TITLE
Add social preview image metadata

### DIFF
--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -1,5 +1,6 @@
 import { LandingPage } from "@/components/landing/landing-page";
 import { getOpenSendGithubStars } from "@/lib/github-stars";
+import { SITE_URL, SOCIAL_PREVIEW_IMAGE } from "@/lib/site-metadata";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -11,17 +12,19 @@ export const metadata: Metadata = {
     description:
       "Open-source, ELv2 email platform with a Resend-compatible API, SDK, dashboard, domain verification, and webhooks. Self-host on your own AWS SES, or use the hosted version.",
     type: "website",
-    url: "https://opensend.namuh.co",
+    url: SITE_URL,
     siteName: "OpenSend",
+    images: [SOCIAL_PREVIEW_IMAGE],
   },
   twitter: {
     card: "summary_large_image",
     title: "OpenSend — Open-source email API you can self-host",
     description:
       "Open-source, ELv2 email platform with a Resend-compatible API, SDK, and dashboard.",
+    images: [SOCIAL_PREVIEW_IMAGE.url],
   },
   alternates: {
-    canonical: "https://opensend.namuh.co/",
+    canonical: `${SITE_URL}/`,
   },
 };
 

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,4 +1,5 @@
 import { PricingPage } from "@/components/landing/pricing-page";
+import { SITE_URL, SOCIAL_PREVIEW_IMAGE } from "@/lib/site-metadata";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -10,17 +11,19 @@ export const metadata: Metadata = {
     description:
       "Self-host free forever under ELv2, or use OpenSend's hosted plans. Usage-based pricing, no per-seat fees, no vendor lock-in.",
     type: "website",
-    url: "https://opensend.namuh.co/pricing",
+    url: `${SITE_URL}/pricing`,
     siteName: "OpenSend",
+    images: [SOCIAL_PREVIEW_IMAGE],
   },
   twitter: {
     card: "summary_large_image",
     title: "Pricing — OpenSend",
     description:
       "Self-host free forever under ELv2, or use OpenSend's hosted plans.",
+    images: [SOCIAL_PREVIEW_IMAGE.url],
   },
   alternates: {
-    canonical: "https://opensend.namuh.co/pricing",
+    canonical: `${SITE_URL}/pricing`,
   },
 };
 

--- a/src/lib/site-metadata.ts
+++ b/src/lib/site-metadata.ts
@@ -1,0 +1,9 @@
+export const SITE_URL = "https://opensend.namuh.co";
+
+export const SOCIAL_PREVIEW_IMAGE = {
+  url: `${SITE_URL}/landing/screenshot-dashboard.png`,
+  width: 3456,
+  height: 2234,
+  alt: "OpenSend dashboard preview",
+  type: "image/png",
+} as const;

--- a/tests/landing-page.test.tsx
+++ b/tests/landing-page.test.tsx
@@ -1,9 +1,18 @@
 import { metadata } from "@/app/landing/page";
+import { metadata as pricingMetadata } from "@/app/pricing/page";
 import { LandingPage } from "@/components/landing/landing-page";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 afterEach(cleanup);
+
+const expectedSocialPreviewImage = {
+  url: "https://opensend.namuh.co/landing/screenshot-dashboard.png",
+  width: 3456,
+  height: 2234,
+  alt: "OpenSend dashboard preview",
+  type: "image/png",
+} as const;
 
 vi.mock("next/link", () => ({
   default: ({
@@ -47,6 +56,39 @@ describe("Landing page metadata", () => {
     expect(metadata.openGraph?.title).toMatch(/OpenSend/);
     expect(metadata.openGraph?.url).toBe("https://opensend.namuh.co");
     expect(metadata.alternates?.canonical).toBe("https://opensend.namuh.co/");
+  });
+
+  it("declares social preview images for shared link cards", () => {
+    const twitter = metadata.twitter as {
+      card?: string;
+      images?: string[];
+    };
+
+    expect(metadata.openGraph?.images).toEqual([expectedSocialPreviewImage]);
+    expect(twitter.card).toBe("summary_large_image");
+    expect(twitter.images).toEqual([
+      "https://opensend.namuh.co/landing/screenshot-dashboard.png",
+    ]);
+  });
+});
+
+describe("Pricing page metadata", () => {
+  it("declares social preview images for shared pricing links", () => {
+    const twitter = pricingMetadata.twitter as {
+      card?: string;
+      images?: string[];
+    };
+
+    expect(pricingMetadata.openGraph?.url).toBe(
+      "https://opensend.namuh.co/pricing",
+    );
+    expect(pricingMetadata.openGraph?.images).toEqual([
+      expectedSocialPreviewImage,
+    ]);
+    expect(twitter.card).toBe("summary_large_image");
+    expect(twitter.images).toEqual([
+      "https://opensend.namuh.co/landing/screenshot-dashboard.png",
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes #670 by adding first-party social preview image metadata for shared OpenSend landing and pricing links.

## Root cause
The landing metadata already requested a `summary_large_image` Twitter/X card, but the landing/root and pricing metadata did not declare `openGraph.images` or `twitter.images`. Social crawlers therefore had no absolute image URL to use and could fall back to a generic placeholder.

## Changed files
- `src/lib/site-metadata.ts` — adds shared canonical site URL and absolute social preview image metadata.
- `src/app/landing/page.tsx` — uses the shared site URL and exposes Open Graph + Twitter image fields for the landing metadata; root inherits this metadata through `src/app/page.tsx`.
- `src/app/pricing/page.tsx` — exposes the same Open Graph + Twitter image fields for pricing shares.
- `tests/landing-page.test.tsx` — locks landing/root social preview metadata and pricing social preview metadata.

## Validation
- `bun run test tests/landing-page.test.tsx` — passed, 1 file / 11 tests.
- `make check` — passed, typecheck + Biome over 833 files.
- `make test` — passed, 215 files / 1,772 tests; 3 files / 10 tests skipped.
- Push guardrails — passed, full-project typecheck + changed-file Biome.

## Caveat
X/Twitter may cache card metadata after deploy. If the old placeholder remains visible, re-scrape the URL with the platform validator/debugger after this reaches the target environment.
