### PR TITLE
Remove stale hosted free copy

### DIFF
--- a/src/app/(dashboard)/settings/billing/page.tsx
+++ b/src/app/(dashboard)/settings/billing/page.tsx
@@ -47,8 +47,8 @@ export default async function BillingSettingsPage() {
       <div className="space-y-3">
         <h1 className="text-2xl font-semibold text-fg">Billing</h1>
         <p className="text-[14px] text-fg-2">
-          No plan record was found. Run the database seed to create the Free
-          plan.
+          No billing plan record was found. Run the database seed to create the
+          hosted paid plans.
         </p>
       </div>
     );

--- a/src/components/landing/pricing-page.tsx
+++ b/src/components/landing/pricing-page.tsx
@@ -597,8 +597,8 @@ export function PricingPage() {
               </span>
             </h1>
             <p className="body" style={{ maxWidth: 580 }}>
-              Start free. Upgrade when your volume grows. Or self-host the same
-              source for free forever — opensend is ELv2 either way.
+              Start with Lite for hosted sending, or self-host the same source
+              for free forever — opensend is ELv2 either way.
             </p>
 
             <PricingTierSelector

--- a/tests/docs-no-free-tier.test.ts
+++ b/tests/docs-no-free-tier.test.ts
@@ -46,5 +46,14 @@ describe("no hosted free tier in public surfaces", () => {
     );
     // No "Free" column in the compare-plans headers.
     expect(pricing).not.toMatch(/headers\s*=\s*\[\s*"Free"/);
+    expect(pricing).not.toMatch(/Start free/i);
+    expect(pricing).not.toMatch(/For tinkering and side projects/i);
+
+    const billingPage = readFileSync(
+      "src/app/(dashboard)/settings/billing/page.tsx",
+      "utf8",
+    );
+    expect(billingPage).not.toMatch(/create the Free\s+plan/i);
+    expect(billingPage).not.toMatch(/No plan record was found/i);
   });
 });


### PR DESCRIPTION
## Summary
- Replace stale pricing hero copy that still said "Start free"
- Replace billing empty-state copy that still told operators to seed the Free plan
- Strengthen docs/free-tier regression test to cover these strings

## Verification
- bunx vitest run tests/docs-no-free-tier.test.ts
- make check
- push guardrails: typecheck + Biome passed

The production page at https://opensend.namuh.co/pricing is currently serving the old deployed copy until this hotfix is merged and deployed.