### PR TITLE
Add GitHub-hosted deploy fallback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ permissions:
 
 concurrency:
   group: deploy-prod
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_path == 'github-hosted-oidc' }}
 
 env:
   AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
@@ -86,6 +86,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 4500
 
       - name: Preflight fallback deploy path
         run: bun run deploy:fallback:preflight

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
-# ABOUTME: Deploys app + ingester to ECS Fargate via the Mac mini self-hosted runner.
-# ABOUTME: Fires on every push to main and via manual workflow_dispatch.
+# ABOUTME: Deploys app + ingester to ECS Fargate with Mac mini primary and OIDC fallback paths.
+# ABOUTME: Fires on every push to main and supports manual break-glass deploys from GitHub-hosted runners.
 # Note: this workflow does not consume any untrusted github.event.* inputs in run: commands.
 name: Deploy
 
@@ -7,6 +7,15 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      deploy_path:
+        description: "Deploy path to use"
+        required: true
+        default: mac-mini
+        type: choice
+        options:
+          - mac-mini
+          - github-hosted-oidc
 
 permissions:
   contents: read
@@ -15,20 +24,28 @@ concurrency:
   group: deploy-prod
   cancel-in-progress: false
 
+env:
+  AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+  AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+  ECS_CLUSTER: ${{ vars.ECS_CLUSTER || 'namuh' }}
+  PRODUCT: ${{ vars.PRODUCT || 'opensend' }}
+  PLATFORM: linux/amd64
+  NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+  NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
+  NEXT_PUBLIC_POSTHOG_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST }}
+  SENTRY_ENVIRONMENT: production
+  SENTRY_RELEASE: ${{ github.sha }}
+
 jobs:
-  deploy:
+  deploy-mac-mini:
+    name: Deploy via Mac mini runner
+    if: ${{ github.event_name == 'push' || inputs.deploy_path == 'mac-mini' }}
     runs-on: [self-hosted, opensend-deploy]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 
       - name: Deploy app + ingester to ECS
-        env:
-          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
-          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
-          NEXT_PUBLIC_POSTHOG_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST }}
-          SENTRY_ENVIRONMENT: production
-          SENTRY_RELEASE: ${{ github.sha }}
         run: |
           # Isolate from Docker Desktop's user config so the launchd-spawned
           # runner does not hit the keychain-bound credsStore helper.
@@ -46,3 +63,32 @@ jobs:
           done
           docker buildx version
           bash scripts/deploy.sh all
+
+  deploy-github-hosted-oidc:
+    name: Deploy via GitHub-hosted OIDC fallback
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_path == 'github-hosted-oidc' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.8"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials from OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Preflight fallback deploy path
+        run: bun run deploy:fallback:preflight
+
+      - name: Deploy app + ingester to ECS
+        run: bash scripts/deploy.sh all

--- a/agent_docs/learnings/active/2026-07-05-issue-645-github-hosted-oidc-fallback.md
+++ b/agent_docs/learnings/active/2026-07-05-issue-645-github-hosted-oidc-fallback.md
@@ -1,0 +1,14 @@
+---
+date: 2026-07-05
+issue: "#645"
+type: decision
+promoted_to: null
+---
+
+## GitHub-hosted OIDC deploy fallback
+
+**What:** Production deploy now keeps the Mac mini runner as the automatic push path, but `workflow_dispatch` exposes a `github-hosted-oidc` path that runs the same preflight and `scripts/deploy.sh all` on `ubuntu-latest` after assuming `vars.AWS_DEPLOY_ROLE_ARN`.
+
+**Why:** A documented workstation runbook is useful, but an incident fallback should stay inside GitHub Actions when the only failed component is the physical self-hosted runner. OIDC avoids copying AWS keys into GitHub secrets and keeps the deploy primitive identical to the normal path.
+
+**Fix:** Keep the fallback gated to manual workflow dispatch, require `PLATFORM=linux/amd64`, run `bun run deploy:fallback:preflight` before any mutation, and grant the OIDC role only deploy-time AWS permissions plus Secrets Manager metadata lookup, not secret value reads.

