### PR TITLE
Improve local dev DB workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,11 +45,17 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
 - `make all` — check + test
 - `bun run dev` — Next.js dev server on port 3015
 - `bun run build` — production build
+- `make db` — start **only** Postgres for local dev (self-heals a stale `postmaster.pid`)
+- `make setup` — one-command local bootstrap: Postgres + deps + schema (`db:push`) + seed
 - `bun run db:generate` — Drizzle migration files
 - `bun run db:migrate` — apply migrations for the configured `DATABASE_URL`
 - `bun run db:push` — push schema (dev)
 - `bun run db:seed` — seed sample data
 - `docker compose up -d` — full stack with Postgres + auto-migration
+
+**Local dev uses `db:push`, not `db:migrate`.** `make setup` bootstraps the dev DB via `drizzle-kit push` (schema sync), so the Drizzle migration-tracking table stays empty. Running `bun run db:migrate` against a push-bootstrapped local DB fails (it tries to replay migration #1 over existing tables) and the error is swallowed — so reach for `db:push` when syncing schema locally. `db:migrate` is for the Docker `migrate` service and real deploys.
+
+**Keep `.env` in sync with `.env.example`.** Compose interpolates every service before starting any one, so a `.env` missing required keys (e.g. `INGESTER_JOB_TOKEN`, `WEBHOOK_SECRET_ENCRYPTION_KEY`) aborts even `make db` / `docker compose up postgres`. After pulling, diff your `.env` keys against `.env.example` and add any new placeholders.
 
 
 ## Worktrees

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,11 +44,17 @@ Open-source, self-hostable email platform. REST API, TypeScript SDK, React email
 - `make all` — check + test
 - `bun run dev` — Next.js dev server on port 3015
 - `bun run build` — production build
+- `make db` — start **only** Postgres for local dev (self-heals a stale `postmaster.pid`)
+- `make setup` — one-command local bootstrap: Postgres + deps + schema (`db:push`) + seed
 - `bun run db:generate` — Drizzle migration files
 - `bun run db:migrate` — apply migrations for the configured `DATABASE_URL`
 - `bun run db:push` — push schema (dev)
 - `bun run db:seed` — seed sample data
 - `docker compose up -d` — full stack with Postgres + auto-migration
+
+**Local dev uses `db:push`, not `db:migrate`.** `make setup` bootstraps the dev DB via `drizzle-kit push` (schema sync), so the Drizzle migration-tracking table stays empty. Running `bun run db:migrate` against a push-bootstrapped local DB fails (it tries to replay migration #1 over existing tables) and the error is swallowed — so reach for `db:push` when syncing schema locally. `db:migrate` is for the Docker `migrate` service and real deploys.
+
+**Keep `.env` in sync with `.env.example`.** Compose interpolates every service before starting any one, so a `.env` missing required keys (e.g. `INGESTER_JOB_TOKEN`, `WEBHOOK_SECRET_ENCRYPTION_KEY`) aborts even `make db` / `docker compose up postgres`. After pulling, diff your `.env` keys against `.env.example` and add any new placeholders.
 
 
 ## Worktrees

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-.PHONY: check test test-e2e typecheck lint format fix all dev build clean setup cli-build cli-test cli-check go-all bench
+.PHONY: check test test-e2e typecheck lint format fix all dev build clean setup db _db-heal cli-build cli-test cli-check go-all bench
 
 # Go CLI version (override with make cli-build VERSION=1.2.3)
 VERSION ?= dev
+
+# Postgres volume/container names (compose project `opensend-staging`).
+PG_VOLUME = opensend-staging_pgdata
+PG_CONTAINER = opensend-staging-postgres-1
 
 # Full validation: check + test
 all: check test
@@ -50,8 +54,22 @@ db-migrate:
 db-push:
 	bunx drizzle-kit push --config drizzle.config.ts
 
+# Start only Postgres for local dev (app runs natively via `make dev`).
+db: _db-heal
+	@echo "→ Starting Postgres..." && docker compose up postgres -d
+	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; echo "  ✓ Postgres up on port $${POSTGRES_PORT:-5432}"
+
+# Remove a stale postmaster.pid left by an unclean shutdown — but ONLY when
+# Postgres is not running, so a live database is never touched. No-op if the
+# volume/container don't exist yet (fresh machine).
+_db-heal:
+	@if [ -z "$$(docker ps -q -f name=$(PG_CONTAINER) -f status=running)" ]; then \
+		docker run --rm -v $(PG_VOLUME):/var/lib/postgresql/data postgres:16-alpine \
+			sh -c 'rm -f /var/lib/postgresql/data/postmaster.pid' >/dev/null 2>&1 || true; \
+	fi
+
 # One-command local setup (requires Docker)
-setup:
+setup: _db-heal
 	@test -f .env || (cp .env.example .env && echo "  ✓ Created .env from .env.example")
 	@echo "→ Starting Postgres..." && docker compose up postgres -d
 	@echo "→ Waiting for Postgres..." && until docker compose exec -T postgres pg_isready -U opensend >/dev/null 2>&1; do sleep 1; done && echo "  ✓ Postgres is ready"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint:fix": "biome check --write .",
     "db:generate": "drizzle-kit generate --config drizzle.config.ts",
     "db:migrate": "drizzle-kit migrate --config drizzle.config.ts",
+    "db:up": "docker compose up postgres -d",
     "db:push": "drizzle-kit push --config drizzle.config.ts",
     "db:seed": "tsx scripts/seed.ts",
     "dev:api": "bun run --cwd services/api dev",


### PR DESCRIPTION
## What
Quality-of-life improvements to the local-dev database workflow, plus docs that capture two gotchas hit in practice.

- Add `make db` / `bun run db:up` — start **only** Postgres for the native-app dev loop.
- Self-heal a stale `postmaster.pid` in `make db` / `make setup`, but **only when Postgres isn't running**, so a live DB is never touched (no-op on a fresh machine).
- Document in both `CLAUDE.md` and `AGENTS.md`:
  - Local dev uses `db:push`, not `db:migrate` (push-bootstrapped DB has an empty migration-tracking table; `db:migrate` fails with a swallowed error).
  - Keep `.env` in sync with `.env.example` — Compose interpolates every service before starting any one, so a `.env` missing required keys (e.g. `INGESTER_JOB_TOKEN`, `WEBHOOK_SECRET_ENCRYPTION_KEY`) aborts even `make db` / `docker compose up postgres`.

## Why
Bringing up just the local DB failed with confusing interpolation errors (missing `.env` keys) and a `postmaster.pid` crash-loop after an unclean shutdown. These changes make the documented `make setup` path Just Work and explain the push-vs-migrate trap.

## Testing
- `make db` verified end-to-end (reports correct mapped port from `.env`).
- Self-heal guard verified to skip when the DB is already running.
- Pre-push typecheck + Biome passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)