### PR TITLE
feat: auto-provision SES MANAGED dedicated IP pools on operator approval (#646)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,10 +140,14 @@ INGESTER_INBOUND_TOKEN=local-dev-ingester-inbound-token-replace-before-productio
 # SES_INBOUND_BUCKET_NAME=
 # Optional SES receipt rule set name managed when dashboard receiving is enabled.
 # SES_INBOUND_RULE_SET_NAME=opensend-inbound
-# Durable scheduler cadence for /jobs/scheduled-emails, /jobs/webhooks, /jobs/domain-verify, and /jobs/billing-overage.
+# Durable scheduler cadence for /jobs/scheduled-emails, /jobs/webhooks, /jobs/domain-verify, /jobs/billing-overage, and /jobs/dedicated-ip-sync.
 # INGESTER_SCHEDULER_INTERVAL_SECONDS=60
 # Bearer token required by /api/cron/* scheduled-email endpoints.
 CRON_AUTH_TOKEN=local-dev-cron-auth-token-replace-before-production
+# Operator-only token for POST /api/internal/dedicated-ips/{id}/approve.
+# SES MANAGED dedicated IP pools bill from creation — only set in environments where
+# a human operator reviews dedicated IP requests before calling this endpoint.
+DEDICATED_IP_OPERATOR_TOKEN=
 
 # ─────────────────────────────────────────────────────────────────
 # Security secrets (REQUIRED in production; dev has fallbacks)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -251,6 +251,7 @@ services:
   #   - /jobs/webhooks
   #   - /jobs/domain-verify
   #   - /jobs/billing-overage
+  #   - /jobs/dedicated-ip-sync
   # The scheduler sends Authorization: Bearer <INGESTER_JOB_TOKEN>.
   scheduler:
     image: ghcr.io/namuh-eng/opensend-ingester:v1.0.0

--- a/docs/ingester-deploy.md
+++ b/docs/ingester-deploy.md
@@ -182,7 +182,7 @@ INGESTER_SCHEDULER_INTERVAL_SECONDS=60
 
 ### Periodic scans
 
-Four scans need to run every minute: `/jobs/scheduled-emails`, `/jobs/webhooks`, `/jobs/domain-verify`, and `/jobs/billing-overage`. The Docker Compose `scheduler` sidecar runs all four by default. For managed production, use one of these patterns:
+Five scans need to run every minute: `/jobs/scheduled-emails`, `/jobs/webhooks`, `/jobs/domain-verify`, `/jobs/billing-overage`, and `/jobs/dedicated-ip-sync`. The Docker Compose `scheduler` sidecar runs all five by default. For managed production, use one of these patterns:
 
 **HTTP-driven** (e.g. AWS EventBridge schedule rule with HTTP target, or any
 cron driver that can issue authenticated POSTs):
@@ -197,11 +197,13 @@ curl -i -X POST "${INGESTER_URL}/jobs/domain-verify" \
   -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
 curl -i -X POST "${INGESTER_URL}/jobs/billing-overage" \
   -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
+curl -i -X POST "${INGESTER_URL}/jobs/dedicated-ip-sync" \
+  -H "Authorization: Bearer ${INGESTER_JOB_TOKEN}"
 ```
 
 **Queue-driven**: publish `scheduled-email.scan` and `webhook-delivery.scan`
 SQS messages on the same minute cadence; the ingester picks them up via the
-normal long-poll loop. Domain verification and billing overage reporting are HTTP-only today, so keep an HTTP schedule for `/jobs/domain-verify` and `/jobs/billing-overage`.
+normal long-poll loop. Domain verification, billing overage reporting, and dedicated IP sync are HTTP-only today, so keep an HTTP schedule for `/jobs/domain-verify`, `/jobs/billing-overage`, and `/jobs/dedicated-ip-sync`.
 
 Manual probes during a deploy:
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -175,7 +175,7 @@ contributor-facing set; the table below adds the production-only entries.
 | `SES_INBOUND_SNS_TOPIC_ARN` | SNS topic for SES receipt-rule S3 notifications. Required for hosted-style receiving provisioning. Subscribe it to `/events/inbound/ses-s3`. |
 | `SES_INBOUND_BUCKET_NAME` | Optional raw MIME bucket allowlist for SES receipt-rule ingestion. Defaults to `S3_BUCKET_NAME`. |
 | `SES_INBOUND_RULE_SET_NAME` | Optional SES receipt rule set managed by the dashboard receiving toggle. Defaults to `opensend-inbound`. |
-| `INGESTER_SCHEDULER_INTERVAL_SECONDS` | Compose scheduler cadence for `/jobs/scheduled-emails`, `/jobs/webhooks`, `/jobs/domain-verify`, and `/jobs/billing-overage`. Default `60`; minimum `10`. |
+| `INGESTER_SCHEDULER_INTERVAL_SECONDS` | Compose scheduler cadence for `/jobs/scheduled-emails`, `/jobs/webhooks`, `/jobs/domain-verify`, `/jobs/billing-overage`, and `/jobs/dedicated-ip-sync`. Default `60`; minimum `10`. |
 | `RATE_LIMIT_BACKEND` | `disabled` (single-process dev outside Compose), or `redis` (Compose/shared/staging/production). |
 | `REDIS_URL` | Redis endpoint. Compose defaults to `redis://redis:6379`; managed production should use a private TLS endpoint such as `rediss://default:<password>@<endpoint>:6379`. Used for rate limiting, auth/domain metadata cache, and ingester cache invalidation. |
 | `OPENSEND_APP_REPLICAS` | Expected app replica count. Set greater than `1` when load balancing app containers; startup checks warn unless `RATE_LIMIT_BACKEND=redis`. |

--- a/drizzle/0038_talented_smasher.sql
+++ b/drizzle/0038_talented_smasher.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "dedicated_ip_pools" ADD COLUMN "aws_region" varchar(32);--> statement-breakpoint
+ALTER TABLE "dedicated_ip_pools" ADD COLUMN "last_synced_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "dedicated_ip_pools" ADD COLUMN "ip_count" integer;

--- a/drizzle/meta/0038_snapshot.json
+++ b/drizzle/meta/0038_snapshot.json
@@ -1,0 +1,5704 @@
+{
+  "id": "6462b42d-6464-4d18-a0aa-84e78b94b960",
+  "prevId": "30476455-8f1e-465b-8873-6b73b2fe6a0d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_preview": {
+          "name": "token_preview",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_access'"
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_token_hash_idx": {
+          "name": "api_keys_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_api_key_id": {
+          "name": "source_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_user_created_at_idx": {
+          "name": "audit_events_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_user_action_idx": {
+          "name": "audit_events_user_action_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_source_api_key_idx": {
+          "name": "audit_events_source_api_key_idx",
+          "columns": [
+            {
+              "expression": "source_api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_runs": {
+      "name": "automation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_event_id": {
+          "name": "trigger_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "current_step_key": {
+          "name": "current_step_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_states": {
+          "name": "step_states",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_step_at": {
+          "name": "next_step_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "automation_runs_status_next_step_at_idx": {
+          "name": "automation_runs_status_next_step_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_step_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_automation_id_created_at_idx": {
+          "name": "automation_runs_automation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_runs_automation_id_automations_id_fk": {
+          "name": "automation_runs_automation_id_automations_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_steps": {
+      "name": "automation_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_steps_automation_id_key_idx": {
+          "name": "automation_steps_automation_id_key_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_steps_automation_id_position_idx": {
+          "name": "automation_steps_automation_id_position_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_steps_automation_id_automations_id_fk": {
+          "name": "automation_steps_automation_id_automations_id_fk",
+          "tableFrom": "automation_steps",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automations": {
+      "name": "automations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "trigger_event_name": {
+          "name": "trigger_event_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connections": {
+          "name": "connections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "automations_status_trigger_idx": {
+          "name": "automations_status_trigger_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automations_user_id_idx": {
+          "name": "automations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_overage_reports": {
+      "name": "billing_overage_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "usage_period_id": {
+          "name": "usage_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_key": {
+          "name": "report_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meter_event_name": {
+          "name": "meter_event_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_overage_emails": {
+          "name": "from_overage_emails",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "through_overage_emails": {
+          "name": "through_overage_emails",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delta_emails": {
+          "name": "delta_emails",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stripe_submission_started_at": {
+          "name": "stripe_submission_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_reported_at": {
+          "name": "stripe_reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_overage_reports_report_key_idx": {
+          "name": "billing_overage_reports_report_key_idx",
+          "columns": [
+            {
+              "expression": "report_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_overage_reports_usage_period_idx": {
+          "name": "billing_overage_reports_usage_period_idx",
+          "columns": [
+            {
+              "expression": "usage_period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_overage_reports_status_idx": {
+          "name": "billing_overage_reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_overage_reports_usage_period_id_usage_periods_id_fk": {
+          "name": "billing_overage_reports_usage_period_id_usage_periods_id_fk",
+          "tableFrom": "billing_overage_reports",
+          "tableTo": "usage_periods",
+          "columnsFrom": [
+            "usage_period_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.broadcasts": {
+      "name": "broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_id": {
+          "name": "audience_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_properties": {
+      "name": "contact_properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'string'"
+        },
+        "fallback_value": {
+          "name": "fallback_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_properties_key_idx": {
+          "name": "contact_properties_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed": {
+          "name": "unsubscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "custom_properties": {
+          "name": "custom_properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segments": {
+          "name": "segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_subscriptions": {
+          "name": "topic_subscriptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contacts_email_idx": {
+          "name": "contacts_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_unsubscribed_idx": {
+          "name": "contacts_unsubscribed_idx",
+          "columns": [
+            {
+              "expression": "unsubscribed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_created_at_idx": {
+          "name": "contacts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts_to_segments": {
+      "name": "contacts_to_segments",
+      "schema": "",
+      "columns": {
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contacts_to_segments_idx": {
+          "name": "contacts_to_segments_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "segment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_to_segments_segment_id_idx": {
+          "name": "contacts_to_segments_segment_id_idx",
+          "columns": [
+            {
+              "expression": "segment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contacts_to_segments_contact_id_contacts_id_fk": {
+          "name": "contacts_to_segments_contact_id_contacts_id_fk",
+          "tableFrom": "contacts_to_segments",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contacts_to_segments_segment_id_segments_id_fk": {
+          "name": "contacts_to_segments_segment_id_segments_id_fk",
+          "tableFrom": "contacts_to_segments",
+          "tableTo": "segments",
+          "columnsFrom": [
+            "segment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_event_deliveries": {
+      "name": "custom_event_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "custom_event_deliveries_event_name_idx": {
+          "name": "custom_event_deliveries_event_name_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_event_deliveries_received_at_idx": {
+          "name": "custom_event_deliveries_received_at_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_events": {
+      "name": "custom_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "custom_events_user_name_idx": {
+          "name": "custom_events_user_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_export_jobs": {
+      "name": "dashboard_export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_email": {
+          "name": "created_by_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'csv'"
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloaded_at": {
+          "name": "downloaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "dashboard_export_jobs_user_created_at_idx": {
+          "name": "dashboard_export_jobs_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_export_jobs_user_status_idx": {
+          "name": "dashboard_export_jobs_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_export_jobs_expires_at_idx": {
+          "name": "dashboard_export_jobs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dedicated_ip_pools": {
+      "name": "dedicated_ip_pools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ses_pool_name": {
+          "name": "ses_pool_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scaling_mode": {
+          "name": "scaling_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MANAGED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "operator_notes": {
+          "name": "operator_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioned_at": {
+          "name": "provisioned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warming_started_at": {
+          "name": "warming_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aws_region": {
+          "name": "aws_region",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_count": {
+          "name": "ip_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dedicated_ip_pools_ses_pool_name_idx": {
+          "name": "dedicated_ip_pools_ses_pool_name_idx",
+          "columns": [
+            {
+              "expression": "ses_pool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dedicated_ip_pools_user_id_idx": {
+          "name": "dedicated_ip_pools_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_deliverability_statuses": {
+      "name": "domain_deliverability_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bimi_selector": {
+          "name": "bimi_selector",
+          "type": "varchar(63)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "bimi_status": {
+          "name": "bimi_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_configured'"
+        },
+        "bimi_logo_url": {
+          "name": "bimi_logo_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bimi_certificate_url": {
+          "name": "bimi_certificate_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bimi_notes": {
+          "name": "bimi_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_branded_mail_status": {
+          "name": "apple_branded_mail_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "apple_branded_mail_notes": {
+          "name": "apple_branded_mail_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_deliverability_statuses_domain_id_idx": {
+          "name": "domain_deliverability_statuses_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_deliverability_statuses_user_id_idx": {
+          "name": "domain_deliverability_statuses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_deliverability_statuses_user_domain_idx": {
+          "name": "domain_deliverability_statuses_user_domain_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domains": {
+      "name": "domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'us-east-1'"
+        },
+        "dkim_tokens": {
+          "name": "dkim_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "records": {
+          "name": "records",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_clicks": {
+          "name": "track_clicks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "track_opens": {
+          "name": "track_opens",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tls": {
+          "name": "tls",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opportunistic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_return_path": {
+          "name": "custom_return_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_subdomain": {
+          "name": "tracking_subdomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_origin": {
+          "name": "dkim_origin",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AWS_SES'"
+        },
+        "dkim_selector": {
+          "name": "dkim_selector",
+          "type": "varchar(63)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_public_key": {
+          "name": "dkim_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_private_key_ct": {
+          "name": "dkim_private_key_ct",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_private_key_iv": {
+          "name": "dkim_private_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedicated_ip_pool_id": {
+          "name": "dedicated_ip_pool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ses_configuration_set_name": {
+          "name": "ses_configuration_set_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_events": {
+      "name": "email_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_events_email_id_idx": {
+          "name": "email_events_email_id_idx",
+          "columns": [
+            {
+              "expression": "email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_events_user_id_idx": {
+          "name": "email_events_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_events_source_id_idx": {
+          "name": "email_events_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_events_email_id_emails_id_fk": {
+          "name": "email_events_email_id_emails_id_fk",
+          "tableFrom": "email_events",
+          "tableTo": "emails",
+          "columnsFrom": [
+            "email_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_email_id": {
+          "name": "source_email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed_at": {
+          "name": "suppressed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_suppressions_user_email_idx": {
+          "name": "email_suppressions_user_email_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_user_idx": {
+          "name": "email_suppressions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_email_idx": {
+          "name": "email_suppressions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.emails": {
+      "name": "emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc": {
+          "name": "cc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider_retry_count": {
+          "name": "provider_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "provider_last_attempted_at": {
+          "name": "provider_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_next_retry_at": {
+          "name": "provider_next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_last_error_code": {
+          "name": "provider_last_error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_last_error_message": {
+          "name": "provider_last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_dead_lettered_at": {
+          "name": "provider_dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_address": {
+          "name": "reply_address",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_token": {
+          "name": "reply_token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "emails_status_idx": {
+          "name": "emails_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_created_at_idx": {
+          "name": "emails_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_status_created_at_idx": {
+          "name": "emails_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_user_created_at_idx": {
+          "name": "emails_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_user_thread_idx": {
+          "name": "emails_user_thread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_tags_gin_idx": {
+          "name": "emails_tags_gin_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "emails_user_id_idempotency_key_idx": {
+          "name": "emails_user_id_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_user_id_reply_token_idx": {
+          "name": "emails_user_id_reply_token_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reply_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forwarding_attempts": {
+      "name": "forwarding_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_email_id": {
+          "name": "received_email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forwarded_email_id": {
+          "name": "forwarded_email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destinations": {
+          "name": "destinations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_eligible": {
+          "name": "retry_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forwarding_attempts_user_created_at_idx": {
+          "name": "forwarding_attempts_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forwarding_attempts_received_email_id_idx": {
+          "name": "forwarding_attempts_received_email_id_idx",
+          "columns": [
+            {
+              "expression": "received_email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forwarding_attempts_rule_id_idx": {
+          "name": "forwarding_attempts_rule_id_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forwarding_attempts_forwarded_email_id_idx": {
+          "name": "forwarding_attempts_forwarded_email_id_idx",
+          "columns": [
+            {
+              "expression": "forwarded_email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forwarding_attempts_rule_id_forwarding_rules_id_fk": {
+          "name": "forwarding_attempts_rule_id_forwarding_rules_id_fk",
+          "tableFrom": "forwarding_attempts",
+          "tableTo": "forwarding_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "forwarding_attempts_received_email_id_received_emails_id_fk": {
+          "name": "forwarding_attempts_received_email_id_received_emails_id_fk",
+          "tableFrom": "forwarding_attempts",
+          "tableTo": "received_emails",
+          "columnsFrom": [
+            "received_email_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "forwarding_attempts_forwarded_email_id_emails_id_fk": {
+          "name": "forwarding_attempts_forwarded_email_id_emails_id_fk",
+          "tableFrom": "forwarding_attempts",
+          "tableTo": "emails",
+          "columnsFrom": [
+            "forwarded_email_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forwarding_rules": {
+      "name": "forwarding_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destinations": {
+          "name": "destinations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invalid_reason": {
+          "name": "invalid_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forwarding_rules_user_id_idx": {
+          "name": "forwarding_rules_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forwarding_rules_domain_id_idx": {
+          "name": "forwarding_rules_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forwarding_rules_route_id_idx": {
+          "name": "forwarding_rules_route_id_idx",
+          "columns": [
+            {
+              "expression": "route_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forwarding_rules_domain_id_domains_id_fk": {
+          "name": "forwarding_rules_domain_id_domains_id_fk",
+          "tableFrom": "forwarding_rules",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "forwarding_rules_route_id_receiving_routes_id_fk": {
+          "name": "forwarding_rules_route_id_receiving_routes_id_fk",
+          "tableFrom": "forwarding_rules",
+          "tableTo": "receiving_routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_provider_events": {
+      "name": "inbound_provider_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "terminal_reason": {
+          "name": "terminal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_metadata": {
+          "name": "raw_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_email_id": {
+          "name": "received_email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_of_event_id": {
+          "name": "duplicate_of_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inbound_provider_events_provider_event_idx": {
+          "name": "inbound_provider_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbound_provider_events_primary_event_idx": {
+          "name": "inbound_provider_events_primary_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status <> 'duplicate_provider_event'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbound_provider_events_status_idx": {
+          "name": "inbound_provider_events_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbound_provider_events_user_created_at_idx": {
+          "name": "inbound_provider_events_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_enc": {
+          "name": "credentials_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "health_status": {
+          "name": "health_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_health_check_at": {
+          "name": "last_health_check_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connections_user_provider_idx": {
+          "name": "integration_connections_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_user_status_idx": {
+          "name": "integration_connections_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "logs_user_created_at_idx": {
+          "name": "logs_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_document_gin_idx": {
+          "name": "logs_document_gin_idx",
+          "columns": [
+            {
+              "expression": "document",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_price_cents": {
+          "name": "monthly_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthly_email_quota": {
+          "name": "monthly_email_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "daily_email_quota": {
+          "name": "daily_email_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_domains": {
+          "name": "max_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_api_keys": {
+          "name": "max_api_keys",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_contacts": {
+          "name": "max_contacts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_segments": {
+          "name": "max_segments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_broadcasts": {
+          "name": "max_broadcasts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_per_second": {
+          "name": "rate_per_second",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_overage_price_id": {
+          "name": "stripe_overage_price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dedicated_ips_enabled": {
+          "name": "dedicated_ips_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_dedicated_ips": {
+          "name": "max_dedicated_ips",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plans_slug_idx": {
+          "name": "plans_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.received_emails": {
+      "name": "received_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "route_decisions": {
+          "name": "route_decisions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_match_status": {
+          "name": "reply_match_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unmatched'"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_email_id": {
+          "name": "reply_to_email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "received_emails_created_at_idx": {
+          "name": "received_emails_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "received_emails_user_thread_idx": {
+          "name": "received_emails_user_thread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "received_emails_reply_to_email_idx": {
+          "name": "received_emails_reply_to_email_idx",
+          "columns": [
+            {
+              "expression": "reply_to_email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "received_emails_contact_id_idx": {
+          "name": "received_emails_contact_id_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "received_emails_reply_to_email_id_emails_id_fk": {
+          "name": "received_emails_reply_to_email_id_emails_id_fk",
+          "tableFrom": "received_emails",
+          "tableTo": "emails",
+          "columnsFrom": [
+            "reply_to_email_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "received_emails_contact_id_contacts_id_fk": {
+          "name": "received_emails_contact_id_contacts_id_fk",
+          "tableFrom": "received_emails",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receiving_routes": {
+      "name": "receiving_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_part": {
+          "name": "local_part",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_local_part": {
+          "name": "target_local_part",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "receiving_routes_user_id_idx": {
+          "name": "receiving_routes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receiving_routes_domain_id_idx": {
+          "name": "receiving_routes_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receiving_routes_domain_type_local_idx": {
+          "name": "receiving_routes_domain_type_local_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_part",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "receiving_routes_domain_id_domains_id_fk": {
+          "name": "receiving_routes_domain_id_domains_id_fk",
+          "tableFrom": "receiving_routes",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduler_heartbeats": {
+      "name": "scheduler_heartbeats",
+      "schema": "",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_result": {
+          "name": "last_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segments": {
+      "name": "segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contacts_count": {
+          "name": "contacts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unsubscribed_count": {
+          "name": "unsubscribed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_customers": {
+      "name": "stripe_customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_customers_user_id_idx": {
+          "name": "stripe_customers_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_customers_stripe_customer_id_idx": {
+          "name": "stripe_customers_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events_processed": {
+      "name": "stripe_events_processed",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_processed_processed_at_idx": {
+          "name": "stripe_events_processed_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_subscription_id_idx": {
+          "name": "subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_status_idx": {
+          "name": "subscriptions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_plan_id_plans_id_fk": {
+          "name": "subscriptions_plan_id_plans_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled Template'"
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_unpublished_versions": {
+          "name": "has_unpublished_versions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_subscription": {
+          "name": "default_subscription",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opt_out'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.unsubscribe_page_settings": {
+      "name": "unsubscribe_page_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_color": {
+          "name": "brand_color",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#10b981'"
+        },
+        "headline": {
+          "name": "headline",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unsubscribed successfully'"
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'You have been removed from this mailing list. You will no longer receive marketing emails from this sender.'"
+        },
+        "footer_text": {
+          "name": "footer_text",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Powered by OpenSend'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unsubscribe_page_settings_user_id_idx": {
+          "name": "unsubscribe_page_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_periods": {
+      "name": "usage_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emails_sent": {
+          "name": "emails_sent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "included_email_quota": {
+          "name": "included_email_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_reported_emails": {
+          "name": "overage_reported_emails",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "overage_claimed_emails": {
+          "name": "overage_claimed_emails",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "overage_last_reported_at": {
+          "name": "overage_last_reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_warning_80_notified_at": {
+          "name": "usage_warning_80_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_warning_100_notified_at": {
+          "name": "usage_warning_100_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_increment_at": {
+          "name": "last_increment_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_periods_user_period_idx": {
+          "name": "usage_periods_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_periods_user_id_idx": {
+          "name": "usage_periods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_periods_period_end_idx": {
+          "name": "usage_periods_period_end_idx",
+          "columns": [
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_webhook_id_idx": {
+          "name": "webhook_deliveries_webhook_id_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_status_idx": {
+          "name": "webhook_deliveries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_deliveries_event_id_email_events_id_fk": {
+          "name": "webhook_deliveries_event_id_email_events_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "email_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "signing_secret_enc": {
+          "name": "signing_secret_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_entitlements": {
+      "name": "workspace_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "limit": {
+          "name": "limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self_hosted'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_entitlements_workspace_key_idx": {
+          "name": "workspace_entitlements_workspace_key_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_entitlements_key_idx": {
+          "name": "workspace_entitlements_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_entitlements_workspace_id_workspaces_id_fk": {
+          "name": "workspace_entitlements_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_entitlements",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_invitations_token_hash_idx": {
+          "name": "workspace_invitations_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_invitations_workspace_status_idx": {
+          "name": "workspace_invitations_workspace_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_invitations_email_status_idx": {
+          "name": "workspace_invitations_email_status_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_invitations_workspace_id_workspaces_id_fk": {
+          "name": "workspace_invitations_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_invitations_invited_by_user_id_user_id_fk": {
+          "name": "workspace_invitations_invited_by_user_id_user_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_memberships": {
+      "name": "workspace_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_memberships_workspace_user_idx": {
+          "name": "workspace_memberships_workspace_user_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_memberships_user_id_idx": {
+          "name": "workspace_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_memberships_workspace_role_idx": {
+          "name": "workspace_memberships_workspace_role_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_memberships_workspace_id_workspaces_id_fk": {
+          "name": "workspace_memberships_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_memberships",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_memberships_user_id_user_id_fk": {
+          "name": "workspace_memberships_user_id_user_id_fk",
+          "tableFrom": "workspace_memberships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_owner_user_id_idx": {
+          "name": "workspaces_owner_user_id_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_created_at_idx": {
+          "name": "workspaces_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspaces_owner_user_id_user_id_fk": {
+          "name": "workspaces_owner_user_id_user_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1781760814476,
       "tag": "0037_real_hawkeye",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1782383309872,
+      "tag": "0038_talented_smasher",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/repositories/dedicatedIpPoolRepo.ts
+++ b/packages/core/src/db/repositories/dedicatedIpPoolRepo.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq } from "drizzle-orm";
+import { and, asc, desc, eq } from "drizzle-orm";
 import { db } from "../client";
 import { dedicatedIpPools } from "../schema";
 
@@ -78,6 +78,9 @@ export const dedicatedIpPoolRepo = {
         | "provisionedAt"
         | "warmingStartedAt"
         | "retiredAt"
+        | "awsRegion"
+        | "lastSyncedAt"
+        | "ipCount"
       >
     >,
   ) {
@@ -87,6 +90,59 @@ export const dedicatedIpPoolRepo = {
       .where(
         and(eq(dedicatedIpPools.id, id), eq(dedicatedIpPools.userId, userId)),
       )
+      .returning();
+    return row;
+  },
+
+  async listByStatus(status: DedicatedIpPoolStatus) {
+    return await db
+      .select()
+      .from(dedicatedIpPools)
+      .where(eq(dedicatedIpPools.status, status))
+      .orderBy(asc(dedicatedIpPools.createdAt));
+  },
+
+  async updateById(
+    id: string,
+    updates: Partial<
+      Pick<
+        typeof dedicatedIpPools.$inferInsert,
+        | "name"
+        | "sesPoolName"
+        | "scalingMode"
+        | "status"
+        | "provider"
+        | "operatorNotes"
+        | "provisionedAt"
+        | "warmingStartedAt"
+        | "retiredAt"
+        | "awsRegion"
+        | "lastSyncedAt"
+        | "ipCount"
+      >
+    >,
+  ) {
+    const [row] = await db
+      .update(dedicatedIpPools)
+      .set({ ...updates, updatedAt: new Date() })
+      .where(eq(dedicatedIpPools.id, id))
+      .returning();
+    return row;
+  },
+
+  async updateSyncMetadata(
+    id: string,
+    data: { lastSyncedAt: Date; ipCount: number; awsRegion?: string },
+  ) {
+    const [row] = await db
+      .update(dedicatedIpPools)
+      .set({
+        lastSyncedAt: data.lastSyncedAt,
+        ipCount: data.ipCount,
+        ...(data.awsRegion ? { awsRegion: data.awsRegion } : {}),
+        updatedAt: new Date(),
+      })
+      .where(eq(dedicatedIpPools.id, id))
       .returning();
     return row;
   },

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -209,6 +209,9 @@ export const dedicatedIpPools = pgTable(
     provisionedAt: timestamp("provisioned_at", { withTimezone: true }),
     warmingStartedAt: timestamp("warming_started_at", { withTimezone: true }),
     retiredAt: timestamp("retired_at", { withTimezone: true }),
+    awsRegion: varchar("aws_region", { length: 32 }),
+    lastSyncedAt: timestamp("last_synced_at", { withTimezone: true }),
+    ipCount: integer("ip_count"),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,6 +75,7 @@ export * from "./services/auditEvents";
 export * from "./services/suppressions";
 export * from "./services/emailProvider";
 export * from "./services/configurationSet";
+export * from "./services/dedicatedIpPoolService";
 export * from "./services/tracking";
 export * from "./services/trackingRoute";
 export * from "./services/sandboxTestRecipients";

--- a/packages/core/src/jobs/scheduled-jobs.ts
+++ b/packages/core/src/jobs/scheduled-jobs.ts
@@ -11,6 +11,7 @@ export const SCHEDULED_JOB_NAMES = [
   "webhooks",
   "domain-verify",
   "billing-overage",
+  "dedicated-ip-sync",
 ] as const satisfies readonly string[];
 
 export type ScheduledJobName = (typeof SCHEDULED_JOB_NAMES)[number];

--- a/packages/core/src/services/configurationSet.ts
+++ b/packages/core/src/services/configurationSet.ts
@@ -9,6 +9,8 @@ import {
   type EventDestinationDefinition,
   type EventType,
   GetConfigurationSetEventDestinationsCommand,
+  GetDedicatedIpPoolCommand,
+  GetDedicatedIpsCommand,
   PutConfigurationSetDeliveryOptionsCommand,
   SESv2Client,
   UpdateConfigurationSetEventDestinationCommand,
@@ -104,6 +106,76 @@ export class ConfigurationSetService {
     } catch (err) {
       if (!isNotFoundException(err)) throw err;
     }
+  }
+
+  /**
+   * Get a dedicated IP pool from SES. Returns null if not found.
+   */
+  async getDedicatedIpPool(input: {
+    poolName: string;
+    region?: string;
+  }): Promise<{ poolName: string; scalingMode: string } | null> {
+    if (useDevStub) {
+      console.log(`[DEV] Would get SES dedicated IP pool: ${input.poolName}`);
+      return { poolName: input.poolName, scalingMode: "MANAGED" };
+    }
+    try {
+      const resp = await this.getClient(input.region).send(
+        new GetDedicatedIpPoolCommand({ PoolName: input.poolName }),
+      );
+      const pool = resp.DedicatedIpPool;
+      if (!pool) return null;
+      return {
+        poolName: pool.PoolName ?? input.poolName,
+        scalingMode: pool.ScalingMode ?? "MANAGED",
+      };
+    } catch (err) {
+      if (isNotFoundException(err)) return null;
+      throw err;
+    }
+  }
+
+  /**
+   * List all dedicated IPs in a pool from SES, with pagination.
+   * Returns empty array if pool not found.
+   */
+  async getDedicatedIps(input: {
+    poolName: string;
+    region?: string;
+  }): Promise<{ ip: string; warmupStatus: string }[]> {
+    if (useDevStub) {
+      console.log(
+        `[DEV] Would list SES dedicated IPs for pool: ${input.poolName}`,
+      );
+      return [];
+    }
+    const results: { ip: string; warmupStatus: string }[] = [];
+    let nextToken: string | undefined;
+    let pages = 0;
+    const MAX_PAGES = 10;
+    try {
+      do {
+        const resp = await this.getClient(input.region).send(
+          new GetDedicatedIpsCommand({
+            PoolName: input.poolName,
+            PageSize: 100,
+            NextToken: nextToken,
+          }),
+        );
+        for (const ip of resp.DedicatedIps ?? []) {
+          results.push({
+            ip: ip.Ip ?? "",
+            warmupStatus: ip.WarmupStatus ?? "UNKNOWN",
+          });
+        }
+        nextToken = resp.NextToken;
+        pages++;
+      } while (nextToken && pages < MAX_PAGES);
+    } catch (err) {
+      if (isNotFoundException(err)) return [];
+      throw err;
+    }
+    return results;
   }
 
   /**

--- a/packages/core/src/services/dedicatedIpPoolService.ts
+++ b/packages/core/src/services/dedicatedIpPoolService.ts
@@ -1,0 +1,241 @@
+import { desc, eq } from "drizzle-orm";
+import { db } from "../db/client";
+import { dedicatedIpPoolRepo } from "../db/repositories/dedicatedIpPoolRepo";
+import { usagePeriods } from "../db/schema";
+import { configurationSetService } from "./configurationSet";
+
+/**
+ * Advisory minimum monthly email volume for a dedicated IP to warm successfully.
+ * SES-recommended threshold for MANAGED dedicated IP pools.
+ */
+export const DEDICATED_IP_MIN_MONTHLY_VOLUME = 50_000;
+
+function isAlreadyExistsError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error as { name: string }).name === "AlreadyExistsException"
+  );
+}
+
+/**
+ * Generate a collision-proof SES pool name from user and pool UUIDs.
+ * SES pool names: alphanumeric + hyphens, max 64 chars.
+ */
+function buildSesPoolName(userId: string, poolId: string): string {
+  const userSlug = userId
+    .replace(/[^a-z0-9]/gi, "")
+    .toLowerCase()
+    .slice(0, 8);
+  const poolSlug = poolId
+    .replace(/[^a-z0-9]/gi, "")
+    .toLowerCase()
+    .slice(0, 8);
+  return `opensend-${userSlug}-${poolSlug}`;
+}
+
+type ApproveResult =
+  | { ok: false; code: "not_found" }
+  | { ok: false; code: "invalid_status"; current: string }
+  | {
+      ok: true;
+      pool: NonNullable<
+        Awaited<ReturnType<typeof dedicatedIpPoolRepo.findById>>
+      >;
+      volumeWarning: boolean;
+      emailsSent: number;
+    };
+
+/**
+ * Operator-approval gate: provisions the SES dedicated IP pool for a requested record.
+ * Never called from user-facing routes — only the internal operator endpoint calls this.
+ *
+ * Billing note: SES MANAGED pools accrue charges from creation. This function
+ * must only be called after explicit operator review.
+ */
+export async function approveAndProvisionPool(
+  poolId: string,
+  opts: { awsRegion?: string; operatorNotes?: string } = {},
+): Promise<ApproveResult> {
+  const pool = await dedicatedIpPoolRepo.findById(poolId);
+  if (!pool) return { ok: false, code: "not_found" };
+
+  if (pool.status !== "requested") {
+    return { ok: false, code: "invalid_status", current: pool.status };
+  }
+
+  // Volume-readiness check (advisory — does not block provisioning).
+  let volumeWarning = false;
+  let emailsSent = 0;
+  try {
+    const [latestPeriod] = await db
+      .select()
+      .from(usagePeriods)
+      .where(eq(usagePeriods.userId, pool.userId))
+      .orderBy(desc(usagePeriods.periodStart))
+      .limit(1);
+    emailsSent = latestPeriod?.emailsSent ?? 0;
+    if (emailsSent < DEDICATED_IP_MIN_MONTHLY_VOLUME) {
+      volumeWarning = true;
+      console.warn(
+        JSON.stringify({
+          level: "warn",
+          event: "dedicated_ip.approve.low_volume",
+          pool_id: poolId,
+          user_id: pool.userId,
+          emails_sent: emailsSent,
+          threshold: DEDICATED_IP_MIN_MONTHLY_VOLUME,
+        }),
+      );
+    }
+  } catch (err) {
+    console.error("dedicated_ip.approve.volume_check_failed", err);
+  }
+
+  // If operator_notes provided, persist them first.
+  if (opts.operatorNotes != null) {
+    await dedicatedIpPoolRepo.updateById(poolId, {
+      operatorNotes: opts.operatorNotes,
+    });
+  }
+
+  // Generate a collision-proof SES pool name.
+  const sesPoolName = pool.sesPoolName.startsWith("manual-")
+    ? buildSesPoolName(pool.userId, poolId)
+    : pool.sesPoolName;
+
+  const awsRegion = opts.awsRegion ?? "us-east-1";
+
+  // Call SES — swallow AlreadyExistsException (idempotent).
+  try {
+    await configurationSetService.createDedicatedIpPool({
+      poolName: sesPoolName,
+      scalingMode: (pool.scalingMode as "STANDARD" | "MANAGED") ?? "MANAGED",
+      region: awsRegion,
+    });
+  } catch (err) {
+    if (!isAlreadyExistsError(err)) throw err;
+    console.warn(
+      JSON.stringify({
+        level: "warn",
+        event: "dedicated_ip.approve.already_exists",
+        pool_id: poolId,
+        ses_pool_name: sesPoolName,
+      }),
+    );
+  }
+
+  const updated = await dedicatedIpPoolRepo.updateById(poolId, {
+    status: "provisioned",
+    sesPoolName,
+    provider: "ses",
+    awsRegion,
+    provisionedAt: new Date(),
+  });
+
+  if (!updated) {
+    throw new Error(
+      `dedicated_ip.approve: pool ${poolId} disappeared after SES provisioning`,
+    );
+  }
+
+  return { ok: true, pool: updated, volumeWarning, emailsSent };
+}
+
+type ReconcileResult = {
+  ok: boolean;
+  ipCount?: number;
+  graduated?: boolean;
+  newStatus?: string;
+};
+
+/**
+ * Poll SES for the current IP list and advance the pool status as IPs warm.
+ *
+ * Status transitions:
+ *   provisioned → warming  (STANDARD: when IPs appear)
+ *   provisioned → active   (MANAGED: when IPs present and none IN_PROGRESS)
+ *   warming     → active   (when ips.length > 0 && none IN_PROGRESS)
+ */
+export async function reconcileProvisionedPool(
+  poolId: string,
+): Promise<ReconcileResult> {
+  const pool = await dedicatedIpPoolRepo.findById(poolId);
+  if (!pool) return { ok: false };
+
+  // Skip if synced recently (< 5 minutes ago).
+  if (pool.lastSyncedAt) {
+    const ageMs = Date.now() - pool.lastSyncedAt.getTime();
+    if (ageMs < 5 * 60 * 1000) {
+      return { ok: true, ipCount: pool.ipCount ?? 0, graduated: false };
+    }
+  }
+
+  let ips: { ip: string; warmupStatus: string }[];
+  try {
+    ips = await configurationSetService.getDedicatedIps({
+      poolName: pool.sesPoolName,
+      region: pool.awsRegion ?? "us-east-1",
+    });
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "dedicated_ip.reconcile.get_ips_failed",
+        pool_id: poolId,
+      }),
+      err,
+    );
+    return { ok: false };
+  }
+
+  await dedicatedIpPoolRepo.updateSyncMetadata(poolId, {
+    lastSyncedAt: new Date(),
+    ipCount: ips.length,
+    awsRegion: pool.awsRegion ?? undefined,
+  });
+
+  // Graduation logic.
+  const allReady =
+    ips.length > 0 && ips.every((ip) => ip.warmupStatus !== "IN_PROGRESS");
+  const isManaged = pool.scalingMode === "MANAGED";
+
+  if (pool.status === "provisioned") {
+    if (allReady && isManaged) {
+      // MANAGED pools auto-warm — advance directly to active.
+      await dedicatedIpPoolRepo.updateById(poolId, { status: "active" });
+      return {
+        ok: true,
+        ipCount: ips.length,
+        graduated: true,
+        newStatus: "active",
+      };
+    }
+    if (ips.length > 0) {
+      // IPs appeared — move to warming.
+      await dedicatedIpPoolRepo.updateById(poolId, {
+        status: "warming",
+        warmingStartedAt: new Date(),
+      });
+      return {
+        ok: true,
+        ipCount: ips.length,
+        graduated: true,
+        newStatus: "warming",
+      };
+    }
+  }
+
+  if (pool.status === "warming" && allReady) {
+    await dedicatedIpPoolRepo.updateById(poolId, { status: "active" });
+    return {
+      ok: true,
+      ipCount: ips.length,
+      graduated: true,
+      newStatus: "active",
+    };
+  }
+
+  return { ok: true, ipCount: ips.length, graduated: false };
+}

--- a/packages/ingester/src/index.ts
+++ b/packages/ingester/src/index.ts
@@ -294,6 +294,41 @@ app.post("/jobs/billing-overage", async (c) =>
   runJobEndpoint(c, async () => await reportBillingOverageUsage()),
 );
 
+app.post("/jobs/dedicated-ip-sync", async (c) =>
+  runJobEndpoint(c, async () => {
+    const { dedicatedIpPoolRepo, reconcileProvisionedPool } = await import(
+      "@opensend/core"
+    );
+
+    const provisioned = await dedicatedIpPoolRepo.listByStatus("provisioned");
+    const warming = await dedicatedIpPoolRepo.listByStatus("warming");
+    const pools = [...provisioned, ...warming];
+
+    const scanned = pools.length;
+    let updated = 0;
+    let failed = 0;
+
+    for (const pool of pools) {
+      try {
+        const result = await reconcileProvisionedPool(pool.id);
+        if (result.graduated) updated++;
+      } catch (err) {
+        failed++;
+        console.error(
+          JSON.stringify({
+            level: "error",
+            event: "dedicated_ip.sync.pool_failed",
+            pool_id: pool.id,
+          }),
+          err,
+        );
+      }
+    }
+
+    return { scanned, updated, failed };
+  }),
+);
+
 app.post("/jobs/domain-verify", async (c) =>
   runJobEndpoint(c, async () => {
     const telemetry = createTelemetryContext({

--- a/packages/ingester/src/job-scheduler.ts
+++ b/packages/ingester/src/job-scheduler.ts
@@ -42,6 +42,7 @@ const JOB_PATHS: Record<(typeof SCHEDULED_JOB_NAMES)[number], string> = {
   webhooks: "/jobs/webhooks",
   "domain-verify": "/jobs/domain-verify",
   "billing-overage": "/jobs/billing-overage",
+  "dedicated-ip-sync": "/jobs/dedicated-ip-sync",
 };
 
 type ScheduledJob = {

--- a/public/docs/api-reference/domains/dedicated-ip-lifecycle.md
+++ b/public/docs/api-reference/domains/dedicated-ip-lifecycle.md
@@ -1,6 +1,71 @@
 # Dedicated IP lifecycle
 
-Dedicated IP APIs track manual lifecycle state for a tenant. They do not provision provider IP pools or run warmup flows in v1.
+Dedicated IP pool APIs let tenants request a dedicated IP pool and track it through its full lifecycle. Once a tenant's request is submitted, an operator approves it via the internal endpoint — at which point OpenSend automatically provisions an AWS SES MANAGED dedicated IP pool and begins reconciling its warmup state via the background scheduler.
+
+> **Billing note:** SES MANAGED pools accrue AWS charges from the moment the operator approval endpoint fires. Operators must review usage volume before approving. OpenSend emits a `volume_warning` flag in the approve response when the tenant's most recent billing period sent fewer than 50 000 emails.
+
+## Status lifecycle
+
+```
+requested → provisioned → warming → active → suspended | retired
+                        ↘ active   (MANAGED pools skip warming)
+```
+
+| Status | Meaning |
+|---|---|
+| `requested` | Tenant has submitted a request; awaiting operator review |
+| `provisioned` | SES pool created; awaiting IP assignment |
+| `warming` | IPs assigned (STANDARD mode); warmup in progress |
+| `active` | Pool ready to send |
+| `suspended` | Sending paused by operator |
+| `retired` | Pool decommissioned; SES pool deleted |
+
+The `/jobs/dedicated-ip-sync` background job (runs on the ingester scheduler) polls SES for pools in `provisioned` or `warming` state and advances them automatically.
+
+---
+
+## Endpoints
+
+### List dedicated IP pools
+
+```http
+GET /api/dedicated-ips
+Authorization: Bearer <api_key>
+```
+
+Returns all pools for the authenticated tenant.
+
+**Response**
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "object": "dedicated_ip_pool",
+      "id": "dip_...",
+      "name": "My production pool",
+      "provider": "ses",
+      "provider_pool_name": "opensend-ab12cd34-ef56ab78",
+      "ses_pool_name": "opensend-ab12cd34-ef56ab78",
+      "scaling_mode": "MANAGED",
+      "status": "active",
+      "operator_notes": null,
+      "ip_count": 1,
+      "aws_region": "us-east-1",
+      "provisioned_at": "2026-06-01T00:00:00Z",
+      "warming_started_at": null,
+      "retired_at": null,
+      "created_at": "2026-05-28T00:00:00Z",
+      "updated_at": "2026-06-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+---
+
+### Create dedicated IP pool
 
 ```http
 POST /api/dedicated-ips
@@ -8,7 +73,36 @@ Authorization: Bearer <api_key>
 Content-Type: application/json
 ```
 
-Creates a lifecycle record with status `requested`. Operators can later update the record to `provisioned`, `warming`, `active`, `suspended`, or `retired`.
+Creates a lifecycle record with status `requested`. Does **not** provision the SES pool — that requires operator approval (see below).
+
+**Body**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Human-readable name (max 255 chars) |
+| `scaling_mode` | `"MANAGED"` \| `"STANDARD"` | no | Default `"MANAGED"` |
+| `provider_pool_name` | string | no | Custom SES pool name (leave blank to auto-generate) |
+
+**Response** — `201 Created`
+
+The new pool object with `status: "requested"`.
+
+---
+
+### Get dedicated IP pool
+
+```http
+GET /api/dedicated-ips/{id}
+Authorization: Bearer <api_key>
+```
+
+**Response** — `200 OK` or `404`
+
+The pool object (same shape as list entries above).
+
+---
+
+### Update dedicated IP pool
 
 ```http
 PATCH /api/dedicated-ips/{id}
@@ -16,4 +110,100 @@ Authorization: Bearer <api_key>
 Content-Type: application/json
 ```
 
-Use `provider_pool_name` and `operator_notes` to record external provider work performed outside OpenSend. `DELETE /api/dedicated-ips/{id}` marks the record `retired` so the lifecycle remains auditable.
+Updates mutable fields. If `status` is set to `"retired"` and the pool has `provider: "ses"`, OpenSend calls `DeleteDedicatedIpPool` in SES first (best-effort; failure is logged but does not block the status update).
+
+**Body**
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Rename the pool |
+| `status` | lifecycle status | Advance or roll back lifecycle state |
+| `provider_pool_name` | string \| null | Override the SES pool name |
+| `scaling_mode` | `"MANAGED"` \| `"STANDARD"` | Change scaling mode |
+| `operator_notes` | string \| null | Internal operator annotations (max 4000 chars) |
+
+---
+
+### Delete (retire) dedicated IP pool
+
+```http
+DELETE /api/dedicated-ips/{id}
+Authorization: Bearer <api_key>
+```
+
+Sets `status: "retired"` and `retired_at: now`. If the pool has `provider: "ses"`, OpenSend calls `DeleteDedicatedIpPool` in SES first (best-effort).
+
+**Response** — `200 OK`
+
+```json
+{
+  "object": "dedicated_ip_pool",
+  "id": "dip_...",
+  "retired": true,
+  "status": "retired"
+}
+```
+
+---
+
+### Approve and provision (operator-only)
+
+```http
+POST /api/internal/dedicated-ips/{id}/approve
+Authorization: Bearer <DEDICATED_IP_OPERATOR_TOKEN>
+Content-Type: application/json
+```
+
+Operator-only gate. Validates the pool is in `requested` status, then calls AWS SES `CreateDedicatedIpPool` and advances the record to `provisioned`. Requires the `DEDICATED_IP_OPERATOR_TOKEN` env var to be set on the server.
+
+**Body**
+
+| Field | Type | Description |
+|---|---|---|
+| `aws_region` | string | SES region (default `"us-east-1"`, max 32 chars) |
+| `operator_notes` | string | Notes recorded on the pool record (max 4000 chars) |
+
+**Response** — `200 OK`
+
+```json
+{
+  "object": "dedicated_ip_pool",
+  "id": "dip_...",
+  "status": "provisioned",
+  "volume_warning": true,
+  "emails_sent": 12000
+}
+```
+
+`volume_warning: true` means the tenant's last billing period sent fewer than 50 000 emails. SES recommends at least that volume for a MANAGED dedicated IP to warm correctly. The approval is not blocked — this is advisory only.
+
+**Error responses**
+
+| Status | `code` | Meaning |
+|---|---|---|
+| `401` | — | Missing or invalid `DEDICATED_IP_OPERATOR_TOKEN` |
+| `404` | — | Pool not found |
+| `409` | `invalid_status` | Pool is not in `requested` status; `current_status` in body |
+| `422` | — | Body validation failed |
+
+---
+
+## Plan gating
+
+Creating a pool requires the tenant to be on a plan that includes the dedicated IP add-on. A `403 Forbidden` with `error: "plan_feature_not_available"` is returned otherwise.
+
+---
+
+## Background sync
+
+The `dedicated-ip-sync` ingester job runs on the configured `INGESTER_SCHEDULER_INTERVAL_SECONDS` cadence. It:
+
+1. Loads all pools in `provisioned` or `warming` status.
+2. Calls `GetDedicatedIps` (paginated, up to 1000 IPs) for each pool's SES pool name.
+3. Updates `ip_count` and `last_synced_at`.
+4. Advances status:
+   - `provisioned` + IPs present + scaling mode `MANAGED` + none `IN_PROGRESS` → `active` (skips warming)
+   - `provisioned` + IPs present + `STANDARD` → `warming`
+   - `warming` + all IPs non-`IN_PROGRESS` → `active`
+
+Pools synced fewer than 5 minutes ago are skipped to avoid thrashing the SES API.

--- a/public/docs/llms.txt
+++ b/public/docs/llms.txt
@@ -74,7 +74,7 @@
 - [Update Contact](https://opensend.namuh.co/docs/api-reference/contacts/update-contact.md): Update contact fields. This page documents the OpenSend-owned API contract for PATCH /contacts/{contactid}.
 - [Auto Configure Domain](https://opensend.namuh.co/docs/api-reference/domains/auto-configure-domain.md): Write DNS records through configured Cloudflare credentials.
 - [Create Domain](https://opensend.namuh.co/docs/api-reference/domains/create-domain.md): Create a sending domain and return the DNS records OpenSend expects operators to publish.
-- [Dedicated IP lifecycle](https://opensend.namuh.co/docs/api-reference/domains/dedicated-ip-lifecycle.md): Dedicated IP APIs track manual lifecycle state for a tenant. They do not provision provider IP pools or run warmup flows in v1.
+- [Dedicated IP lifecycle](https://opensend.namuh.co/docs/api-reference/domains/dedicated-ip-lifecycle.md): Dedicated IP pool APIs let tenants request a dedicated IP pool and track it through its full lifecycle. Once a tenant's request is submitted, an operator approves it via the internal endpoint — at which point OpenSend automatically provisions an AWS SES MANAGED dedicated IP pool and begins reconciling its warmup state via the background scheduler.
 - [Delete Domain](https://opensend.namuh.co/docs/api-reference/domains/delete-domain.md): Delete a domain from the authenticated tenant after any operator-side cleanup you require.
 - [Get domain deliverability readiness](https://opensend.namuh.co/docs/api-reference/domains/get-domain-deliverability.md): Returns readiness/status information for one tenant-owned domain.
 - [Get Domain](https://opensend.namuh.co/docs/api-reference/domains/get-domain.md): Retrieve one domain, including verification status and DNS record metadata.

--- a/src/app/api/dedicated-ips/[id]/route.ts
+++ b/src/app/api/dedicated-ips/[id]/route.ts
@@ -4,7 +4,7 @@ import {
   unauthorizedResponse,
 } from "@/lib/api-auth";
 import { requireFullAccessForApiKeyCaller } from "@/lib/api-key-permissions";
-import { dedicatedIpPoolRepo } from "@opensend/core";
+import { configurationSetService, dedicatedIpPoolRepo } from "@opensend/core";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
@@ -73,6 +73,8 @@ function toDedicatedIpPoolResponse(
     scaling_mode: pool.scalingMode,
     status: pool.status,
     operator_notes: pool.operatorNotes,
+    ip_count: pool.ipCount ?? null,
+    aws_region: pool.awsRegion ?? null,
     provisioned_at: pool.provisionedAt,
     warming_started_at: pool.warmingStartedAt,
     retired_at: pool.retiredAt,
@@ -127,6 +129,29 @@ export async function PATCH(
   const providerPoolName =
     parsed.data.provider_pool_name ?? parsed.data.ses_pool_name ?? undefined;
   const status = parsed.data.status;
+
+  // If retiring a SES-provisioned pool, release it from SES first (best-effort).
+  if (status === "retired") {
+    const existing = await dedicatedIpPoolRepo.findByIdForUser(id, userId);
+    if (existing?.provider === "ses") {
+      try {
+        await configurationSetService.deleteDedicatedIpPool({
+          poolName: existing.sesPoolName,
+          region: existing.awsRegion ?? undefined,
+        });
+      } catch (err) {
+        console.error(
+          JSON.stringify({
+            level: "error",
+            event: "dedicated_ip.patch.delete_ses_pool_failed",
+            pool_id: id,
+          }),
+          err,
+        );
+      }
+    }
+  }
+
   const updated = await dedicatedIpPoolRepo.updateForUser(id, userId, {
     name: parsed.data.name,
     sesPoolName: providerPoolName === null ? undefined : providerPoolName,
@@ -152,6 +177,31 @@ export async function DELETE(
   const userId = userIdOrResponse;
 
   const { id } = await params;
+
+  // Load the pool before retiring so we know its SES name and provider.
+  const existing = await dedicatedIpPoolRepo.findByIdForUser(id, userId);
+  if (!existing) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // Release the SES pool if it was auto-provisioned (best-effort).
+  if (existing.provider === "ses") {
+    try {
+      await configurationSetService.deleteDedicatedIpPool({
+        poolName: existing.sesPoolName,
+        region: existing.awsRegion ?? undefined,
+      });
+    } catch (err) {
+      console.error(
+        JSON.stringify({
+          level: "error",
+          event: "dedicated_ip.delete.delete_ses_pool_failed",
+          pool_id: id,
+        }),
+        err,
+      );
+    }
+  }
 
   const pool = await dedicatedIpPoolRepo.updateForUser(id, userId, {
     status: "retired",

--- a/src/app/api/dedicated-ips/route.ts
+++ b/src/app/api/dedicated-ips/route.ts
@@ -79,6 +79,8 @@ function toDedicatedIpPoolResponse(
     scaling_mode: pool.scalingMode,
     status: pool.status,
     operator_notes: pool.operatorNotes,
+    ip_count: pool.ipCount ?? null,
+    aws_region: pool.awsRegion ?? null,
     provisioned_at: pool.provisionedAt,
     warming_started_at: pool.warmingStartedAt,
     retired_at: pool.retiredAt,

--- a/src/app/api/internal/dedicated-ips/[id]/approve/route.ts
+++ b/src/app/api/internal/dedicated-ips/[id]/approve/route.ts
@@ -1,0 +1,118 @@
+import {
+  approveAndProvisionPool,
+  type dedicatedIpPoolRepo,
+  timingSafeStringEqual,
+} from "@opensend/core";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+/**
+ * POST /api/internal/dedicated-ips/[id]/approve
+ *
+ * Operator-only endpoint for approving and provisioning a dedicated IP pool
+ * via SES. Requires the DEDICATED_IP_OPERATOR_TOKEN header.
+ *
+ * This is the only path that calls SES CreateDedicatedIpPool.
+ * SES MANAGED pools accrue AWS charges from the moment this endpoint fires.
+ * Only call after explicit operator review.
+ */
+
+const approveBodySchema = z.object({
+  aws_region: z.string().min(1).max(32).optional(),
+  operator_notes: z.string().max(4000).optional(),
+});
+
+function toDedicatedIpPoolResponse(
+  pool: NonNullable<Awaited<ReturnType<typeof dedicatedIpPoolRepo.findById>>>,
+) {
+  return {
+    object: "dedicated_ip_pool",
+    id: pool.id,
+    name: pool.name,
+    provider: pool.provider,
+    provider_pool_name: pool.sesPoolName.startsWith("manual-")
+      ? null
+      : pool.sesPoolName,
+    ses_pool_name: pool.sesPoolName,
+    scaling_mode: pool.scalingMode,
+    status: pool.status,
+    operator_notes: pool.operatorNotes,
+    ip_count: pool.ipCount ?? null,
+    aws_region: pool.awsRegion ?? null,
+    provisioned_at: pool.provisionedAt,
+    warming_started_at: pool.warmingStartedAt,
+    retired_at: pool.retiredAt,
+    created_at: pool.createdAt,
+    updated_at: pool.updatedAt,
+  };
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authHeader = request.headers.get("authorization");
+  const expectedToken = process.env.DEDICATED_IP_OPERATOR_TOKEN;
+
+  if (
+    !expectedToken ||
+    !timingSafeStringEqual(authHeader, `Bearer ${expectedToken}`)
+  ) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = approveBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 422 },
+    );
+  }
+
+  try {
+    const result = await approveAndProvisionPool(id, {
+      awsRegion: parsed.data.aws_region,
+      operatorNotes: parsed.data.operator_notes,
+    });
+
+    if (!result.ok) {
+      if (result.code === "not_found") {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
+      if (result.code === "invalid_status") {
+        return NextResponse.json(
+          {
+            error: "Pool is not in requested status",
+            current_status: result.current,
+          },
+          { status: 409 },
+        );
+      }
+    }
+
+    if (result.ok) {
+      return NextResponse.json({
+        ...toDedicatedIpPoolResponse(result.pool),
+        volume_warning: result.volumeWarning,
+        emails_sent: result.emailsSent,
+      });
+    }
+
+    return NextResponse.json({ error: "Unexpected error" }, { status: 500 });
+  } catch (err) {
+    console.error("dedicated_ip.approve.failed", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -209,6 +209,9 @@ export const dedicatedIpPools = pgTable(
     provisionedAt: timestamp("provisioned_at", { withTimezone: true }),
     warmingStartedAt: timestamp("warming_started_at", { withTimezone: true }),
     retiredAt: timestamp("retired_at", { withTimezone: true }),
+    awsRegion: varchar("aws_region", { length: 32 }),
+    lastSyncedAt: timestamp("last_synced_at", { withTimezone: true }),
+    ipCount: integer("ip_count"),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/tests/configuration-set-service.test.ts
+++ b/tests/configuration-set-service.test.ts
@@ -14,6 +14,14 @@ vi.mock("@aws-sdk/client-sesv2", () => {
       _name: "DeleteDedicatedIpPoolCommand",
       input,
     })),
+    GetDedicatedIpPoolCommand: vi.fn().mockImplementation((input) => ({
+      _name: "GetDedicatedIpPoolCommand",
+      input,
+    })),
+    GetDedicatedIpsCommand: vi.fn().mockImplementation((input) => ({
+      _name: "GetDedicatedIpsCommand",
+      input,
+    })),
     CreateConfigurationSetCommand: vi.fn().mockImplementation((input) => ({
       _name: "CreateConfigurationSetCommand",
       input,
@@ -103,6 +111,55 @@ describe("ConfigurationSetService", () => {
     await expect(
       svc.deleteDedicatedIpPool({ poolName: "gone-pool" }),
     ).resolves.toBeUndefined();
+  });
+
+  it("getDedicatedIpPool returns pool data from SES response", async () => {
+    mockSend.mockResolvedValueOnce({
+      DedicatedIpPool: { PoolName: "my-pool", ScalingMode: "MANAGED" },
+    });
+    const svc = new ConfigurationSetService();
+    const result = await svc.getDedicatedIpPool({
+      poolName: "my-pool",
+      region: "us-east-1",
+    });
+    expect(result).toEqual({ poolName: "my-pool", scalingMode: "MANAGED" });
+    const cmd = mockSend.mock.calls[0][0];
+    expect(cmd._name).toBe("GetDedicatedIpPoolCommand");
+    expect(cmd.input.PoolName).toBe("my-pool");
+  });
+
+  it("getDedicatedIpPool returns null on NotFoundException", async () => {
+    const err = new Error("not found");
+    (err as Error & { name: string }).name = "NotFoundException";
+    mockSend.mockRejectedValueOnce(err);
+    const svc = new ConfigurationSetService();
+    const result = await svc.getDedicatedIpPool({ poolName: "gone-pool" });
+    expect(result).toBeNull();
+  });
+
+  it("getDedicatedIps returns mapped IP array", async () => {
+    mockSend.mockResolvedValueOnce({
+      DedicatedIps: [
+        { Ip: "1.2.3.4", WarmupStatus: "NOT_APPLICABLE" },
+        { Ip: "5.6.7.8", WarmupStatus: "IN_PROGRESS" },
+      ],
+      NextToken: undefined,
+    });
+    const svc = new ConfigurationSetService();
+    const ips = await svc.getDedicatedIps({ poolName: "my-pool" });
+    expect(ips).toEqual([
+      { ip: "1.2.3.4", warmupStatus: "NOT_APPLICABLE" },
+      { ip: "5.6.7.8", warmupStatus: "IN_PROGRESS" },
+    ]);
+  });
+
+  it("getDedicatedIps returns empty array on NotFoundException", async () => {
+    const err = new Error("not found");
+    (err as Error & { name: string }).name = "NotFoundException";
+    mockSend.mockRejectedValueOnce(err);
+    const svc = new ConfigurationSetService();
+    const ips = await svc.getDedicatedIps({ poolName: "gone-pool" });
+    expect(ips).toEqual([]);
   });
 
   it("syncDomainConfigurationSet creates new set and returns name", async () => {

--- a/tests/dedicated-ip-plan-gating.test.ts
+++ b/tests/dedicated-ip-plan-gating.test.ts
@@ -11,8 +11,11 @@ const mockRequireFullAccessForApiKeyCaller = vi.hoisted(() => vi.fn());
 const mockListForUser = vi.hoisted(() => vi.fn());
 const mockCountForUser = vi.hoisted(() => vi.fn());
 const mockCreate = vi.hoisted(() => vi.fn());
+const mockFindByIdForUser = vi.hoisted(() => vi.fn());
+const mockUpdateForUser = vi.hoisted(() => vi.fn());
 const mockFindBySubscription = vi.hoisted(() => vi.fn());
 const mockFindByPlanId = vi.hoisted(() => vi.fn());
+const mockDeleteDedicatedIpPool = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/api-auth", () => ({
   authorizeDashboardOrApiKey: mockAuthorizeDashboardOrApiKey,
@@ -47,6 +50,11 @@ vi.mock("@opensend/core", () => ({
     listForUser: mockListForUser,
     countForUser: mockCountForUser,
     create: mockCreate,
+    findByIdForUser: mockFindByIdForUser,
+    updateForUser: mockUpdateForUser,
+  },
+  configurationSetService: {
+    deleteDedicatedIpPool: mockDeleteDedicatedIpPool,
   },
 }));
 
@@ -54,6 +62,7 @@ vi.mock("zod", async (importOriginal) => {
   return await importOriginal();
 });
 
+import { DELETE, PATCH } from "@/app/api/dedicated-ips/[id]/route";
 import { GET, POST } from "@/app/api/dedicated-ips/route";
 
 const SESSION = { user: { id: "user-1", email: "test@example.com" } };
@@ -204,5 +213,125 @@ describe("POST /api/dedicated-ips — plan gating", () => {
     expect(body.object).toBe("dedicated_ip_pool");
     expect(body.status).toBe("requested");
     expect(body.provider_pool_name).toBe("ses-pool");
+  });
+});
+
+const POOL_FIXTURE = {
+  id: "pool-1",
+  userId: "user-1",
+  name: "Pool",
+  sesPoolName: "opensend-abcd1234-abcd1234",
+  scalingMode: "MANAGED",
+  status: "active",
+  provider: "ses",
+  operatorNotes: null,
+  awsRegion: "us-east-1",
+  ipCount: 1,
+  lastSyncedAt: null,
+  provisionedAt: new Date(),
+  warmingStartedAt: null,
+  retiredAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe("DELETE /api/dedicated-ips/[id] — SES pool release", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireFullAccessForApiKeyCaller.mockReturnValue(null);
+    mockDeleteDedicatedIpPool.mockResolvedValue(undefined);
+  });
+
+  it("calls deleteDedicatedIpPool when provider===ses before retiring", async () => {
+    mockAuthorizeDashboardOrApiKey.mockResolvedValueOnce({ dashboard: true });
+    mockGetServerSession.mockResolvedValueOnce(SESSION);
+    mockFindByIdForUser.mockResolvedValueOnce(POOL_FIXTURE);
+    mockUpdateForUser.mockResolvedValueOnce({
+      ...POOL_FIXTURE,
+      status: "retired",
+      retiredAt: new Date(),
+    });
+
+    const req = new Request("http://localhost/api/dedicated-ips/pool-1", {
+      method: "DELETE",
+    });
+    const res = await DELETE(req, {
+      params: Promise.resolve({ id: "pool-1" }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockDeleteDedicatedIpPool).toHaveBeenCalledWith({
+      poolName: POOL_FIXTURE.sesPoolName,
+      region: POOL_FIXTURE.awsRegion,
+    });
+  });
+
+  it("does not call deleteDedicatedIpPool for manual provider", async () => {
+    mockAuthorizeDashboardOrApiKey.mockResolvedValueOnce({ dashboard: true });
+    mockGetServerSession.mockResolvedValueOnce(SESSION);
+    mockFindByIdForUser.mockResolvedValueOnce({
+      ...POOL_FIXTURE,
+      provider: "manual",
+    });
+    mockUpdateForUser.mockResolvedValueOnce({
+      ...POOL_FIXTURE,
+      provider: "manual",
+      status: "retired",
+    });
+
+    const req = new Request("http://localhost/api/dedicated-ips/pool-1", {
+      method: "DELETE",
+    });
+    const res = await DELETE(req, {
+      params: Promise.resolve({ id: "pool-1" }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockDeleteDedicatedIpPool).not.toHaveBeenCalled();
+  });
+});
+
+describe("PATCH /api/dedicated-ips/[id] — SES pool release on retire", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireFullAccessForApiKeyCaller.mockReturnValue(null);
+    mockDeleteDedicatedIpPool.mockResolvedValue(undefined);
+  });
+
+  it("calls deleteDedicatedIpPool when PATCH sets status=retired and provider===ses", async () => {
+    mockAuthorizeDashboardOrApiKey.mockResolvedValueOnce({ dashboard: true });
+    mockGetServerSession.mockResolvedValueOnce(SESSION);
+    mockFindByIdForUser.mockResolvedValueOnce(POOL_FIXTURE);
+    mockUpdateForUser.mockResolvedValueOnce({
+      ...POOL_FIXTURE,
+      status: "retired",
+      retiredAt: new Date(),
+    });
+
+    const req = new Request("http://localhost/api/dedicated-ips/pool-1", {
+      method: "PATCH",
+      body: JSON.stringify({ status: "retired" }),
+    });
+    const res = await PATCH(req, { params: Promise.resolve({ id: "pool-1" }) });
+    expect(res.status).toBe(200);
+    expect(mockDeleteDedicatedIpPool).toHaveBeenCalledWith({
+      poolName: POOL_FIXTURE.sesPoolName,
+      region: POOL_FIXTURE.awsRegion,
+    });
+  });
+
+  it("does not call deleteDedicatedIpPool when PATCH status is not retired", async () => {
+    mockAuthorizeDashboardOrApiKey.mockResolvedValueOnce({ dashboard: true });
+    mockGetServerSession.mockResolvedValueOnce(SESSION);
+    mockUpdateForUser.mockResolvedValueOnce({
+      ...POOL_FIXTURE,
+      status: "active",
+    });
+
+    const req = new Request("http://localhost/api/dedicated-ips/pool-1", {
+      method: "PATCH",
+      body: JSON.stringify({ status: "active" }),
+    });
+    const res = await PATCH(req, { params: Promise.resolve({ id: "pool-1" }) });
+    expect(res.status).toBe(200);
+    expect(mockDeleteDedicatedIpPool).not.toHaveBeenCalled();
   });
 });

--- a/tests/dedicated-ip-provisioning.test.ts
+++ b/tests/dedicated-ip-provisioning.test.ts
@@ -1,0 +1,331 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+const mockFindById = vi.hoisted(() => vi.fn());
+const mockUpdateById = vi.hoisted(() => vi.fn());
+const mockUpdateSyncMetadata = vi.hoisted(() => vi.fn());
+const mockCreateDedicatedIpPool = vi.hoisted(() => vi.fn());
+const mockGetDedicatedIps = vi.hoisted(() => vi.fn());
+
+vi.mock("../packages/core/src/db/repositories/dedicatedIpPoolRepo", () => ({
+  dedicatedIpPoolRepo: {
+    findById: mockFindById,
+    updateById: mockUpdateById,
+    updateSyncMetadata: mockUpdateSyncMetadata,
+  },
+}));
+
+vi.mock("../packages/core/src/services/configurationSet", () => ({
+  configurationSetService: {
+    createDedicatedIpPool: mockCreateDedicatedIpPool,
+    getDedicatedIps: mockGetDedicatedIps,
+  },
+}));
+
+// Mock db client for volume check
+const mockSelect = vi.hoisted(() => vi.fn().mockReturnThis());
+const mockFrom = vi.hoisted(() => vi.fn().mockReturnThis());
+const mockWhere = vi.hoisted(() => vi.fn().mockReturnThis());
+const mockOrderBy = vi.hoisted(() => vi.fn().mockReturnThis());
+const mockLimit = vi.hoisted(() => vi.fn());
+
+vi.mock("../packages/core/src/db/client", () => ({
+  db: {
+    select: mockSelect,
+  },
+}));
+
+vi.mock("../packages/core/src/db/schema", () => ({
+  usagePeriods: { userId: "userId", periodStart: "periodStart" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
+  desc: vi.fn((col: unknown) => ({ desc: col })),
+}));
+
+import {
+  DEDICATED_IP_MIN_MONTHLY_VOLUME,
+  approveAndProvisionPool,
+  reconcileProvisionedPool,
+} from "../packages/core/src/services/dedicatedIpPoolService";
+
+const BASE_POOL = {
+  id: "pool-uuid-1234",
+  userId: "user-abcdefgh",
+  name: "My Pool",
+  sesPoolName: "manual-some-uuid",
+  scalingMode: "MANAGED",
+  status: "requested" as const,
+  provider: "manual",
+  operatorNotes: null,
+  awsRegion: null,
+  ipCount: null,
+  lastSyncedAt: null,
+  provisionedAt: null,
+  warmingStartedAt: null,
+  retiredAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe("approveAndProvisionPool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: volume check returns no data (volume = 0)
+    mockSelect.mockReturnValue({
+      from: mockFrom.mockReturnValue({
+        where: mockWhere.mockReturnValue({
+          orderBy: mockOrderBy.mockReturnValue({
+            limit: mockLimit.mockResolvedValue([]),
+          }),
+        }),
+      }),
+    });
+    mockCreateDedicatedIpPool.mockResolvedValue(undefined);
+    mockUpdateById.mockResolvedValue({
+      ...BASE_POOL,
+      status: "provisioned",
+      provider: "ses",
+    });
+  });
+
+  it("returns not_found when pool does not exist", async () => {
+    mockFindById.mockResolvedValueOnce(undefined);
+    const result = await approveAndProvisionPool("nonexistent-id");
+    expect(result).toEqual({ ok: false, code: "not_found" });
+    expect(mockCreateDedicatedIpPool).not.toHaveBeenCalled();
+  });
+
+  it("returns invalid_status when pool is not in requested state", async () => {
+    mockFindById.mockResolvedValueOnce({ ...BASE_POOL, status: "provisioned" });
+    const result = await approveAndProvisionPool(BASE_POOL.id);
+    expect(result).toEqual({
+      ok: false,
+      code: "invalid_status",
+      current: "provisioned",
+    });
+    expect(mockCreateDedicatedIpPool).not.toHaveBeenCalled();
+  });
+
+  it("happy path: calls createDedicatedIpPool with collision-proof name and marks provisioned", async () => {
+    mockFindById.mockResolvedValueOnce(BASE_POOL);
+    const updatedPool = {
+      ...BASE_POOL,
+      status: "provisioned",
+      provider: "ses",
+      awsRegion: "us-east-1",
+      sesPoolName: "opensend-userabcd-pooluuid",
+    };
+    mockUpdateById.mockResolvedValue(updatedPool);
+
+    const result = await approveAndProvisionPool(BASE_POOL.id, {
+      awsRegion: "us-east-1",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Verifies SES pool was called
+    expect(mockCreateDedicatedIpPool).toHaveBeenCalledOnce();
+    const callArgs = mockCreateDedicatedIpPool.mock.calls[0][0];
+    // Should NOT be the original manual- name
+    expect(callArgs.poolName).not.toContain("manual-");
+    expect(callArgs.poolName).toMatch(/^opensend-/);
+    expect(callArgs.scalingMode).toBe("MANAGED");
+    expect(callArgs.region).toBe("us-east-1");
+    // Verifies DB was updated
+    expect(mockUpdateById).toHaveBeenCalledWith(
+      BASE_POOL.id,
+      expect.objectContaining({
+        status: "provisioned",
+        provider: "ses",
+        awsRegion: "us-east-1",
+      }),
+    );
+  });
+
+  it("is idempotent: swallows AlreadyExistsException from SES", async () => {
+    mockFindById.mockResolvedValueOnce(BASE_POOL);
+    const alreadyExists = new Error("already exists");
+    (alreadyExists as Error & { name: string }).name = "AlreadyExistsException";
+    mockCreateDedicatedIpPool.mockRejectedValueOnce(alreadyExists);
+
+    const result = await approveAndProvisionPool(BASE_POOL.id);
+    // Should succeed even with AlreadyExistsException
+    expect(result.ok).toBe(true);
+    expect(mockUpdateById).toHaveBeenCalled();
+  });
+
+  it("sets volumeWarning=true when emailsSent < threshold", async () => {
+    mockFindById.mockResolvedValueOnce(BASE_POOL);
+    mockSelect.mockReturnValue({
+      from: mockFrom.mockReturnValue({
+        where: mockWhere.mockReturnValue({
+          orderBy: mockOrderBy.mockReturnValue({
+            limit: mockLimit.mockResolvedValue([{ emailsSent: 1000 }]),
+          }),
+        }),
+      }),
+    });
+
+    const result = await approveAndProvisionPool(BASE_POOL.id);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.volumeWarning).toBe(true);
+    expect(result.emailsSent).toBe(1000);
+  });
+
+  it("sets volumeWarning=false when emailsSent >= threshold", async () => {
+    mockFindById.mockResolvedValueOnce(BASE_POOL);
+    mockSelect.mockReturnValue({
+      from: mockFrom.mockReturnValue({
+        where: mockWhere.mockReturnValue({
+          orderBy: mockOrderBy.mockReturnValue({
+            limit: mockLimit.mockResolvedValue([
+              { emailsSent: DEDICATED_IP_MIN_MONTHLY_VOLUME },
+            ]),
+          }),
+        }),
+      }),
+    });
+
+    const result = await approveAndProvisionPool(BASE_POOL.id);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.volumeWarning).toBe(false);
+  });
+
+  it("reuses existing ses pool name when not manual-prefixed", async () => {
+    const poolWithExistingName = {
+      ...BASE_POOL,
+      sesPoolName: "opensend-custom-pool",
+    };
+    mockFindById.mockResolvedValueOnce(poolWithExistingName);
+
+    await approveAndProvisionPool(BASE_POOL.id);
+
+    const callArgs = mockCreateDedicatedIpPool.mock.calls[0][0];
+    expect(callArgs.poolName).toBe("opensend-custom-pool");
+  });
+});
+
+describe("reconcileProvisionedPool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const PROVISIONED_POOL = {
+    ...BASE_POOL,
+    status: "provisioned" as const,
+    provider: "ses",
+    sesPoolName: "opensend-userabcd-pooluuid",
+    awsRegion: "us-east-1",
+    lastSyncedAt: null,
+  };
+
+  it("returns ok:false when pool does not exist", async () => {
+    mockFindById.mockResolvedValueOnce(undefined);
+    const result = await reconcileProvisionedPool("nonexistent");
+    expect(result).toEqual({ ok: false });
+  });
+
+  it("skips reconcile when lastSyncedAt < 5 minutes ago", async () => {
+    const recentSync = new Date(Date.now() - 60_000); // 1 minute ago
+    mockFindById.mockResolvedValueOnce({
+      ...PROVISIONED_POOL,
+      lastSyncedAt: recentSync,
+      ipCount: 2,
+    });
+    const result = await reconcileProvisionedPool(PROVISIONED_POOL.id);
+    expect(result).toEqual({ ok: true, ipCount: 2, graduated: false });
+    expect(mockGetDedicatedIps).not.toHaveBeenCalled();
+  });
+
+  it("calls getDedicatedIps and updateSyncMetadata", async () => {
+    mockFindById.mockResolvedValueOnce(PROVISIONED_POOL);
+    mockGetDedicatedIps.mockResolvedValueOnce([]);
+    mockUpdateSyncMetadata.mockResolvedValueOnce(PROVISIONED_POOL);
+
+    await reconcileProvisionedPool(PROVISIONED_POOL.id);
+
+    expect(mockGetDedicatedIps).toHaveBeenCalledWith({
+      poolName: PROVISIONED_POOL.sesPoolName,
+      region: PROVISIONED_POOL.awsRegion,
+    });
+    expect(mockUpdateSyncMetadata).toHaveBeenCalledWith(
+      PROVISIONED_POOL.id,
+      expect.objectContaining({ ipCount: 0 }),
+    );
+  });
+
+  it("graduates provisioned→warming for STANDARD pool when IPs appear", async () => {
+    mockFindById.mockResolvedValueOnce({
+      ...PROVISIONED_POOL,
+      scalingMode: "STANDARD",
+    });
+    mockGetDedicatedIps.mockResolvedValueOnce([
+      { ip: "1.2.3.4", warmupStatus: "IN_PROGRESS" },
+    ]);
+    mockUpdateSyncMetadata.mockResolvedValueOnce({});
+    mockUpdateById.mockResolvedValueOnce({});
+
+    const result = await reconcileProvisionedPool(PROVISIONED_POOL.id);
+    expect(result.graduated).toBe(true);
+    expect(result.newStatus).toBe("warming");
+    expect(mockUpdateById).toHaveBeenCalledWith(
+      PROVISIONED_POOL.id,
+      expect.objectContaining({ status: "warming" }),
+    );
+  });
+
+  it("graduates provisioned→active for MANAGED pool when IPs not IN_PROGRESS", async () => {
+    mockFindById.mockResolvedValueOnce(PROVISIONED_POOL);
+    mockGetDedicatedIps.mockResolvedValueOnce([
+      { ip: "1.2.3.4", warmupStatus: "NOT_APPLICABLE" },
+    ]);
+    mockUpdateSyncMetadata.mockResolvedValueOnce({});
+    mockUpdateById.mockResolvedValueOnce({});
+
+    const result = await reconcileProvisionedPool(PROVISIONED_POOL.id);
+    expect(result.graduated).toBe(true);
+    expect(result.newStatus).toBe("active");
+    expect(mockUpdateById).toHaveBeenCalledWith(
+      PROVISIONED_POOL.id,
+      expect.objectContaining({ status: "active" }),
+    );
+  });
+
+  it("graduates warming→active when all IPs not IN_PROGRESS", async () => {
+    mockFindById.mockResolvedValueOnce({
+      ...PROVISIONED_POOL,
+      status: "warming",
+      scalingMode: "STANDARD",
+    });
+    mockGetDedicatedIps.mockResolvedValueOnce([
+      { ip: "1.2.3.4", warmupStatus: "DONE" },
+      { ip: "5.6.7.8", warmupStatus: "DONE" },
+    ]);
+    mockUpdateSyncMetadata.mockResolvedValueOnce({});
+    mockUpdateById.mockResolvedValueOnce({});
+
+    const result = await reconcileProvisionedPool(PROVISIONED_POOL.id);
+    expect(result.graduated).toBe(true);
+    expect(result.newStatus).toBe("active");
+  });
+
+  it("does not graduate when some IPs still IN_PROGRESS", async () => {
+    mockFindById.mockResolvedValueOnce({
+      ...PROVISIONED_POOL,
+      status: "warming",
+    });
+    mockGetDedicatedIps.mockResolvedValueOnce([
+      { ip: "1.2.3.4", warmupStatus: "IN_PROGRESS" },
+      { ip: "5.6.7.8", warmupStatus: "DONE" },
+    ]);
+    mockUpdateSyncMetadata.mockResolvedValueOnce({});
+
+    const result = await reconcileProvisionedPool(PROVISIONED_POOL.id);
+    expect(result.graduated).toBe(false);
+    expect(mockUpdateById).not.toHaveBeenCalled();
+  });
+});

--- a/tests/e2e/dedicated-ips-api.spec.ts
+++ b/tests/e2e/dedicated-ips-api.spec.ts
@@ -56,3 +56,15 @@ test.describe("DELETE /api/dedicated-ips/{id} — unauthenticated", () => {
     expect(res.status()).toBe(401);
   });
 });
+
+test.describe("POST /api/internal/dedicated-ips/{id}/approve — unauthenticated", () => {
+  test("returns 401 when no Authorization header is provided", async ({
+    request,
+  }) => {
+    const res = await request.post(
+      `${BASE_URL}/api/internal/dedicated-ips/00000000-0000-0000-0000-000000000001/approve`,
+      { data: {} },
+    );
+    expect(res.status()).toBe(401);
+  });
+});

--- a/tests/ingester-job-scheduler-coverage.test.ts
+++ b/tests/ingester-job-scheduler-coverage.test.ts
@@ -21,6 +21,7 @@ describe("ingester job scheduler coverage", () => {
 
     expect(scheduledEndpoints).toEqual([
       "/jobs/billing-overage",
+      "/jobs/dedicated-ip-sync",
       "/jobs/domain-verify",
       "/jobs/scheduled-emails",
       "/jobs/webhooks",


### PR DESCRIPTION
## Summary

- Operator-gated `POST /api/internal/dedicated-ips/{id}/approve` creates an AWS SES MANAGED dedicated IP pool and advances the pool record from `requested` → `provisioned`
- New background ingester job `dedicated-ip-sync` reconciles SES warmup state: `provisioned → warming → active` (MANAGED pools skip warming)
- `PATCH /api/dedicated-ips/{id}` with `status: retired` and `DELETE /api/dedicated-ips/{id}` now call `DeleteDedicatedIpPool` in SES (best-effort cleanup)
- Schema migration 0038: adds `aws_region`, `last_synced_at`, `ip_count` columns to `dedicated_ip_pools`
- Advisory `volume_warning` flag in approve response (< 50 000 emails/month threshold)
- Collision-proof SES pool name generation: `opensend-{userSlug8}-{poolSlug8}`
- Full unit tests (`tests/dedicated-ip-provisioning.test.ts`, extended `configuration-set-service`, `dedicated-ip-plan-gating`) and E2E test for 401 gate
- Updated docs: `public/docs/api-reference/domains/dedicated-ip-lifecycle.md` fully rewritten, `llms.txt` updated

Closes #646

## Test plan

- [ ] `make check && make test` pass (1794 tests, 0 failures)
- [ ] `bun run db:push` syncs new columns locally
- [ ] `POST /api/internal/dedicated-ips/{id}/approve` returns 401 without token, 409 for non-requested pool, 200 on valid request
- [ ] Background sync advances `provisioned → active` for MANAGED pool after SES assigns IPs
- [ ] DELETE retires the pool and removes the SES pool
- [ ] `volume_warning: true` appears when tenant emails_sent < 50 000

🤖 Generated with [Claude Code](https://claude.com/claude-code)