--- a/agent_docs/runbooks/deploy-fallback.md
+++ b/agent_docs/runbooks/deploy-fallback.md
@@ -17,6 +17,7 @@ Use a trusted operator machine with:
 - Network access to AWS ECR/ECS/Secrets Manager in the deploy region.
 - No copied GitHub Actions secrets and no dumped runner environment. Authenticate through an operator AWS profile, SSO session, or equivalent approved AWS credential source.
 - For GitHub-hosted OIDC fallback: repository variables `AWS_DEPLOY_ROLE_ARN`, `AWS_REGION`, `AWS_ACCOUNT_ID`, `ECS_CLUSTER`, and `PRODUCT` configured for production. `AWS_DEPLOY_ROLE_ARN` must trust this repository's GitHub Actions OIDC subject for manual Deploy workflow runs.
+- For GitHub-hosted OIDC fallback: the IAM role's max session duration must be at least 4,500 seconds (75 minutes). The workflow requests `role-duration-seconds: 4500` so credentials stay valid for the full fallback job timeout.
 
 Required tools:
 
@@ -64,7 +65,9 @@ Use this path first when the Mac mini runner is the only blocker and GitHub Acti
 3. Set `deploy_path` to `github-hosted-oidc`.
 4. Start the run and monitor the `Deploy via GitHub-hosted OIDC fallback` job.
 
-The fallback job runs on `ubuntu-latest`, installs Bun with `oven-sh/setup-bun@v2`, requests an OIDC token with `id-token: write`, assumes `vars.AWS_DEPLOY_ROLE_ARN`, runs `bun run deploy:fallback:preflight`, then runs `bash scripts/deploy.sh all`. The preflight performs the same non-mutating checks documented below before any image push, task registration, migration task, or ECS service update.
+The fallback job runs on `ubuntu-latest`, installs Bun with `oven-sh/setup-bun@v2`, requests an OIDC token with `id-token: write`, assumes `vars.AWS_DEPLOY_ROLE_ARN` for 4,500 seconds to match the 75-minute job timeout, runs `bun run deploy:fallback:preflight`, then runs `bash scripts/deploy.sh all`. The preflight performs the same non-mutating checks documented below before any image push, task registration, migration task, or ECS service update.
+
+Starting a manual `github-hosted-oidc` fallback intentionally supersedes the shared `deploy-prod` workflow concurrency group. That run cancels any pending or running Deploy workflow in the group, including a Mac mini deploy stuck waiting for the offline self-hosted runner, so the fallback is not trapped behind the outage it is meant to bypass. Normal push deploys and manual `mac-mini` deploys keep `cancel-in-progress` disabled; do not start the fallback unless the operator decision is to replace the blocked deploy with the selected production SHA.
 
 Required GitHub repository variables:
 
@@ -76,7 +79,7 @@ Required GitHub repository variables:
 | `ECS_CLUSTER` | ECS cluster name; defaults to `namuh` in the workflow when unset. |
 | `PRODUCT` | Service/repository prefix; defaults to `opensend` in the workflow when unset. |
 
-The OIDC role needs the same production permissions as the Mac mini deploy identity for STS, ECR push/login, ECS service/task-definition updates, migration task execution, CloudWatch Logs reads/writes used by the deploy script, and Secrets Manager `describe-secret` metadata lookups. It must not grant `secretsmanager:GetSecretValue` for this deploy path.
+The OIDC role needs the same production permissions as the Mac mini deploy identity for STS, ECR push/login, ECS service/task-definition updates, migration task execution, CloudWatch Logs reads/writes used by the deploy script, and Secrets Manager `describe-secret` metadata lookups. It must not grant `secretsmanager:GetSecretValue` for this deploy path. Its IAM max session duration must be configured to at least 4,500 seconds, matching the workflow's `role-duration-seconds` and 75-minute timeout.
 
 ## Preflight
 

--- a/agent_docs/runbooks/deploy-fallback.md
+++ b/agent_docs/runbooks/deploy-fallback.md
@@ -2,9 +2,9 @@
 
 Issue: #645
 
-OpenSend production deploys normally run through `.github/workflows/deploy.yml` on the `[self-hosted, opensend-deploy]` Mac mini runner. If that runner is offline or unreachable, use this break-glass path from a trusted non-Mac-mini workstation that is already authorized for production AWS deploys.
+OpenSend production deploys normally run through `.github/workflows/deploy.yml` on the `[self-hosted, opensend-deploy]` Mac mini runner. If that runner is offline or unreachable, use the GitHub-hosted OIDC fallback in the same workflow, or the local workstation fallback from a trusted non-Mac-mini machine that is already authorized for production AWS deploys.
 
