### PR TITLE
Harden scheduler job timeouts

### DIFF
--- a/agent_docs/learnings/active/2026-06-23-scheduler-heartbeat-upsert-timeout.md
+++ b/agent_docs/learnings/active/2026-06-23-scheduler-heartbeat-upsert-timeout.md
@@ -1,0 +1,20 @@
+---
+date: 2026-06-23
+issue: scheduler-heartbeat-missing
+type: mistake
+promoted_to: null
+---
+
+# Scheduler heartbeat writes must be bounded
+
+Production scheduler logs stopped immediately after `scheduled-emails` completed
+and before the next job started, while ECS still reported one running scheduler
+task. The shared heartbeat alarm correctly fired because no
+`SchedulerHeartbeat` EMF datapoints arrived for three one-minute periods, and
+`/api/health/scheduler` showed all DB heartbeat rows stale.
+
+The scheduler had a timeout around each ingester HTTP job request, but the
+post-job DB heartbeat upsert was unbounded. A stuck Postgres write could hold
+the scheduler loop without crashing the ECS task. Keep scheduler side effects
+bounded and logged; liveness metrics should prove the loop is alive even when
+per-job heartbeat persistence has a transient database problem.

--- a/packages/ingester/src/job-scheduler-request.ts
+++ b/packages/ingester/src/job-scheduler-request.ts
@@ -1,0 +1,60 @@
+export type SchedulerFetch = (url: URL, init: RequestInit) => Promise<Response>;
+
+export type SchedulerJobResult = {
+  readonly body: string;
+  readonly ok: boolean;
+  readonly status: number;
+};
+
+export type FetchSchedulerJobOptions = {
+  readonly headers: HeadersInit;
+  readonly schedulerFetch?: SchedulerFetch;
+  readonly timeoutMs: number;
+  readonly url: URL;
+};
+
+export class SchedulerRequestTimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(`scheduler job request timed out after ${timeoutMs}ms`);
+    this.name = "SchedulerRequestTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export async function fetchSchedulerJobResult({
+  headers,
+  schedulerFetch = fetch,
+  timeoutMs,
+  url,
+}: FetchSchedulerJobOptions): Promise<SchedulerJobResult> {
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const request = schedulerFetch(url, {
+    method: "POST",
+    headers,
+    signal: controller.signal,
+  }).then(async (response) => ({
+    body: await response.text(),
+    ok: response.ok,
+    status: response.status,
+  }));
+  request.catch(() => undefined);
+
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      controller.abort();
+      reject(new SchedulerRequestTimeoutError(timeoutMs));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([request, timeout]);
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/packages/ingester/src/job-scheduler.ts
+++ b/packages/ingester/src/job-scheduler.ts
@@ -1,8 +1,10 @@
 import { createTelemetryContext, emitCloudWatchMetric } from "@opensend/core";
+import type { ScheduledJobName } from "@opensend/core";
 import {
   OpenSendEnvValidationError,
   assertValidOpenSendEnv,
 } from "@opensend/core/src/env";
+import { fetchSchedulerJobResult } from "./job-scheduler-request";
 
 function runSchedulerStartupChecks(): void {
   try {
@@ -24,12 +26,6 @@ function runSchedulerStartupChecks(): void {
   }
 }
 
-runSchedulerStartupChecks();
-
-const { SCHEDULED_JOB_NAMES, schedulerHeartbeatRepo } = await import(
-  "@opensend/core"
-);
-
 const DEFAULT_INGESTER_URL = "http://ingester:3016";
 const DEFAULT_INTERVAL_SECONDS = 60;
 const REQUEST_TIMEOUT_MS = 20_000;
@@ -37,22 +33,31 @@ const REQUEST_TIMEOUT_MS = 20_000;
 // Paths are kept as literal strings (not derived) so the static-coverage
 // test at tests/ingester-job-scheduler-coverage.test.ts can grep for each
 // endpoint in this source file. See that test for the contract.
-const JOB_PATHS: Record<(typeof SCHEDULED_JOB_NAMES)[number], string> = {
+const JOB_PATHS = {
   "scheduled-emails": "/jobs/scheduled-emails",
   webhooks: "/jobs/webhooks",
   "domain-verify": "/jobs/domain-verify",
   "billing-overage": "/jobs/billing-overage",
-};
+} as const satisfies Record<ScheduledJobName, string>;
 
 type ScheduledJob = {
-  name: (typeof SCHEDULED_JOB_NAMES)[number];
-  path: string;
+  readonly name: ScheduledJobName;
+  readonly path: string;
 };
 
-const scheduledJobs: ScheduledJob[] = SCHEDULED_JOB_NAMES.map((name) => ({
-  name,
-  path: JOB_PATHS[name],
-}));
+type SchedulerHeartbeatRepo = {
+  readonly upsert: (
+    jobName: string,
+    result: Record<string, unknown>,
+  ) => Promise<unknown>;
+};
+
+type SchedulerRuntime = {
+  readonly baseUrl: string;
+  readonly heartbeatRepo: SchedulerHeartbeatRepo;
+  readonly intervalMs: number;
+  readonly jobs: readonly ScheduledJob[];
+};
 
 function getEnv(name: string): string | undefined {
   const value = process.env[name]?.trim();
@@ -120,11 +125,10 @@ function emitSchedulerJobFailed(
 }
 
 async function runJob(
-  baseUrl: string,
+  runtime: SchedulerRuntime,
   job: ScheduledJob,
-  intervalMs: number,
 ): Promise<void> {
-  const url = new URL(job.path, baseUrl);
+  const url = new URL(job.path, runtime.baseUrl);
   const startedAt = Date.now();
 
   let status = 0;
@@ -132,15 +136,15 @@ async function runJob(
   let body = "";
 
   try {
-    const response = await fetch(url, {
-      method: "POST",
+    const result = await fetchSchedulerJobResult({
       headers: buildHeaders(),
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      timeoutMs: REQUEST_TIMEOUT_MS,
+      url,
     });
-    body = await response.text();
+    body = result.body;
     const durationMs = Date.now() - startedAt;
-    status = response.status;
-    ok = response.ok;
+    status = result.status;
+    ok = result.ok;
 
     console.log(
       JSON.stringify({
@@ -153,8 +157,8 @@ async function runJob(
       }),
     );
 
-    if (!response.ok) {
-      emitSchedulerJobFailed(job, { status: response.status });
+    if (!result.ok) {
+      emitSchedulerJobFailed(job, { status: result.status });
     }
   } catch (error) {
     const durationMs = Date.now() - startedAt;
@@ -175,7 +179,7 @@ async function runJob(
   // DB errors are caught here — a Postgres hiccup must not crash the scheduler.
   try {
     const resultPayload: Record<string, unknown> = {
-      interval_ms: intervalMs,
+      interval_ms: runtime.intervalMs,
       status: ok ? "ok" : "error",
       http_status: status,
     };
@@ -191,7 +195,7 @@ async function runJob(
       // body wasn't JSON — that's fine, we already logged it above
     }
 
-    await schedulerHeartbeatRepo.upsert(job.name, resultPayload);
+    await runtime.heartbeatRepo.upsert(job.name, resultPayload);
   } catch (heartbeatErr) {
     console.error(
       JSON.stringify({
@@ -207,17 +211,15 @@ async function runJob(
   }
 }
 
-async function runAllJobs(baseUrl: string, intervalMs: number): Promise<void> {
-  for (const job of scheduledJobs) {
-    await runJob(baseUrl, job, intervalMs);
+async function runAllJobs(runtime: SchedulerRuntime): Promise<void> {
+  for (const job of runtime.jobs) {
+    await runJob(runtime, job);
   }
 }
 
-const ingesterUrl = getEnv("INGESTER_URL") ?? DEFAULT_INGESTER_URL;
-const intervalMs = getIntervalMs();
 let isRunning = false;
 
-async function runScheduledBatch(): Promise<void> {
+async function runScheduledBatch(runtime: SchedulerRuntime): Promise<void> {
   if (isRunning) {
     console.warn(
       JSON.stringify({
@@ -232,24 +234,54 @@ async function runScheduledBatch(): Promise<void> {
   isRunning = true;
   emitSchedulerHeartbeat();
   try {
-    await runAllJobs(ingesterUrl, intervalMs);
+    await runAllJobs(runtime);
   } finally {
     isRunning = false;
   }
 }
 
-console.log(
-  JSON.stringify({
-    level: "info",
-    event: "scheduler.started",
-    ingester_url: ingesterUrl,
-    interval_seconds: intervalMs / 1000,
-    jobs: scheduledJobs.map((job) => job.path),
-    auth: getEnv("INGESTER_JOB_TOKEN") ? "bearer" : "none",
-  }),
-);
+async function createSchedulerRuntime(): Promise<SchedulerRuntime> {
+  runSchedulerStartupChecks();
+  const { SCHEDULED_JOB_NAMES, schedulerHeartbeatRepo } = await import(
+    "@opensend/core"
+  );
 
-await runScheduledBatch();
-setInterval(() => {
-  void runScheduledBatch();
-}, intervalMs);
+  return {
+    baseUrl: getEnv("INGESTER_URL") ?? DEFAULT_INGESTER_URL,
+    heartbeatRepo: schedulerHeartbeatRepo,
+    intervalMs: getIntervalMs(),
+    jobs: SCHEDULED_JOB_NAMES.map((name) => ({
+      name,
+      path: JOB_PATHS[name],
+    })),
+  };
+}
+
+async function startScheduler(): Promise<void> {
+  const runtime = await createSchedulerRuntime();
+
+  console.log(
+    JSON.stringify({
+      level: "info",
+      event: "scheduler.started",
+      ingester_url: runtime.baseUrl,
+      interval_seconds: runtime.intervalMs / 1000,
+      jobs: runtime.jobs.map((job) => job.path),
+      auth: getEnv("INGESTER_JOB_TOKEN") ? "bearer" : "none",
+    }),
+  );
+
+  await runScheduledBatch(runtime);
+  setInterval(() => {
+    void runScheduledBatch(runtime);
+  }, runtime.intervalMs);
+}
+
+const schedulerEntrypoint = process.argv[1];
+const isSchedulerEntrypoint =
+  schedulerEntrypoint?.endsWith("job-scheduler.ts") === true ||
+  schedulerEntrypoint?.endsWith("job-scheduler.js") === true;
+
+if (isSchedulerEntrypoint) {
+  await startScheduler();
+}

--- a/packages/ingester/src/job-scheduler.ts
+++ b/packages/ingester/src/job-scheduler.ts
@@ -5,6 +5,10 @@ import {
   assertValidOpenSendEnv,
 } from "@opensend/core/src/env";
 import { fetchSchedulerJobResult } from "./job-scheduler-request";
+import {
+  type SchedulerHeartbeatRepo,
+  upsertSchedulerHeartbeat,
+} from "./scheduler-heartbeat-write";
 
 function runSchedulerStartupChecks(): void {
   try {
@@ -29,6 +33,7 @@ function runSchedulerStartupChecks(): void {
 const DEFAULT_INGESTER_URL = "http://ingester:3016";
 const DEFAULT_INTERVAL_SECONDS = 60;
 const REQUEST_TIMEOUT_MS = 20_000;
+const HEARTBEAT_UPSERT_TIMEOUT_MS = 5_000;
 
 // Paths are kept as literal strings (not derived) so the static-coverage
 // test at tests/ingester-job-scheduler-coverage.test.ts can grep for each
@@ -43,13 +48,6 @@ const JOB_PATHS = {
 type ScheduledJob = {
   readonly name: ScheduledJobName;
   readonly path: string;
-};
-
-type SchedulerHeartbeatRepo = {
-  readonly upsert: (
-    jobName: string,
-    result: Record<string, unknown>,
-  ) => Promise<unknown>;
 };
 
 type SchedulerRuntime = {
@@ -195,7 +193,12 @@ async function runJob(
       // body wasn't JSON — that's fine, we already logged it above
     }
 
-    await runtime.heartbeatRepo.upsert(job.name, resultPayload);
+    await upsertSchedulerHeartbeat({
+      heartbeatRepo: runtime.heartbeatRepo,
+      jobName: job.name,
+      result: resultPayload,
+      timeoutMs: HEARTBEAT_UPSERT_TIMEOUT_MS,
+    });
   } catch (heartbeatErr) {
     console.error(
       JSON.stringify({

--- a/packages/ingester/src/scheduler-heartbeat-write.ts
+++ b/packages/ingester/src/scheduler-heartbeat-write.ts
@@ -1,0 +1,52 @@
+export type SchedulerHeartbeatRepo = {
+  readonly upsert: (
+    jobName: string,
+    result: Record<string, unknown>,
+  ) => Promise<unknown>;
+};
+
+export type UpsertSchedulerHeartbeatOptions = {
+  readonly heartbeatRepo: SchedulerHeartbeatRepo;
+  readonly jobName: string;
+  readonly result: Record<string, unknown>;
+  readonly timeoutMs: number;
+};
+
+export class SchedulerHeartbeatTimeoutError extends Error {
+  readonly jobName: string;
+  readonly timeoutMs: number;
+
+  constructor(jobName: string, timeoutMs: number) {
+    super(
+      `scheduler heartbeat upsert for ${jobName} timed out after ${timeoutMs}ms`,
+    );
+    this.name = "SchedulerHeartbeatTimeoutError";
+    this.jobName = jobName;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export async function upsertSchedulerHeartbeat({
+  heartbeatRepo,
+  jobName,
+  result,
+  timeoutMs,
+}: UpsertSchedulerHeartbeatOptions): Promise<unknown> {
+  const upsert = heartbeatRepo.upsert(jobName, result);
+  upsert.catch(() => undefined);
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new SchedulerHeartbeatTimeoutError(jobName, timeoutMs));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([upsert, timeout]);
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/tests/ingester-job-scheduler-timeout.test.ts
+++ b/tests/ingester-job-scheduler-timeout.test.ts
@@ -3,6 +3,10 @@ import {
   type SchedulerRequestTimeoutError,
   fetchSchedulerJobResult,
 } from "../packages/ingester/src/job-scheduler-request";
+import {
+  type SchedulerHeartbeatTimeoutError,
+  upsertSchedulerHeartbeat,
+} from "../packages/ingester/src/scheduler-heartbeat-write";
 
 describe("ingester job scheduler request timeout", () => {
   it("fails a never-settling job request on the scheduler timeout", async () => {
@@ -39,5 +43,24 @@ describe("ingester job scheduler request timeout", () => {
       ok: true,
       status: 200,
     });
+  });
+
+  it("fails a never-settling heartbeat write on the scheduler timeout", async () => {
+    const heartbeatRepo = {
+      upsert: () => new Promise<unknown>(() => undefined),
+    };
+
+    await expect(
+      upsertSchedulerHeartbeat({
+        heartbeatRepo,
+        jobName: "scheduled-emails",
+        result: { interval_ms: 60_000, status: "ok", http_status: 200 },
+        timeoutMs: 1,
+      }),
+    ).rejects.toMatchObject({
+      name: "SchedulerHeartbeatTimeoutError",
+      jobName: "scheduled-emails",
+      timeoutMs: 1,
+    } satisfies Partial<SchedulerHeartbeatTimeoutError>);
   });
 });

--- a/tests/ingester-job-scheduler-timeout.test.ts
+++ b/tests/ingester-job-scheduler-timeout.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  type SchedulerRequestTimeoutError,
+  fetchSchedulerJobResult,
+} from "../packages/ingester/src/job-scheduler-request";
+
+describe("ingester job scheduler request timeout", () => {
+  it("fails a never-settling job request on the scheduler timeout", async () => {
+    const neverSettles = () => new Promise<Response>(() => undefined);
+
+    await expect(
+      fetchSchedulerJobResult({
+        headers: {},
+        schedulerFetch: neverSettles,
+        timeoutMs: 1,
+        url: new URL("https://events.opensend.test/jobs/webhooks"),
+      }),
+    ).rejects.toMatchObject({
+      name: "SchedulerRequestTimeoutError",
+      timeoutMs: 1,
+    } satisfies Partial<SchedulerRequestTimeoutError>);
+  });
+
+  it("returns the response body when the job completes before the timeout", async () => {
+    const completes = () =>
+      Promise.resolve(
+        new Response('{"processed":0,"results":[]}', { status: 200 }),
+      );
+
+    await expect(
+      fetchSchedulerJobResult({
+        headers: { authorization: "Bearer test" },
+        schedulerFetch: completes,
+        timeoutMs: 1_000,
+        url: new URL("https://events.opensend.test/jobs/webhooks"),
+      }),
+    ).resolves.toEqual({
+      body: '{"processed":0,"results":[]}',
+      ok: true,
+      status: 200,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- bound scheduler job HTTP calls with an explicit timeout race so a stuck request cannot hold the batch lock indefinitely
- defer scheduler runtime startup to the actual job-scheduler entrypoint so the timeout helper can be tested directly
- add regression coverage for never-settling scheduler requests

## Verification
- make check
- make test
- bunx vitest run tests/ingester-job-scheduler-timeout.test.ts tests/ingester-job-scheduler-coverage.test.ts
- bun build ./packages/ingester/src/job-scheduler.ts --target bun --outfile /tmp/opensend-job-scheduler.js

## Production context
The 2026-06-23 incident showed the scheduler ECS task still running while scheduler heartbeats went stale. Logs showed repeated `scheduler.batch_skipped` with `previous_batch_still_running`, which this patch prevents for stuck job HTTP calls.