-This runbook keeps the Mac mini as the normal deploy runner. It does **not** migrate the workflow to GitHub-hosted OIDC, does **not** replace the deployment topology, and does **not** fully close the runner SPOF until one real no-op fallback deploy exercise is completed and recorded.
+The GitHub-hosted OIDC path is the preferred break-glass path because it keeps deployment inside GitHub Actions while removing the physical Mac mini dependency. The workstation path remains available when GitHub Actions cannot assume the deploy role or the workflow control plane itself is impaired. Neither path replaces the normal Mac mini runner until a real no-op fallback deploy exercise is completed and recorded.
 
 ## Prerequisites
 
@@ -16,6 +16,7 @@ Use a trusted operator machine with:
 - Docker authenticated to the production ECR registry; the preflight performs this with `aws ecr get-login-password | docker login --password-stdin` and does not print the password.
 - Network access to AWS ECR/ECS/Secrets Manager in the deploy region.
 - No copied GitHub Actions secrets and no dumped runner environment. Authenticate through an operator AWS profile, SSO session, or equivalent approved AWS credential source.
+- For GitHub-hosted OIDC fallback: repository variables `AWS_DEPLOY_ROLE_ARN`, `AWS_REGION`, `AWS_ACCOUNT_ID`, `ECS_CLUSTER`, and `PRODUCT` configured for production. `AWS_DEPLOY_ROLE_ARN` must trust this repository's GitHub Actions OIDC subject for manual Deploy workflow runs.
 
 Required tools:
 
@@ -53,6 +54,29 @@ If Bun is missing, install it through the workstation's approved package manager
 Do not run `env`, `printenv`, `aws secretsmanager get-secret-value`, or any command that prints credential material into logs, issues, PRs, terminals being recorded, or chat. The fallback deploy only needs secret name/ARN metadata through `aws secretsmanager describe-secret`; it must not fetch secret values.
 
 ECR repository and ECS service names are derived by `scripts/deploy.sh` from `PRODUCT` as `${PRODUCT}-app` and `${PRODUCT}-ingester`. The scheduler service defaults to `${PRODUCT}-scheduler`; if `SCHED_SERVICE` is set, the preflight validates that same scheduler service name before deploy. Do not set separate app/ingester repository or service override names for the fallback path unless `scripts/deploy.sh` is changed to honor them first.
+
+## GitHub-hosted OIDC fallback
+
+Use this path first when the Mac mini runner is the only blocker and GitHub Actions itself is healthy:
+
+1. Open **Actions → Deploy → Run workflow**.
+2. Select the production branch/SHA intended for deployment.
+3. Set `deploy_path` to `github-hosted-oidc`.
+4. Start the run and monitor the `Deploy via GitHub-hosted OIDC fallback` job.
+
+The fallback job runs on `ubuntu-latest`, installs Bun with `oven-sh/setup-bun@v2`, requests an OIDC token with `id-token: write`, assumes `vars.AWS_DEPLOY_ROLE_ARN`, runs `bun run deploy:fallback:preflight`, then runs `bash scripts/deploy.sh all`. The preflight performs the same non-mutating checks documented below before any image push, task registration, migration task, or ECS service update.
+
+Required GitHub repository variables:
+
+| Name | Purpose |
+| --- | --- |
+| `AWS_DEPLOY_ROLE_ARN` | IAM role assumed by `aws-actions/configure-aws-credentials` through GitHub Actions OIDC. |
+| `AWS_REGION` | AWS deploy region; defaults to `us-east-1` in the workflow when unset. |
+| `AWS_ACCOUNT_ID` | Optional account guard passed through to `scripts/deploy.sh` and the preflight. |
+| `ECS_CLUSTER` | ECS cluster name; defaults to `namuh` in the workflow when unset. |
+| `PRODUCT` | Service/repository prefix; defaults to `opensend` in the workflow when unset. |
+
+The OIDC role needs the same production permissions as the Mac mini deploy identity for STS, ECR push/login, ECS service/task-definition updates, migration task execution, CloudWatch Logs reads/writes used by the deploy script, and Secrets Manager `describe-secret` metadata lookups. It must not grant `secretsmanager:GetSecretValue` for this deploy path.
 
 ## Preflight
 

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -461,7 +461,41 @@ describe("deploy-001: ECS Fargate deployment configuration", () => {
     expect(runbook).toContain("bash scripts/deploy.sh all");
     expect(runbook).toContain("no-op fallback deploy exercise");
     expect(runbook).toContain("not the Mac mini runner");
-    expect(runbook).toContain("not proven fully closed");
+    expect(runbook).toContain("real no-op fallback deploy exercise");
+    expect(runbook).toContain("GitHub-hosted OIDC fallback");
+    expect(runbook).toContain("AWS_DEPLOY_ROLE_ARN");
+    expect(runbook).toContain("deploy_path` to `github-hosted-oidc");
+  });
+
+  it("deploy workflow exposes a GitHub-hosted OIDC fallback path", () => {
+    const workflow = readFileSync(
+      join(root, ".github", "workflows", "deploy.yml"),
+      "utf-8",
+    );
+
+    expect(workflow).toContain("deploy_path:");
+    expect(workflow).toContain("github-hosted-oidc");
+    expect(workflow).toContain("id-token: write");
+    expect(workflow).toContain("deploy-mac-mini:");
+    expect(workflow).toContain("runs-on: [self-hosted, opensend-deploy]");
+    expect(workflow).toContain("deploy-github-hosted-oidc:");
+    expect(workflow).toContain("runs-on: ubuntu-latest");
+    expect(workflow).toContain("oven-sh/setup-bun@v2");
+    expect(workflow).toContain('bun-version: "1.3.8"');
+    expect(workflow).toContain("docker/setup-buildx-action@v3");
+    expect(workflow).toContain("aws-actions/configure-aws-credentials@v4");
+    expect(workflow).toContain(
+      "role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}",
+    );
+    expect(workflow).toContain("bun run deploy:fallback:preflight");
+    expect(workflow).toContain("bash scripts/deploy.sh all");
+    expect(workflow).toContain("PLATFORM: linux/amd64");
+    expect(workflow).toContain(
+      "github.event_name == 'push' || inputs.deploy_path == 'mac-mini'",
+    );
+    expect(workflow).toContain(
+      "github.event_name == 'workflow_dispatch' && inputs.deploy_path == 'github-hosted-oidc'",
+    );
   });
 
   it("deploy fallback preflight passes when app and ingester ECS services are ACTIVE", () => {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -465,6 +465,17 @@ describe("deploy-001: ECS Fargate deployment configuration", () => {
     expect(runbook).toContain("GitHub-hosted OIDC fallback");
     expect(runbook).toContain("AWS_DEPLOY_ROLE_ARN");
     expect(runbook).toContain("deploy_path` to `github-hosted-oidc");
+    expect(runbook).toContain("role-duration-seconds: 4500");
+    expect(runbook).toContain(
+      "max session duration must be at least 4,500 seconds",
+    );
+    expect(runbook).toContain(
+      "shared `deploy-prod` workflow concurrency group",
+    );
+    expect(runbook).toContain("cancels any pending or running Deploy workflow");
+    expect(runbook).toContain(
+      "manual `mac-mini` deploys keep `cancel-in-progress` disabled",
+    );
   });
 
   it("deploy workflow exposes a GitHub-hosted OIDC fallback path", () => {
@@ -487,9 +498,15 @@ describe("deploy-001: ECS Fargate deployment configuration", () => {
     expect(workflow).toContain(
       "role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}",
     );
+    expect(workflow).toContain("timeout-minutes: 75");
+    expect(workflow).toContain("role-duration-seconds: 4500");
     expect(workflow).toContain("bun run deploy:fallback:preflight");
     expect(workflow).toContain("bash scripts/deploy.sh all");
     expect(workflow).toContain("PLATFORM: linux/amd64");
+    expect(workflow).toContain("group: deploy-prod");
+    expect(workflow).toContain(
+      "cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_path == 'github-hosted-oidc' }}",
+    );
     expect(workflow).toContain(
       "github.event_name == 'push' || inputs.deploy_path == 'mac-mini'",
     );


### PR DESCRIPTION
## Summary
- Adds a manual `github-hosted-oidc` deploy path to the existing Deploy workflow while keeping the Mac mini as the push/default path.
- Runs the existing deploy fallback preflight before the GitHub-hosted path mutates ECR/ECS.
- Updates the deploy fallback runbook, static deployment coverage, and operational learning for issue #645.

## Verification
- `python3` YAML parse/assertions for `.github/workflows/deploy.yml`
- `bun run test tests/deploy.test.ts`
- `make check`
- `make test`

## Follow-up to fully close #645
- Run one real no-op deploy through `deploy_path=github-hosted-oidc` after the OIDC role/repo variables are configured and record the run evidence in issue #645/runbook.

Refs #645